### PR TITLE
[In progress] Use python logging framework consistently

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -506,7 +506,7 @@ class Benchmarker:
               Running Test: {name} ...
             -----------------------------------------------------
             """.format(name=test.name))
-          test_process = Process(target=self.__run_test, args=(test,))
+          test_process = Process(target=self.__run_test, name="Test Runner (%s)" % test.name, args=(test,))
           test_process.start()
           test_process.join(self.run_test_timeout_seconds)
           self.__load_results()  # Load intermediate result from child process
@@ -522,13 +522,9 @@ class Benchmarker:
 
   ############################################################
   # __run_test
-  # 2013-10-02 ASB  Previously __run_tests.  This code now only
-  #                 processes a single test.
   #
-  # Ensures that the system has all necessary software to run
-  # the tests. This does not include that software for the individual
-  # test, but covers software such as curl and weighttp that
-  # are needed.
+  # Checks test prerequisites, makes calls into framework_test
+  # to orchestrate benchmarking this test, and stores results
   ############################################################
   def __run_test(self, test):
     log.info("__run_test")
@@ -696,7 +692,7 @@ class Benchmarker:
       self.__finish()
       sys.exit()
   ############################################################
-  # End __run_tests
+  # End __run_test
   ############################################################
 
   ############################################################

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -643,16 +643,16 @@ class Benchmarker:
     except (OSError, IOError, subprocess.CalledProcessError) as e:
       self.__write_intermediate_results(test.name,"<setup.py> raised an exception")
       log.error(Header("Subprocess Error %s" % test.name))
-      log.error("%s" % e)
-      log.error("%s" % sys.exc_info()[:2])
+      log.error("%s", e)
+      log.error("%s", sys.exc_info()[:2])
       log.debug("Subprocess Error Details", exc_info=True)
       try:
         test.stop(log)
       except (subprocess.CalledProcessError) as e:
         self.__write_intermediate_results(test.name,"<setup.py>#stop() raised an error")
         log.error(Header("Subprocess Error: Test .stop() raised exception %s" % test.name))
-        log.error("%s" % e)
-        log.error("%s" % sys.exc_info()[:2])
+        log.error("%s", e)
+        log.error("%s", sys.exc_info()[:2])
         log.debug("Subprocess Error Details", exc_info=True)
     except (KeyboardInterrupt, SystemExit) as e:
       test.stop(log)

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -365,7 +365,7 @@ class FrameworkTest:
       url = self.benchmarker.generate_url(self.json_url, self.port)
       output = self.__curl_url(url, self.JSON, logger)
       logger.info("VALIDATING JSON ... ")
-      if self.validateJson(output, log):
+      if self.validateJson(output, logger):
         self.json_url_passed = True
         logger.info("PASS")
       else:

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -636,7 +636,7 @@ class FrameworkTest:
             pass
         if self.plaintext_url_passed:
           remote_script = self.__generate_concurrency_script(self.plaintext_url, self.port, self.accept_plaintext, wrk_command="wrk", intervals=[256,1024,4096,16384], pipeline="16")
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.PLAINTEXT)
         self.benchmarker.report_results(framework=self, test=self.PLAINTEXT, results=results['results'])
         logger.info( "Complete" )

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -12,6 +12,7 @@ import traceback
 import json
 import textwrap
 import logging
+log = logging.getLogger('framework_test')
 
 class FrameworkTest:
   ##########################################################################################
@@ -287,6 +288,8 @@ class FrameworkTest:
   # Start the test using it's setup file
   ############################################################
   def start(self, out, err):
+    log.info("start")
+
     # Load profile for this installation
     profile="%s/bash_profile.sh" % self.directory
     if not os.path.exists(profile):
@@ -306,6 +309,7 @@ class FrameworkTest:
   # Stops the test using it's setup file
   ############################################################
   def stop(self, out, err):
+    log.info("stop")
     return self.setup_module.stop(out, err)
   ############################################################
   # End stop
@@ -670,6 +674,7 @@ class FrameworkTest:
   # Method meant to be run for a given timestamp
   ############################################################
   def parse_all(self):
+    log.info("parse_all")
     # JSON
     if os.path.exists(self.benchmarker.get_output_file(self.name, self.JSON)):
       results = self.__parse_test(self.JSON)
@@ -707,6 +712,7 @@ class FrameworkTest:
   # __parse_test(test_type)
   ############################################################
   def __parse_test(self, test_type):
+    log.info("__parse_test") 
     try:
       results = dict()
       results['results'] = []
@@ -907,6 +913,7 @@ class FrameworkTest:
   # Constructor
   ##########################################################################################  
   def __init__(self, name, directory, benchmarker, runTests, args):
+    log.debug("__init__: %s in %s" % (name, directory))
     self.name = name
     self.directory = directory
     self.benchmarker = benchmarker

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -15,9 +15,22 @@ import logging
 log = logging.getLogger('framework_test')
 
 class FrameworkTest:
-  ##########################################################################################
-  # Class variables
-  ##########################################################################################
+  """
+  Represents a framework test, including all types (JSON, plaintext, DB, etc)
+  defined in that test. Used by Benchmarker to start, verify, benchmark, and 
+  stop tests. Calls into the test's setup.py as needed. 
+
+  Note: Any method in this class called from Benchmarker#__run_test is run 
+        inside a thread
+  Note: Many methods have a parameter 'logger' passed in from Benchmarker. 
+        This uses python's logging module to support writing output to both a 
+        file and stdout concurrently. If you wish to print something to stdout,
+        regardless of the current global log level, use logger.info("Something"). 
+        If you wish to respect the current global log level, use the logger 
+        defined for this class e.g. log.info("Something else"). If you would 
+        like to use this 'logger' with subprocess, see class WrapLogger
+  """
+
   headers_template = "-H 'Host: localhost' -H '{accept}' -H 'Connection: keep-alive'"
   headers_full_template = "-H 'Host: localhost' -H '{accept}' -H 'Accept-Language: en-US,en;q=0.5' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) Gecko/20130501 Firefox/30.0 AppleWebKit/600.00 Chrome/30.0.0000.0 Trident/10.0 Safari/600.00' -H 'Cookie: uid=12345678901234567890; __utma=1.1234567890.1234567890.1234567890.1234567890.12; wd=2560x1600' -H 'Connection: keep-alive'"
  
@@ -137,7 +150,7 @@ class FrameworkTest:
   # and a "randomNumber" key, and that both keys map to 
   # integers.
   ############################################################
-  def validateDb(self, jsonString, out, err):
+  def validateDb(self, jsonString, logger=log):
     try:
       obj = {k.lower(): v for k,v in json.loads(jsonString).items()}
 
@@ -156,7 +169,7 @@ class FrameworkTest:
       pass
     return False
 
-  def validateDbStrict(self, jsonString, out, err):
+  def validateDbStrict(self, jsonString, logger=log):
     try:
       obj = {k.lower(): v for k,v in json.loads(jsonString).items()}
 
@@ -177,7 +190,7 @@ class FrameworkTest:
   # each object has an "id" and a "randomNumber" key, and that
   # both keys map to integers.
   ############################################################
-  def validateQuery(self, jsonString, out, err):
+  def validateQuery(self, jsonString, logger=log):
     try:
       arr = [{k.lower(): v for k,v in d.items()} for d in json.loads(jsonString)]
 
@@ -196,7 +209,7 @@ class FrameworkTest:
   # each object has an "id" and a "randomNumber" key, and that
   # both keys map to integers.
   ############################################################
-  def validateQueryOneOrLess(self, jsonString, out, err):
+  def validateQueryOneOrLess(self, jsonString, logger=log):
     try:
       arr = {k.lower(): v for k,v in json.loads(jsonString).items()}
 
@@ -221,7 +234,7 @@ class FrameworkTest:
   # each object has an "id" and a "randomNumber" key, and that
   # both keys map to integers.
   ############################################################
-  def validateQueryFiveHundredOrMore(self, jsonString, out, err):
+  def validateQueryFiveHundredOrMore(self, jsonString, logger=log):
     try:
       arr = {k.lower(): v for k,v in json.loads(jsonString).items()}
 
@@ -244,7 +257,7 @@ class FrameworkTest:
   # Parses the given HTML string and asks a FortuneHTMLParser
   # whether the parsed string is a valid fortune return.
   ############################################################
-  def validateFortune(self, htmlString, out, err):
+  def validateFortune(self, htmlString, logger=log):
     try:
       parser = FortuneHTMLParser()
       parser.feed(htmlString)
@@ -260,7 +273,7 @@ class FrameworkTest:
   # each object has an "id" and a "randomNumber" key, and that
   # both keys map to integers.
   ############################################################
-  def validateUpdate(self, jsonString, out, err):
+  def validateUpdate(self, jsonString, logger=log):
     try:
       arr = [{k.lower(): v for k,v in d.items()} for d in json.loads(jsonString)]
 
@@ -276,7 +289,7 @@ class FrameworkTest:
   ############################################################
   #
   ############################################################
-  def validatePlaintext(self, jsonString, out, err):
+  def validatePlaintext(self, jsonString, logger=log):
     try:
       return jsonString.lower().strip() == "hello, world!"
     except:
@@ -293,13 +306,13 @@ class FrameworkTest:
     # Load profile for this installation
     profile="%s/bash_profile.sh" % self.directory
     if not os.path.exists(profile):
-      logging.warning("Framework %s does not have a bash_profile" % self.name)
+      logger.warning("Framework %s does not have a bash_profile", self.name)
       profile="$FWROOT/config/benchmark_profile"
     
     set_iroot="export IROOT=%s" % self.install_root
     setup_util.replace_environ(config=profile, command=set_iroot)
 
-    (out, err) = WrapLogger(logger, 'out'), WrapLogger(logger, 'err')
+    (out, err) = WrapLogger(logger, logging.INFO), WrapLogger(logger, logging.ERROR)
     return self.setup_module.start(self.benchmarker, out, err)
   ############################################################
   # End start
@@ -310,8 +323,8 @@ class FrameworkTest:
   # Stops the test using it's setup file
   ############################################################
   def stop(self, logger=log):
-    logger.info("stop")
-    (out, err) = WrapLogger(logger, 'out'), WrapLogger(logger, 'err')
+    log.info("stop")
+    (out, err) = WrapLogger(logger, logging.INFO), WrapLogger(logger, logging.ERROR)
     return self.setup_module.stop(out, err)
   ############################################################
   # End stop
@@ -325,178 +338,155 @@ class FrameworkTest:
   # or not it passed
   ############################################################
   def verify_urls(self, logger=log):
-    (out, err) = WrapLogger(logger, 'out'), WrapLogger(logger, 'err')
 
     # JSON
     if self.runTests[self.JSON]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING JSON ({url})
-        -----------------------------------------------------
-        """.format(url = self.json_url)))
-      out.flush()
+        -----------------------------------------------------""".format(url = self.json_url)))
 
       url = self.benchmarker.generate_url(self.json_url, self.port)
-      output = self.__curl_url(url, self.JSON, out, err)
-      out.write("VALIDATING JSON ... ")
-      if self.validateJson(output, out, err):
+      output = self.__curl_url(url, self.JSON, logger)
+      logger.info("VALIDATING JSON ... ")
+      if self.validateJson(output, log):
         self.json_url_passed = True
-        out.write("PASS\n\n")
+        logger.info("PASS")
       else:
         self.json_url_passed = False
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
     # DB
     if self.runTests[self.DB]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING DB ({url})
-        -----------------------------------------------------
-        """.format(url = self.db_url)))
-      out.flush()
+        -----------------------------------------------------""".format(url = self.db_url)))
 
       url = self.benchmarker.generate_url(self.db_url, self.port)
-      output = self.__curl_url(url, self.DB, out, err)
-      if self.validateDb(output, out, err):
+      output = self.__curl_url(url, self.DB, logger)
+      if self.validateDb(output, logger):
         self.db_url_passed = True
       else:
         self.db_url_passed = False
-      if self.validateDbStrict(output, out, err):
+      if self.validateDbStrict(output, logger):
         self.db_url_warn = False
       else:
         self.db_url_warn = True
 
-      out.write("VALIDATING DB ... ")
+      logger.info("VALIDATING DB ... ")
       if self.db_url_passed:
-        out.write("PASS")
         if self.db_url_warn:
-          out.write(" (with warnings)")
-        out.write("\n\n")
+          logger.info("PASS (with warnings)")
+        else:
+          logger.info("PASS")
       else:
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
     # Query
     if self.runTests[self.QUERY]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING QUERY ({url})
-        -----------------------------------------------------
-        """.format(url=self.query_url+"2")))
-      out.flush()
+        -----------------------------------------------------""".format(url=self.query_url+"2")))
 
       url = self.benchmarker.generate_url(self.query_url + "2", self.port)
-      output = self.__curl_url(url, self.QUERY, out, err)
-      if self.validateQuery(output, out, err):
+      output = self.__curl_url(url, self.QUERY, logger)
+      if self.validateQuery(output, logger):
         self.query_url_passed = True
-        out.write(self.query_url + "2 - PASS\n\n")
+        logger.info(self.query_url + "2 - PASS")
       else:
         self.query_url_passed = False
-        out.write(self.query_url + "2 - FAIL\n\n")
-      out.write("-----------------------------------------------------\n\n")
-      out.flush()
-
+        logger.info(self.query_url + "2 - FAIL")
+      logger.info("-----------------------------------------------------")
+      
       self.query_url_warn = False
       url2 = self.benchmarker.generate_url(self.query_url + "0", self.port)
-      output2 = self.__curl_url(url2, self.QUERY, out, err)
-      if not self.validateQueryOneOrLess(output2, out, err):
+      output2 = self.__curl_url(url2, self.QUERY, logger)
+      if not self.validateQueryOneOrLess(output2, logger):
         self.query_url_warn = True
-        out.write(self.query_url + "0 - WARNING\n\n")
+        logger.info(self.query_url + "0 - WARNING")
       else:
-        out.write(self.query_url + "0 - PASS\n\n")
-      out.write("-----------------------------------------------------\n\n")
-      out.flush()
+        logger.info(self.query_url + "0 - PASS")
+      logger.info("-----------------------------------------------------")
 
       url3 = self.benchmarker.generate_url(self.query_url + "foo", self.port)
-      output3 = self.__curl_url(url3, self.QUERY, out, err)
-      if not self.validateQueryOneOrLess(output3, out, err):
+      output3 = self.__curl_url(url3, self.QUERY, logger)
+      if not self.validateQueryOneOrLess(output3, logger):
         self.query_url_warn = True
-        out.write(self.query_url + "foo - WARNING\n\n")
+        logger.info(self.query_url + "foo - WARNING")
       else:
-        out.write(self.query_url + "foo - PASS\n\n")
-      out.write("-----------------------------------------------------\n\n")
-      out.flush()
+        logger.info(self.query_url + "foo - PASS")
+      logger.info("-----------------------------------------------------")  
 
       url4 = self.benchmarker.generate_url(self.query_url + "501", self.port)
-      output4 = self.__curl_url(url4, self.QUERY, out, err)
-      if not self.validateQueryFiveHundredOrMore(output4, out, err):
+      output4 = self.__curl_url(url4, self.QUERY, logger)
+      if not self.validateQueryFiveHundredOrMore(output4, logger):
         self.query_url_warn = True
-        out.write(self.query_url + "501 - WARNING\n\n")
+        logger.info(self.query_url + "501 - WARNING")
       else:
-        out.write(self.query_url + "501 - PASS\n\n")
-      out.write("-----------------------------------------------------\n\n\n")
-      out.flush()
+        logger.info(self.query_url + "501 - PASS")
+      logger.info("-----------------------------------------------------")
 
-      out.write("VALIDATING QUERY ... ")
-      if self.query_url_passed:
-        out.write("PASS")
-        if self.query_url_warn:
-          out.write(" (with warnings)")
-        out.write("\n\n")
+      logger.info("VALIDATING QUERY ... ")
+      if self.query_url_passed and self.query_url_warn:
+        logger.info("PASS (with warnings)")
+      elif self.query_url_passed:
+        logger.info("PASS")
       else:
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
     # Fortune
     if self.runTests[self.FORTUNE]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING FORTUNE ({url})
-        -----------------------------------------------------
-        """.format(url = self.fortune_url)))
-      out.flush()
+        -----------------------------------------------------""".format(url = self.fortune_url)))
 
       url = self.benchmarker.generate_url(self.fortune_url, self.port)
-      output = self.__curl_url(url, self.FORTUNE, out, err)
-      out.write("VALIDATING FORTUNE ... ")
-      if self.validateFortune(output, out, err):
+      output = self.__curl_url(url, self.FORTUNE, logger)
+      logger.info("VALIDATING FORTUNE ... ")
+      if self.validateFortune(output, logger):
         self.fortune_url_passed = True
-        out.write("PASS\n\n")
+        logger.info("PASS")
       else:
         self.fortune_url_passed = False
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
     # Update
     if self.runTests[self.UPDATE]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING UPDATE ({url})
         -----------------------------------------------------
         """.format(url = self.update_url)))
