### PR TITLE
Possible fix for DB issues with PHPixie

### DIFF
--- a/php-phpixie/assets/config/db.php
+++ b/php-phpixie/assets/config/db.php
@@ -7,7 +7,7 @@ return array(
 		'driver' => 'PDO',
 		
 		//'Connection' is required if you use the PDO driver
-		'connection'=>'mysql:host=tfbdata;dbname=hello_world',
+		'connection'=>'mysql:host=localhost;dbname=hello_world',
 		
 		// 'db' and 'host' are required if you use Mysqli driver
 		'db' => 'hello_world',


### PR DESCRIPTION
When writing the phpixie database config file I used Silex as a reference. It used "tfbdata" as the database host. The default php benchmark implementation (only one that worked) used "locahost".

So I'm switching phpixie config file also to "localhost" database. If this fixes the problem, than perhaps other php implementations should also use that setup.
