### PR TITLE
PHP-Kohana - Fixed Cookie salt error

### DIFF
--- a/php-kohana/application/bootstrap.php
+++ b/php-kohana/application/bootstrap.php
@@ -63,6 +63,13 @@ ini_set('unserialize_callback_func', 'spl_autoload_call');
  */
 I18n::lang('en-us');
 
+
+/**
+ * Set a magic salt to the Cookie (required)
+ * http://kohanaframework.org/3.3/guide/kohana/cookies#cookie-settings
+ */
+Cookie::$salt = 'please, set a Cookie salt';
+
 /**
  * Set Kohana::$environment if a 'KOHANA_ENV' environment variable has been supplied.
  *


### PR DESCRIPTION
Added a default Cookie::$salt in the bootstrap as required in the docs :
http://kohanaframework.org/3.3/guide/kohana/cookies#cookie-settings

> The most important setting is Cookie::$salt, which is used for secure signing. This value should be changed and kept secret:
> `Cookie::$salt = 'your secret is safe with me';`

If the `Cookie::$salt` is not set, we can see here [Kohana/Cookie.php#L149](https://github.com/kohana/core/blob/3.3/master/classes/Kohana/Cookie.php#L149) that there's an exception thrown `A valid cookie salt is required. Please set Cookie::$salt.` (the error you were talking about in your [blog post](http://www.techempower.com/blog/2013/05/17/frameworks-round-5/http://www.techempower.com/blog/2013/05/17/frameworks-round-5/))