-      out.flush()
 
       url = self.benchmarker.generate_url(self.update_url + "2", self.port)
-      output = self.__curl_url(url, self.UPDATE, out, err)
-      out.write("VALIDATING UPDATE ... ")
-      if self.validateUpdate(output, out, err):
+      output = self.__curl_url(url, self.UPDATE, logger)
+      logger.info("VALIDATING UPDATE ... ")
+      if self.validateUpdate(output, logger):
         self.update_url_passed = True
-        out.write("PASS\n\n")
+        logger.info("PASS")
       else:
         self.update_url_passed = False
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
     # plaintext
     if self.runTests[self.PLAINTEXT]:
-      out.write(textwrap.dedent("""
+      logger.info(textwrap.dedent("""
         -----------------------------------------------------
           VERIFYING PLAINTEXT ({url})
-        -----------------------------------------------------
-        """.format(url = self.plaintext_url)))
-      out.flush()
+        -----------------------------------------------------""".format(url = self.plaintext_url)))
 
       url = self.benchmarker.generate_url(self.plaintext_url, self.port)
-      output = self.__curl_url(url, self.PLAINTEXT, out, err)
-      out.write("VALIDATING PLAINTEXT ... ")
-      if self.validatePlaintext(output, out, err):
+      output = self.__curl_url(url, self.PLAINTEXT, logger)
+      logger.info("VALIDATING PLAINTEXT ... ")
+      if self.validatePlaintext(output, logger):
         self.plaintext_url_passed = True
