### PR TITLE
Remove Running PID if Present for All Java Play2 Variations, Resolve #1377

### DIFF
--- a/frameworks/Java/play2-java/setup_java.sh
+++ b/frameworks/Java/play2-java/setup_java.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 cd play2-java
+
+# If application is running, clear old running app.
+if [ -f ${TROOT}/play2-java/target/universal/stage/RUNNING_PID ]
+then
+  rm -f -r ${TROOT}/play2-java/target/universal/stage/RUNNING_PID
+fi
+
 ${IROOT}/sbt/bin/sbt stage
 target/universal/stage/bin/play2-java &

--- a/frameworks/Java/play2-java/setup_java_ebean_bonecp.sh
+++ b/frameworks/Java/play2-java/setup_java_ebean_bonecp.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 cd play2-java-ebean-bonecp
+
+# If application is running, clear old running app.
+if [ -f ${TROOT}/play2-java-ebean-bonecp/target/universal/stage/RUNNING_PID ]
+then
+  rm -f -r ${TROOT}/play2-java-ebean-bonecp/target/universal/stage/RUNNING_PID
+fi
+
 ${IROOT}/sbt/bin/sbt stage
 target/universal/stage/bin/play2-java-ebean-bonecp &

--- a/frameworks/Java/play2-java/setup_java_ebean_hikaricp.sh
+++ b/frameworks/Java/play2-java/setup_java_ebean_hikaricp.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 cd play2-java-ebean-hikaricp
+
+# If application is running, clear old running app.
+if [ -f ${TROOT}/play2-java-ebean-hikaricp/target/universal/stage/RUNNING_PID ]
+then
+  rm -f -r ${TROOT}/play2-java-ebean-hikaricp/target/universal/stage/RUNNING_PID
+fi
+
 ${IROOT}/sbt/bin/sbt stage
 target/universal/stage/bin/play2-java-ebean-hikaricp &

--- a/frameworks/Java/play2-java/setup_java_jpa_bonecp.sh
+++ b/frameworks/Java/play2-java/setup_java_jpa_bonecp.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 cd play2-java-jpa-bonecp
+
+# If application is running, clear old running app.
+if [ -f ${TROOT}/play2-java-jpa-bonecp/target/universal/stage/RUNNING_PID ]
+then
+  rm -f -r ${TROOT}/play2-java-jpa-bonecp/target/universal/stage/RUNNING_PID
+fi
+
 ${IROOT}/sbt/bin/sbt stage
 target/universal/stage/bin/play2-java-jpa-bonecp &

--- a/frameworks/Java/play2-java/setup_java_jpa_hikaricp.sh
+++ b/frameworks/Java/play2-java/setup_java_jpa_hikaricp.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
 cd play2-java-jpa-hikaricp
+
+# If application is running, clear old running app.
+if [ -f ${TROOT}/play2-java-jpa-hikaricp/target/universal/stage/RUNNING_PID ]
+then
+  rm -f -r ${TROOT}/play2-java-jpa-hikaricp/target/universal/stage/RUNNING_PID
+fi
+
 ${IROOT}/sbt/bin/sbt stage
 target/universal/stage/bin/play2-java-jpa-hikaricp &


### PR DESCRIPTION
When preview 2 of round 10 ran these tests didn't run. It appears to be because there were issues with a running pid already existing. So, we need to remove the running pid if it exists for each test. 

Here is an example of the error from the preview: 
```bash
Play server process ID is 19810
This application is already running (Or delete /home/techempower/FrameworkBenchmarks/frameworks/Java/play2-java/play2-java/target/universal/stage/RUNNING_PID file).
--------------------------------------------------------------------------------
```

The same thing is set up for the Scala Play2 frameworks and they didn't have issues during the preview round.