### PR TITLE
Go, Revel: Stop server-side fan-out

### DIFF
--- a/go/src/hello/hello.go
+++ b/go/src/hello/hello.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"sync"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -91,18 +90,12 @@ func worldHandler(w http.ResponseWriter, r *http.Request) {
 			log.Fatalf("Error scanning world row: %v", err)
 		}
 	} else {
-		var wg sync.WaitGroup
-		wg.Add(n)
 		for i := 0; i < n; i++ {
-			go func(i int) {
-				err := worldStatement.QueryRow(rand.Intn(WorldRowCount)+1).Scan(&ww[i].Id, &ww[i].RandomNumber)
-				if err != nil {
-					log.Fatalf("Error scanning world row: %v", err)
-				}
-				wg.Done()
-			}(i)
+			err := worldStatement.QueryRow(rand.Intn(WorldRowCount)+1).Scan(&ww[i].Id, &ww[i].RandomNumber)
+			if err != nil {
+				log.Fatalf("Error scanning world row: %v", err)
+			}
 		}
-		wg.Wait()
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ww)
@@ -142,20 +135,14 @@ func updateHandler(w http.ResponseWriter, r *http.Request) {
 		ww[0].RandomNumber = uint16(rand.Intn(WorldRowCount) + 1)
 		updateStatement.Exec(ww[0].RandomNumber, ww[0].Id)
 	} else {
-		var wg sync.WaitGroup
-		wg.Add(n)
 		for i := 0; i < n; i++ {
-			go func(i int) {
-				err := worldStatement.QueryRow(rand.Intn(WorldRowCount)+1).Scan(&ww[i].Id, &ww[i].RandomNumber)
-				ww[i].RandomNumber = uint16(rand.Intn(WorldRowCount) + 1)
-				updateStatement.Exec(ww[i].RandomNumber, ww[i].Id)
-				if err != nil {
-					log.Fatalf("Error scanning world row: %v", err)
-				}
-				wg.Done()
-			}(i)
+			err := worldStatement.QueryRow(rand.Intn(WorldRowCount)+1).Scan(&ww[i].Id, &ww[i].RandomNumber)
+			ww[i].RandomNumber = uint16(rand.Intn(WorldRowCount) + 1)
+			updateStatement.Exec(ww[i].RandomNumber, ww[i].Id)
+			if err != nil {
+				log.Fatalf("Error scanning world row: %v", err)
+			}
 		}
-		wg.Wait()
 	}
 	j, _ := json.Marshal(ww)
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
My local tests indicated that the fan-out was not helpful.  In fact, the only time the fan-out is done is during the 256-concurrency tests, where there is _already_ client-side fan-out.  Intuitively, what's the point, unless MySQL can effectively process > 256 transactions in parallel? 

(My only concern is that I didn't test this on EC2, only locally with client, server, MySQL on the same workstation.)