-        out.write("PASS\n\n")
+        logger.info("PASS")
       else:
         self.plaintext_url_passed = False
-        out.write("FAIL\n\n")
-      out.flush
+        logger.info("FAIL")
 
   ############################################################
   # End verify_urls
@@ -535,13 +525,11 @@ class FrameworkTest:
   # JSON/DB/Query.
   ############################################################
   def benchmark(self, logger=log):
-    (out, err) = WrapLogger(logger, 'out'), WrapLogger(logger, 'err')
     
     # JSON
     if self.runTests[self.JSON]:
       try:
-        out.write("BENCHMARKING JSON ... ") 
-        out.flush()
+        logger.info("BENCHMARKING JSON ... ") 
         results = None
         output_file = self.benchmarker.output_file(self.name, self.JSON)
         if not os.path.exists(output_file):
@@ -550,19 +538,17 @@ class FrameworkTest:
             pass
         if self.json_url_passed:
           remote_script = self.__generate_concurrency_script(self.json_url, self.port, self.accept_json)
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.JSON)
         self.benchmarker.report_results(framework=self, test=self.JSON, results=results['results'])
-        out.write( "Complete\n" )
-        out.flush()
+        logger.info("Complete")
       except AttributeError:
         pass
 
     # DB
     if self.runTests[self.DB]:
       try:
