### PR TITLE
Updated installer.py w/ latest Mono version

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -151,7 +151,7 @@ class Installer:
     # Mono
     #
     self.__run_command("git clone git://github.com/mono/mono")
-    self.__run_command("git checkout mono-3.0.10", cwd="mono")
+    self.__run_command("git checkout mono-3.2.1", cwd="mono")
     self.__run_command("./autogen.sh --prefix=/usr/local", cwd="mono")
     self.__run_command("make get-monolite-latest", cwd="mono")
     self.__run_command("make EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/gmcs.exe", cwd="mono")


### PR DESCRIPTION
Updated installer.py with the latest Mono version (3.2.1), which, according to the documentation, has improved GC performance.
