### PR TITLE
django: turn off i18n mechanism

### DIFF
--- a/django-stripped/hello/hello/settings.py
+++ b/django-stripped/hello/hello/settings.py
@@ -38,7 +38,7 @@ SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
-USE_I18N = True
+USE_I18N = False
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.

--- a/django/hello/hello/settings.py
+++ b/django/hello/hello/settings.py
@@ -38,7 +38,7 @@ SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
-USE_I18N = True
+USE_I18N = False
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.


### PR DESCRIPTION
internationalization is not needed for this kind of tests so let's turn it off
