### PR TITLE
Disable CodeIgniter query profiling.

### DIFF
--- a/php-codeigniter/application/config/database.php
+++ b/php-codeigniter/application/config/database.php
@@ -63,6 +63,7 @@ $db['default']['dbcollat'] = 'utf8_general_ci';
 $db['default']['swap_pre'] = '';
 $db['default']['autoinit'] = TRUE;
 $db['default']['stricton'] = FALSE;
+$db['default']['save_queries'] = FALSE;
 
 
 /* End of file database.php */


### PR DESCRIPTION
The 'save_queries' option is used exclusively by the profiler, but is enabled even when the profiler isn't running, adding some unnecessary overhead.
