### PR TITLE
Use more gunicorn threads when pooling database connector isn't availabl...

### DIFF
--- a/django/setup.py
+++ b/django/setup.py
@@ -9,6 +9,10 @@ home = expanduser("~")
 def start(args):
   setup_util.replace_text("django/hello/hello/settings.py", "HOST': '.*'", "HOST': '" + args.database_host + "'")
   setup_util.replace_text("django/hello/hello/settings.py", "\/home\/ubuntu",  home)
+  # because pooling doesn't work with meinheld, it's necessary to create a ton of gunicorn threads (think apache pre-fork)
+  # to allow the OS to switch processes when waiting for socket I/O.
+  args.max_threads *= 8
+  # and go from there until the database server runs out of memory for new threads (connections)
   subprocess.Popen("gunicorn hello.wsgi:application --worker-class=\"egg:meinheld#gunicorn_worker\"  -b 0.0.0.0:8080 -w " + str((args.max_threads * 2)) + " --log-level=critical", shell=True, cwd="django/hello")
   return 0
 def stop():


### PR DESCRIPTION
...e.

When using postgres with meinheld, the best you can do so far (as far as I know) is up the number of threads.
