### PR TITLE
Update main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ build queue. This means 1) only your commits/branches are being verified, so the
 no delay waiting for an unrelated pull request, and 2) you can cancel unneeded items. 
 This does not affect our own Travis-CI setup at all - any commits added to a pull 
 request will be verifed as normal. 
+* **Read the README**: We know that's cliche. However, our toolset drags in a lot of 
+different concepts and frameworks, and it can really help to read the README's, such 
+as this one, the one inside the `toolset/` directory, and the ones inside specific 
+framework directories
 
 ---
 


### PR DESCRIPTION
thoughts? I'm really slimming down the main file - it's so dense no one was reading it. I think we should rely on links for complex issues like passwordless sudo, passwordless ssh, etc. These things are tough to get right in a general sense anyway, and they prevent anyone from ever getting to the details of how TFB works from a high level - they are too busy focusing on the string of 100 commands in front of them. I'm not against big strings of commands, but they should either be external links or links to another, more detailed readme file
