### PR TITLE
cpoll_cppsp: add "date" HTTP response header (update to cppsp 0.2.3)

### DIFF
--- a/cpoll_cppsp/Makefile
+++ b/cpoll_cppsp/Makefile
@@ -1,13 +1,13 @@
 all: cppsp_0.2
 
 clean:
-	rm -rf cppsp_rel0.2.2 cppsp_0.2
+	rm -rf cppsp_rel0.2.3 cppsp_0.2
 	rm -f www/*.so www/*.txt
-cppsp_0.2: cppsp_0.2.2.tar.xz
-	tar xf cppsp_0.2.2.tar.xz
-	ln -s cppsp_rel0.2.2 cppsp_0.2
+cppsp_0.2: cppsp_0.2.3.tar.xz
+	tar xf cppsp_0.2.3.tar.xz
+	ln -s cppsp_rel0.2.3 cppsp_0.2
 	$(MAKE) CXX=g++-4.8 -C cppsp_0.2 all
 
-cppsp_0.2.2.tar.xz:
-	wget -c http://downloads.sourceforge.net/project/cpollcppsp/CPPSP%200.2%20%28testing%29/cppsp_0.2.2.tar.xz
+cppsp_0.2.3.tar.xz:
+	wget -c http://downloads.sourceforge.net/project/cpollcppsp/CPPSP%200.2%20%28testing%29/cppsp_0.2.3.tar.xz
 


### PR DESCRIPTION
as mentioned in https://github.com/TechEmpower/FrameworkBenchmarks/issues/356, the HTTP "date" response header is required by spec. The "date" header is added in CPPSP 0.2.3.
