### PR TITLE
Downgrade gunicorn for tornado worker

### DIFF
--- a/config/requirements-py3.txt
+++ b/config/requirements-py3.txt
@@ -8,7 +8,7 @@ ujson==1.33
 # uwsgi is released too often to stick on single version.
 uwsgi
 
-gunicorn==18.0
+gunicorn==19.0
 meinheld==0.5.6
 
 # Tornado

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -9,7 +9,7 @@ gevent==1.0.1
 # uwsgi is released too often to stick on single version.
 uwsgi
 
-gunicorn==18.0
+gunicorn==19.0
 meinheld==0.5.6
 
 # Tornado


### PR DESCRIPTION
Gunicorn 19.0 has regression. Tornado worker doesn't works with it.
Tornado is best worker for PyPy (speed and keep-alive).
Until Gunicorn 19.1 is released, downgrade to 18.0.