-        out.write("BENCHMARKING DB ... ") 
-        out.flush()
+        logger.info("BENCHMARKING DB ... ") 
         results = None
         output_file = self.benchmarker.output_file(self.name, self.DB)
         warning_file = self.benchmarker.warning_file(self.name, self.DB)
@@ -575,18 +561,17 @@ class FrameworkTest:
             pass
         if self.db_url_passed:
           remote_script = self.__generate_concurrency_script(self.db_url, self.port, self.accept_json)
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.DB)
         self.benchmarker.report_results(framework=self, test=self.DB, results=results['results'])
-        out.write( "Complete\n" )
+        logger.info("Complete")
       except AttributeError:
         pass
 
     # Query
     if self.runTests[self.QUERY]:
       try:
-        out.write("BENCHMARKING Query ... ")
-        out.flush()
+        logger.info("BENCHMARKING Query ...")
         results = None
         output_file = self.benchmarker.output_file(self.name, self.QUERY)
         warning_file = self.benchmarker.warning_file(self.name, self.QUERY)
@@ -599,19 +584,17 @@ class FrameworkTest:
             pass
         if self.query_url_passed:
           remote_script = self.__generate_query_script(self.query_url, self.port, self.accept_json)
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.QUERY)
         self.benchmarker.report_results(framework=self, test=self.QUERY, results=results['results'])
