### PR TITLE
uwsgi: Stop using -d option

### DIFF
--- a/frameworks/Python/bottle/setup_nginxuwsgi.sh
+++ b/frameworks/Python/bottle/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 ${NGINX_HOME}/sbin/nginx -c ${TROOT}/nginx.conf
-${PY2_ROOT}/bin/uwsgi -d ${ERR} --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app
+${PY2_ROOT}/bin/uwsgi --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app &

--- a/frameworks/Python/flask/setup_nginxuwsgi.sh
+++ b/frameworks/Python/flask/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf
-${PY2_ROOT}/bin/uwsgi -d ${ERR} --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app
+${PY2_ROOT}/bin/uwsgi --ini ${TROOT}/uwsgi.ini --processes ${MAX_THREADS} --wsgi app:app &

--- a/frameworks/Python/uwsgi/setup_nginx.sh
+++ b/frameworks/Python/uwsgi/setup_nginx.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c ${TROOT}/nginx.conf
-$PY2_ROOT/bin/uwsgi -d ${ERR} --ini uwsgi.ini --processes ${MAX_THREADS} --gevent 1000 --wsgi hello
+$PY2_ROOT/bin/uwsgi --ini uwsgi.ini --processes ${MAX_THREADS} --gevent 1000 --wsgi hello &

--- a/frameworks/Python/wsgi/setup_nginxuwsgi.sh
+++ b/frameworks/Python/wsgi/setup_nginxuwsgi.sh
@@ -3,4 +3,4 @@
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
 $NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf
-$PY2_ROOT/bin/uwsgi -d ${ERR} --ini uwsgi.ini --processes ${MAX_THREADS} --wsgi hello:app
+$PY2_ROOT/bin/uwsgi --ini uwsgi.ini --processes ${MAX_THREADS} --wsgi hello:app &


### PR DESCRIPTION
err.txt in Round10 preview2 was broken.
https://github.com/TechEmpower/TFB-Round-10/blob/master/peak/linux/results-2015-02-26-peak-preview2/latest/logs/bottle-nginx-uwsgi/err.txt

While uwsgi is safe to write errorlog concurrently, other tool may
conflict somewhat.

This commit makes uwsgi writes errorlog to stderr.
It may (and may not) fix the errorlog.