### PR TITLE
Bump Ninja to version 4.0.0.

### DIFF
--- a/frameworks/Java/ninja-standalone/pom.xml
+++ b/frameworks/Java/ninja-standalone/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java-version>1.7</java-version>
-        <ninja.version>3.3.1</ninja.version>
+        <ninja.version>4.0.0</ninja.version>
         <mysql.version>5.1.26</mysql.version>
         <jetty.version>9.2.1.v20140609</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Ninja 4.0.0 was released last week - that's the update for the TE benchmarks - upgrade is painless... Thanks!