-        out.write( "Complete\n" )
-        out.flush()
+        logger.info("Complete")
       except AttributeError:
         pass
 
     # fortune
     if self.runTests[self.FORTUNE]:
       try:
-        out.write("BENCHMARKING Fortune ... ") 
-        out.flush()
+        logger.info("BENCHMARKING Fortune ... ") 
         results = None
         output_file = self.benchmarker.output_file(self.name, self.FORTUNE)
         if not os.path.exists(output_file):
@@ -620,19 +603,17 @@ class FrameworkTest:
             pass
         if self.fortune_url_passed:
           remote_script = self.__generate_concurrency_script(self.fortune_url, self.port, self.accept_html)
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.FORTUNE)
         self.benchmarker.report_results(framework=self, test=self.FORTUNE, results=results['results'])
-        out.write( "Complete\n" )
-        out.flush()
+        logger.info("Complete")
       except AttributeError:
         pass
 
     # update
     if self.runTests[self.UPDATE]:
       try:
-        out.write("BENCHMARKING Update ... ") 
-        out.flush()
+        logger.info("BENCHMARKING Update ... ") 
         results = None
         output_file = self.benchmarker.output_file(self.name, self.UPDATE)
         if not os.path.exists(output_file):
@@ -641,19 +622,17 @@ class FrameworkTest:
             pass
         if self.update_url_passed:
           remote_script = self.__generate_query_script(self.update_url, self.port, self.accept_json)
-          self.__run_benchmark(remote_script, output_file, err)
+          self.__run_benchmark(remote_script, output_file, logger)
         results = self.__parse_test(self.UPDATE)
         self.benchmarker.report_results(framework=self, test=self.UPDATE, results=results['results'])
-        out.write( "Complete\n" )
-        out.flush()
+        logger.info( "Complete" )
       except AttributeError:
         pass
 
     # plaintext
     if self.runTests[self.PLAINTEXT]:
       try:
-        out.write("BENCHMARKING Plaintext ... ")
-        out.flush()
+        logger.info("BENCHMARKING Plaintext ... ")
         results = None
         output_file = self.benchmarker.output_file(self.name, self.PLAINTEXT)
         if not os.path.exists(output_file):
@@ -665,10 +644,9 @@ class FrameworkTest:
           self.__run_benchmark(remote_script, output_file, err)
         results = self.__parse_test(self.PLAINTEXT)
         self.benchmarker.report_results(framework=self, test=self.PLAINTEXT, results=results['results'])
-        out.write( "Complete\n" )
-        out.flush()
+        logger.info( "Complete" )
       except AttributeError:
-        traceback.print_exc()
+        logger.exception("Error Running Benchmark for %s", self.name)
         pass
 
   ############################################################
@@ -819,12 +797,11 @@ class FrameworkTest:
   # template that uses weighttp to run the test. All the results
   # outputed to the output_file.
   ############################################################
-  def __run_benchmark(self, script, output_file, err):
+  def __run_benchmark(self, script, output_file, logger):
+    err = WrapLogger(logger, logging.ERROR)
     with open(output_file, 'w') as raw_file:
-	  
       p = subprocess.Popen(self.benchmarker.client_ssh_string.split(" "), stdin=subprocess.PIPE, stdout=raw_file, stderr=err)
       p.communicate(script)
-      err.flush()
   ############################################################
   # End __run_benchmark
   ############################################################
@@ -880,7 +857,10 @@ class FrameworkTest:
   # Dump HTTP response and headers. Throw exception if there
   # is an HTTP error.
   ############################################################
