### PR TITLE
start distinct Go process per 2 (virtual) cores.

### DIFF
--- a/frameworks/Go/go/benchmark_config
+++ b/frameworks/Go/go/benchmark_config
@@ -23,6 +23,29 @@
       "display_name": "go",
       "notes": "",
       "versus": "go"
+    },
+    "prefork": {
+      "setup_file": "setup_prefork",
+      "json_url": "/json",
+      "db_url": "/db",
+      "query_url": "/queries?queries=",
+      "fortune_url": "/fortune",
+      "update_url": "/update?queries=",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
+      "framework": "go",
+      "language": "Go",
+      "orm": "Raw",
+      "platform": "Go",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "go",
+      "notes": "",
+      "versus": "go"
     }
   }]
 }

--- a/frameworks/Go/go/setup_prefork.sh
+++ b/frameworks/Go/go/setup_prefork.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sed -i 's|tcp(.*:3306)|tcp('"${DBHOST}"':3306)|g' src/hello/hello.go
+
+# Where to find the go executable
+export PATH="$GOROOT/bin:$PATH"
+
+go get ./...
+
+go run src/hello/hello.go -prefork &


### PR DESCRIPTION
It is very similar to usage nodejs cluster package or Ruby Unicorn server, so i think it is legitimate.

It is simple version, just to benchmark, but it could be easily extended to match Ruby Unicorn or nodejs cluster functionality.

I think it is able to greatly improve Go performance on Peak and EC2. Even i7 benchmark can benefit from this change.