### PR TITLE
Fix a typo that causes installs to fail.

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -240,7 +240,7 @@ class Installer:
     # Snap
     ##############################
     self.__run_command("cabal update")
-    self.__run_commnad("cabal install HDBC HDBC-mysql MonadCatchIO-transformers configurator json snap-core snap-server resource-pool")
+    self.__run_command("cabal install HDBC HDBC-mysql MonadCatchIO-transformers configurator json snap-core snap-server resource-pool")
 
     ##############################################################
     #


### PR DESCRIPTION
The installer script has commnad instead of command for one of its calls.
