### PR TITLE
$config_url should be composed from $rawRepo, not $basedir

### DIFF
--- a/setup-sqlserver-bootstrap.ps1
+++ b/setup-sqlserver-bootstrap.ps1
@@ -5,7 +5,7 @@
 $basedir = "C:\FrameworkBenchmarks"
 $rawRepo = "https://raw.github.com/TechEmpower/FrameworkBenchmarks/master"
 
-$config_url = $basedir + "/config"
+$config_url = $rawRepo + "/config"
 $config_local = $basedir + "\config"
 $setup_sqlserver_url = $rawRepo + "/setup-sqlserver.ps1"
 $setup_sqlserver_local = $basedir + "\setup-sqlserver.ps1"


### PR DESCRIPTION
`$config_url` needs to be composed of `$rawRepo + "/config"` and not `$basdir + "/config"`.

This yields the correct URL [https://raw.github.com/TechEmpower/FrameworkBenchmarks/master/config] instead of [C:\FrameworkBenchmarks/config].
