### PR TITLE
Start Nancy Mono

### DIFF
--- a/frameworks/CSharp/nancy/bash_profile.sh
+++ b/frameworks/CSharp/nancy/bash_profile.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-export MONO_ROOT=${IROOT}/mono-3.6.0-install
-
-export NGINX_HOME=${IROOT}/nginx

--- a/frameworks/CSharp/nancy/benchmark_config.json
+++ b/frameworks/CSharp/nancy/benchmark_config.json
@@ -47,7 +47,7 @@
       "db_url": "/db",
       "query_url": "/db/",
       "port": 8080,
-	        "approach": "Realistic",
+      "approach": "Realistic",
       "classification": "Micro",
       "database": "MySQL",
       "framework": "nancy",

--- a/frameworks/CSharp/nancy/setup_libevent.sh
+++ b/frameworks/CSharp/nancy/setup_libevent.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 . ${IROOT}/mono.installed
 
-sed -i 's|localhost|'"$DBHOST"'|g' src/Web.config
-sed -i 's|include /usr/local/nginx/conf/fastcgi_params;|include '"${NGINX_HOME}"'/conf/fastcgi_params;|g' nginx.conf
+sed -i 's|localhost|${DBHOST}|g' src/Web.config
 
-# build
-cd src
 rm -rf bin obj
-xbuild /p:Configuration=Release
+xbuild src/NancyBenchmark.csproj /p:Configuration=Release
 
 # nginx
 conf="upstream mono {\n"
@@ -20,13 +17,15 @@ done
 conf+="}"
 echo -e $conf > $TROOT/nginx.upstream.conf
 
-$NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf -g "worker_processes '"${MAX_THREADS}"';"
+$NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf.libevent -g "worker_processes '"${MAX_THREADS}"';"
+
+export MONO_GC_PARAMS=nursery-size=16m
 
 # Start fastcgi for each thread
 # To debug, use --printlog --verbose --loglevels=All
 current=9001
 end=$(($current+$MAX_THREADS))
 while [ $current -lt $end ]; do
-  MONO_OPTIONS=--gc=sgen fastcgi-mono-server4 --applications=/:${TROOT}/src --socket=tcp:127.0.0.1:$current &
+  mono-sgen -O=all LibeventHost/bin/Release/LibeventHost.exe 127.0.0.1 $current ${DBHOST} &
   let current=current+1
 done

--- a/frameworks/CSharp/nancy/setup_libevent.sh
+++ b/frameworks/CSharp/nancy/setup_libevent.sh
@@ -1,31 +1,34 @@
 #!/bin/bash
+
+export NGINX_HOME=${IROOT}/nginx
+export LIBEVENTHOST_HOME=${TROOT}/src/LibeventHost
+export MONO_GC_PARAMS="nursery-size=16m"
+
 . ${IROOT}/mono.installed
 
-sed -i 's|localhost|${DBHOST}|g' src/Web.config
+sed -i 's|localhost|'"${DBHOST}"'|g' src/Web.config
 
-rm -rf bin obj
+rm -rf src/bin src/obj
+xbuild src/NancyBenchmark.csproj /t:Clean
 xbuild src/NancyBenchmark.csproj /p:Configuration=Release
 
+rm -rf ${LIBEVENTHOST_HOME}/bin ${LIBEVENTHOST_HOME}/obj
+xbuild ${LIBEVENTHOST_HOME}/LibeventHost.csproj /p:Configuration=Release
+
 # nginx
+port_start=9001
+port_end=$((${port_start}+${MAX_THREADS}))
 conf="upstream mono {\n"
-current=9001
-end=$(($current+$MAX_THREADS))
-while [ $current -lt $end ]; do
-  conf+="\tserver 127.0.0.1:${current};\n"
-  let current=current+1
+for port in $(seq ${port_start} ${port_end} ); do
+  conf+="\tserver 127.0.0.1:${port};\n"
 done
 conf+="}"
-echo -e $conf > $TROOT/nginx.upstream.conf
 
-$NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf.libevent -g "worker_processes '"${MAX_THREADS}"';"
-
-export MONO_GC_PARAMS=nursery-size=16m
+echo -e $conf > ${TROOT}/nginx.upstream.conf
+${NGINX_HOME}/sbin/nginx -c ${TROOT}/nginx.conf.libevent -g "worker_processes '"${MAX_THREADS}"';"
 
 # Start fastcgi for each thread
 # To debug, use --printlog --verbose --loglevels=All
