### PR TITLE
Multiplied the length of the back pressure queue by the max # of queries...

### DIFF
--- a/play-java/conf/application.conf
+++ b/play-java/conf/application.conf
@@ -35,7 +35,7 @@ db.default.user=benchmarkdbuser
 db.default.password=benchmarkdbpass
 db.default.jndiName=DefaultDS
 
-db.default.partitionCount=64
+db.default.partitionCount=4
 
 # The number of connections to create per partition. Setting this to 
 # 5 with 3 partitions means you will have 15 unique connections to the 

--- a/play-scala/conf/application.conf
+++ b/play-scala/conf/application.conf
@@ -30,13 +30,12 @@ application.langs="en"
 # You can expose this datasource via JNDI if needed (Useful for JPA)
 # db.default.jndiName=DefaultDS
 db.default.driver= com.mysql.jdbc.Driver
-db.default.url="jdbc:mysql://172.16.98.98:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
-#db.default.url="jdbc:mysql://172.16.98.98:3306/hello_world"
+db.default.url="jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
 db.default.user=benchmarkdbuser
 db.default.password=benchmarkdbpass
 db.default.jndiName=DefaultDS
 
-db.default.partitionCount=64
+db.default.partitionCount=4
 
 # The number of connections to create per partition. Setting this to 
 # 5 with 3 partitions means you will have 15 unique connections to the 


### PR DESCRIPTION
... per request. This should prevent failures from occurring sooner.
