### PR TITLE
Bump TorqBox from 0.1.2 to 0.1.4

### DIFF
--- a/rack/Gemfile-jruby
+++ b/rack/Gemfile-jruby
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'torqbox', '0.1.2'
+gem 'torqbox', '0.1.4'
 gem 'json', '1.7.6'
 gem "rubyzip", "~> 1.0.0"
 gem "zip-zip", "~> 0.1"

--- a/rack/README.md
+++ b/rack/README.md
@@ -13,7 +13,7 @@ The tests were run with:
 * [JRuby 1.7.8](http://jruby.org/)
 * [Rack 1.5.1](http://rack.github.com/)
 * [Unicorn 4.6.2](http://unicorn.bogomips.org/)
-* [TorqBox 0.1.2](http://torquebox.org/torqbox/)
+* [TorqBox 0.1.4](http://torquebox.org/torqbox/)
 
 ## References
 * https://github.com/FooBarWidget/passenger/pull/71

--- a/rails-stripped/Gemfile-jruby
+++ b/rails-stripped/Gemfile-jruby
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.13'
-gem 'torqbox', '0.1.2'
+gem 'torqbox', '0.1.4'
 gem 'activerecord-jdbcmysql-adapter', '1.2.6'
 gem "rubyzip", "~> 1.0.0"
 gem "zip-zip", "~> 0.1"

--- a/rails-stripped/README.md
+++ b/rails-stripped/README.md
@@ -16,7 +16,7 @@ The tests were run with:
 * [JRuby 1.7.8](http://jruby.org/)
 * [Rails 3.2.11](http://rubyonrails.org/)
 * [Unicorn 4.6.2](http://unicorn.bogomips.org/)
-* [TorqBox 0.1.2](http://torquebox.org/torqbox/)
+* [TorqBox 0.1.4](http://torquebox.org/torqbox/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## References

--- a/rails/Gemfile-jruby
+++ b/rails/Gemfile-jruby
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.13'
-gem 'torqbox', '0.1.2'
+gem 'torqbox', '0.1.4'
 gem 'activerecord-jdbcmysql-adapter', '1.2.6'
 gem "rubyzip", "~> 1.0.0"
 gem "zip-zip", "~> 0.1"

--- a/rails/README.md
+++ b/rails/README.md
@@ -16,7 +16,7 @@ The tests were run with:
 * [JRuby 1.7.8](http://jruby.org/)
 * [Rails 3.2.11](http://rubyonrails.org/)
 * [Unicorn 4.6.2](http://unicorn.bogomips.org/)
-* [TorqBox 0.1.2](http://torquebox.org/torqbox/)
+* [TorqBox 0.1.4](http://torquebox.org/torqbox/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## References

--- a/sinatra/Gemfile-jruby
+++ b/sinatra/Gemfile-jruby
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gem 'sinatra', '1.3.4'
 gem 'sinatra-contrib', '1.3.2'
-gem 'torqbox', '0.1.2'
+gem 'torqbox', '0.1.4'
 gem 'activerecord-jdbcmysql-adapter', '1.2.6'
 gem "sinatra-activerecord", "1.2.2"
 gem "rubyzip", "~> 1.0.0"

--- a/sinatra/README.md
+++ b/sinatra/README.md
@@ -15,7 +15,7 @@ The tests were run with:
 * [JRuby 1.7.8](http://jruby.org/)
 * [Sinatra 1.3.4](http://www.sinatrarb.com/)
 * [Unicorn 4.6.2](http://unicorn.bogomips.org/)
-* [TorqBox 0.1.2](http://torquebox.org/torqbox/)
+* [TorqBox 0.1.4](http://torquebox.org/torqbox/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## References


### PR DESCRIPTION
This adds the required Server and Date headers to all responses and
fixes a regression in the performance of parsing HTTP request headers.
