### PR TITLE
Reduce verbosity of python and mono

### DIFF
--- a/toolset/setup/linux/languages/mono.sh
+++ b/toolset/setup/linux/languages/mono.sh
@@ -25,8 +25,8 @@ cd mono-3.6.0
 ./autogen.sh --prefix=$IROOT/mono-3.6.0-install
 # make -j4 EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/basic.exe
 echo -n "Installing Mono"
-make -j4 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
-make install 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 2>&1 | tee $IROOT/mono-install.log | awk '{ if (NR%100 == 0) printf "."}'
+make install 2>&1 | tee -a $IROOT/mono-install.log | awk '{ if (NR%100 == 0) printf "."}'
 
 echo "Installing RootCAs from Mozilla..."; 
 mozroots --import --sync;

--- a/toolset/setup/linux/languages/mono.sh
+++ b/toolset/setup/linux/languages/mono.sh
@@ -24,8 +24,9 @@ fw_untar mono-3.6.0.tar.bz2
 cd mono-3.6.0
 ./autogen.sh --prefix=$IROOT/mono-3.6.0-install
 # make -j4 EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/basic.exe
-make -j4 | grep -i "error"
-make install | grep -i "error"
+echo -n "Installing Mono"
+make -j4 | awk '{ if (NR%100 == 0) printf "."}'
+make install | awk '{ if (NR%100 == 0) printf "."}'
 
 echo "Installing RootCAs from Mozilla..."; 
 mozroots --import --sync;

--- a/toolset/setup/linux/languages/mono.sh
+++ b/toolset/setup/linux/languages/mono.sh
@@ -10,7 +10,7 @@ RETCODE=$(fw_exists mono.installed)
   sudo $IROOT/mono-3.6.0-install/bin/mozroots --import --sync;
   return 0; }
 
-sudo apt-get install -y build-essential \
+sudo apt-get install -qqy build-essential \
              autoconf \
              automake \
              libtool \

--- a/toolset/setup/linux/languages/mono.sh
+++ b/toolset/setup/linux/languages/mono.sh
@@ -25,8 +25,8 @@ cd mono-3.6.0
 ./autogen.sh --prefix=$IROOT/mono-3.6.0-install
 # make -j4 EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/basic.exe
 echo -n "Installing Mono"
-make -j4 | awk '{ if (NR%100 == 0) printf "."}'
-make install | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make install 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
 
 echo "Installing RootCAs from Mozilla..."; 
 mozroots --import --sync;

--- a/toolset/setup/linux/languages/mono.sh
+++ b/toolset/setup/linux/languages/mono.sh
@@ -24,8 +24,8 @@ fw_untar mono-3.6.0.tar.bz2
 cd mono-3.6.0
 ./autogen.sh --prefix=$IROOT/mono-3.6.0-install
 # make -j4 EXTERNAL_MCS=${PWD}/mcs/class/lib/monolite/basic.exe
-make -j4
-make install
+make -j4 | grep -i "error"
+make install | grep -i "error"
 
 echo "Installing RootCAs from Mozilla..."; 
 mozroots --import --sync;

--- a/toolset/setup/linux/languages/python2.sh
+++ b/toolset/setup/linux/languages/python2.sh
@@ -9,8 +9,8 @@ pre=$(pwd)
 cd Python-2.7.8
 ./configure --prefix=${pre}/py2 --disable-shared --quiet
 echo -n "Installing Python 2"
-make -j4 --quiet | awk '{ if (NR%100 == 0) printf "."}'
-make install --quiet | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python2.sh
+++ b/toolset/setup/linux/languages/python2.sh
@@ -8,8 +8,9 @@ fw_untar Python-2.7.8.tgz
 pre=$(pwd)
 cd Python-2.7.8
 ./configure --prefix=${pre}/py2 --disable-shared --quiet
-make -j4 --quiet | grep -i "error"
-make install --quiet | grep -i "error"
+echo -n "Installing Python 2"
+make -j4 --quiet | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python2.sh
+++ b/toolset/setup/linux/languages/python2.sh
@@ -8,8 +8,8 @@ fw_untar Python-2.7.8.tgz
 pre=$(pwd)
 cd Python-2.7.8
 ./configure --prefix=${pre}/py2 --disable-shared --quiet
-make -j4 --quiet
-make install --quiet
+make -j4 --quiet | grep -i "error"
+make install --quiet | grep -i "error"
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python2.sh
+++ b/toolset/setup/linux/languages/python2.sh
@@ -9,8 +9,8 @@ pre=$(pwd)
 cd Python-2.7.8
 ./configure --prefix=${pre}/py2 --disable-shared --quiet
 echo -n "Installing Python 2"
-make -j4 --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
-make install --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 --quiet 2>&1 | tee $IROOT/python-install.log | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet 2>&1 | tee -a $IROOT/python-install.log | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -9,8 +9,8 @@ pre=$(pwd)
 cd Python-3.4.1
 ./configure --prefix=${pre}/py3 --disable-shared --quiet
 echo -n "Installing Python 3"
-make -j4 --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
-make install --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 --quiet 2>&1 | tee $IROOT/python3-install.log | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet 2>&1 | tee -a $IROOT/python3-install.log | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -8,8 +8,9 @@ fw_untar Python-3.4.1.tar.xz
 pre=$(pwd)
 cd Python-3.4.1
 ./configure --prefix=${pre}/py3 --disable-shared --quiet
-make -j4 --quiet | grep -i "error"
-make install --quiet | grep -i "error"
+echo -n "Installing Python 3"
+make -j4 --quiet | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -9,8 +9,8 @@ pre=$(pwd)
 cd Python-3.4.1
 ./configure --prefix=${pre}/py3 --disable-shared --quiet
 echo -n "Installing Python 3"
-make -j4 --quiet | awk '{ if (NR%100 == 0) printf "."}'
-make install --quiet | awk '{ if (NR%100 == 0) printf "."}'
+make -j4 --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
+make install --quiet 2>&1 | awk '{ if (NR%100 == 0) printf "."}'
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -8,8 +8,8 @@ fw_untar Python-3.4.1.tar.xz
 pre=$(pwd)
 cd Python-3.4.1
 ./configure --prefix=${pre}/py3 --disable-shared --quiet
-make -j4 --quiet
-make install --quiet
+make -j4 --quiet | grep -i "error"
+make install --quiet | grep -i "error"
 cd ..
 
 if [ ! -f "get-pip.py" ]; then

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -18,7 +18,7 @@ sudo apt-get -y update
 sudo apt-get -y upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
 # WARNING: DONT PUT A SPACE AFTER ANY BACKSLASH OR APT WILL BREAK
-sudo apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
   cmake build-essential automake    `# Needed for building code` \
   curl wget unzip                   `# Common tools` \
   software-properties-common        `# Needed for add-apt-repository` \
@@ -43,7 +43,7 @@ sudo apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::=
 # Install gcc-4.8
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get -y update
-sudo apt-get install -y gcc-4.8 g++-4.8
+sudo apt-get install -qqy gcc-4.8 g++-4.8
 
 # Stop permanently overwriting people's files just for 
 # trying out our software!


### PR DESCRIPTION
Python and Mono are both established projects with little to no possibility of errors/issues during compilation and install. It really bugs me that in Travis, we run up the 10k line limit with them. Until we develop some way to use the caching mechanism on Travis, this hack should work. 