### PR TITLE
Gemini

### DIFF
--- a/gemini/setup.py
+++ b/gemini/setup.py
@@ -1,4 +1,3 @@
-
 import subprocess
 import sys
 import setup_util
@@ -10,8 +9,7 @@ def start(args, logfile, errfile):
   setup_util.replace_text("gemini/Docroot/WEB-INF/resin.xml", "root-directory=\".*\/FrameworkBenchmarks", "root-directory=\"%s" % args.fwroot)
   
   try:
-    # This was reporting an error because it already exists... not sure.
-    #subprocess.call("mkdir classes", shell=True, cwd="gemini/Docroot/WEB-INF", stderr=errfile, stdout=logfile)
+    subprocess.call("mkdir -p classes", shell=True, cwd="gemini/Docroot/WEB-INF", stderr=errfile, stdout=logfile)
     subprocess.check_call("ant compile", shell=True, cwd="gemini", stderr=errfile, stdout=logfile)
     subprocess.check_call("$RESIN_HOME/bin/resinctl -conf $FWROOT/gemini/Docroot/WEB-INF/resin.xml start", shell=True, stderr=errfile, stdout=logfile)
     return 0


### PR DESCRIPTION
Gemini was not running because `gemini/Docroot/classes` did not exist on any system that was fresh - since I was running the tests manually before, this folder was always present (which is why the comment line about `mkdir classes` failing was put there and the line below was commented out).

I added the `-p` flag to `mkdir` and now it is always there and does not error out when it already exists.

My first pull request -- how exciting ^_^
