### PR TITLE
Install GHC 7.8.2 instead of 7.6.3

### DIFF
--- a/toolset/setup/linux/installer.py
+++ b/toolset/setup/linux/installer.py
@@ -147,7 +147,8 @@ class Installer:
     #
     # Haskell
     #
-    self.__run_command("sudo apt-get install ghc cabal-install", True)
+    self.__run_command("sudo apt-get -t experimental install ghc", True)
+    self.__run_command("sudo apt-get install cabal-install", True)
 
     #
     # RingoJs


### PR DESCRIPTION
This is a little awkward in that 7.8.2 is in `experimental` right now but should make it to `unstable` pretty soon. `-t experimental` should get changed to `-t unstable` once the 7.8 series makes it there.

Also, in `/etc/apt/sources` configured for experimental? If not, it should be as simple as adding `experimental` after `main` in the `sources` list. https://wiki.debian.org/DebianExperimental
