### PR TITLE
Update Lwan to a version that supports request pipelining.

### DIFF
--- a/frameworks/C/lwan/install.sh
+++ b/frameworks/C/lwan/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV='8ae98d2b6e146948a7ed13e76141e0f69228d690'
+REV='49607addb31879e2aa2b701317773674662315aa'
 
 INSTALLED_FILE="${IROOT}/lwan-${REV}.installed"
 RETCODE=$(fw_exists ${INSTALLED_FILE})


### PR DESCRIPTION
After seeing the abysmal results from Lwan in the preview round, I had to either pull Lwan from the `plaintext` test or lobby @bhauer to make pipelining optional per framework. The first wouldn't be fair to Lwan, the second wouldn't be fair to all of the other frameworks.

So I implemented pipelining support last night. It wasn't that difficult after all; the rule clarification regarding pipelined requests served as a motivator.

This pull requests updates Lwan to the latest version.