### PR TITLE
Plain: Not using the 'professional' mysql connstring leads to huge garbage

### DIFF
--- a/plain/setup.py
+++ b/plain/setup.py
@@ -10,8 +10,8 @@ def start(args):
     subprocess.check_call("./sbt.bat assembly", shell=True, cwd="plain")
   else:
     subprocess.check_call("./sbt assembly", shell=True, cwd="plain")
-      
-  subprocess.Popen("java -server -Xnoclassgc -XX:MaxPermSize=1g -XX:ReservedCodeCacheSize=384m -Xmx8g -Xss8m -Xmn4g -jar target/scala-2.10/plain-benchmark-assembly-1.0.1.jar", cwd="plain", shell=True)
+     
+  subprocess.Popen("java -server -Xnoclassgc -XX:MaxPermSize=1g -XX:ReservedCodeCacheSize=384m -Xmx8g -Xss8m -Xmn4g -Xms6g -XX:+AggressiveOpts -XX:+UseBiasedLocking -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -jar target/scala-2.10/plain-benchmark-assembly-1.0.1.jar", cwd="plain", shell=True)
   time.sleep(10)
   return 0
 

--- a/plain/src/main/resources/application.conf
+++ b/plain/src/main/resources/application.conf
@@ -32,7 +32,7 @@ benchmark-mysql {
 	name = MysqlBenchmark
 	driver = mysql-5-6-12
 	datasource-settings {	
-		setUrl = "jdbc:mysql://127.0.0.1:3306/hello_world"
+        	setUrl = "jdbc:mysql://127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&dontTrackOpenResources=true&enableQueryTimeouts=false&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=1024&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=true&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&poolPreparedStatements=true&maxOpenPreparedStatements=100"
 		setUser = "benchmarkdbuser"
 		setPassword = "benchmarkdbpass"
 	}	


### PR DESCRIPTION
Hi,
in the last commit I removed the highly professional mysql connection string (actually copied from the play-scala config) to the simplest possible one. Although this had no effect on the performance in short tests, this will lead to huge memory consumption in the long run. After the test suite completed json and then db there was 6.5 gb of uncollectable garbage. The following query tests eventually fail with OOM errors. Any later tests fail. 
With the highly elaborated mysql connection string a GC forced by jvisualvm after the db tests drops memory consumption to a healthy 17 mb.
I fear this is too late to make it into round 7. We would very much appreciate if you could still merge the one-liner in application.conf.
Thanks in advance for your support.
