### PR TITLE
Fix the Sinatra tests to more closely resemble production settings

### DIFF
--- a/sinatra/hello_world.rb
+++ b/sinatra/hello_world.rb
@@ -4,12 +4,26 @@ require "sinatra/activerecord"
 
 set :logging, false
 set :activerecord_logger, nil
+set :static, false
+
+# Specify the encoder - otherwise, sinatra/json inefficiently
+# attempts to load one of several on each request
+set :json_encoder => :to_json
 
 if RUBY_PLATFORM == 'java'
   set :database, { :adapter => 'jdbcmysql', :database => 'hello_world', :username => 'benchmarkdbuser', :password => 'benchmarkdbpass', :host => 'localhost', :pool => 256, :timeout => 5000 }
 else
   set :database, { :adapter => 'mysql2', :database => 'hello_world', :username => 'benchmarkdbuser', :password => 'benchmarkdbpass', :host => 'localhost', :pool => 256, :timeout => 5000 }
 end
+
+# The sinatra-activerecord gem registers before and after filters that
+# call expensive synchronized ActiveRecord methods on every request to
+# verify every connection in the pool, even for routes that don't use
+# the database. Clear those filters and handle connection management
+# ourselves, which is what applications seeking high throughput with
+# ActiveRecord need to do anyway.
+settings.filters[:before].clear
+settings.filters[:after].clear
 
 class World < ActiveRecord::Base
   self.table_name = "World"
@@ -28,9 +42,11 @@ end
 get '/db' do
   queries = (params[:queries] || 1).to_i
 
-  results = (1..queries).map do
-    World.find(Random.rand(10000) + 1)
+  ActiveRecord::Base.connection_pool.with_connection do
+    results = (1..queries).map do
+      World.find(Random.rand(10000) + 1)
+    end
+
+    json results
   end
-  
-  results.to_json
 end


### PR DESCRIPTION
This commit makes 3 changes to the Sinatra application that more
closely resembles what someone would use in production (if throughput
is a concern) and should improve performance on both JRuby and Ruby.
- We disable Sinatra's static file serving so it doesn't waste time on
  each request looking for static files, since we have none. In
  production this is usually handled by a frontend server anyway.
- We specify which JSON encoder to use so that sinatra/json doesn't
  try several options on each request until it finds one it can use.
- We disable the per-request connection pooling in
  sinatra/activerecord and instead use ActiveRecord's with_connection to
  explicitly control connections. The default behavior is overly
  simplistic and incurs expensive synchronized method calls on every
  request, even if the request doesn't touch the database.

This change makes the non-database routes several times faster, and
should improve the performance of the database route a bit less.
