### PR TITLE
Dancer: use JSON::XS for faster serialization

### DIFF
--- a/dancer/app.pl
+++ b/dancer/app.pl
@@ -4,6 +4,7 @@ use warnings;
 
 use Dancer ':syntax';
 use DBI;
+use JSON::XS;  # Ensure that the fast implementation of the serializer is installed
 
 set serializer => 'JSON';
 


### PR DESCRIPTION
For Perl Dancer, ensure that the Dancer serializer will be able to use the fast JSON implementation (JSON::XS) by loading explicitely JSON::XS: if the fast implementation is not available, the app will now fail at startup.
