### PR TITLE
Update nginx from 1.4.1 to 1.6.2, Resolve #1291

### DIFF
--- a/frameworks/CSharp/aspnet/README.md
+++ b/frameworks/CSharp/aspnet/README.md
@@ -24,7 +24,7 @@
 
 * IIS 8 (Windows)
 * XSP latest (Linux)
-* nginx 1.4.1 & XSP FastCGI (Linux)
+* nginx 1.6.2 & XSP FastCGI (Linux)
 
 **Web Stack**
 

--- a/frameworks/CSharp/nancy/README.md
+++ b/frameworks/CSharp/nancy/README.md
@@ -50,7 +50,7 @@
 **Web Servers**
 
 * IIS 8 (Windows)
-* nginx 1.4.0 & XSP FastCGI (Linux)
+* nginx 1.6.2 & XSP FastCGI (Linux)
 
 **Web Stack**
 

--- a/frameworks/CSharp/servicestack/README.md
+++ b/frameworks/CSharp/servicestack/README.md
@@ -78,7 +78,7 @@
 
 * Self Hosting using HTTPListener (Windows/Linux)
 * IIS 8 (Windows) - includes [Swagger](http://www.nuget.org/packages/ServiceStack.Api.Swagger/)
-* nginx 1.4.0 & XSP FastCGI (Linux)
+* nginx 1.6.2 & XSP FastCGI (Linux)
 
 **Web Stack**
 

--- a/frameworks/Nim/jester/README.md
+++ b/frameworks/Nim/jester/README.md
@@ -10,7 +10,7 @@ This is the Nimrod jester portion of a [benchmarking test suite](../) comparing 
 The tests were run with:
 * [Nimrod 0.9.2](http://www.nimrod-code.org/)
 * [Jester a7914d5](https://github.com/dom96/jester/commit/a7914d5ab918debec24343286b3939ccd3c4619d)
-* Nginx 1.4.1
+* Nginx 1.6.2
 
 ## Test URLs
 

--- a/frameworks/PHP/Yii2/README.md
+++ b/frameworks/PHP/Yii2/README.md
@@ -29,7 +29,7 @@ The tests were run with:
 
 * [Yii2 Version 2](http://yiiframework.com/)
 * [PHP Version 5.4.*](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/cakephp/README.md
+++ b/frameworks/PHP/cakephp/README.md
@@ -20,7 +20,7 @@ The tests were run with:
 
 * [Cake Version 2.3.0](http://cakephp.org/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 Cake Debug mode is set to 0 in [core.php](app/Config/core.php), as

--- a/frameworks/PHP/codeigniter/README.md
+++ b/frameworks/PHP/codeigniter/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [Codeigniter Version 2.1.3](http://ellislab.com/codeigniter)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/fuel/README.md
+++ b/frameworks/PHP/fuel/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [FuelPHP 1.5.3](http://fuelphp.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/kohana/README.md
+++ b/frameworks/PHP/kohana/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [Kohana Version 3.3.0](http://kohanaframework.org/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/lithium/README.md
+++ b/frameworks/PHP/lithium/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [Lithium Version 0.11](http://lithify.me)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-laravel/readme.md
+++ b/frameworks/PHP/php-laravel/readme.md
@@ -24,7 +24,7 @@ The tests were run with:
 
 * [Laravel Version 4.2](http://laravel.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.1](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-micromvc/README.md
+++ b/frameworks/PHP/php-micromvc/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [Micromvc 4.0.0](http://www.micromvc.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-phalcon-micro/README.md
+++ b/frameworks/PHP/php-phalcon-micro/README.md
@@ -24,7 +24,7 @@ The tests were run with:
 
 * [Phalcon 1.0.0](http://phalconphp.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM, APC and Phalcon extension
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-phalcon/README.md
+++ b/frameworks/PHP/php-phalcon/README.md
@@ -25,7 +25,7 @@ The tests were run with:
 
 * [Phalcon 1.0.0](http://phalconphp.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM, APC and Phalcon extension
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 * [MongoDB 2.4.8](https://mongodb.org/)
 

--- a/frameworks/PHP/php-pimf/README.md
+++ b/frameworks/PHP/php-pimf/README.md
@@ -24,7 +24,7 @@ The tests were run with:
 
 * [PIMF Version 1.8.6](http://pimf-framework.de/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-silex-orm/README.md
+++ b/frameworks/PHP/php-silex-orm/README.md
@@ -20,7 +20,7 @@ The tests were run with:
 * [Silex Version 1.0](http://silex.sensiolabs.org/)
 * [Doctrine ORM Service Provider](https://github.com/dflydev/dflydev-doctrine-orm-service-provider)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.2.7](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-silex/README.md
+++ b/frameworks/PHP/php-silex/README.md
@@ -19,7 +19,7 @@ The tests were run with:
 
 * [Silex Version 1.0](http://silex.sensiolabs.org/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-slim/README.md
+++ b/frameworks/PHP/php-slim/README.md
@@ -20,7 +20,7 @@ The tests were run with:
 * [Slim 2.2.0](http://www.slimframework.com/)
 * [RedBeanPHP 3.4.2](http://redbeanphp.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php-yaf/README.md
+++ b/frameworks/PHP/php-yaf/README.md
@@ -21,7 +21,7 @@ The tests were run with:
 
 * [YAF 2.2.9](http://www.yafdev.com/)
 * [PHP Version 5.4.14](http://www.php.net/) with FPM, APC and YAF extension
-* [nginx 1.2.8](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.31](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/php/README.md
+++ b/frameworks/PHP/php/README.md
@@ -16,7 +16,7 @@ Use the PHP standard [JSON encoder](http://www.php.net/manual/en/function.json-e
 The tests were run with:
 
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 * [PHP ActiveRecord Nightly 20121221](http://www.phpactiverecord.org/)
 

--- a/frameworks/PHP/symfony2-stripped/README.md
+++ b/frameworks/PHP/symfony2-stripped/README.md
@@ -25,7 +25,7 @@ The tests were run with:
 
 * [Symfony Version 2.2.1](http://symfony.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/symfony2/README.md
+++ b/frameworks/PHP/symfony2/README.md
@@ -35,7 +35,7 @@ The tests were run with:
 
 * [Symfony Version 2.2.1](http://symfony.com/)
 * [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
+* [nginx 1.6.2](http://nginx.org/)
 * [MySQL 5.5.29](https://dev.mysql.com/)
 
 ## Test URLs

--- a/toolset/setup/linux/webservers/nginx.sh
+++ b/toolset/setup/linux/webservers/nginx.sh
@@ -3,9 +3,9 @@
 RETCODE=$(fw_exists ${IROOT}/nginx.installed)
 [ ! "$RETCODE" == 0 ] || { return 0; }
 
-fw_get http://nginx.org/download/nginx-1.4.1.tar.gz
-fw_untar nginx-1.4.1.tar.gz
-cd nginx-1.4.1
+fw_get http://nginx.org/download/nginx-1.6.2.tar.gz
+fw_untar nginx-1.6.2.tar.gz
+cd nginx-1.6.2
 
 # There is no --quiet flag that I could find...
 echo "Configuring nginx..."


### PR DESCRIPTION
Update nginx version from 1.4.1 to the latest stable version 1.6.2 resolves issue #1291. From what I can tell everything is running fine without updating the nginx config file.

Tests with nginx (from what I could quickly get from the benchmark_configs):
* Csharp: 
  * aspnet-mono
  * aspnet-mono-jsonnet
  * aspnet-mono-servicestack
  * aspnet-mono-mysql-raw
  * aspnet-mono-postgresql-raw
  * aspnet-mono-mongodb-raw
  * aspnet-mono-mysql-entityframework
  * aspnet-mono-postgresql-entityframework
  * nancy-mono
  * nancy-libevent2
  * servicestack-nginx-default
  * servicestack-nginx-sqlserver
  * servicestack-nginx-postgresql
  * servicestack-nginx-mongodb
* Dart:
  * start-postgresql-raw
  * start-mongodb-raw
  * stream-postgresql-raw
  * stream-mongodb-raw
* Lua: 
  * lapis
  * openresty
* Nim: 
  * jester
* PHP: 
  * yii2
  * cakephp
  * codeigniter
  * codeigniter-raw
  * fuel
  * hhvm
  * php-kahona
  * php-kahona-raw
  * lithium
  * fat-free
  * fat-free-raw
  * laravel
  * larravel-raw
  * micromvc
  * php-phalcon-micro
  * php-phalcon
  * php-phalcon-mongodb
  * php-phpixie
  * pimf
  * pimf-raw
  * silex-orm
  * silex
  * silex-raw
  * slim
  * yaf-raw
  * ZendFramework
  * ZendFramework1
  * php
  * php-raw
  * phreeze
  * symfony2-stripped
  * symfony2-stripped-php-templates
  * symfony2-stripped-raw
  * symfony2
  * symfony2-php-templates
  * symfony2-raw
* Perl: 
  * plack
  * bottle-nginx-uwsgi
  * flask-nginx-uwsgi
* Phython: 
  * uwsgi-nginx-uwsgi
  * wsgi-nginx-uwsgi
* Ruby: 
  * ngx_mruby
  * padrino 

Everything appears to be running fine in my private Travis, except for Perl (see issue #1366).