### PR TITLE
Restart/not restart databases depending on test type

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -491,13 +491,14 @@ class Benchmarker:
       -----------------------------------------------------
       """.format(name=test.name))
       try:
-        p = subprocess.Popen(self.database_ssh_string, stdin=subprocess.PIPE, shell=True)
-        p.communicate("""
-          sudo restart mysql
-          sudo restart mongodb
-		      sudo /etc/init.d/postgresql restart
-        """)
-        time.sleep(10)
+        if test.requires_database():
+          p = subprocess.Popen(self.database_ssh_string, stdin=subprocess.PIPE, shell=True)
+          p.communicate("""
+            sudo restart mysql
+            sudo restart mongodb
+            sudo /etc/init.d/postgresql restart
+          """)
+          time.sleep(10)
 
         if self.__is_port_bound(test.port):
           self.__write_intermediate_results(test.name, "port " + str(test.port) + " is not available before start")

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -192,17 +192,17 @@ class FrameworkTest:
   ############################################################
   def contains_type(self, type):
     try:
-      if type == 'json' and self.json_url != None:
+      if type == 'json' and self.json_url is not None:
         return True
-      if type == 'db' and self.db_url != None:
+      if type == 'db' and self.db_url is not None:
         return True
-      if type == 'query' and self.query_url != None:
+      if type == 'query' and self.query_url is not None:
         return True
-      if type == 'fortune' and self.fortune_url != None:
+      if type == 'fortune' and self.fortune_url is not None:
         return True
-      if type == 'update' and self.update_url != None:
+      if type == 'update' and self.update_url is not None:
         return True
-      if type == 'plaintext' and self.plaintext_url != None:
+      if type == 'plaintext' and self.plaintext_url is not None:
         return True
     except AttributeError:
       pass
@@ -527,6 +527,10 @@ class FrameworkTest:
   ##############################################################
   # End __curl_url
   ##############################################################
+
+  def requires_database(self):
+      """Returns True/False if this test requires a database"""
+      return self.contains_type('fortune') or self.contains_type('database') or self.contains_type('query')
 
   ##########################################################################################
   # Constructor


### PR DESCRIPTION
There's no reason to interact with the database machine if the user has requested to run test types that only require the client/server machine. 

If they have a DB machine setup and configured, then this will speed up tests. If they do not, then this will avoid errors. Either way, it should help new users get started
