### PR TITLE
remove use of async package

### DIFF
--- a/yesod/bench/bench.cabal
+++ b/yesod/bench/bench.cabal
@@ -30,6 +30,5 @@ executable         bench
                  , mwc-random                    >= 0.12
                  , pool-conduit                  >= 0.1
                  , network
-                 , lifted-async                  >= 0.1
                  , mongoDB
                  , aeson

--- a/yesod/bench/src/yesod.hs
+++ b/yesod/bench/src/yesod.hs
@@ -20,7 +20,6 @@ import Data.Conduit.Network (bindPort)
 import System.Posix.Process (forkProcess)
 import Control.Monad (replicateM_)
 import Network (PortID (PortNumber))
-import Control.Concurrent.Async.Lifted (mapConcurrently)
 import Data.Int (Int64)
 import Data.Aeson (ToJSON(..))
 
@@ -124,7 +123,7 @@ multiRandomHandler :: ToJSON a
 multiRandomHandler operation cnt = do
     App {..} <- getYesod
     nums <- liftIO $ replicateM cnt (randomNumber appGen)
-    jsonToRepJson . array =<< mapConcurrently operation nums
+    jsonToRepJson . array =<< mapM operation nums
 
 documentToJson :: [Field] -> Value
 documentToJson = object . map toAssoc


### PR DESCRIPTION
used to run db queries concurrently
in benchmarks it slowed things down a little.
Probably the db queries are so fast that it isn't worthwhile.
