### PR TITLE
Warmup cache on Symfony2 before launching the bench

### DIFF
--- a/php-symfony2/setup.py
+++ b/php-symfony2/setup.py
@@ -13,6 +13,7 @@ def start(args, logfile, errfile):
     subprocess.check_call("composer.phar install --optimize-autoloader", shell=True, cwd="php-symfony2", stderr=errfile, stdout=logfile)
     subprocess.check_call("php app/console cache:clear --env=prod --no-debug", shell=True, cwd="php-symfony2", stderr=errfile, stdout=logfile)
     subprocess.check_call("sudo chown -R www-data:www-data php-symfony2", shell=True, stderr=errfile, stdout=logfile)
+    subprocess.check_call("php app/console cache:warmup --env=prod --no-debug", shell=True, cwd="php-symfony2", stderr=errfile, stdout=logfile)
     subprocess.check_call("sudo php-fpm --fpm-config config/php-fpm.conf -g " + home + "/FrameworkBenchmarks/php-symfony2/deploy/php-fpm.pid", shell=True, stderr=errfile, stdout=logfile)
     subprocess.check_call("sudo /usr/local/nginx/sbin/nginx -c " + home + "/FrameworkBenchmarks/php-symfony2/deploy/nginx.conf", shell=True, stderr=errfile, stdout=logfile)
     return 0


### PR DESCRIPTION
If you don't warmup the cache before running the benchmark on Symfony, it's like if you don't compile your ASP.NET project before running... I don't find it fair.
