### PR TITLE
importing the end product, dumps

### DIFF
--- a/django/hello/world/views.py
+++ b/django/hello/world/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponse
 from django.core import serializers
 from world.models import World, Fortune
 from django.shortcuts import render
-import ujson
+from ujson import dumps as uj_dumps
 import random
 from operator import attrgetter
 import numpy.random as nprnd
@@ -15,7 +15,7 @@ def json(request):
   response = {
     "message": "Hello, World!"
   }
-  return HttpResponse(ujson.dumps(response), mimetype="application/json")
+  return HttpResponse(uj_dumps(response), mimetype="application/json")
 
 def db(request):
   queries = int(request.GET.get('queries', 1))
@@ -43,7 +43,7 @@ def db(request):
   # by creating dicts, we don't need to user the model serializer, which is probably slow and only appropriate
   # for complicated serializations of joins and crazy query sets etc
   # test xrange vs range if the query number is gigantic
-  worlds = ujson.dumps([{'id' : r, 'randomNumber' : g(id=r).randomnumber} for r in [rp() for q in xrange(queries)]])  
+  worlds = uj_dumps([{'id' : r, 'randomNumber' : g(id=r).randomnumber} for r in [rp() for q in xrange(queries)]])  
   return HttpResponse(worlds, mimetype="application/json")
 
 def fortunes(request):


### PR DESCRIPTION
And omitting another dot-notation **getattr** call.  This technique can get a little ridiculous as it's hard to tell which modules the functions came from and face it, uj_dumps is a name I came up with, not a standard name in the API for the module.
On the JSON response test, it will possibly give detectable improvements.
