### PR TITLE
Boost python3 performance

### DIFF
--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -6,7 +6,7 @@ RETCODE=$(fw_exists ${IROOT}/py3.installed)
 fw_get http://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz
 fw_untar Python-3.4.2.tar.xz
 cd Python-3.4.2
-./configure --prefix=${IROOT}/py3 --disable-shared --quiet
+./configure --prefix=${IROOT}/py3 --disable-shared --with-computed-gotos --quiet
 make -j4 --quiet
 make install --quiet
 


### PR DESCRIPTION
Hi,

I added `--with-computed-gotos` to compile Python3, because, at least on my computer, it increases +/- 5%.
Normally, you don't need to enable this option, ./configure detects that, but apparently, it doesn't work all the time.

Regards.