### PR TITLE
[Symfony2] Generate configuration cache before starting benchmarks

### DIFF
--- a/php-symfony2/setup.py
+++ b/php-symfony2/setup.py
@@ -11,7 +11,7 @@ def start(args):
 
   try:
     subprocess.check_call("composer.phar install", shell=True, cwd="php-symfony2")
-    subprocess.check_call("php app/console cache:clear --env=prod --no-debug")
+    subprocess.check_call("php app/console cache:clear --env=prod --no-debug", shell=True, cwd="php-symfony2")
     subprocess.check_call("sudo chown -R www-data:www-data php-symfony2", shell=True)
     subprocess.check_call("sudo php-fpm --fpm-config config/php-fpm.conf -g " + home + "/FrameworkBenchmarks/php-symfony2/deploy/php-fpm.pid", shell=True)
     subprocess.check_call("sudo /usr/local/nginx/sbin/nginx -c " + home + "/FrameworkBenchmarks/php-symfony2/deploy/nginx.conf", shell=True)


### PR DESCRIPTION
Symfony relies on configuration caching to avoid booting the whole system on every request over and over again. If you are not doing this during the build process, then the application might run into cache slams during the first 2-3 second when the cache is generated the first time.

Compared to lightweight frameworks such as Laravel or Silex, Symfony uses lots of configuration files that are parsed and compiled into two php files (one for the services, one for the routing). This is comparable to the compile step of any static language and only done once. It is not a runtime cache.
