### PR TITLE
Fix uwsgi errorlog is written to `--ini` file.

### DIFF
--- a/frameworks/Python/bottle/setup_nginxuwsgi.sh
+++ b/frameworks/Python/bottle/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 ${NGINX_HOME}/sbin/nginx -c ${TROOT}/nginx.conf
-${PY2_ROOT}/bin/uwsgi -d --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app
+${PY2_ROOT}/bin/uwsgi -d ${ERR} --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app

--- a/frameworks/Python/flask/setup_nginxuwsgi.sh
+++ b/frameworks/Python/flask/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf
-${PY2_ROOT}/bin/uwsgi -d --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app
+${PY2_ROOT}/bin/uwsgi -d ${ERR} --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app

--- a/frameworks/Python/uwsgi/setup_nginx.sh
+++ b/frameworks/Python/uwsgi/setup_nginx.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c ${TROOT}/nginx.conf
-$PY2_ROOT/bin/uwsgi -d --ini uwsgi.ini --processes ${MAX_THREADS} --gevent 1000 --wsgi hello
+$PY2_ROOT/bin/uwsgi -d ${ERR} --ini uwsgi.ini --processes ${MAX_THREADS} --gevent 1000 --wsgi hello

--- a/frameworks/Python/wsgi/setup_nginxuwsgi.sh
+++ b/frameworks/Python/wsgi/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf
-$PY2_ROOT/bin/uwsgi -d --ini uwsgi.ini --processes ${MAX_THREADS} --wsgi hello:app
+$PY2_ROOT/bin/uwsgi -d ${ERR} --ini uwsgi.ini --processes ${MAX_THREADS} --wsgi hello:app


### PR DESCRIPTION
uwsgi's `-d` option requires argument specifying file to write errorlog.
Currently, errorlog is written into file named `--ini`. So I cannot see any messages in [err.txt](https://github.com/TechEmpower/TFB-Round-10/blob/master/peak/linux/results-2015-01-21-peak-preview1/latest/logs/bottle-nginx-uwsgi/err.txt).