### PR TITLE
Upgrading Curacao benchmark libraries to Jetty 9.2.9.v20150224 and Curacao 2.9-M1

### DIFF
--- a/frameworks/Java/curacao/build.sbt
+++ b/frameworks/Java/curacao/build.sbt
@@ -13,9 +13,9 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.kolich.curacao" % "curacao" % "2.6.3" % "compile",
-  "com.kolich.curacao" % "curacao-gson" % "2.6.3" % "compile",
-  "org.eclipse.jetty" % "jetty-webapp" % "9.2.3.v20140905" % "compile",
+  "com.kolich.curacao" % "curacao" % "2.9-M1" % "compile",
+  "com.kolich.curacao" % "curacao-gson" % "2.9-M1" % "compile",
+  "org.eclipse.jetty" % "jetty-webapp" % "9.2.9.v20150224" % "compile",
   "javax.servlet" % "javax.servlet-api" % "3.0.1" % "provided",
   "org.slf4j" % "slf4j-api" % "1.7.2" % "compile",
   "ch.qos.logback" % "logback-core" % "1.0.7" % "compile",

--- a/frameworks/Java/curacao/src/main/java/benchmark/Benchmarks.java
+++ b/frameworks/Java/curacao/src/main/java/benchmark/Benchmarks.java
@@ -2,8 +2,8 @@ package benchmark;
 
 import benchmark.entities.HelloWorld;
 import com.kolich.curacao.annotations.Controller;
-import com.kolich.curacao.annotations.methods.RequestMapping;
-import com.kolich.curacao.handlers.requests.matchers.AntPathMatcher;
+import com.kolich.curacao.annotations.RequestMapping;
+import com.kolich.curacao.mappers.request.matchers.AntPathMatcher;
 
 @Controller
 public final class Benchmarks {


### PR DESCRIPTION
Upgrading the versions of 2 libraries used in the Curacao benchmark:
* Curacao 2.9-M1
* Jetty 9.2.9.v20150224