### PR TITLE
removes finagle's db test

### DIFF
--- a/finagle/src/main/scala/com/falmarri/finagle/Finagle.scala
+++ b/finagle/src/main/scala/com/falmarri/finagle/Finagle.scala
@@ -65,7 +65,7 @@ object FinagleBenchmark extends App {
   val muxService = new HttpMuxer()
     .withHandler("/json", new Service[HttpRequest, HttpResponse] {
       def apply(req: HttpRequest): Future[HttpResponse] =
-        createResponse(req, serialize(Map("message" -> "Hello, World!")))
+        Future.value(createResponse(req, serialize(Map("message" -> "Hello, World!"))))
     })
   /*
     .withHandler("/db", new Service[HttpRequest, HttpResponse] {


### PR DESCRIPTION
removes finagle's db test (will add it back in when finagle-mysql is a little more stable), removes some of the context switching.  fixes #701
