### PR TITLE
fixed scala-unfiltered

### DIFF
--- a/frameworks/Scala/unfiltered/install.sh
+++ b/frameworks/Scala/unfiltered/install.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 
+fw_depends scala sbt

--- a/frameworks/Scala/unfiltered/setup_unfiltered.py
+++ b/frameworks/Scala/unfiltered/setup_unfiltered.py
@@ -8,7 +8,7 @@ def start(args, logfile, errfile):
   setup_util.replace_text("unfiltered/src/main/resources/application.conf", "jdbc:mysql:\/\/.*:3306", "jdbc:mysql://" + args.database_host + ":3306")
   setup_util.replace_text("unfiltered/src/main/resources/application.conf", "maxThreads = \\d+", "maxThreads = " + str(args.max_threads))
 
-  subprocess.check_call("../sbt/sbt assembly", shell=True, cwd="unfiltered", stderr=errfile, stdout=logfile)
+  subprocess.check_call(args.iroot + "/sbt/bin/sbt assembly", shell=True, cwd="unfiltered", stderr=errfile, stdout=logfile)
   subprocess.Popen("java -jar bench-assembly-1.0.0.jar", shell=True, cwd="unfiltered/target/scala-2.10", stderr=errfile, stdout=logfile)
 
   return 0

--- a/frameworks/Scala/unfiltered/src/main/scala/Plans.scala
+++ b/frameworks/Scala/unfiltered/src/main/scala/Plans.scala
@@ -25,7 +25,7 @@ object Plans extends cycle.Plan
   val db = DatabaseAccess.databases("db.default")
 
   def intent = {
-    case GET(Path("/json")) => JsonContent ~> ResponseString(compact(render("message" -> "Hello world")))
+    case GET(Path("/json")) => JsonContent ~> ResponseString(compact(render("message" -> "Hello, world!")))
     case GET(Path("/db") & Params(params)) =>
       val random = ThreadLocalRandom.current()
       val queries = params.get("queries").flatMap(_.headOption).getOrElse("1").toInt

--- a/toolset/setup/linux/languages/scala.sh
+++ b/toolset/setup/linux/languages/scala.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+fw_get "http://downloads.typesafe.com/scala/2.11.4/scala-2.11.4.tgz"
+fw_untar "scala-2.11.4.tgz"
+


### PR DESCRIPTION
This is a clean fix (no extra express framework changes) of the unfiltered framework. Just like PR #1232 a `scala.sh` installation script needed to be added.
