### PR TITLE
Reduce pgsql socket pool to match 2000 maximum connections

### DIFF
--- a/frameworks/Python/API-Hour/hello/etc/hello/main/main.yaml
+++ b/frameworks/Python/API-Hour/hello/etc/hello/main/main.yaml
@@ -1,3 +1,4 @@
+---
 engines:
   pg:
     host: 127.0.0.1
@@ -5,5 +6,5 @@ engines:
     dbname: hello_world
     user: benchmarkdbuser
     password: benchmarkdbpass
-    minsize: 40
-    maxsize: 40
+    minsize: 22
+    maxsize: 22


### PR DESCRIPTION
As discussed on ML, I've reduced pgsql socket pool to match 2000 maximum connections.

Thanks for the merge.