-  def __curl_url(self, url, testType, out, err):
+  def __curl_url(self, url, testType, logger=log):
+    # Send output to our benchmark's logger for archival to file,
+    # but only show err on stdout by default
+    (out, err) = WrapLogger(logger, logging.DEBUG), WrapLogger(logger, logging.ERROR)
     output = None
     try:
       # Use -m 15 to make curl stop trying after 15sec.
@@ -890,10 +870,6 @@ class FrameworkTest:
       # error output for sure in stdout.
       # Use -sS to hide progress bar, but show errors.
       subprocess.check_call(["curl", "-m", "15", "-i", "-sS", url], stderr=err, stdout=out)
-      # HTTP output may not end in a newline, so add that here.
-      out.write( "\n\n" )
-      out.flush()
-      err.flush()
 
       # We need to get the respond body from the curl and return it.
       p = subprocess.Popen(["curl", "-m", "15", "-s", url], stdout=subprocess.PIPE)
@@ -924,10 +900,7 @@ class FrameworkTest:
     self.benchmarker = benchmarker
     self.runTests = runTests
     self.fwroot = benchmarker.fwroot
-    
-    # setup logging
-    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-    
+        
     self.install_root="%s/%s" % (self.fwroot, "installs")
     if benchmarker.install_strategy is 'pertest':
       self.install_root="%s/pertest/%s" % (self.install_root, name)
@@ -993,14 +966,8 @@ class WrapLogger():
     self.level = level
     self.file = tempfile.TemporaryFile()
 
-  def write(self, str):
-    if self.level == "out":
-      self.logger.info(str)
-    elif self.level == "err":
-      self.logger.error(str)
-    else:
-      self.logger.error("Unknown level %s" % self.level)
-      self.logger.error(str)
+  def write(self, message):
+    self.logger.log(self.level, message)
 
   def __getattr__(self, name):
     return getattr(self.file, name)

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -10,11 +10,12 @@ import pprint
 import sys
 import traceback
 import json
-import textwrap
 import logging
 log = logging.getLogger('framework_test')
 
 from utils import WrapLogger
+from utils import Header
+
 class FrameworkTest:
   """
   Represents a framework test, including all types (JSON, plaintext, DB, etc)
@@ -360,11 +361,7 @@ class FrameworkTest:
 
     # JSON
     if self.runTests[self.JSON]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING JSON ({url})
-        -----------------------------------------------------""".format(url = self.json_url)))
-
+      logger.info(Header("VERIFYING JSON (%s)" % self.json_url))
       url = self.benchmarker.generate_url(self.json_url, self.port)
       output = self.__curl_url(url, self.JSON, logger)
       logger.info("VALIDATING JSON ... ")
@@ -377,11 +374,7 @@ class FrameworkTest:
 
     # DB
     if self.runTests[self.DB]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING DB ({url})
-        -----------------------------------------------------""".format(url = self.db_url)))
-
+      logger.info(Header("VERIFYING DB (%s)" % self.db_url))
       url = self.benchmarker.generate_url(self.db_url, self.port)
       output = self.__curl_url(url, self.DB, logger)
       if self.validateDb(output, logger):
@@ -404,11 +397,7 @@ class FrameworkTest:
 
     # Query
     if self.runTests[self.QUERY]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING QUERY ({url})
-        -----------------------------------------------------""".format(url=self.query_url+"2")))
-
+      logger.info(Header("VERIFYING QUERY (%s)" % self.query_url+"2"))
       url = self.benchmarker.generate_url(self.query_url + "2", self.port)
       output = self.__curl_url(url, self.QUERY, logger)
       if self.validateQuery(output, logger):
@@ -457,11 +446,7 @@ class FrameworkTest:
 
     # Fortune
     if self.runTests[self.FORTUNE]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING FORTUNE ({url})
-        -----------------------------------------------------""".format(url = self.fortune_url)))
-
+      logger.info(Header("VERIFYING FORTUNE (%s)" % self.fortune_url))
       url = self.benchmarker.generate_url(self.fortune_url, self.port)
       output = self.__curl_url(url, self.FORTUNE, logger)
       logger.info("VALIDATING FORTUNE ... ")
@@ -474,12 +459,7 @@ class FrameworkTest:
 
     # Update
     if self.runTests[self.UPDATE]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING UPDATE ({url})
-        -----------------------------------------------------
-        """.format(url = self.update_url)))
-
+      logger.info(Header("VERIFYING UPDATE (%s)" % self.update_url))
       url = self.benchmarker.generate_url(self.update_url + "2", self.port)
       output = self.__curl_url(url, self.UPDATE, logger)
       logger.info("VALIDATING UPDATE ... ")
@@ -492,11 +472,7 @@ class FrameworkTest:
 
     # plaintext
     if self.runTests[self.PLAINTEXT]:
-      logger.info(textwrap.dedent("""
-        -----------------------------------------------------
-          VERIFYING PLAINTEXT ({url})
-        -----------------------------------------------------""".format(url = self.plaintext_url)))
-
+      logger.info(Header("VERIFYING PLAINTEXT (%s)" % self.plaintext_url))
       url = self.benchmarker.generate_url(self.plaintext_url, self.port)
       output = self.__curl_url(url, self.PLAINTEXT, logger)
       logger.info("VALIDATING PLAINTEXT ... ")

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -14,6 +14,7 @@ import textwrap
 import logging
 log = logging.getLogger('framework_test')
 
