### PR TITLE
Add `--server` to servicestack mono options

### DIFF
--- a/servicestack/setup_xsp.py
+++ b/servicestack/setup_xsp.py
@@ -12,7 +12,7 @@ def start(args, logfile, errfile):
   try:
     subprocess.check_call("rm -rf bin obj", shell=True, cwd="servicestack/src", stderr=errfile, stdout=logfile)
     subprocess.check_call("xbuild /p:Configuration=Release", shell=True, cwd="servicestack/src", stderr=errfile, stdout=logfile)
-    subprocess.Popen("MONO_OPTIONS=--gc=sgen xsp4 --nonstop", shell=True, cwd="servicestack/src", stderr=errfile, stdout=logfile)
+    subprocess.Popen("MONO_OPTIONS=--server --gc=sgen xsp4 --nonstop", shell=True, cwd="servicestack/src", stderr=errfile, stdout=logfile)
     return 0
   except subprocess.CalledProcessError:
     return 1


### PR DESCRIPTION
It's supposed to improve performance: http://www.mono-project.com/Release_Notes_Mono_3.2