### PR TITLE
Upgrade Ur/Web version to fix performance problem

### DIFF
--- a/toolset/setup/linux/installer.py
+++ b/toolset/setup/linux/installer.py
@@ -198,7 +198,7 @@ class Installer:
     #
     # Ur/Web
     #
-    self.__run_command("hg clone -r126d24ef6678 http://hg.impredicative.com/urweb")
+    self.__run_command("hg clone -r6bea98c7f736 http://hg.impredicative.com/urweb")
     self.__run_command("./autogen.sh", cwd="urweb")
     self.__run_command("./configure", cwd="urweb")
     self.__run_command("make", cwd="urweb")


### PR DESCRIPTION
I think I found the performance problem I asked about before, and it should be fixed now in Ur/Web itself.  It turned out to be a very expensive security measure that newer GCCs associate with the "%n" printf() specifier!

I'd really appreciate it if you could run a quick sanity benchmarking of the json test with the new Ur/Web version installed.  I verified myself in EC2 that it's now competitive with netty, the champion from Round 8.  Thanks!!
