### PR TITLE
Improve setup robustness of Windows tests

### DIFF
--- a/HttpListener/setup.ps1
+++ b/HttpListener/setup.ps1
@@ -1,14 +1,32 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $root = "C:\FrameworkBenchmarks\HttpListener"
 $msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
 
 # Stop
-Stop-Process -Name HttpListener -ErrorAction SilentlyContinue
+Get-Process | Where-Object { $_.Name -ieq "HttpListener" } | Stop-Process
 
 if ($action -eq 'start') {
     # Build the project
-    &$msbuild "$root\HttpListener.sln" /p:DownloadNuGetExe=true /p:RequireRestoreConsent=false /p:Configuration=Release /t:Rebuild
+    Exec { & $msbuild "$root\HttpListener.sln" /p:DownloadNuGetExe=true /p:RequireRestoreConsent=false /p:Configuration=Release /t:Rebuild }
     
     Start-Process "$root\HttpListener\bin\Release\HttpListener.exe"
 }

--- a/HttpListener/setup.py
+++ b/HttpListener/setup.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("HttpListener/HttpListener/App.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup.ps1 start", cwd="HttpListener")
+    subprocess.check_call("powershell -Command .\\setup.ps1 start", cwd="HttpListener")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup.ps1 stop", cwd="HttpListener")
+  subprocess.check_call("powershell -Command .\\setup.ps1 stop", cwd="HttpListener")
   return 0

--- a/aspnet-stripped/setup_iis.ps1
+++ b/aspnet-stripped/setup_iis.ps1
@@ -1,5 +1,23 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $source = "C:\FrameworkBenchmarks\aspnet-stripped\src"
 
 # Stop
@@ -8,7 +26,7 @@ if (Get-WebSite -Name Benchmarks) { Remove-WebSite -Name Benchmarks }
 if ($action -eq 'start') {
     # Because we don't use msbuild to compile the code, we do this all manually.
     
-    & .\NuGet.exe install -o src\packages src\packages.config
+    Exec { & .\NuGet.exe install -o src\packages src\packages.config }
 
     if (-Not (Test-Path src\bin)) { New-Item -Path src\bin -ItemType directory | Out-Null }
 

--- a/aspnet-stripped/setup_iis.py
+++ b/aspnet-stripped/setup_iis.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("aspnet-stripped/src/Web.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup_iis.ps1 start", cwd="aspnet-stripped")
+    subprocess.check_call("powershell -Command .\\setup_iis.ps1 start", cwd="aspnet-stripped")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup_iis.ps1 stop", cwd="aspnet-stripped")
+  subprocess.check_call("powershell -Command .\\setup_iis.ps1 stop", cwd="aspnet-stripped")
   return 0

--- a/aspnet/setup_iis.ps1
+++ b/aspnet/setup_iis.ps1
@@ -1,5 +1,23 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $wwwroot = "C:\FrameworkBenchmarks\aspnet\www"
 $source = "C:\FrameworkBenchmarks\aspnet\src"
 $msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
@@ -15,7 +33,7 @@ if ($action -eq 'start') {
     New-WebSite -Name Benchmarks -Port 8080 -PhysicalPath $wwwroot
     
     # Build the project
-    &$msbuild "$source\Benchmarks.AspNet.csproj" /t:RestorePackages
-    &$msbuild "$source\Benchmarks.AspNet.csproj" /p:Configuration=Release /p:Platform=x64 /t:Clean
-    &$msbuild "$source\Benchmarks.AspNet.csproj" /p:Configuration=Release /p:Platform=x64 /p:DeployOnBuild=true /p:PublishProfile=IIS
+    Exec { & $msbuild "$source\Benchmarks.AspNet.csproj" /t:RestorePackages }
+    Exec { & $msbuild "$source\Benchmarks.AspNet.csproj" /p:Configuration=Release /p:Platform=x64 /t:Clean }
+    Exec { & $msbuild "$source\Benchmarks.AspNet.csproj" /p:Configuration=Release /p:Platform=x64 /p:DeployOnBuild=true /p:PublishProfile=IIS }
 }

--- a/aspnet/setup_iis.py
+++ b/aspnet/setup_iis.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("aspnet/src/Web.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup_iis.ps1 start", cwd="aspnet")
+    subprocess.check_call("powershell -Command .\\setup_iis.ps1 start", cwd="aspnet")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup_iis.ps1 stop", cwd="aspnet")
+  subprocess.check_call("powershell -Command .\\setup_iis.ps1 stop", cwd="aspnet")
   return 0

--- a/nancy/setup_iis.ps1
+++ b/nancy/setup_iis.ps1
@@ -1,7 +1,26 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $wwwroot = "C:\FrameworkBenchmarks\nancy\www"
 $source = "C:\FrameworkBenchmarks\nancy\src"
+$msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
 
 # Stop
 if (Get-WebSite -Name Benchmarks) { Remove-WebSite -Name Benchmarks }
@@ -14,6 +33,6 @@ if ($action -eq 'start') {
     New-WebSite -Name Benchmarks -Port 8080 -PhysicalPath $wwwroot
     
     # Build the project
-    C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe "$source\NancyBenchmark.csproj" /p:Configuration=Release /p:Platform="AnyCPU" /t:Clean
-    C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe "$source\NancyBenchmark.csproj" /p:Configuration=Release /p:Platform="AnyCPU" /p:DeployOnBuild=true /p:PublishProfile=IIS
+    Exec { & $msbuild "$source\NancyBenchmark.csproj" /p:Configuration=Release /p:Platform="AnyCPU" /t:Clean }
+    Exec { & $msbuild "$source\NancyBenchmark.csproj" /p:Configuration=Release /p:Platform="AnyCPU" /p:DeployOnBuild=true /p:PublishProfile=IIS }
 }

--- a/nancy/setup_iis.py
+++ b/nancy/setup_iis.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("nancy/src/Web.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup_iis.ps1 start", cwd="nancy")
+    subprocess.check_call("powershell -Command .\\setup_iis.ps1 start", cwd="nancy")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup_iis.ps1 stop", cwd="nancy")
+  subprocess.check_call("powershell -Command .\\setup_iis.ps1 stop", cwd="nancy")
   return 0

--- a/servicestack/setup_iis.ps1
+++ b/servicestack/setup_iis.ps1
@@ -1,5 +1,23 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $wwwroot = "C:\FrameworkBenchmarks\servicestack\www"
 $source = "C:\FrameworkBenchmarks\servicestack\src"
 $msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
@@ -16,6 +34,6 @@ if ($action -eq 'start') {
     New-WebSite -Name Benchmarks -Port 8080 -PhysicalPath $wwwroot
     
     # Build the project
-    &$msbuild "$source\ServiceStackBenchmark.csproj" /p:Configuration=Release /p:Platform="x64" /t:Clean
-    &$msbuild "$source\ServiceStackBenchmark.csproj" /p:Configuration=Release /p:Platform="x64" /p:DeployOnBuild=true /p:PublishProfile=IIS
+    Exec { & $msbuild "$source\ServiceStackBenchmark.csproj" /p:Configuration=Release /p:Platform="x64" /t:Clean }
+    Exec { & $msbuild "$source\ServiceStackBenchmark.csproj" /p:Configuration=Release /p:Platform="x64" /p:DeployOnBuild=true /p:PublishProfile=IIS }
 }

--- a/servicestack/setup_iis.py
+++ b/servicestack/setup_iis.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("servicestack/src/Web.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup_iis.ps1 start", cwd="servicestack")
+    subprocess.check_call("powershell -Command .\\setup_iis.ps1 start", cwd="servicestack")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup_iis.ps1 stop", cwd="servicestack")
+  subprocess.check_call("powershell -Command .\\setup_iis.ps1 stop", cwd="servicestack")
   return 0

--- a/servicestack/setup_self.ps1
+++ b/servicestack/setup_self.ps1
@@ -1,14 +1,32 @@
 param($action)
 
+$ErrorActionPreference = 'Stop'
+
+# From http://zduck.com/2012/powershell-batch-files-exit-codes/
+function Exec
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0, Mandatory=1)]
+        [scriptblock]$Command,
+        [Parameter(Position=1, Mandatory=0)]
+        [string]$ErrorMessage = "Execution of command failed.`n$Command"
+    )
+    & $Command
+    if ($LastExitCode -ne 0) {
+        throw "Exec: $ErrorMessage"
+    }
+}
+
 $source = "C:\FrameworkBenchmarks\servicestack\src"
 $msbuild = "C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe"
 
 # Stop
