### PR TITLE
Turned of Debug Setting for ASP.Net, as it can affect performance

### DIFF
--- a/aspnet/src/Web.config
+++ b/aspnet/src/Web.config
@@ -22,6 +22,6 @@
   </entityFramework>
   <system.web>
     <customErrors mode="Off" />
-    <compilation debug="true" />
+    <compilation debug="false" />
   </system.web>
 </configuration>


### PR DESCRIPTION
Leaving  <compilation debug="true" /> for release deployments can affect performance badly. This is especially true for ASP.MVC templating. This change takes the easiest route to turn the setting off, as it should be compatible with Mono. Using Publish Profiles might only affect ASP, not mono, as I doubt it supports them.
