### PR TITLE
Fixed PHP install and silex-raw #720

### DIFF
--- a/frameworks/PHP/php-silex/benchmark_config
+++ b/frameworks/PHP/php-silex/benchmark_config
@@ -3,8 +3,9 @@
   "tests": [{
     "default": {
       "setup_file": "setup",
+      "json_url": "/json",
       "db_url": "/db",
-      "query_url": "/db?queries=",
+      "query_url": "/queries?queries=",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Micro",

--- a/frameworks/PHP/php-silex/setup.sh
+++ b/frameworks/PHP/php-silex/setup.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-sed -i 's|192.168.100.102|'"${DBHOST}"'|g' web/index.php
+sed -i 's|localhost|'"${DBHOST}"'|g' web/index.php
 sed -i 's|".*\FrameworkBenchmarks/php-silex|"'"${TROOT}"'|g' deploy/php-silex
 sed -i 's|Directory .*/FrameworkBenchmarks/php-silex|Directory '"${TROOT}"'|g' deploy/php-silex
 sed -i 's|root .*/FrameworkBenchmarks/php-silex|root '"${TROOT}"'|g' deploy/nginx.conf
 sed -i 's|/usr/local/nginx/|'"${IROOT}"'/nginx/|g' deploy/nginx.conf
 
+PHP_HOME=${IROOT}/php-5.5.17
+
 export PATH="$COMPOSER_HOME:$PHP_HOME/bin:$PHP_HOME/sbin:$PATH"
 
-composer.phar install --optimize-autoloader
+${PHP_HOME}/bin/php ${IROOT}/composer.phar install --optimize-autoloader
 $PHP_FPM --fpm-config $FWROOT/config/php-fpm.conf -g $TROOT/deploy/php-fpm.pid
 $NGINX_HOME/sbin/nginx -c $TROOT/deploy/nginx.conf

--- a/frameworks/PHP/php-silex/setup_raw.sh
+++ b/frameworks/PHP/php-silex/setup_raw.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-sed -i 's|192.168.100.102|'"${DBHOST}"'|g' web/index_raw.php
+sed -i 's|localhost|'"${DBHOST}"'|g' web/index_raw.php
 sed -i 's|".*\FrameworkBenchmarks/php-silex|"'"${TROOT}"'|g' deploy/php-silex
 sed -i 's|Directory .*/FrameworkBenchmarks/php-silex|Directory '"${TROOT}"'|g' deploy/php-silex
 sed -i 's|root .*/FrameworkBenchmarks/php-silex|root '"${TROOT}"'|g' deploy/nginx_raw.conf
 sed -i 's|/usr/local/nginx/|'"${IROOT}"'/nginx/|g' deploy/nginx_raw.conf
 
+PHP_HOME=${IROOT}/php-5.5.17
+
 export PATH="$COMPOSER_HOME:$PHP_HOME/bin:$PHP_HOME/sbin:$PATH"
 
-composer.phar install --optimize-autoloader
+${PHP_HOME}/bin/php ${IROOT}/composer.phar install --optimize-autoloader
 $PHP_FPM --fpm-config $FWROOT/config/php-fpm.conf -g $TROOT/deploy/php-fpm.pid
 $NGINX_HOME/sbin/nginx -c $TROOT/deploy/nginx_raw.conf

--- a/frameworks/PHP/php-silex/web/index.php
+++ b/frameworks/PHP/php-silex/web/index.php
@@ -9,7 +9,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Silex\Application();
 
-$dbh = new PDO('mysql:host=192.168.100.102;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$dbh = new PDO('mysql:host=localhost;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
     PDO::ATTR_PERSISTENT => true
 ));
 
@@ -24,21 +24,33 @@ $app->get('/json', function() {
 });
 
 $app->get('/db', function(Request $request) use ($app) {
+    $world = $app['db']->fetchAssoc('SELECT * FROM World WHERE id = ?', array(mt_rand(1, 10000)));
+    $world['id'] = (int) $world['id'];
+    $world['randomNumber'] = (int) $world['randomNumber'];
+
+    return new JsonResponse($world);
+});
+
+$app->get('/queries', function(Request $request) use ($app) {
     $queries = $request->query->getInt('queries', 1);
+    if ($queries < 1) {
+        $queries = 1;
+    }
+    elseif ($queries > 500) {
+        $queries = 500;
+    }
     // possibility for micro enhancement could be the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
     $worlds = array();
 
     for($i = 0; $i < $queries; ++$i) {
-        $worlds[] = $app['db']->fetchAssoc('SELECT * FROM World WHERE id = ?', array(mt_rand(1, 10000)));
-    }
-
-    if (count($worlds) == 1) {
-        $worlds = $worlds[0];
+        $world = $app['db']->fetchAssoc('SELECT * FROM World WHERE id = ?', array(mt_rand(1, 10000)));
+        $world['id'] = (int) $world['id'];
+        $world['randomNumber'] = (int) $world['randomNumber'];
+        $worlds[] = $world;
     }
 
     return new JsonResponse($worlds);
 });
-
 
 $app->run();
 

--- a/toolset/setup/linux/languages/php.sh
+++ b/toolset/setup/linux/languages/php.sh
@@ -22,7 +22,7 @@ echo "Configuring PHP quietly..."
 ./configure --prefix=$IROOT/php-${VERSION} --with-pdo-mysql \
   --with-mysql --with-mcrypt --enable-intl --enable-mbstring \
   --enable-fpm --with-fpm-user=testrunner --with-fpm-group=testrunner \
-  --with-openssl --enable-opcache --quiet
+  --with-openssl --with-mysqli --with-zlib --enable-opcache --quiet
 echo "Making PHP quietly..."
 make --quiet
 echo "Installing PHP quietly"
@@ -40,6 +40,7 @@ cp $FWROOT/config/php-fpm.conf $IROOT/php-${VERSION}/lib/php-fpm.conf
 # ========================
 echo PHP compilation finished, installing extensions
 
+$IROOT/php-${VERSION}/bin/pecl channel-update pecl.php.net
 # Apc.so
 $IROOT/php-${VERSION}/bin/pecl config-set php_ini $IROOT/php-${VERSION}/lib/php.ini
 #printf "\n" | $IROOT/php-5.5.17/bin/pecl install -f apc-beta


### PR DESCRIPTION
Fixed the PHP install so that silex-raw successfully runs. Fixes #720. Also fixed validation warnings for both silex and silex-raw. Since this affects the PHP installation script PHP will have to be reinstalled if you already have it installed. This might also help address some of the issues we've had running other PHP frameworks (see #1406).