-current=9001
-end=$(($current+$MAX_THREADS))
-while [ $current -lt $end ]; do
-  mono-sgen -O=all LibeventHost/bin/Release/LibeventHost.exe 127.0.0.1 $current ${DBHOST} &
-  let current=current+1
+for port in $(seq ${port_start} ${port_end} ); do
+  mono-sgen -O=all ${LIBEVENTHOST_HOME}/bin/Release/LibeventHost.exe 127.0.0.1 ${port} ${DBHOST} &
 done

--- a/frameworks/CSharp/nancy/setup_nginx.sh
+++ b/frameworks/CSharp/nancy/setup_nginx.sh
@@ -1,32 +1,31 @@
 #!/bin/bash
+
+export NGINX_HOME=${IROOT}/nginx
+
 . ${IROOT}/mono.installed
 
-sed -i 's|localhost|'"$DBHOST"'|g' src/Web.config
+sed -i 's|localhost|'"${DBHOST}"'|g' src/Web.config
 sed -i 's|include /usr/local/nginx/conf/fastcgi_params;|include '"${NGINX_HOME}"'/conf/fastcgi_params;|g' nginx.conf
 
 # build
-cd src
-rm -rf bin obj
-xbuild /p:Configuration=Release
+rm -rf src/bin src/obj
+xbuild src/NancyBenchmark.csproj /t:Clean
+xbuild src/NancyBenchmark.csproj /p:Configuration=Release
 
 # nginx
+port_start=9001
+port_end=$((${port_start}+${MAX_THREADS}))
 conf="upstream mono {\n"
-current=9001
-end=$(($current+$MAX_THREADS))
-while [ $current -lt $end ]; do
-  conf+="\tserver 127.0.0.1:${current};\n"
-  let current=current+1
+for port in $(seq ${port_start} $port_end); do
+  conf+="\tserver 127.0.0.1:${port};\n"
 done
 conf+="}"
-echo -e $conf > $TROOT/nginx.upstream.conf
 
-$NGINX_HOME/sbin/nginx -c $TROOT/nginx.conf -g "worker_processes '"${MAX_THREADS}"';"
+echo -e $conf > ${TROOT}/nginx.upstream.conf
+${NGINX_HOME}/sbin/nginx -c ${TROOT}/nginx.conf -g "worker_processes '"${MAX_THREADS}"';"
 
 # Start fastcgi for each thread
 # To debug, use --printlog --verbose --loglevels=All
-current=9001
-end=$(($current+$MAX_THREADS))
-while [ $current -lt $end ]; do
-  MONO_OPTIONS=--gc=sgen fastcgi-mono-server4 --applications=/:${TROOT}/src --socket=tcp:127.0.0.1:$current &
-  let current=current+1
+for port in $(seq ${port_start} $port_end); do
+  MONO_OPTIONS=--gc=sgen fastcgi-mono-server4 --applications=/:${TROOT}/src --socket=tcp:127.0.0.1:$port &
 done

--- a/frameworks/CSharp/nancy/src/Global.asax.cs
+++ b/frameworks/CSharp/nancy/src/Global.asax.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Web;
 using Nancy;
+using Nancy.ErrorHandling;
 using System.Threading;
 
 namespace NancyBenchmark
@@ -10,6 +11,7 @@ namespace NancyBenchmark
     {
         protected void Application_Start()
         {
+            StaticConfiguration.DisableErrorTraces = false;
             var threads = 40 * Environment.ProcessorCount;
             ThreadPool.SetMaxThreads(threads, threads);
             ThreadPool.SetMinThreads(threads, threads);

--- a/frameworks/CSharp/nancy/src/Global.asax.cs
+++ b/frameworks/CSharp/nancy/src/Global.asax.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Web;
 using Nancy;
-using Nancy.ErrorHandling;
 using System.Threading;
 
 namespace NancyBenchmark

--- a/frameworks/CSharp/nancy/src/LibeventHost/LibeventHost.csproj
+++ b/frameworks/CSharp/nancy/src/LibeventHost/LibeventHost.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nancy">
-      <HintPath>..\..\lib\Nancy.0.17.1\lib\net40\Nancy.dll</HintPath>
+      <HintPath>..\..\lib\Nancy.0.23.0\lib\net40\Nancy.dll</HintPath>
     </Reference>
     <Reference Include="Nancy.Hosting.Event2">
       <HintPath>..\..\lib\Nancy.Hosting.Event2.dll</HintPath>


### PR DESCRIPTION
Closes #1304 by replacement.

Again, using lgratrix's commits and working on updating them. This doesn't get nancy passing, but at least gets nancy's webserver running - so better than the current state.
Also, removed bash_profile.

Update: nancy-mono tests pass/warn, but nancy-libevent2 gets 502s from nginx. 