-Stop-Process -Name servicestack -ErrorAction SilentlyContinue
+Get-Process | Where-Object { $_.Name -ieq "servicestack" } | Stop-Process
 
 if ($action -eq 'start') {
     # Build the project
-    &$msbuild "$source\ServiceStackBenchmark.sln" /p:DownloadNuGetExe=true /p:RequireRestoreConsent=false /p:Configuration=Release /p:Platform="x64" /t:Rebuild
+    Exec { & $msbuild "$source\ServiceStackBenchmark.sln" /p:DownloadNuGetExe=true /p:RequireRestoreConsent=false /p:Configuration=Release /p:Platform="x64" /t:Rebuild }
         
     Start-Process "$source\SelfHost\bin\Release\ServiceStackBenchmark.SelfHost.exe http://*:8080"
 }

--- a/servicestack/setup_self.py
+++ b/servicestack/setup_self.py
@@ -9,7 +9,7 @@ def start(args):
   
   try:
     setup_util.replace_text("servicestack/svc/SelfHost/App.config", "localhost", args.database_host)
-    subprocess.check_call("powershell -File setup_self.ps1 start", cwd="servicestack")
+    subprocess.check_call("powershell -Command .\\setup_self.ps1 start", cwd="servicestack")
     return 0
   except subprocess.CalledProcessError:
     return 1
@@ -18,5 +18,5 @@ def stop():
   if os.name != 'nt':
     return 0
   
-  subprocess.Popen("powershell -File setup_self.ps1 stop", cwd="servicestack")
+  subprocess.check_call("powershell -Command .\\setup_self.ps1 stop", cwd="servicestack")
   return 0


### PR DESCRIPTION
In an attempt to solve or figure out the supposed performance regression described at the bottom of #539:
- In PowerShell scripts:
  - Use $ErrorActionPreference = 'Stop' so we stop on any error
  - Use Exec helper that throws an error on any errorlevel
  - Try not to use -ErrorAction SilentlyContinue as often
- In Python scripts:
  - Use powershell -Command instead of -File which does not propagate
    the errorlevel properly.
  - For stop(), use subprocess.check_call() which is synchronous and
    which can check the exit code, unlike subprocess.Popen() which
    is asynchronous.