+from utils import WrapLogger
 class FrameworkTest:
   """
   Represents a framework test, including all types (JSON, plaintext, DB, etc)
@@ -958,19 +959,3 @@ def parse_config(config, directory, benchmarker):
 ##############################################################
 # End parse_config
 ##############################################################
-
-import tempfile
-class WrapLogger():
-  def __init__(self, logger, level):
-    self.logger = logger
-    self.level = level
-    self.file = tempfile.TemporaryFile()
-
-  def write(self, message):
-    self.logger.log(self.level, message)
-
-  def __getattr__(self, name):
-    return getattr(self.file, name)
-
-
-

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -910,10 +910,10 @@ class FrameworkTest:
 
   def requires_database(self):
       """Returns True/False if this test requires a database"""
-      return (self.contains_type(self.FORTUNE) or 
-              self.contains_type(self.DB) or 
-              self.contains_type(self.QUERY) or
-              self.contains_type(self.UPDATE))
+      return (self.runTests[self.FORTUNE] or 
+              self.runTests[self.DB] or 
+              self.runTests[self.QUERY] or
+              self.runTests[self.UPDATE])
 
   ##########################################################################################
   # Constructor

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -136,13 +136,15 @@ class FrameworkTest:
   # Validates the jsonString is a JSON object with a 'message'
   # key with the value "hello, world!" (case-insensitive).
   ############################################################
-  def validateJson(self, jsonString, out, err):
+  def validateJson(self, jsonString, logger=log):
     try:
       obj = {k.lower(): v for k,v in json.loads(jsonString).items()}
 
       if  obj["message"].lower() == "hello, world!":
         return True
     except:
+      logger.debug("Expected: %s", "{'message':'hello, world!'}")
+      logger.debug("Got: '%s'", jsonString)
       pass
     return False
 
@@ -167,6 +169,8 @@ class FrameworkTest:
           type(float(obj["randomnumber"])) == float):
         return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -181,6 +185,8 @@ class FrameworkTest:
           type(float(obj["randomnumber"])) == float):
         return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -201,6 +207,8 @@ class FrameworkTest:
           type(float(arr[1]["randomnumber"])) == float):
         return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -226,6 +234,8 @@ class FrameworkTest:
       # By here, it's passed validation
       return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -251,6 +261,8 @@ class FrameworkTest:
       # By here, it's passed validation
       return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -265,6 +277,8 @@ class FrameworkTest:
 
       return parser.isValidFortune()
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", htmlString)
       pass
     return False
 
@@ -284,6 +298,8 @@ class FrameworkTest:
           type(float(arr[1]["randomnumber"])) == float):
         return True
     except:
+      # logger.debug("Expected: %s", "")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 
@@ -294,6 +310,8 @@ class FrameworkTest:
     try:
       return jsonString.lower().strip() == "hello, world!"
     except:
+      logger.debug("Expected: %s", "hello, world!")
+      logger.debug("Got: %s", jsonString)
       pass
     return False
 

--- a/toolset/benchmark/utils.py
+++ b/toolset/benchmark/utils.py
@@ -1,0 +1,25 @@
+import tempfile
+
+
+class WrapLogger():
+  """
+  Used to convert a Logger into file streams. Adds easy integration 
+  of Logger into subprocess, which takes file parameters for stdout
+  and stderr. 
+
+  Use: 
+    (out, err) = WrapLogger(logger, logging.INFO), WrapLogger(logger, logging.ERROR)
+    subprocess.Popen(command, stdout=out, stderr=err)
+  """
+  def __init__(self, logger, level):
+    self.logger = logger
+    self.level = level
+    self.file = tempfile.TemporaryFile()
+
+  def write(self, message):
+    self.logger.log(self.level, message)
+
+  def __getattr__(self, name):
+    return getattr(self.file, name)
+
+

--- a/toolset/benchmark/utils.py
+++ b/toolset/benchmark/utils.py
@@ -37,5 +37,5 @@ class Header():
     topheader = topheader[:80]
     bottomheader = self.bottom * 80
     bottomheader = bottomheader[:80]
-    return "%s\n  %s\n%s" % (topheader, self.message, bottomheader)
+    return "\n%s\n  %s\n%s" % (topheader, self.message, bottomheader)
 

--- a/toolset/benchmark/utils.py
+++ b/toolset/benchmark/utils.py
@@ -22,6 +22,14 @@ class WrapLogger():
   def __getattr__(self, name):
     return getattr(self.file, name)
 
+  def __del__(self):
+    """Grabs any output that was written directly to the file (e.g. bypassing 
+    the write method). Subprocess.call, Popen, etc have a habit of accessing 
+    the file directly for faster writing. See http://bugs.python.org/issue1631
+    """
+    self.file.seek(0)
+    for line in self.file.readlines():
+      self.logger.log(self.level, line.rstrip('\n'))
 
 class Header():
   """

