### PR TITLE
play-activate-mysql fixes

### DIFF
--- a/play-activate-mysql/app/models/Migrations.scala
+++ b/play-activate-mysql/app/models/Migrations.scala
@@ -48,3 +48,19 @@ class MigrateWorlds extends Migration {
     }
 
 }
+
+class CreateVersionIndexes extends Migration {
+    
+    def timestamp = System.currentTimeMillis + 400
+    
+    def up = {
+        customScript {
+            val con = storage.directAccess
+            try {
+                con.createStatement.executeUpdate("CREATE UNIQUE INDEX IX_WORLD_VERSION ON ActivateWorld(id, version)")
+                con.createStatement.executeUpdate("CREATE UNIQUE INDEX IX_WORLD_VERSION ON ActivateFortune(id, version)")
+            } finally
+                con.close
+        }
+    }
+}

--- a/play-activate-mysql/app/models/Models.scala
+++ b/play-activate-mysql/app/models/Models.scala
@@ -9,19 +9,17 @@ import play.api.libs.json.Writes
 class ActivateFortune(val legacyId: Long, val message: String) extends Entity
 
 object ActivateFortune {
-    def all =
-        cachedQuery {
-            (fortune: ActivateFortune) => where()
-        }
+    def all = indexFortuneAll.get(1)
 }
 
 class ActivateWorld(val legacyId: Long, var randomNumber: Long) extends Entity
 
 object ActivateWorld {
-    def fingByLegacyId(legacyId: Long) = {
-        val lazyList = indexWorldByLegacyId.get(legacyId)
-        lazyList.headOption.getOrElse(throw new IllegalStateException("invalid id " + legacyId))
-    }
+    def fingByLegacyId(legacyId: Long) =
+        indexWorldByLegacyId
+            .get(legacyId)
+            .headOption
+            .getOrElse(throw new IllegalStateException("invalid id " + legacyId))
 }
 
 object Models {

--- a/play-activate-mysql/app/models/PersistenceContext.scala
+++ b/play-activate-mysql/app/models/PersistenceContext.scala
@@ -19,8 +19,10 @@ object persistenceContext extends ActivateContext {
         val password = config.getString("db.default.password").get
         val url = config.getString("db.default.url").get
         val dialect = mySqlDialect
+        override val poolSize = 400
     }
     
     val indexWorldByLegacyId = memoryIndex[ActivateWorld].on(_.legacyId)
+    val indexFortuneAll = memoryIndex[ActivateFortune].on(_ => 1)
 
 }

--- a/play-activate-mysql/conf/application.conf
+++ b/play-activate-mysql/conf/application.conf
@@ -65,6 +65,8 @@ logger.play=ERROR
 # Logger provided to your application:
 logger.application=ERROR
 
+iteratee-threadpool-size=300
+
 play {
   akka {
     event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
@@ -72,7 +74,7 @@ play {
     actor {
       default-dispatcher = {
         fork-join-executor {
-          parallelism-factor = 1.0
+          parallelism-factor = 4.0
           parallelism-max = 50
         }
       }

--- a/play-activate-mysql/project/Build.scala
+++ b/play-activate-mysql/project/Build.scala
@@ -7,10 +7,10 @@ object ApplicationBuild extends Build {
   val appName         = "play-activate-mysql"
   val appVersion      = "1.0-SNAPSHOT"
 
-  val activateVersion = "1.4.2"
+  val activateVersion = "1.4.3"
   val activateCore = "net.fwbrasil" %% "activate-core" % activateVersion
   val activateJdbc = "net.fwbrasil" %% "activate-jdbc" % activateVersion
-  val activatePlay = "net.fwbrasil" %% "activate-play" % "1.4.2-PLAY-2.1.2-RC1"
+  val activatePlay = "net.fwbrasil" %% "activate-play" % "1.4.3-PLAY-2.1.2-RC1"
 
   val mysql = "mysql" % "mysql-connector-java" % "5.1.16"
 


### PR DESCRIPTION
This PR has some fixes to the play-activate-mysql:
1. Create indexes for the version columns
2. Replace the fortunes cached query with a index
3. Configure play to use more threads
4. Update to Activate 1.4.3, that has some performance enhancements

These fixes are important to the Round 7. Without them, the result isn't reliable.
