### PR TITLE
Add MySQL tests for Lwan

### DIFF
--- a/frameworks/C/lwan/benchmark_config
+++ b/frameworks/C/lwan/benchmark_config
@@ -1,7 +1,7 @@
 {
   "framework": "lwan",
   "tests": [{
-    "raw": {
+    "sqlite": {
       "setup_file": "setup",
       "db_url": "/db",
       "query_url": "/queries?queries=",
@@ -12,6 +12,28 @@
       "approach": "Realistic",
       "classification": "Platform",
       "database": "SQLite",
+      "framework": "lwan",
+      "language": "C",
+      "orm": "Raw",
+      "platform": "Lwan",
+      "webserver": "Lwan",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Lwan",
+      "notes": "",
+      "versus": ""
+    },
+    "mysql": {
+      "setup_file": "setup",
+      "db_url": "/db",
+      "query_url": "/queries?queries=",
+      "fortune_url": "/fortunes",
+      "plaintext_url": "/plaintext",
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
       "framework": "lwan",
       "language": "C",
       "orm": "Raw",

--- a/frameworks/C/lwan/install.sh
+++ b/frameworks/C/lwan/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV='aa6c15fbdf63d9db722ddc72bd736b23381331be'
+REV='eb96604657dd940ecb70b56fef4279077e3f9c21'
 
 INSTALLED_FILE="${IROOT}/lwan-${REV}.installed"
 RETCODE=$(fw_exists ${INSTALLED_FILE})
@@ -10,7 +10,7 @@ RETCODE=$(fw_exists ${INSTALLED_FILE})
 
 # Lwan is only built during installation as a dependency sanity check.
 sudo apt-get update && \
-	sudo apt-get install libjemalloc-dev && \
+	sudo apt-get install libjemalloc-dev libmysqlclient-dev libsqlite3-dev && \
 	git clone git://github.com/lpereira/lwan.git && \
         cd lwan && \
         git checkout ${REV} && \

--- a/frameworks/C/lwan/setup.py
+++ b/frameworks/C/lwan/setup.py
@@ -2,6 +2,17 @@ import subprocess
 import sys
 import os
 
+def get_env_for_database(args):
+  if args.database == 'MySQL':
+    return {
+      'USE_MYSQL': '1',
+      'MYSQL_USER': 'benchmarkdbuser',
+      'MYSQL_PASS': 'benchmarkdbpass',
+      'MYSQL_HOST': args.database_host,
+      'MYSQL_DB': 'hello_world'
+    }
+  return None
+
 def start(args, logfile, errfile):
   subprocess.call('rm -rf ${LWAN_BUILD}', shell=True, stderr=errfile, stdout=logfile)
   subprocess.call('mkdir -p ${LWAN_BUILD}', shell=True, stderr=errfile, stdout=logfile)
@@ -10,7 +21,9 @@ def start(args, logfile, errfile):
 
   db_dir = os.path.join(os.environ['LWAN_ROOT'], 'techempower')
   exe_path = os.path.join(os.environ['LWAN_BUILD'], 'techempower', 'techempower')
-  subprocess.Popen(exe_path, cwd=db_dir, stderr=errfile, stdout=logfile, shell=True)
+
+  subprocess.Popen(exe_path, cwd=db_dir, stderr=errfile, stdout=logfile, shell=True,
+      env = get_env_for_database(args))
 
   return 0
 


### PR DESCRIPTION
This updates the Lwan boilerplate so that it uses a newer version that contains a simple database abstraction layer; with it, the same binary can be set up to use either a MySQL connection, or a SQLite file.

All tests are passing as per [my Travis-CI build log](https://travis-ci.org/lpereira/FrameworkBenchmarks/jobs/39023739).
