### PR TITLE
Vagrant Scripts: Fix Typo, Increase Memory

### DIFF
--- a/deployment/vagrant-common/checks.rb
+++ b/deployment/vagrant-common/checks.rb
@@ -81,7 +81,7 @@ To workaround, consider using the Amazon (e.g. AWS) provider
    $ vagrant up --provider=aws
 
 Or forcing FrameworkBenchmarks to attempt a 32-bit VM
-   $ TFB_VM_ARCH=32 vagrant up
+   $ TFB_VB_ARCH=32 vagrant up
   
   See http://askubuntu.com/questions/41550 for more info\033[0m"
 

--- a/deployment/vagrant-common/core.rb
+++ b/deployment/vagrant-common/core.rb
@@ -95,7 +95,7 @@ def provider_virtualbox(config, role, ip_address='172.16.0.16')
       vb.gui = true
     end
 
-    vb.memory = ENV.fetch('TFB_VB_MEM', 2048)
+    vb.memory = ENV.fetch('TFB_VB_MEM', 3022)
     vb.cpus = ENV.fetch('TFB_VB_CPU', 2)
 
     # mount_options addresses issue mitchellh/vagrant#4997


### PR DESCRIPTION
* Updated `TFB_VM_ARCH` to `TFB_VB_ARCH`. It appeared that `TFB_VB_ARCH` was the intended name.
* Increase memory. All tests with postgres were failing with 2048MB of memory.