### PR TITLE
servlet3-cass updates: use Java 8, fix "source_code" file, upgrade libs

### DIFF
--- a/frameworks/Java/servlet3-cass/bash_profile.sh
+++ b/frameworks/Java/servlet3-cass/bash_profile.sh
@@ -1,2 +1,3 @@
-export JAVA_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64
+export JAVA_HOME=/opt/java8
+export JAVA_EXE=$JAVA_HOME/bin/java
 export RESIN_HOME=${IROOT}/resin-4.0.41

--- a/frameworks/Java/servlet3-cass/install.sh
+++ b/frameworks/Java/servlet3-cass/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-fw_depends java resin maven
+fw_depends java8 resin maven

--- a/frameworks/Java/servlet3-cass/pom.xml
+++ b/frameworks/Java/servlet3-cass/pom.xml
@@ -10,7 +10,7 @@
         <sourceEncoding>UTF-8</sourceEncoding>
         <java.version>1.7</java.version>
 
-        <slf4j.version>1.7.7</slf4j.version>
+        <slf4j.version>1.7.10</slf4j.version>
         <logback.version>1.1.2</logback.version>
     </properties>
 
@@ -22,7 +22,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.2</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.6</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -62,13 +62,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.1</version>
+            <version>2.5.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>2.0.3</version>
+            <version>2.1.4</version>
             <scope>compile</scope>
         </dependency>
 

--- a/frameworks/Java/servlet3-cass/source_code
+++ b/frameworks/Java/servlet3-cass/source_code
@@ -4,8 +4,6 @@
 ./servlet3-cass/src/main/java/fi/markoa
 ./servlet3-cass/src/main/java/fi/markoa/tfb
 ./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3
-./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3/AsyncErrorServlet1.java
-./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3/AsyncErrorServlet2.java
 ./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3/DatabaseBaseServlet.java
 ./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3/DatabaseQueriesServlet.java
 ./servlet3-cass/src/main/java/fi/markoa/tfb/servlet3/DatabaseQueryServlet.java


### PR DESCRIPTION
use Oracle Java 8, delete unnecessary files from source_code file, upgrade libs