### PR TITLE
Port Mojolicious to Postgres

### DIFF
--- a/frameworks/Perl/mojolicious/benchmark_config
+++ b/frameworks/Perl/mojolicious/benchmark_config
@@ -12,7 +12,7 @@
       "port": 8080,
       "approach": "Realistic",
       "classification": "Fullstack",
-      "database": "MongoDB",
+      "database": "Postgres",
       "framework": "mojolicious",
       "language": "Perl",
       "orm": "Raw",

--- a/frameworks/Perl/mojolicious/cpanfile
+++ b/frameworks/Perl/mojolicious/cpanfile
@@ -1,5 +1,5 @@
-requires 'Mojolicious', '>= 5.29';
-requires 'Mango', '>= 1.0';
+requires 'Mojolicious', '>= 6.02';
+requires 'Mojo::Pg', '>= 1.14';
 requires 'JSON::XS';
 requires 'EV';
 

--- a/frameworks/Perl/mojolicious/cpanfile.snapshot
+++ b/frameworks/Perl/mojolicious/cpanfile.snapshot
@@ -1,5 +1,112 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
+  DBD-Pg-3.5.1
+    pathname: T/TU/TURNSTEP/DBD-Pg-3.5.1.tar.gz
+    provides:
+      Bundle::DBD::Pg v3.5.1
+      DBD::Pg v3.5.1
+    requirements:
+      DBI 1.614
+      ExtUtils::MakeMaker 6.11
+      Test::More 0.88
+      Time::HiRes 0
+      version 0
+  DBI-1.633
+    pathname: T/TI/TIMB/DBI-1.633.tar.gz
+    provides:
+      Bundle::DBI 12.008696
+      DBD::DBM 0.08
+      DBD::DBM::Statement 0.08
+      DBD::DBM::Table 0.08
+      DBD::DBM::db 0.08
+      DBD::DBM::dr 0.08
+      DBD::DBM::st 0.08
+      DBD::ExampleP 12.014311
+      DBD::ExampleP::db 12.014311
+      DBD::ExampleP::dr 12.014311
+      DBD::ExampleP::st 12.014311
+      DBD::File 0.44
+      DBD::File::DataSource::File 0.44
+      DBD::File::DataSource::Stream 0.44
+      DBD::File::Statement 0.44
+      DBD::File::Table 0.44
+      DBD::File::TableSource::FileSystem 0.44
+      DBD::File::db 0.44
+      DBD::File::dr 0.44
+      DBD::File::st 0.44
+      DBD::Gofer 0.015327
+      DBD::Gofer::Policy::Base 0.010088
+      DBD::Gofer::Policy::classic 0.010088
+      DBD::Gofer::Policy::pedantic 0.010088
+      DBD::Gofer::Policy::rush 0.010088
+      DBD::Gofer::Transport::Base 0.014121
+      DBD::Gofer::Transport::corostream undef
+      DBD::Gofer::Transport::null 0.010088
+      DBD::Gofer::Transport::pipeone 0.010088
+      DBD::Gofer::Transport::stream 0.014599
+      DBD::Gofer::db 0.015327
+      DBD::Gofer::dr 0.015327
+      DBD::Gofer::st 0.015327
+      DBD::NullP 12.014715
+      DBD::NullP::db 12.014715
+      DBD::NullP::dr 12.014715
+      DBD::NullP::st 12.014715
+      DBD::Proxy 0.2004
+      DBD::Proxy::RPC::PlClient 0.2004
+      DBD::Proxy::db 0.2004
+      DBD::Proxy::dr 0.2004
+      DBD::Proxy::st 0.2004
+      DBD::Sponge 12.010003
+      DBD::Sponge::db 12.010003
+      DBD::Sponge::dr 12.010003
+      DBD::Sponge::st 12.010003
+      DBDI 12.015129
+      DBI 1.633
+      DBI::Const::GetInfo::ANSI 2.008697
+      DBI::Const::GetInfo::ODBC 2.011374
+      DBI::Const::GetInfoReturn 2.008697
+      DBI::Const::GetInfoType 2.008697
+      DBI::DBD 12.015129
+      DBI::DBD::Metadata 2.014214
+      DBI::DBD::SqlEngine 0.06
+      DBI::DBD::SqlEngine::DataSource 0.06
+      DBI::DBD::SqlEngine::Statement 0.06
+      DBI::DBD::SqlEngine::Table 0.06
+      DBI::DBD::SqlEngine::TableSource 0.06
+      DBI::DBD::SqlEngine::TieMeta 0.06
+      DBI::DBD::SqlEngine::TieTables 0.06
+      DBI::DBD::SqlEngine::db 0.06
+      DBI::DBD::SqlEngine::dr 0.06
+      DBI::DBD::SqlEngine::st 0.06
+      DBI::FAQ 1.014935
+      DBI::Gofer::Execute 0.014283
+      DBI::Gofer::Request 0.012537
+      DBI::Gofer::Response 0.011566
+      DBI::Gofer::Serializer::Base 0.009950
+      DBI::Gofer::Serializer::DataDumper 0.009950
+      DBI::Gofer::Serializer::Storable 0.015586
+      DBI::Gofer::Transport::Base 0.012537
+      DBI::Gofer::Transport::pipeone 0.012537
+      DBI::Gofer::Transport::stream 0.012537
+      DBI::Profile 2.015065
+      DBI::ProfileData 2.010008
+      DBI::ProfileDumper 2.015325
+      DBI::ProfileDumper::Apache 2.014121
+      DBI::ProfileSubs 0.009396
+      DBI::ProxyServer 0.3005
+      DBI::ProxyServer::db 0.3005
+      DBI::ProxyServer::dr 0.3005
+      DBI::ProxyServer::st 0.3005
+      DBI::SQL::Nano 1.015544
+      DBI::SQL::Nano::Statement_ 1.015544
+      DBI::SQL::Nano::Table_ 1.015544
+      DBI::Util::CacheMemory 0.010315
+      DBI::Util::_accessor 0.009479
+      DBI::common 1.633
+    requirements:
+      ExtUtils::MakeMaker 6.48
+      Test::Simple 0.90
+      perl 5.008
   EV-4.18
     pathname: M/ML/MLEHMANN/EV-4.18.tar.gz
     provides:
