### PR TITLE
ringojs: fix fortune query

### DIFF
--- a/ringojs-convinient/app/views.js
+++ b/ringojs-convinient/app/views.js
@@ -29,7 +29,7 @@ app.get('/db/:queries?', function(request, queries) {
 });
 
 app.get('/fortune', function() {
-   var fortunes = models.Fortune.all();
+   var fortunes = models.store.query('select Fortune.* from Fortune');
    fortunes.push({
       _id: 0,
       message: 'Additional fortune added at request time.'


### PR DESCRIPTION
the fortune test was doing 11 queries per request (which is what happens when you use `all()` without entity-cache); this fixes it to only do 1 query per request
