### PR TITLE
go: remove charset param from driver DSN

### DIFF
--- a/falcore/src/framework_benchmarks/falcore.go
+++ b/falcore/src/framework_benchmarks/falcore.go
@@ -31,11 +31,9 @@ type Fortune struct {
 	Message string `json:"message"`
 }
 
-// TODO: remove ?charset=utf8 from DSN after the next Go-MySQL-Driver release
-// https://github.com/go-sql-driver/mysql#unicode-support
 const (
 	// Database
-	connectionString   = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world?charset=utf8"
+	connectionString   = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world"
 	worldSelect        = "SELECT id, randomNumber FROM World WHERE id = ?"
 	worldUpdate        = "UPDATE World SET randomNumber = ? WHERE id = ?"
 	fortuneSelect      = "SELECT id, message FROM Fortune;"

--- a/go/src/hello/hello.go
+++ b/go/src/hello/hello.go
@@ -28,11 +28,9 @@ type Fortune struct {
 	Message string `json:"message"`
 }
 
-// TODO: remove ?charset=utf8 from DSN after the next Go-MySQL-Driver release
-// https://github.com/go-sql-driver/mysql#unicode-support
 const (
 	// Database
-	connectionString   = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world?charset=utf8"
+	connectionString   = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world"
 	worldSelect        = "SELECT id, randomNumber FROM World WHERE id = ?"
 	worldUpdate        = "UPDATE World SET randomNumber = ? WHERE id = ?"
 	fortuneSelect      = "SELECT id, message FROM Fortune;"

--- a/revel-jet/src/benchmark/conf/app.conf
+++ b/revel-jet/src/benchmark/conf/app.conf
@@ -4,7 +4,7 @@ http.port=8080
 
 db.driver = mysql
 db.import = github.com/go-sql-driver/mysql
-db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world?charset=utf8
+db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world
 
 results.pretty=false
 results.chunked=false

--- a/revel-qbs/src/benchmark/conf/app.conf
+++ b/revel-qbs/src/benchmark/conf/app.conf
@@ -4,7 +4,7 @@ http.port=8080
 
 db.driver = mysql
 db.import = github.com/go-sql-driver/mysql
-db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world?charset=utf8
+db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world
 
 results.pretty=false
 results.chunked=false

--- a/revel/src/benchmark/conf/app.conf
+++ b/revel/src/benchmark/conf/app.conf
@@ -4,7 +4,7 @@ http.port=8080
 
 db.driver = mysql
 db.import = github.com/go-sql-driver/mysql
-db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world?charset=utf8
+db.spec = benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world
 
 results.pretty=false
 results.chunked=false


### PR DESCRIPTION
We released v1.1 of Go-MySQL-Driver shortly after the latest run.
The charset param is not necessary anymore in the new version.