@@ -24,31 +131,19 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Types::Serialiser 0
       common::sense 0
-  Mango-1.16
-    pathname: O/OD/ODC/Mango-1.16.tar.gz
+  Mojo-Pg-1.14
+    pathname: S/SR/SRI/Mojo-Pg-1.14.tar.gz
     provides:
-      Mango 1.16
-      Mango::BSON undef
-      Mango::BSON::Binary undef
-      Mango::BSON::Code undef
-      Mango::BSON::Document undef
-      Mango::BSON::ObjectID undef
-      Mango::BSON::Time undef
-      Mango::BSON::Timestamp undef
-      Mango::BSON::_MaxKey undef
-      Mango::BSON::_MinKey undef
-      Mango::Bulk undef
-      Mango::Collection undef
-      Mango::Cursor undef
-      Mango::Cursor::Query undef
-      Mango::Database undef
-      Mango::GridFS undef
-      Mango::GridFS::Reader undef
-      Mango::GridFS::Writer undef
-      Mango::Protocol undef
+      Mojo::Pg 1.14
+      Mojo::Pg::Database undef
+      Mojo::Pg::Migrations undef
+      Mojo::Pg::PubSub undef
+      Mojo::Pg::Results undef
+      Mojo::Pg::Transaction undef
     requirements:
+      DBD::Pg 0
       ExtUtils::MakeMaker 0
-      Mojolicious 5.40
+      Mojolicious 6.0
       perl 5.010001
   Mojolicious-6.02
     pathname: S/SR/SRI/Mojolicious-6.02.tar.gz

--- a/frameworks/Perl/mojolicious/cpanfile.snapshot
+++ b/frameworks/Perl/mojolicious/cpanfile.snapshot
@@ -50,8 +50,8 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Mojolicious 5.40
       perl 5.010001
-  Mojolicious-5.81
-    pathname: S/SR/SRI/Mojolicious-5.81.tar.gz
+  Mojolicious-6.02
+    pathname: S/SR/SRI/Mojolicious-6.02.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
@@ -114,7 +114,7 @@ DISTRIBUTIONS
       Mojo::UserAgent::Server undef
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
-      Mojolicious 5.81
+      Mojolicious 6.02
       Mojolicious::Command undef
       Mojolicious::Command::cgi undef
       Mojolicious::Command::cpanify undef

--- a/frameworks/Perl/mojolicious/setup.sh
+++ b/frameworks/Perl/mojolicious/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+export LIBEV_FLAGS=7
 HYPNOTOAD=$(${PERL_HOME}/bin/carton exec which hypnotoad)
 ${PERL_HOME}/bin/carton exec ${PERL_HOME}/bin/perl ${HYPNOTOAD} ${TROOT}/app.pl


### PR DESCRIPTION
Mojo's old MongoDB driver has been abandoned because they kept changing their wire protocol out from under us. It seems that the mongodb version that broke caught up to this app. I have thus done a quick port to Postgres. The structure of the app is all completely the same.