### PR TITLE
Go - Increase idle connection pool to 5k

### DIFF
--- a/go/src/hello/hello.go
+++ b/go/src/hello/hello.go
@@ -35,7 +35,7 @@ const (
 	WorldUpdate        = "UPDATE World SET randomNumber = ? where id = ?"
 	FortuneSelect      = "SELECT id, message FROM Fortune;"
 	WorldRowCount      = 10000
-	MaxConnectionCount = 5000
+	MaxConnectionCount = 256
 )
 
 var (


### PR DESCRIPTION
These were the peak QPS results I got on m1.large just now, from changing the idle connection limit from 100 to 5000 (to match the MySQL connection limit). 

I'm not sure the original motivation to set it so low, however, so perhaps I'm missing something. 

```
           w/5000     w/100
 query       7769      6633
  json      18363     18726
    db       8416      8189
update       4252      4030
```

   fortune       3360      3295
