### PR TITLE
Create a more idiomatic Finagle setup

### DIFF
--- a/finagle/benchmark_config
+++ b/finagle/benchmark_config
@@ -9,15 +9,6 @@
             "port": 8080,
             "sort": 44
             }
-        },
-        {
-        "future-pool" : {
-            "setup_file" : "setup",
-            "db_url" : "/pooling",
-            "query_url" : "/pooling?queries=",
-            "port": 8080,
-            "sort": 46
-            }
         }
         ]
 

--- a/finagle/build.sbt
+++ b/finagle/build.sbt
@@ -7,9 +7,7 @@ scalaVersion := "2.10.0"
 version := "1.0"
 
 libraryDependencies ++= Seq(
-                "com.twitter" % "finagle-http_2.10" % "6.+",
-                "com.fasterxml.jackson.module" % "jackson-module-scala_2.10" % "2.+",
-                "com.typesafe.slick" % "slick_2.10" % "1.0.0",
-                "mysql" % "mysql-connector-java" % "5.1.24",
-                "commons-dbcp" % "commons-dbcp" % "1.+"
+                "com.twitter" %% "finagle-http" % "6.+",
+                "com.twitter" %% "finagle-mysql" % "6.+",
+                "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.+"
                 )


### PR DESCRIPTION
The previous version was effectively serializing all incoming requests by doing all work on on the event loop. This patch provides a setup closer to what one might see in production code.

The serialization benchmark ships serialization off to a thread pool. Previously work was being done on the event loop and the result was sent to the pool.

We have a (still experimental) mysql client built on finagle that we're using for the db benchmarks. This ensures the bottleneck is never how the jdbc adapter is tuned. Also the previous setup was doing all queries on the event loop and providing the result. This patch provides true parallelization of queries.

Finally we have jackson emit byte arrays and use wrapped buffers instead of copied buffers to avoid the extra work of copying.
