### PR TITLE
Symfony 2 (Doctrine) fixes

### DIFF
--- a/php-symfony2/app/config/config_prod.yml
+++ b/php-symfony2/app/config/config_prod.yml
@@ -11,11 +11,11 @@ framework:
     #validation:
     #    cache: apc
 
-#doctrine:
-#    orm:
-#        metadata_cache_driver: apc
+doctrine:
+    orm:
+        metadata_cache_driver: apc
 #        result_cache_driver: apc
-#        query_cache_driver: apc
+        query_cache_driver: apc
 
 monolog:
     handlers:


### PR DESCRIPTION
Doctrine is never intended to be (and it definitely should not be) used in a live environment without metadata and query caching (note this is not result caching). 

Its performance will be significantly impeded without it - this will be unfairly impacting the result of the test for Symfony 2. 
