### PR TITLE
Vagrant: update APT index before installing packages

### DIFF
--- a/deployment/vagrant-common/bootstrap.sh
+++ b/deployment/vagrant-common/bootstrap.sh
@@ -90,6 +90,7 @@ if [ ! -e "~/.firstboot" ]; then
 
   # Install prerequisite tools
   echo "Installing prerequisites"
+  sudo apt-get update
   sudo apt-get install -y git
   sudo apt-get install -y python-pip
 


### PR DESCRIPTION
The bootstrap script fails when the APT index in the base box is not up to date, as it will try to install obsolete packages and get 404 errors.
