### PR TITLE
Fixed the issue about foo/0/501

### DIFF
--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -51,22 +51,22 @@ class QueryTestType(DBTestType):
     else:
       return problems
 
-  def _verifyQueryList(self, expectedLength, body, url, incorrect_length_response='fail'):
+  def _verifyQueryList(self, expectedLength, body, url, max_infraction='fail'):
     '''Validates high-level structure (array length, object 
       types, etc) before calling into DBTestType to 
       validate a few individual JSON objects'''
 
     # Empty response
     if body is None:
-      return [('fail','No response', url)]
+      return [(max_infraction,'No response', url)]
     elif len(body) == 0:
-      return [('fail','Empty Response', url)]
+      return [(max_infraction,'Empty Response', url)]
   
     # Valid JSON? 
     try: 
       response = json.loads(body)
     except ValueError as ve:
-      return [('fail',"Invalid JSON - %s" % ve, url)]
+      return [(max_infraction,"Invalid JSON - %s" % ve, url)]
 
     problems = []
 
@@ -79,11 +79,11 @@ class QueryTestType(DBTestType):
       return problems
 
     if any(type(item) != dict for item in response):
-      problems.append(('fail','All items JSON array must be JSON objects', url))
+      problems.append((max_infraction,'All items JSON array must be JSON objects', url))
 
     # For some edge cases we only warn
     if len(response) != expectedLength:
-      problems.append((incorrect_length_response,
+      problems.append((max_infraction,
         "JSON array length of %s != expected length of %s" % (len(response), expectedLength), 
         url))
 


### PR DESCRIPTION
This new implementation allows for a maximum infraction level to be set when calling _verifyQueryList, and this is set to 'fail' by default, but overridden with 'warn' for these tests.
