### PR TITLE
Various fixes and improvements in the OpenResty installer

### DIFF
--- a/toolset/setup/linux/installer.py
+++ b/toolset/setup/linux/installer.py
@@ -232,7 +232,7 @@ class Installer:
     self.__run_command("./configure --with-luajit-xcflags=-DLUAJIT_NUMMODE=2 --with-cc-opt=-O2 --with-http_postgres_module -j2", cwd="ngx_openresty-1.5.12.1")
     self.__run_command("make -j2", cwd="ngx_openresty-1.5.12.1")
     self.__run_command("sudo make install", cwd="ngx_openresty-1.5.12.1")
-    
+
     #
     # Lapis
     #


### PR DESCRIPTION
- removed the trailing line spaces in the OpenResty installer script.
- always enable the dual number mode in OpenResty's LuaJIT build for Linux.
- specify -j2 for both ./configure and make to speed up the OpenResty build.
- specify the C compiler option -O2 for the openresty build.
- fix lettercase in the OpenResty installer.
- upgraded OpenResty to the latest formal release, 1.5.12.1.
  - we also remove the --with-luajit option from ./configure because it is already the default.
