### PR TITLE
Remove syslog logging

### DIFF
--- a/frameworks/Python/API-Hour/hello/etc/hello/api_hour/logging.ini
+++ b/frameworks/Python/API-Hour/hello/etc/hello/api_hour/logging.ini
@@ -31,41 +31,41 @@ formatter=detailed
 
 [logger_root]
 level=ERROR
-handlers=console,syslog
+handlers=console
 
 # You can add smtp in handlers list to receive e-mail alerts
 [logger_warnings]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=py.warnings
 propagate=0
 
 [logger_asyncio]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=asyncio
 propagate=0
 
 [logger_gunicorn]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=gunicorn
 propagate=0
 
 [logger_aiohttp]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=aiohttp
 propagate=0
 
 [logger_api_hour]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=api_hour
 propagate=0
 
 [logger_hello]
 level=WARN
-handlers=console,syslog
+handlers=console
 qualname=hello
 propagate=0


### PR DESCRIPTION
On the server where you launch API-Hour, you certainly have a lot of logs in /var/log/*.
This PR disable syslog logging from API-Hour.