### PR TITLE
Let FrameworkTest catch Exception from setup.py files

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -474,8 +474,9 @@ class FrameworkTest:
     os.chdir(os.path.dirname(self.troot))
     logging.info("Running setup module start (cwd=%s)", os.path.dirname(self.troot))
     try:
-      self.setup_module.start(self, out, err)    
-      retcode = 0
+      retcode = self.setup_module.start(self, out, err)    
+      if retcode == None: 
+        retcode = 0
     except Exception:
       retcode = 1
       st = traceback.format_exc()
@@ -517,8 +518,9 @@ class FrameworkTest:
     os.chdir(os.path.dirname(self.troot))
     logging.info("Running setup module stop (cwd=%s)", os.path.dirname(self.troot))
     try:
-      self.setup_module.stop(out, err)
-      retcode = 0
+      retcode = self.setup_module.stop(out, err)
+      if retcode == None: 
+        retcode = 0
     except Exception:
       retcode = 1 
       st = traceback.format_exc()


### PR DESCRIPTION
Removes `Exception`-handling responsibility from `setup.py` files, so `FrameworkTest` can choose how to handle exceptions. For now, `FrameworkTest` prints stack traces to stdout as they happen (which is super useful), and also maintains the previous behavior or printing them to the `err.txt` file. 

Example output: 

```
-------------------------------------------------------------------------------- Rough ETA:  --:--:--
  Running Test: aspnet-mono
--------------------------------------------------------------------------------
INFO:root:Running setup module start (cwd=/home/vagrant/FrameworkBenchmarks/frameworks/C#)
INFO:root:Start exception:
    Traceback (most recent call last):
      File "/FrameworkBenchmarks/toolset/benchmark/framework_test.py", line 477, in start
        self.setup_module.start(self, out, err)
      File "/home/vagrant/FrameworkBenchmarks/frameworks/C#/aspnet/setup_nginx.py", line 15, in start
        subprocess.check_call("xbuild /p:Configuration=Release", shell=True, cwd="aspnet/src", stderr=errfile, stdout=logfile)
      File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
        raise CalledProcessError(retcode, cmd)
    CalledProcessError: Command 'xbuild /p:Configuration=Release' returned non-zero exit status 1
INFO:root:Start completed, running benchmark
INFO:root:Running setup module stop (cwd=/home/vagrant/FrameworkBenchmarks/frameworks/C#)
INFO:root:Stop exception:
    Traceback (most recent call last):
      File "/FrameworkBenchmarks/toolset/benchmark/framework_test.py", line 520, in stop
        self.setup_module.stop(out, err)
      File "/home/vagrant/FrameworkBenchmarks/frameworks/C#/aspnet/setup_nginx.py", line 40, in stop
        subprocess.check_call("sudo /usr/local/nginx/sbin/nginx -c $TROOT/nginx.conf -s stop", shell=True, stderr=errfile, stdout=logfile)
      File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
        raise CalledProcessError(retcode, cmd)
    CalledProcessError: Command 'sudo /usr/local/nginx/sbin/nginx -c $TROOT/nginx.conf -s stop' returned non-zero exit status 1
```

This removes the need for this horrible pattern, which only hides exceptions from the user. Obviously if there is a valid reason to try-except it can still be done, but it's no longer required

```
def start(args, logfile, errfile):
  try:
    # Do stuff here
    return 0
  except subprocess.CalledProcessError:
    return 1
```
