### PR TITLE
worker class gevent processes concurrent requests

### DIFF
--- a/flask/setup.py
+++ b/flask/setup.py
@@ -5,7 +5,7 @@ import os
 
 def start(args):
   setup_util.replace_text("flask/app.py", "DBHOSTNAME", args.database_host)
-  subprocess.Popen("gunicorn app:app -b 0.0.0.0:8080 -w " + str((args.max_threads * 2)) + " --worker-class gevent --log-level=critical", shell=True, cwd="flask")
+  subprocess.Popen("gunicorn app:app -b 0.0.0.0:8080 -w " + str((args.max_threads * 2)) + " --worker-class=gevent --preload=True --log-level=critical", shell=True, cwd="flask")
   
   return 0
 


### PR DESCRIPTION
with no worker class specified, it is using 'sync' which is essentially just those four forked processes, which in python means: slower than a single process. gevent will give better performance. nobody in their right mind would run gunicorn with just 'sync' workers.
