### PR TITLE
PostgreSQL JDBC driver version bump 

### DIFF
--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
 
 	<dependency>
-	    <groupId>postgresql</groupId>
+	    <groupId>org.postgresql</groupId>
 	    <artifactId>postgresql</artifactId>
 	    <version>9.3-1102-jdbc41</version>
 	</dependency>

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -20,7 +20,7 @@
 	<dependency>
 	    <groupId>postgresql</groupId>
 	    <artifactId>postgresql</artifactId>
-	    <version>9.1-901.jdbc4</version>
+	    <version>9.3-1102-jdbc41</version>
 	</dependency>
             
 

--- a/frameworks/Java/servlet/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/servlet/src/main/webapp/WEB-INF/resin-web.xml
@@ -3,7 +3,7 @@
 <database jndi-name='jdbc/hello_world'>
   <driver>
     <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
     <useUnicode/>
@@ -13,7 +13,7 @@
 <database jndi-name='jdbc/postgres_hello_world'>
   <driver>
     <type>org.postgresql.Driver</type>
-    <url>jdbc:postgresql://127.0.0.1:5432/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:postgresql://localhost:5432/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
   </driver>

--- a/frameworks/Java/servlet/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/servlet/src/main/webapp/WEB-INF/resin-web.xml
@@ -3,7 +3,7 @@
 <database jndi-name='jdbc/hello_world'>
   <driver>
     <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:mysql://127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
     <useUnicode/>
@@ -13,7 +13,7 @@
 <database jndi-name='jdbc/postgres_hello_world'>
   <driver>
     <type>org.postgresql.Driver</type>
-    <url>jdbc:postgresql://localhost:5432/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:postgresql://127.0.0.1:5432/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
   </driver>

--- a/frameworks/Java/undertow-edge/pom.xml
+++ b/frameworks/Java/undertow-edge/pom.xml
@@ -43,8 +43,8 @@
             <version>5.1.25</version>
         </dependency>
         <dependency>
-            <groupId>postgresql</groupId>
-            <artifactId>postgresql</artifactId>
+            <groupId>org.postgresql</groupId>
+	    <artifactId>postgresql</artifactId>
             <version>9.3-1102-jdbc41</version>
 	</dependency>
         <dependency>

--- a/frameworks/Java/undertow-edge/pom.xml
+++ b/frameworks/Java/undertow-edge/pom.xml
@@ -45,8 +45,8 @@
         <dependency>
             <groupId>postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.0-801.jdbc4</version>
-        </dependency>
+            <version>9.3-1102-jdbc41</version>
+	</dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>

--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -34,8 +34,8 @@
             <version>5.1.30</version>
         </dependency>
         <dependency>
-            <groupId>postgresql</groupId>
-            <artifactId>postgresql</artifactId>
+            <groupId>org.postgresql</groupId>
+	    <artifactId>postgresql</artifactId>
             <version>9.3-1102-jdbc41</version>
 	</dependency>
         <dependency>

--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -36,8 +36,8 @@
         <dependency>
             <groupId>postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.1-901-1.jdbc4</version>
-        </dependency>
+            <version>9.3-1102-jdbc41</version>
+	</dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>


### PR DESCRIPTION
Now using version 9.3-1102-jdbc41(for Java 7/8). See the [documentation](http://jdbc.postgresql.org/download.html).
Please note the file: ./installs/resin-4.0.41/webapps/servlet/META-INF/maven/hello.world/world/pom.xml also contains PostgreSQL JDBC driver dependency but it seems it is generated. So I'm not sure where it gets the dependencies. Someone should check.