### PR TITLE
ringojs: do dependency install in setup.py (like everyone else...)

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -138,10 +138,6 @@ class Installer:
     self.__run_command("sudo apt-get install jsvc", True)
     self.__run_command("sudo dpkg -i ringojs_0.9-1_all.deb", True)
     self.__run_command("rm ringojs_0.9-1_all.deb")
-    self.__run_command("sudo ringo-admin install oberhamsi/sql-ringojs-client")
-    self.__run_command("sudo ringo-admin install ringo/stick")
-    self.__run_command("sudo ringo-admin install oberhamsi/reinhardt")
-    self.__run_command("sudo ringo-admin install grob/ringo-sqlstore")
     
     #
     # Mono

--- a/ringojs-convinient/setup.py
+++ b/ringojs-convinient/setup.py
@@ -8,8 +8,11 @@ def start(args):
   setup_util.replace_text("ringojs-convinient/app/models.js", "dbHost = '.*';", "dbHost = '" + args.database_host + "';")
 
   try:
+    subprocess.check_call("sudo ringo-admin install --force oberhamsi/sql-ringojs-client", shell=True)
+    subprocess.check_call("sudo ringo-admin install --force grob/ringo-sqlstore", shell=True)
+    subprocess.check_call("sudo ringo-admin install --force ringo/stick", shell=True)
+    subprocess.check_call("sudo ringo-admin install --force oberhamsi/reinhardt", shell=True)
     subprocess.check_call("sudo mkdir -p /usr/share/ringojs/packages/ringo-sqlstore/jars/", shell=True)
-    
     subprocess.check_call("sudo cp /usr/share/ringojs//packages/sql-ringojs-client/jars/mysql.jar /usr/share/ringojs/packages/ringo-sqlstore/jars/", shell=True)
     subprocess.Popen("ringo --production ringo-main.js", shell=True, cwd="ringojs-convinient")
     return 0

--- a/ringojs/setup.py
+++ b/ringojs/setup.py
@@ -8,6 +8,7 @@ def start(args):
   setup_util.replace_text("ringojs/ringo-main.js", "dbHost = '.*';", "dbHost = '" + args.database_host + "';")
 
   try:
+    subprocess.check_call("sudo ringo-admin install --force oberhamsi/sql-ringojs-client", shell=True)
     subprocess.Popen("ringo --production ringo-main.js", shell=True, cwd="ringojs")
     return 0
   except subprocess.CalledProcessError:


### PR DESCRIPTION
I don't find it too elegant and it probably makes the tests run longer.. but most other frameworks seem to do install deps in setup.py and I suspect the frameworkbenchmarks' installation is not reset before rounds
