### PR TITLE
nginx keepalive to fastcgi backends for PHP frameworks #332

### DIFF
--- a/php-fuel/deploy/nginx.conf
+++ b/php-fuel/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-kohana/deploy/nginx.conf
+++ b/php-kohana/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-laravel/deploy/nginx.conf
+++ b/php-laravel/deploy/nginx.conf
@@ -12,7 +12,6 @@ events {
     worker_connections  1024;
 }
 
-
 http {
     include       /usr/local/nginx/conf/mime.types;
     default_type  application/octet-stream;
@@ -30,6 +29,11 @@ http {
     keepalive_timeout  65;
 
     #gzip  on;
+
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
 
     server {
         listen       8080;
@@ -70,7 +74,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-lithium/deploy/nginx.conf
+++ b/php-lithium/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-micromvc/deploy/nginx.conf
+++ b/php-micromvc/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-silex-orm/deploy/nginx.conf
+++ b/php-silex-orm/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-silex/deploy/nginx.conf
+++ b/php-silex/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-silica/deploy/nginx.conf
+++ b/php-silica/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -73,7 +78,8 @@ http {
         # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
         #
         location ~ \.php$ {
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-slim/deploy/nginx.conf
+++ b/php-slim/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-symfony2/deploy/nginx.conf
+++ b/php-symfony2/deploy/nginx.conf
@@ -31,6 +31,11 @@ http {
 
     #gzip  on;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -70,7 +75,8 @@ http {
         #
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/php-yaf/deploy/nginx.conf
+++ b/php-yaf/deploy/nginx.conf
@@ -10,6 +10,11 @@ http {
     sendfile      on;
     keepalive_timeout  65;
 
+    upstream fastcgi_backend {
+        server 127.0.0.1:9001;
+        keepalive 32;
+    }
+
     server {
         listen       8080;
         server_name  localhost;
@@ -28,7 +33,8 @@ http {
 
         location ~ \.php$ {
             try_files $uri =404;
-            fastcgi_pass   127.0.0.1:9001;
+            fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             include        /usr/local/nginx/conf/fastcgi_params;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;


### PR DESCRIPTION
Added keepalive in nginx for all PHP frameworks. See #332

Haven't tested it out, but it should work.
