### PR TITLE
restore the reading of the old random number in mongo update test

### DIFF
--- a/undertow/src/main/java/hello/UpdatesMongoHandler.java
+++ b/undertow/src/main/java/hello/UpdatesMongoHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBObject;
+
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
@@ -42,6 +43,11 @@ final class UpdatesMongoHandler implements HttpHandler {
       // produce the correct output and side effects.
       //
       DBObject object = database.getCollection("World").findOne(key);
+      
+      @SuppressWarnings("unused")
+      // Per test requirement the old value must be read
+      int oldRandomNumber = ((Number) object.get("randomNumber")).intValue(); 
+      
       int newRandomNumber = Helper.randomWorld();
       object.put("randomNumber", newRandomNumber);
       database.getCollection("World").update(key, object);


### PR DESCRIPTION
I mistakenly removed this var since it wasn't being used. Per the requirement it must be read so I added some comments/docs to prevent someone else from accidentally removing it in the future.
