### PR TITLE
During verify, show HTTP headers, and during errors show HTTP response

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -132,8 +132,7 @@ class FrameworkTest:
     try:
       print "VERIFYING JSON (" + self.json_url + ") ..."
       url = self.benchmarker.generate_url(self.json_url, self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.json_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.json_url_passed = False
@@ -142,8 +141,7 @@ class FrameworkTest:
     try:
       print "VERIFYING DB (" + self.db_url + ") ..."
       url = self.benchmarker.generate_url(self.db_url, self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.db_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.db_url_passed = False
@@ -152,8 +150,7 @@ class FrameworkTest:
     try:
       print "VERIFYING Query (" + self.query_url + "2) ..."
       url = self.benchmarker.generate_url(self.query_url + "2", self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.query_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.query_url_passed = False
@@ -162,8 +159,7 @@ class FrameworkTest:
     try:
       print "VERIFYING Fortune (" + self.fortune_url + ") ..."
       url = self.benchmarker.generate_url(self.fortune_url, self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.fortune_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.fortune_url_passed = False
@@ -172,8 +168,7 @@ class FrameworkTest:
     try:
       print "VERIFYING Update (" + self.update_url + "2) ..."
       url = self.benchmarker.generate_url(self.update_url + "2", self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.update_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.update_url_passed = False
@@ -182,8 +177,7 @@ class FrameworkTest:
     try:
       print "VERIFYING Plaintext (" + self.plaintext_url + ") ..."
       url = self.benchmarker.generate_url(self.plaintext_url, self.port)
-      subprocess.check_call(["curl", "-f", url])
-      print ""
+      self.__curl_url(url)
       self.plaintext_url_passed = True
     except (AttributeError, subprocess.CalledProcessError) as e:
       self.plaintext_url_passed = False
@@ -507,6 +501,32 @@ class FrameworkTest:
   ############################################################
   # End __format_request_headers
   ############################################################
+
+  ############################################################
+  # __curl_url
+  # Dump HTTP response and headers. Throw exception if there
+  # is an HTTP error.
+  ############################################################
+  def __curl_url(self, url):
+    # Use -i to output response with headers.
+    # Don't use -f so that the HTTP response code is ignored.
+    # Use --stderr - to redirect stderr to stdout so we get
+    # error output for sure in stdout.
+    # Use -sS to hide progress bar, but show errors.
+    subprocess.check_call(["curl", "-i", "--stderr", "-", "-sS", url])
+    # HTTP output may not end in a newline, so add that here.
+    print ""
+    # In the curl invocation above we could not use -f because
+    # then the HTTP response would not be output, so use -f in
+    # an additional invocation so that if there is an HTTP error,
+    # subprocess.CalledProcessError will be thrown. Note that this
+    # uses check_output() instead of check_call() so that we can
+    # ignore the HTTP response because we already output that in
+    # the first curl invocation.
+    subprocess.check_output(["curl", "-fsS", url])
+  ##############################################################
+  # End __curl_url
+  ##############################################################
 
   ##########################################################################################
   # Constructor


### PR DESCRIPTION
To help with #373 and to more easily diagnose problems: Call curl twice, once to get full HTTP output including headers and again to throw an error if an HTTP error occurs.

Here's stdout when the webserver returns a successful HTTP response:

<pre>
VERIFYING Plaintext (/plaintext) ...
HTTP/1.1 200 OK
Content-Length: 13
Content-Type: text/plain; charset=utf-8
Server: Microsoft-HTTPAPI/2.0
Date: Fri, 25 Oct 2013 22:44:30 GMT

Hello, World!
</pre>


Here's the combined stderr/stdout when the webserver returns an error:

<pre>
VERIFYING JSON (/json) ...
HTTP/1.1 404 Not Found
Content-Length: 9
Content-Type: text/plain; charset=utf-8
Server: Microsoft-HTTPAPI/2.0
Date: Fri, 25 Oct 2013 22:44:30 GMT

not found
curl: (22) The requested URL returned error: 404 Not Found
</pre>


Here's the combined stderr/stdout when the webserver isn't running:

<pre>
VERIFYING JSON (/json) ...
curl: (7) Failed connect to 192.168.1.140:8080; No error
</pre>
