### PR TITLE
increased buffersizes to avoid 'chunked input' warnings

### DIFF
--- a/plain/src/main/resources/application.conf
+++ b/plain/src/main/resources/application.conf
@@ -6,11 +6,17 @@ akka {
 	loggers = [ "akka.event.slf4j.Slf4jLogger" ]
 	loglevel = OFF
 	stdout-loglevel = OFF
+	actor.default-dispatcher.fork-join-executor.parallelism-min = 1
+	actor.default-dispatcher.fork-join-executor.parallelism-factor = 1.0 
 }
 
 plain {
 	logging.level = INFO
+	aio.default-buffer-size = 128k
+	aio.large-buffer-size = 256k
+	aio.huge-buffer-size = 512k
 	aio.send-receive-buffer-size = 1m
+	http.default-server.feature.max-entity-buffer-size = 128k
 	http.startup-servers = [ benchmark-server ]
 	jdbc.startup-connection-factories = [ benchmark-mysql ]
 }
@@ -36,7 +42,7 @@ benchmark-mysql {
 		setUser = "benchmarkdbuser"
 		setPassword = "benchmarkdbpass"
 	}	
-	min-pool-size = 16
+	min-pool-size = 32
 	max-pool-size = 128
 }
 


### PR DESCRIPTION
Hi,
thanks for fixing the 'database_host' issue for us. This is an additional small update to avoid some buffer overflow warnings.
