### PR TITLE
Fix Scruffy errors from bad merge conflict resolution, Resolves #1481

### DIFF
--- a/frameworks/Scala/scruffy/src/main/scala/scruffy/examples/Test2Endpoint.scala
+++ b/frameworks/Scala/scruffy/src/main/scala/scruffy/examples/Test2Endpoint.scala
@@ -1,7 +1,7 @@
 package scruffy.examples
 
 import com.mongodb.casbah.Imports._
-import com.sksamuel.scruffy.EndpointProvider
+import com.sksamuel.scruffy.HttpEndpointProvider
 import java.util.concurrent.ThreadLocalRandom
 
 /** @author Stephen Samuel */
@@ -17,8 +17,8 @@ class Test2Endpoint() extends HttpEndpointProvider {
   //for ( k <- 1 to 10000 )
   //  collection.save(DBObject("_id" -> k, "id" -> k, "randomNumber" -> random.nextInt(10000).toDouble))
 
-  get("db").json {
-    req =>
+  get("db") { implicit req =>
+    json {
       val id = ThreadLocalRandom.current.nextInt(10000)
       val dbo = collection.findOne(DBObject("_id" -> id), fields)
       val randomNumber = Math.round(dbo.get("randomNumber").toString.toFloat)


### PR DESCRIPTION
After further investigation, I realized that the curly brace was supposed to be there after all. I actually ended up taking the wrong code when resolving the merge conflict for #1436. This should get scruffy back to passing.

- Update import from EndpointProvider to HttpEndpointProvider
- Add back missing code from merge conflict in PR 1436