--- a/toolset/benchmark/utils.py
+++ b/toolset/benchmark/utils.py
@@ -23,3 +23,19 @@ class WrapLogger():
     return getattr(self.file, name)
 
 
+class Header():
+  """
+  """
+
+  def __init__(self, message, top='-', bottom='-'):
+    self.message = message
+    self.top = top
+    self.bottom = bottom
+
+  def __str__(self):
+    topheader = self.top * 80
+    topheader = topheader[:80]
+    bottomheader = self.bottom * 80
+    bottomheader = bottomheader[:80]
+    return "%s\n  %s\n%s" % (topheader, self.message, bottomheader)
+

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -132,11 +132,18 @@ def main(argv=None):
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 
-    # Set up our initial logging level
+    # Set up logging
+
     numeric_level = getattr(logging, args.log.upper(), logging.ERROR)
     if not isinstance(numeric_level, int):
         raise ValueError('Invalid log level: %s' % loglevel)
-    logging.basicConfig(level=numeric_level)
+    stdout = logging.StreamHandler()
+    stdout.setLevel(numeric_level)
+    stdout.setFormatter(logging.Formatter("%(name)-12s: %(levelname)-8s %(message)s"))
+    rootlogger = logging.getLogger()
+    rootlogger.setLevel(logging.DEBUG)  # Pass all messages to all handlers
+    rootlogger.addHandler(stdout)
+    logging.captureWarnings(True)
 
     # Verify and massage options
     if args.client_user is None:

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -4,8 +4,9 @@ import ConfigParser
 import sys
 import os
 import multiprocessing
+import logging
+log = logging.getLogger('run-tests')
 import subprocess
-from pprint import pprint 
 from benchmark.benchmarker import Benchmarker
 from setup.linux.unbuffered import Unbuffered
 from setup.linux import setup_util
@@ -55,7 +56,7 @@ def main(argv=None):
             defaults = dict(config.items("Defaults"))
     except IOError:
         if args.conf_file != 'benchmark.cfg':
-            print 'Configuration file not found!'
+            log.warn('Configuration file not found!')
         defaults = { "client-host":"localhost"}
 
     ##########################################################
@@ -127,15 +128,21 @@ def main(argv=None):
 
     # Misc Options
     parser.add_argument('--parse', help='Parses the results of the given timestamp and merges that with the latest results')
-    parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Causes the configuration to print before any other commands are executed.')
+    parser.add_argument('--log', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], default='ERROR', help='Set the logging level')
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 
+    # Set up our initial logging level
+    numeric_level = getattr(logging, args.log.upper(), logging.ERROR)
+    if not isinstance(numeric_level, int):
+        raise ValueError('Invalid log level: %s' % loglevel)
+    logging.basicConfig(level=numeric_level)
+
     # Verify and massage options
     if args.client_user is None:
-      print 'Usernames (e.g. --client-user and --database-user) are required!'
-      print 'The system will SSH into the client and the database for the install stage'
-      print 'Aborting'
+      log.critical('Usernames (e.g. --client-user and --database-user) are required!')
+      log.critical('The system will SSH into the client and the database for the install stage')
+      log.critical('Aborting')
       exit(1)
 
     if args.database_user is None:
@@ -144,9 +151,7 @@ def main(argv=None):
     if args.database_host is None:
       args.database_host = args.client_host
 
-    if args.verbose:
-        print 'Configuration options: '
-        pprint(args)
+    log.info("Configuration: %s" % str(args))
 
     benchmarker = Benchmarker(vars(args))
 

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -165,5 +165,13 @@ def main(argv=None):
     else:
       benchmarker.run()
 
+# Integrate uncaught exceptions into our logging system
+# Note: This doesn't work if the exception happens in a 
+# thread (e.g. inside benchmark#__run_test). This is a 
+# python issue at http://bugs.python.org/issue1230540
+def handleException(excType, excValue, traceback, logger=log):
+    logger.error("Uncaught exception", exc_info=(excType, excValue, traceback))
+sys.excepthook = handleException
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/toolset/setup/linux/installer.py
+++ b/toolset/setup/linux/installer.py
@@ -389,9 +389,6 @@ EOF
     self.fwroot = benchmarker.fwroot
     self.strategy = install_strategy
     
-    # setup logging
-    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-
     try:
       os.mkdir(self.install_dir)
     except OSError:


### PR DESCRIPTION
This is basically a forward-looking commit. Currently some modules use logging, some dont, some use 
print, etc. This just standardizes us on python's logging and provides enough logging code to allow 
people to have an idea of what is expected from their additions

Replaces `--verbose` flag with `--log` flag

I'd propose some minimal guidelines for logging: 
* Use info to report standard, expected system operation e.g. method entry
* Don't use info on methods you expect to be called more than 10 times (e.g. get_foo())
* avoid re-writing code just to add logs e.g. don't add `else` statements just to log

Obviously these are just some general thoughts, feedback welcome
