### PR TITLE
Updated incorrect monolite exe filename

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -160,7 +160,7 @@ class Installer:
     self.__run_command("git checkout mono-3.10", cwd="mono")
     self.__run_command("./autogen.sh --prefix=/usr/local", cwd="mono")
     self.__run_command("make get-monolite-latest", cwd="mono")
-    self.__run_command("make EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/gmcs.exe", cwd="mono")
+    self.__run_command("make EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/basic.exe", cwd="mono")
     self.__run_command("sudo make install", cwd="mono")
 
     self.__run_command("git clone git://github.com/mono/xsp")


### PR DESCRIPTION
Although the mono documentation states that the monolite exe name is 'gmcs.exe', the actual name in the current monolite package is 'basic.exe' (http://storage.bos.xamarin.com/mono-dist-master/latest/monolite-110-latest.tar.gz).
