### PR TITLE
spray: update to snapshot with better pipelining support

### DIFF
--- a/spray/build.sbt
+++ b/spray/build.sbt
@@ -15,7 +15,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "io.spray" %% "spray-json" % "1.2.4",
-  "io.spray" % "spray-can" % "1.1-M8",
+  "io.spray" % "spray-can" % "1.1-20130619",
   "com.typesafe.akka" %%  "akka-actor" % "2.1.2",
   "com.typesafe.akka" %%  "akka-slf4j" % "2.1.2",
   "ch.qos.logback"% "logback-classic" % "1.0.12" % "runtime"


### PR DESCRIPTION
This is an update to #346. We fixed our part of the pipelining issue. We hope you can still include it in the latest run of the benchmark.

Thanks!
