### PR TITLE
Made hello.go faster

### DIFF
--- a/go/hello.go
+++ b/go/hello.go
@@ -17,7 +17,7 @@ func hello(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	runtime.GOMAXPROCS(runtime.NumCPU() * 5) // per mailing list thread results
 	http.HandleFunc("/json", hello)
 	http.ListenAndServe(":8080", nil)
 }


### PR DESCRIPTION
Mailing list discussions have concluded that you want GOMAXPROCS higher than, not equal to the number of CPUs, but not excessively so.
