### PR TITLE
Add warning to remove results dir if test exists there, Resolve #1448

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -526,6 +526,7 @@ class Benchmarker:
       out.write("self.results['completed']: {completed}\n".format(completed=str(self.results['completed'])))
       if self.results['frameworks'] != None and test.name in self.results['completed']:
         out.write('Framework {name} found in latest saved data. Skipping.\n'.format(name=str(test.name)))
+        print 'WARNING: Test {test} exists in the results directory; this must be removed before running a new test.\n'.format(test=str(test.name))
         return exit_with_code(1)
       out.flush()
 


### PR DESCRIPTION
I realized that the "NO RESULTS (Did framework launch?)" error wasn't necessarily when the test doesn't exist in the results directory. Instead, I added the error to print on on the console with a warning that explains why the test isn't updating. Here's an example of what that looks like: 
 
![warning](https://cloud.githubusercontent.com/assets/4926965/6909045/4ad20c72-d6f7-11e4-90b4-62da93435f64.png)
