### PR TITLE
Add go env variable exports to go-prefork test

### DIFF
--- a/frameworks/Go/go/setup_prefork.sh
+++ b/frameworks/Go/go/setup_prefork.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Set the root of our go installation
+export GOROOT=${IROOT}/go
+export GOPATH=${TROOT}
+
 sed -i 's|tcp(.*:3306)|tcp('"${DBHOST}"':3306)|g' src/hello/hello.go
 
 # Where to find the go executable


### PR DESCRIPTION
- Add export variables to go-prefork test
- This should have been done when removing bash_profile, but was missed.