### PR TITLE
Set apc.enable_cli = 1

### DIFF
--- a/config/php.ini
+++ b/config/php.ini
@@ -1,4 +1,3 @@
-
 [PHP]
 
 ;;;;;;;;;;;;;;;;;;;
@@ -1864,3 +1863,5 @@ ldap.max_links = -1
 ; End:
 [apc]
 apc.stat = 0
+apc.enable_cli = 1
+apc.shm_size = 64M


### PR DESCRIPTION
Without this Symfony2 will not use APC cache for Doctrine metadata annotations.

More info here: http://gogs.info/2013/05/using-apc-cache-with-doctrine-symfony/
