### PR TITLE
Potential improvement for Go (RE: Issue #171)

### DIFF
--- a/go/src/hello/hello.go
+++ b/go/src/hello/hello.go
@@ -24,7 +24,7 @@ const (
 	DB_CONN_STR   = "benchmarkdbuser:benchmarkdbpass@tcp(172.16.98.98:3306)/hello_world?charset=utf8"
 	DB_SELECT_SQL = "SELECT id, randomNumber FROM World where id = ?"
 	DB_ROWS       = 10000
-	MAX_CON       = 100
+	MAX_CON       = 80
 )
 
 var (
@@ -68,19 +68,15 @@ func init() {
 	// use cores
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	// setup connection pool
-	if db, err := sql.Open("mysql", DB_CONN_STR); err == nil {
-		for i := 0; i < MAX_CON; i++ {
-			tx, err := db.Begin()
-			if err != nil {
-				log.Fatal(err)
-			}
-			stmt, err := tx.Prepare(DB_SELECT_SQL)
+	for i := 0; i < MAX_CON; i++ {
+		if db, err := sql.Open("mysql", DB_CONN_STR); err == nil {
+			stmt, err := db.Prepare(DB_SELECT_SQL)
 			if err != nil {
 				log.Fatal(err)
 			}
 			stmts <- stmt
+		} else {
+			log.Fatalf("Error opening database: %s", err)
 		}
-	} else {
-		log.Fatalf("Error opening database: %s", err)
 	}
 }


### PR DESCRIPTION
RE: Issue #171 

The major problem with the Go test appears to be that it opens far too many concurrent database connections then struggles to decide which ones to use to run the statement.

Go's database/sql package does not let you put an upper limit on the number of connections that are opened, so it is up to you to rate-limit there usage.

Unfortunately even this is tricky as there is no direct access to individual connections. However by abusing database transactions we can sort-of work around this.

This patch, shows a way to open `MAX_CON` connections, and only use those connections for making queries. This should drastically improve the performance of the db test. As a rule of thumb I've found about 25 connections per core to be quite enough, after that it seems the scheduler starts getting a bit fed up with all the switching.

There are [improvements](https://code.google.com/p/go/issues/detail?id=4805&q=sql.db&colspec=ID%20Status%20Stars%20Priority%20Owner%20Reporter%20Summary) in upcoming Go versions that should also be relevant.
