### PR TITLE
Fixed validation warnings for Yesod and Snap

### DIFF
--- a/frameworks/Haskell/snap/benchmark_config
+++ b/frameworks/Haskell/snap/benchmark_config
@@ -5,7 +5,7 @@
       "setup_file": "setup",
       "json_url": "/json",
       "db_url": "/db",
-      "query_url": "/db?queries=",
+      "query_url": "/dbs?queries=",
       "plaintext_url": "/plaintext",
       "port": 8000,
       "approach": "Realistic",


### PR DESCRIPTION
This should fix the warnings for the multiple queries tests for Yesod and Snap when given bad input for the number of queries. For Yesod this should include the MongoDB tests as well as the MySQL tests, but for some reason the MongoDB queries randomly fail causing Yesod to return an error. This means it will likely fail when the number of queries is high (e.g. the max of 500).