### PR TITLE
Downgrade bonecp for play 2.2 apps

### DIFF
--- a/play-java-jpa/build.sbt
+++ b/play-java-jpa/build.sbt
@@ -9,4 +9,6 @@ libraryDependencies ++= Seq(
   "org.hibernate" % "hibernate-entitymanager" % "4.2.1.Final"
   )
 
+dependencyOverrides += "com.jolbox" % "bonecp" % "0.7.1.RELEASE"
+
 playJavaSettings

--- a/play-java/build.sbt
+++ b/play-java/build.sbt
@@ -8,4 +8,6 @@ libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "5.1.22"
   )
 
+dependencyOverrides += "com.jolbox" % "bonecp" % "0.7.1.RELEASE"
+
 playJavaSettings

--- a/play-scala/build.sbt
+++ b/play-scala/build.sbt
@@ -4,4 +4,6 @@ version := "1.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(jdbc, anorm, "mysql" % "mysql-connector-java" % "5.1.22")
 
+dependencyOverrides += "com.jolbox" % "bonecp" % "0.7.1.RELEASE"
+
 playScalaSettings


### PR DESCRIPTION
The 0.8.0-rc3 release of bonecp that we upgraded to in Play 2.2.0 introduced a performance problem whereby prepared statements were not being reused:

https://bugs.launchpad.net/bonecp/+bug/1168616

0.8.0-rc4-snapshot apparently fixes this issue, but it is not yet deployed to a release repository.

The workaround here is to downgrade bonecp back to what it was for the 2.1.x branch i.e. 0.7.1.RELEASE.

Bonecp will hopefully release 0.8.0 and Play 2.2.1 will be released with it as a dependency.
