### PR TITLE
Fix play2 scala mongodb test display name typo

### DIFF
--- a/frameworks/Scala/play2-scala/benchmark_config
+++ b/frameworks/Scala/play2-scala/benchmark_config
@@ -98,7 +98,7 @@
         "webserver": "None",
         "os": "Linux",
         "database_os": "Linux",
-        "display_name": "play2-scala-rmongo",
+        "display_name": "play2-scala-mongodb",
         "notes": "Uses Reactive Mongo",
         "versus": "netty"
       }


### PR DESCRIPTION
I noticed there was a typo in the display_name value for play2 scala mongodb. Just a minor correction.