### PR TITLE
Change API-Hour version because 0.6.0 release is broken on PyPI

### DIFF
--- a/frameworks/Python/API-Hour/requirements.txt
+++ b/frameworks/Python/API-Hour/requirements.txt
@@ -1,4 +1,4 @@
-api_hour==0.6.0
+api_hour==0.6.1
 aiopg==0.5.2
 gunicorn==19.1.1
 psycopg2==2.5.4


### PR DESCRIPTION
Hi,

I don't know if you have already launch Round 10 benchmark, but for your information, API-Hour 0.6.0 is broken on PyPI, the benchmark won't run.

This is the fix with 0.6.1 release, no code change, I've tested on my laptop.
Tracis-CI is still running, it should prove that.

Regards.