### PR TITLE
[toolset] Set timeout = concurrency.

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -27,7 +27,7 @@ class FrameworkTest:
     echo ""
     echo "---------------------------------------------------------"
     echo " Running Primer {name}"
-    echo " {wrk} {headers} d 5 -c 8 --timeout 8 -t 8 \"http://{server_host}:{port}{url}\""
+    echo " {wrk} {headers} -d 5 -c 8 --timeout 8 -t 8 \"http://{server_host}:{port}{url}\""
     echo "---------------------------------------------------------"
     echo ""
     {wrk} {headers} -d 5 -c 8 --timeout 8 -t 8 "http://{server_host}:{port}{url}"


### PR DESCRIPTION
Default timeout of wrk is 2 sec. It is too small for large concurrency.

Here is sample scenario.

Given: concurrency=64, backlog (or queue in reverse proxy)=256, average response time=100ms, worker=2
1. wrk sends 64 requests.
2. workers start processing 2 requests. 62 requests are queued.
3. After 2 seconds, 20 requests are processed and 42 requests are in queue.
4. wrk sends new 20 requests in the 2 seconds. After 2 seconds, wrk timeout remained 44 requests and send new 44 requests.
5. Server continue to process old requests in queue without knowing wrk has timeouted those.
6. When server reaches new 20+44 requests, wrk has timeouted those requests already.

In this scenario, server may process 100 \* 2 \* duration requests. But wrk only reports 20 success.
