### PR TITLE
Set CPU governor properly on linux benchmarks

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -402,7 +402,7 @@ class Benchmarker:
     try:
       if os.name == 'nt':
         return True
-      subprocess.check_call(["sudo","bash","-c","cd /sys/devices/system/cpu; ls -d cpu[0-9]|while read x; do echo performance > $x/cpufreq/scaling_governor; done"])
+      subprocess.check_call(["sudo","bash","-c","cd /sys/devices/system/cpu; ls -d cpu[0-9]*|while read x; do echo performance > $x/cpufreq/scaling_governor; done"])
       subprocess.check_call("sudo sysctl -w net.ipv4.tcp_max_syn_backlog=65535".rsplit(" "))
       subprocess.check_call("sudo sysctl -w net.core.somaxconn=65535".rsplit(" "))
       subprocess.check_call("sudo -s ulimit -n 65535".rsplit(" "))


### PR DESCRIPTION
cpu\* was used to select all CPUs, but this incorrectly selects 
folders such as cpufreq and cpuidle, which you cannot set a 
governor on. Therefore this call not only always failed, but 
actually stopped the other tuning calls from running. The 
proper wildcard should only select folders named 
cpu[number], so I've used cpu[0-9]. This may fail "softly" 
if someone has more than 10 CPUs e.g. cpu14, perhaps there's a 
bash wildcard option to allow [0-9]*?
