### PR TITLE
benchmarker.py: set cpu frequency governor to "performance" before running tests

### DIFF
--- a/benchmarker.py
+++ b/benchmarker.py
@@ -244,6 +244,7 @@ class Benchmarker:
     try:
       if os.name == 'nt':
         return True
+      subprocess.check_call(["sudo","bash","-c","cd /sys/devices/system/cpu; ls -d cpu*|while read x; do echo performance > $x/cpufreq/scaling_governor; done"])
       subprocess.check_call("sudo sysctl -w net.core.somaxconn=5000".rsplit(" "))
       subprocess.check_call("sudo -s ulimit -n 16384".rsplit(" "))
       subprocess.check_call("sudo sysctl net.ipv4.tcp_tw_reuse=1".rsplit(" "))


### PR DESCRIPTION
btw the command "sudo -s ulimit -n 16384" does nothing; ulimit limits are per-process, and the "ulimit" command is a shell built-in that calls setrlimit(2). when the child shell (started by sudo) executes the ulimit command, it only sets the resource limits for that shell, not the parent shell.

as far as i know, there isn't a way to modify resource limits of another process (other than loading a kernel module, of course), but what you can do is write a shell script that runs as root, sets ulimit, and "su" back to the original user, and then execute the benchmarker
