### PR TITLE
Change CakePHP cache engine from File to Apc

### DIFF
--- a/cake/app/Config/core.php
+++ b/cake/app/Config/core.php
@@ -248,7 +248,7 @@ Configure::write('App.baseUrl', env('SCRIPT_NAME'));
  *       Please check the comments in boostrap.php for more info on the cache engines available
  *       and their setttings.
  */
-$engine = 'File';
+$engine = 'Apc';
 
 // In development mode, caches should expire quickly.
 $duration = '+999 days';


### PR DESCRIPTION
As of CakePHP 2.3 the default cache engine is File and a different
engine like APC must be configured manually.

See: http://book.cakephp.org/2.0/en/core-libraries/caching.html
