### PR TITLE
Fix fortune insertion for redis

### DIFF
--- a/config/create-redis.sh
+++ b/config/create-redis.sh
@@ -21,5 +21,5 @@ echo "RPUSH fortunes \"Any program that runs right is obsolete.\"" | redis-cli
 echo "RPUSH fortunes \"A list is only as strong as its weakest link. — Donald Knuth\"" | redis-cli
 echo "RPUSH fortunes \"Feature: A bug with seniority.\"" | redis-cli
 echo "RPUSH fortunes \"Computers make very fast, very accurate mistakes.\"" | redis-cli
-echo "RPUSH fortunes \"<script>alert(\\"This should not be displayed in a browser alert box.\\");</script>\"" | redis-cli
+echo "RPUSH fortunes \"<script>alert(\\\"This should not be displayed in a browser alert box.\\\");</script>\"" | redis-cli
 echo "RPUSH fortunes \"フレームワークのベンチマーク\"" | redis-cli


### PR DESCRIPTION
One of the fortunes didn't validate because of missing quotes in the alert.
