### PR TITLE
Explicit CGLib dependency is no longer required for Spring 3.2.x.

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -54,13 +54,6 @@
             <version>5.1.22</version>
         </dependency>
 
-        <!-- CGLIB, only required and used for @Configuration usage -->
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>2.2</version>
-        </dependency>
- 
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
You may try removing this. CGLib 3.0 is incorporated in spring-core:
http://docs.spring.io/spring/docs/3.2.x/spring-framework-reference/html/migration-3.2.html
