### PR TITLE
improvements to play-java

### DIFF
--- a/play-java/app/controllers/Application.java
+++ b/play-java/app/controllers/Application.java
@@ -1,9 +1,11 @@
 package controllers;
 
-import play.*;
-import play.mvc.*;
 import play.libs.Json;
+import play.mvc.*;
+import static play.libs.Akka.future;
+import java.util.concurrent.Callable;
 import org.codehaus.jackson.node.ObjectNode;
+import org.codehaus.jackson.map.ObjectMapper;
 import views.html.*;
 import models.*;
 import java.util.*;
@@ -11,24 +13,36 @@ import java.util.concurrent.*;
 
 public class Application extends Controller {
 
-  private static final int TEST_DATABASE_ROWS = 10000;
-  
-  public static Result json() {
-    ObjectNode result = Json.newObject();
-    result.put("message", "Hello World!");
-    return ok(result);
-  }
+    private static final int TEST_DATABASE_ROWS = 10000;
+    //http://stackoverflow.com/questions/3907929/should-i-make-jacksons-objectmapper-as-static-final
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
-  public static Result db(Integer queries) {
-    final Random random = ThreadLocalRandom.current();
-    final World[] worlds = new World[queries];
-
-    for (int i = 0; i < queries; i++)
-    {
-      worlds[i] = World.find.byId((long)(random.nextInt(TEST_DATABASE_ROWS) + 1));
+    public static Result json() {
+        return async(
+          future(new Callable<Result>() {
+              public Result call() {
+                  ObjectNode result = objectMapper.createObjectNode();
+                  result.put("message", "Hello World!");
+                  return ok(result);
+              }
+          })
+        );
     }
 
-    return ok(Json.toJson(worlds));
-  }
+    public static Result db(final Integer queries) {
+        return async(
+          future(new Callable<Result>() {
+              public Result call() {
+                  final Random random = ThreadLocalRandom.current();
+                  final World[] worlds = new World[queries];
 
+                  for (int i = 0; i < queries; i++) {
+                      worlds[i] = World.find.byId((long)(random.nextInt(TEST_DATABASE_ROWS) + 1));
+                  }
+                  return ok(Json.toJson(worlds));
+              }
+          })
+        );
+
+    }
 }

--- a/play-java/conf/application.conf
+++ b/play-java/conf/application.conf
@@ -71,4 +71,22 @@ logger.play=ERROR
 
 # Logger provided to your application:
 logger.application=ERROR
-
+play {
+  akka {
+    event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+    loglevel = WARNING
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 50
+        }
+      }
+      application = {
+        fork-join-executor {
+          parallelism-max = 300
+        }
+      }	
+    }
+  }
+}


### PR DESCRIPTION
- thread-safe jackson ObjectMapper is kept on class level
- blocking tasks were moved off from main thread pool
- increased default threadpool size as well as configured Akka plugin for blocking tasks
