### PR TITLE
Fixed a bug with maven-shade-plugin

### DIFF
--- a/frameworks/Java/grizzly-jersey/pom.xml
+++ b/frameworks/Java/grizzly-jersey/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
More information here:
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
