### PR TITLE
Proposal : Increasing the max connections of PostgreSQL

### DIFF
--- a/config/postgresql.conf
+++ b/config/postgresql.conf
@@ -61,7 +61,7 @@ listen_addresses = '*'		# what IP address(es) to listen on;
 					# defaults to 'localhost', '*' = all
 					# (change requires restart)
 port = 5432				# (change requires restart)
-max_connections = 512			# (change requires restart)
+max_connections = 2000			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3	# (change requires restart)


### PR DESCRIPTION
Set the maximum connections of postgresql to 2000, for which TreeFrog Framework finishes this benchmarking without error.
