### PR TITLE
Make header verification case insensitive

### DIFF
--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -28,8 +28,8 @@ class DBTestType(FrameworkTestType):
       return [('fail','Empty Response', url)]
 
     # Ensure required response headers are present
-    if any(v not in response for v in ('Server','Date','Content-Type: application/json')) \
-       or all(v not in response for v in ('Content-Length','Transfer-Encoding')):
+    if any(v.lower() not in response.lower() for v in ('Server','Date','Content-Type: application/json')) \
+       or all(v.lower() not in response.lower() for v in ('Content-Length','Transfer-Encoding')):
       return [('warn','Required response header missing.',url)]
 
     # Valid JSON? 

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -28,8 +28,8 @@ class FortuneTestType(FrameworkTestType):
       return [('fail','Empty Response', url)]
 
     # Ensure required response headers are present
-    if any(v not in response for v in ('Server','Date','Content-Type: text/html')) \
-       or all(v not in response for v in ('Content-Length','Transfer-Encoding')):
+    if any(v.lower() not in response.lower() for v in ('Server','Date','Content-Type: text/html')) \
+       or all(v.lower() not in response.lower() for v in ('Content-Length','Transfer-Encoding')):
       return [('warn','Required response header missing.',url)]
 
     parser = FortuneHTMLParser()

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -27,8 +27,8 @@ class JsonTestType(FrameworkTestType):
       return [('fail','Empty Response', url)]
 
     # Ensure required response headers are present
-    if any(v not in response for v in ('Server','Date','Content-Type: application/json')) \
-       or all(v not in response for v in ('Content-Length','Transfer-Encoding')):
+    if any(v.lower() not in response.lower() for v in ('Server','Date','Content-Type: application/json')) \
+       or all(v.lower() not in response.lower() for v in ('Content-Length','Transfer-Encoding')):
       return [('warn','Required response header missing.',url)]
 
     # Valid JSON? 

--- a/toolset/benchmark/test_types/plaintext_type.py
+++ b/toolset/benchmark/test_types/plaintext_type.py
@@ -17,8 +17,8 @@ class PlaintextTestType(FrameworkTestType):
       return [('fail','Empty Response', url)]
 
     # Ensure required response headers are present
-    if any(v not in response for v in ('Server','Date','Content-Type: text/plain')) \
-       or all(v not in response for v in ('Content-Length','Transfer-Encoding')):
+    if any(v.lower() not in response.lower() for v in ('Server','Date','Content-Type: text/plain')) \
+       or all(v.lower() not in response.lower() for v in ('Content-Length','Transfer-Encoding')):
       return [('warn','Required response header missing.',url)]
 
     # Case insensitive

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -67,8 +67,8 @@ class QueryTestType(DBTestType):
       return [(max_infraction,'Empty Response', url)]
 
     # Ensure required response headers are present
-    if any(v not in curlResponse for v in ('Server','Date','Content-Type: application/json')) \
-       or all(v not in curlResponse for v in ('Content-Length','Transfer-Encoding')):
+    if any(v.lower() not in curlResponse.lower() for v in ('Server','Date','Content-Type: application/json')) \
+       or all(v.lower() not in curlResponse.lower() for v in ('Content-Length','Transfer-Encoding')):
       return [('warn','Required response header missing.',url)]
   
     # Valid JSON? 


### PR DESCRIPTION
When checking for the response for required headers some tests were warning when they shouldn't have been due to case sensitivity. 