### PR TITLE
Improve Django template performance

### DIFF
--- a/django-stripped/hello/hello/settings.py
+++ b/django-stripped/hello/hello/settings.py
@@ -85,8 +85,10 @@ SECRET_KEY = '_7mb6#v4yf@qhc(r(zbyh&amp;z_iby-na*7wz&amp;-v6pohsul-d#y5f'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    ))
 )
 
 MIDDLEWARE_CLASSES = (

--- a/django/hello/hello/settings.py
+++ b/django/hello/hello/settings.py
@@ -86,8 +86,10 @@ SECRET_KEY = '_7mb6#v4yf@qhc(r(zbyh&amp;z_iby-na*7wz&amp;-v6pohsul-d#y5f'
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    ))
 )
 
 MIDDLEWARE_CLASSES = (


### PR DESCRIPTION
Hi guys,

So it's rumored that Django template is slow, but in fact there's a missed setting since Django 1.2

https://docs.djangoproject.com/en/1.2/ref/templates/api/#loader-types

By using `django.template.loaders.cached.Loader`, django doesn't have to look up piles of directories and read template file from harddisk everytime. This is common practice for production Django stacks. 

Please add, thanks!
