### PR TITLE
Updating Go to 1.1 beta

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -84,7 +84,7 @@ class Installer:
     # go
     #
 
-    self.__run_command("curl http://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz | tar xvz")
+    self.__run_command("curl http://go.googlecode.com/files/go1.1beta1.linux-amd64.tar.gz | tar xvz")
 
     #
     # php


### PR DESCRIPTION
People have seen requests per second with Revel (Golang web framework) increase by 2-3x by switching from 1.0.3 to 1.1 beta. Don't know if the raw bench will improve by this much, but the other golangers aren't going to stop squawking until the benches use tip/beta. :)

Love these benchmarks by the way! They're some of the best and most thorough around!
