### PR TITLE
[toolset] innodb_flush_log_at_trx_commit = 2

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -63,6 +63,8 @@ table_definition_cache  = 800
 max_heap_table_size     = 128M
 tmp_table_size          = 128M
 innodb_use_native_aio   = 1
+# sync for every sec. not for every commit.
+innodb_flush_log_at_trx_commit = 2
 
 #
 # * Query Cache Configuration


### PR DESCRIPTION
Our benchmark measures performance of frameworks. Not IO performance.
Avoiding sync for every transaction make update test more stable.
