### PR TITLE
discard logging in webgo framework.

### DIFF
--- a/webgo/src/hello/hello.go
+++ b/webgo/src/hello/hello.go
@@ -19,7 +19,7 @@ func hello(val string) string {
 }
 
 func main() {
-	logger := log.New(ioutil.Discard, "", log.Ldate|log.Ltime)
+	logger := log.New(ioutil.Discard, "", 0)
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	web.Get("/(.*)", hello)
 	web.SetLogger(logger)


### PR DESCRIPTION
This creates a logger with output to a /dev/null equivalent. You still pay
the price for formatting and copying, but there will be no IO or write
syscalls caused by logging.

refs #253

If you also like to disable the logging the standard library does
sometimes, the add `log.SetOutput(ioutil.Discard)` too.

Please note, that such programs are very hard to analyse then!
If you want me to make it an option, please say so.

@bhauer please take a look.
