### PR TITLE
cpoll_cppsp: fixed "pipeline stall" (update to cppsp 0.2.1)

### DIFF
--- a/cpoll_cppsp/Makefile
+++ b/cpoll_cppsp/Makefile
@@ -1,13 +1,13 @@
 all: cppsp_0.2
 
 clean:
-	rm -rf cppsp_rel0.2.1 cppsp_0.2
+	rm -rf cppsp_rel0.2.2 cppsp_0.2
 	rm -f www/*.so www/*.txt
-cppsp_0.2: cppsp_0.2.1.tar.xz
-	tar xf cppsp_0.2.1.tar.xz
-	ln -s cppsp_rel0.2.1 cppsp_0.2
+cppsp_0.2: cppsp_0.2.2.tar.xz
+	tar xf cppsp_0.2.2.tar.xz
+	ln -s cppsp_rel0.2.2 cppsp_0.2
 	$(MAKE) CXX=g++-4.8 -C cppsp_0.2 all
 
-cppsp_0.2.1.tar.xz:
-	wget -c http://downloads.sourceforge.net/project/cpollcppsp/CPPSP%200.2%20%28testing%29/cppsp_0.2.1.tar.xz
+cppsp_0.2.2.tar.xz:
+	wget -c http://downloads.sourceforge.net/project/cpollcppsp/CPPSP%200.2%20%28testing%29/cppsp_0.2.2.tar.xz
 


### PR DESCRIPTION
A bug existed in cppsp 0.2-rc9 where if multiple requests are received at once, it would sometimes cause an infinite recursion or a hang.

be sure to run a "make clean" before benchmarking to make sure the new version gets used
