### PR TITLE
jvm runs faster with -server than with -client

### DIFF
--- a/http-kit/hello/project.clj
+++ b/http-kit/hello/project.clj
@@ -6,8 +6,10 @@
                  [ring/ring-json "0.2.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [http-kit/dbcp "0.1.0"]
-                 [http-kit "2.0.0-RC4"]
+                 [http-kit "2.0.0"]
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  [mysql/mysql-connector-java "5.1.6"]]
   :main hello.handler
+  :aot [hello.handler]
+  :uberjar-name "http-kit-standalone.jar"
   :profiles {:dev {:dependencies [[ring-mock "0.1.3"]]}})

--- a/http-kit/setup.py
+++ b/http-kit/setup.py
@@ -7,8 +7,11 @@ def start(args):
 
   try:
     subprocess.check_call("lein deps", shell=True, cwd="http-kit/hello")
-    # lein run -- --help for more options
-    command = "lein run -- --db-host " + args.database_host
+    # pack all dependencies into a single jar: target/http-kit-standalone.jar
+    subprocess.check_call("lein uberjar", shell=True, cwd="http-kit/hello")
+    # -server is much faster
+    # 'lein run' passes '-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1' which make it starts fast, but runs slow
+    command = "java -server -jar target/http-kit-standalone.jar --db-host " + args.database_host
     subprocess.Popen(command, shell=True, cwd="http-kit/hello")
     return 0
   except subprocess.CalledProcessError:


### PR DESCRIPTION
`lein run` passes `-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1` to JVM, with makes JVM starts much faster, but runs slower.

jvm with -server runs much faster.  
