### PR TITLE
Improve framework server log handling

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -563,7 +563,7 @@ class Benchmarker:
 
         if self.__is_port_bound(test.port):
           # This can happen sometimes - let's try again
-          self.__stop_test(out, err)
+          self.__stop_test(test, out, err)
           out.flush()
           err.flush()
           time.sleep(15)
@@ -577,7 +577,7 @@ class Benchmarker:
 
         result = test.start(out, err)
         if result != 0: 
-          self.__stop_test(out, err)
+          self.__stop_test(test, out, err)
           time.sleep(5)
           err.write( "ERROR: Problem starting {name}\n".format(name=test.name) )
           err.flush()
@@ -611,14 +611,14 @@ class Benchmarker:
         ##########################
         out.write(header("Stopping %s" % test.name))
         out.flush()
-        self.__stop_test(out, err)
+        self.__stop_test(test, out, err)
         out.flush()
         err.flush()
         time.sleep(15)
 
         if self.__is_port_bound(test.port):
           # This can happen sometimes - let's try again
-          self.__stop_test(out, err)
+          self.__stop_test(test, out, err)
           out.flush()
           err.flush()
           time.sleep(15)
@@ -650,7 +650,7 @@ class Benchmarker:
         traceback.print_exc(file=err)
         err.flush()
         try:
-          self.__stop_test(out, err)
+          self.__stop_test(test, out, err)
         except (subprocess.CalledProcessError) as e:
           self.__write_intermediate_results(test.name,"<setup.py>#stop() raised an error")
           err.write(header("Subprocess Error: Test .stop() raised exception %s" % test.name))
@@ -662,7 +662,7 @@ class Benchmarker:
       # TODO - subprocess should not catch this exception!
       # Parent process should catch it and cleanup/exit
       except (KeyboardInterrupt) as e:
-        self.__stop_test(out, err)
+        self.__stop_test(test, out, err)
         out.write(header("Cleaning up..."))
         out.flush()
         self.__finish()
@@ -680,7 +680,7 @@ class Benchmarker:
   # __stop_test(benchmarker)
   # Stops all running tests
   ############################################################
-  def __stop_test(self, out, err):
+  def __stop_test(self, test, out, err):
     try:
       subprocess.check_call('sudo killall -s 9 -u %s' % self.runner_user, shell=True, stderr=err, stdout=out)
       retcode = 0

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -563,7 +563,7 @@ class Benchmarker:
 
         if self.__is_port_bound(test.port):
           # This can happen sometimes - let's try again
-          self.__stop_test(test, out, err)
+          self.__stop_test(out, err)
           out.flush()
           err.flush()
           time.sleep(15)
@@ -577,7 +577,7 @@ class Benchmarker:
 
         result = test.start(out, err)
         if result != 0: 
-          self.__stop_test(test, out, err)
+          self.__stop_test(out, err)
           time.sleep(5)
           err.write( "ERROR: Problem starting {name}\n".format(name=test.name) )
           err.flush()
@@ -611,14 +611,14 @@ class Benchmarker:
         ##########################
         out.write(header("Stopping %s" % test.name))
         out.flush()
-        self.__stop_test(test, out, err)
+        self.__stop_test(out, err)
         out.flush()
         err.flush()
         time.sleep(15)
 
         if self.__is_port_bound(test.port):
           # This can happen sometimes - let's try again
-          self.__stop_test(test, out, err)
+          self.__stop_test(out, err)
           out.flush()
           err.flush()
           time.sleep(15)
@@ -650,7 +650,7 @@ class Benchmarker:
         traceback.print_exc(file=err)
         err.flush()
         try:
-          self.__stop_test(test, out, err)
+          self.__stop_test(out, err)
         except (subprocess.CalledProcessError) as e:
           self.__write_intermediate_results(test.name,"<setup.py>#stop() raised an error")
           err.write(header("Subprocess Error: Test .stop() raised exception %s" % test.name))
@@ -662,7 +662,7 @@ class Benchmarker:
       # TODO - subprocess should not catch this exception!
       # Parent process should catch it and cleanup/exit
       except (KeyboardInterrupt) as e:
-        self.__stop_test(test, out, err)
+        self.__stop_test(out, err)
         out.write(header("Cleaning up..."))
         out.flush()
         self.__finish()
@@ -680,7 +680,7 @@ class Benchmarker:
   # __stop_test(benchmarker)
   # Stops all running tests
   ############################################################
-  def __stop_test(self, test, out, err):
+  def __stop_test(self, out, err):
     try:
       subprocess.check_call('sudo killall -s 9 -u %s' % self.runner_user, shell=True, stderr=err, stdout=out)
       retcode = 0

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -383,8 +383,10 @@ class Benchmarker:
       sudo sysctl -w kernel.shmmax=2147483648
       sudo sysctl -w kernel.shmall=2097152
       sudo sysctl -w kernel.sem="250 32000 256 512"
-      echo "Printing kernel configuration:" && sudo sysctl -a
     """)
+    # TODO - print kernel configuration to file
+    # echo "Printing kernel configuration:" && sudo sysctl -a
+
         # Explanations:
         # net.ipv4.tcp_max_syn_backlog, net.core.somaxconn, kernel.sched_autogroup_enabled: http://tweaked.io/guide/kernel/
         # ulimit -n: http://www.cyberciti.biz/faq/linux-increase-the-maximum-number-of-open-files/

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -692,6 +692,9 @@ class Benchmarker:
   # End __stop_test
   ############################################################
 
+  def is_port_bound(self, port):
+    return self.__is_port_bound(port)
+
   ############################################################
   # __is_port_bound
   # Check if the requested port is available. If it

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -246,10 +246,10 @@ class FrameworkTest:
           shell=True, stdout=subprocess.PIPE, 
           stderr=subprocess.STDOUT)
     nbsr = setup_util.NonBlockingStreamReader(p.stdout, 
-      "%s: Setup.sh and framework processes have terminated" % self.name)
+      "%s: %s.sh and framework processes have terminated" % (self.name, self.setup_file))
 
     # Setup a timeout
-    timeout = datetime.now() + timedelta(minutes = 10)
+    timeout = datetime.now() + timedelta(minutes = 20)
     time_remaining = timeout - datetime.now()
 
     # Flush output until setup.sh work is finished. This is 
@@ -288,7 +288,7 @@ class FrameworkTest:
 
     # Did we time out?
     if time_remaining.total_seconds() < 0: 
-      tee_output(prefix, "Setup.sh timed out!! Aborting...\n")
+      tee_output(prefix, "%s.sh timed out!! Aborting...\n" % self.setup_file)
       p.kill()
       return 1
 
@@ -297,9 +297,9 @@ class FrameworkTest:
     # Otherwise, detect if the port was bound
     retcode = (p.poll() or 0 if self.benchmarker.is_port_bound(self.port) else 1)
     if p.poll():
-      tee_output(prefix, "setup.sh process exited with %s\n" % p.poll())
+      tee_output(prefix, "%s.sh process exited with %s\n" % (self.setup_file, p.poll()))
     elif self.benchmarker.is_port_bound(self.port):
-      tee_output(prefix, "setup.sh exited due to bound port\n")
+      tee_output(prefix, "%s.sh exited due to bound port\n" % self.setup_file)
 
     # Before we return control to the benchmarker, spin up a 
     # thread to keep an eye on the pipes in case the running 

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -300,9 +300,14 @@ class FrameworkTest:
       or self.benchmarker.is_port_bound(self.port)
       or time_remaining.total_seconds() < 0):
       
-      line = nbsr.readline(0.1)
-      if line:
-        tee_output(prefix, line)
+      # The conditions above are slow to check, so 
+      # we miss many lines of output if we only
+      # print one line per condition check. Adding a 
+      # tight loop here mitigates the effect
+      for i in xrange(10):
+        line = nbsr.readline(0.05)
+        if line:
+          tee_output(prefix, line)
       time_remaining = timeout - datetime.now()
 
     # Were we timed out?

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -216,16 +216,12 @@ class FrameworkTest:
       export IROOT=%s && \\
       export DBHOST=%s && \\
       export MAX_THREADS=%s && \\
-      export OUT=%s && \\
-      export ERR=%s && \\
       cd %s && \\
       %s''' % (self.fwroot, 
         self.directory, 
         self.install_root, 
         self.database_host, 
         self.benchmarker.threads, 
-        os.path.join(self.fwroot, out.name), 
-        os.path.join(self.fwroot, err.name),
         self.directory,
         command)
     logging.info("To run %s manually, copy/paste this:\n%s", self.name, debug_command)

--- a/toolset/run-ci.py
+++ b/toolset/run-ci.py
@@ -536,6 +536,7 @@ if __name__ == "__main__":
     if os.path.isfile('.run-ci.should_not_run'):
       sys.exit(retcode)
 
+    '''
     log.error("Running inside Travis-CI, so I will print err and out to console...")
     
     for name in runner.names:
@@ -555,6 +556,7 @@ if __name__ == "__main__":
             log.info(line.rstrip('\n'))
       except IOError:
         log.error("No OUT file found")
+    '''
 
     log.error("Running inside Travis-CI, so I will print a copy of the verification summary")
 

--- a/toolset/run-ci.py
+++ b/toolset/run-ci.py
@@ -556,7 +556,7 @@ if __name__ == "__main__":
             log.info(line.rstrip('\n'))
       except IOError:
         log.error("No OUT file found")
-    '''
+
 
     log.error("Running inside Travis-CI, so I will print a copy of the verification summary")
 
@@ -594,7 +594,7 @@ if __name__ == "__main__":
       else:
         print prefix + "|      " + Fore.RED + "NO RESULTS (Did framework launch?)"
     print prefix + header('', top='', bottom='=') + Style.RESET_ALL
-
+    '''
 
     sys.exit(retcode)
 

--- a/toolset/run-ci.py
+++ b/toolset/run-ci.py
@@ -526,77 +526,7 @@ if __name__ == "__main__":
     log.critical("Unknown error")
     print traceback.format_exc()
     retcode = 1
-  finally:  # Ensure that logs are printed
-    
-    # Only print logs if we ran a verify
-    if mode != 'verify':
-      sys.exit(retcode)
-
-    # Only print logs if we actually did something
-    if os.path.isfile('.run-ci.should_not_run'):
-      sys.exit(retcode)
-
-    '''
-    log.error("Running inside Travis-CI, so I will print err and out to console...")
-    
-    for name in runner.names:
-      log.error("Test %s", name)
-      try:
-        log.error("Here is ERR:")
-        with open("results/ec2/latest/logs/%s/err.txt" % name, 'r') as err:
-          for line in err:
-            log.info(line.rstrip('\n'))
-      except IOError:
-        log.error("No ERR file found")
-
-      try:
-        log.error("Here is OUT:")
-        with open("results/ec2/latest/logs/%s/out.txt" % name, 'r') as out:
-          for line in out:
-            log.info(line.rstrip('\n'))
-      except IOError:
-        log.error("No OUT file found")
-
-
-    log.error("Running inside Travis-CI, so I will print a copy of the verification summary")
-
-    results = None
-    try:
-      with open('results/ec2/latest/results.json', 'r') as f:
-        results = json.load(f)
-    except IOError:
-      log.critical("No results.json found, unable to print verification summary") 
-      sys.exit(retcode)
-
-    target_dir = setup_util.get_fwroot() + '/frameworks/' + testdir
-    dirtests = [t for t in gather_tests() if t.directory == target_dir]
-
-    # Normally you don't have to use Fore.* before each line, but 
-    # Travis-CI seems to reset color codes on newline (see travis-ci/travis-ci#2692)
-    # or stream flush, so we have to ensure that the color code is printed repeatedly
-    prefix = Fore.CYAN
-    for line in header("Verification Summary", top='=', bottom='').split('\n'):
-      print prefix + line
-
-    for test in dirtests:
-      print prefix + "| Test: %s" % test.name
-      if test.name not in runner.names:
-        print prefix + "|      " + Fore.YELLOW + "Unable to verify in Travis-CI"
-      elif test.name in results['verify'].keys():
-        for test_type, result in results['verify'][test.name].iteritems():
-          if result.upper() == "PASS":
-            color = Fore.GREEN
-          elif result.upper() == "WARN":
-            color = Fore.YELLOW
-          else:
-            color = Fore.RED
-          print prefix + "|       " + test_type.ljust(11) + ' : ' + color + result.upper()
-      else:
-        print prefix + "|      " + Fore.RED + "NO RESULTS (Did framework launch?)"
-    print prefix + header('', top='', bottom='=') + Style.RESET_ALL
-    '''
-
+  finally:
     sys.exit(retcode)
-
 
 # vim: set sw=2 ts=2 expandtab

--- a/toolset/setup/linux/installer.py
+++ b/toolset/setup/linux/installer.py
@@ -148,47 +148,21 @@ class Installer:
   ############################################################
   # __run_command
   ############################################################
-  def __run_command(self, command, send_yes=False, cwd=None, retry=False):
+  def __run_command(self, command, send_yes=False, cwd=None):
     if cwd is None: 
         cwd = self.install_dir
 
-    if retry:
-      max_attempts = 5
-    else:
-      max_attempts = 1
-    attempt = 1
-    delay = 0
     if send_yes:
       command = "yes yes | " + command
         
     rel_cwd = setup_util.path_relative_to_root(cwd)
     print("INSTALL: %s (cwd=$FWROOT/%s)" % (command, rel_cwd))
 
-    while attempt <= max_attempts:
-      error_message = ""
-      try:
-
-        # Execute command.
-        subprocess.check_call(command, shell=True, cwd=cwd, executable='/bin/bash')
-        break  # Exit loop if successful.
-      except:
-        exceptionType, exceptionValue, exceptionTraceBack = sys.exc_info()
-        error_message = "".join(traceback.format_exception_only(exceptionType, exceptionValue))
-
-      # Exit if there are no more attempts left.
-      attempt += 1
-      if attempt > max_attempts:
-        break
-
-      # Delay before next attempt.
-      if delay == 0:
-        delay = 5
-      else:
-        delay = delay * 2
-      print("Attempt %s/%s starting in %s seconds." % (attempt, max_attempts, delay))
-      time.sleep(delay)
-
-    if error_message:
+    try:
+      subprocess.check_call(command, shell=True, cwd=cwd, executable='/bin/bash')
+    except:
+      exceptionType, exceptionValue, exceptionTraceBack = sys.exc_info()
+      error_message = "".join(traceback.format_exception_only(exceptionType, exceptionValue))
       self.__install_error(error_message)
   ############################################################
   # End __run_command

--- a/toolset/setup/linux/setup_util.py
+++ b/toolset/setup/linux/setup_util.py
@@ -1,7 +1,61 @@
 import re
 import os
+import sys
 import subprocess
 import platform
+
+from threading import Thread
+from Queue import Queue, Empty
+
+class NonBlockingStreamReader:
+  '''
+  Enables calling readline in a non-blocking manner with a blocking stream, 
+  such as the ones returned from subprocess.Popen
+
+  Originally written by Eyal Arubas, who granted permission to use this inside TFB
+  See http://eyalarubas.com/python-subproc-nonblock.html
+  '''
+  def __init__(self, stream, eof_message = None):
+    '''
+    stream: the stream to read from.
+            Usually a process' stdout or stderr.
+    eof_message: A message to print to stdout as soon
+      as the stream's end is reached. Useful if you
+      want to track the exact moment a stream terminates
+    '''
+
+    self._s = stream
+    self._q = Queue()
+    self._eof_message = eof_message
+    self._poisonpill = 'MAGIC_POISONPILL_STRING'
+
+    def _populateQueue(stream, queue):
+      while True:
+        line = stream.readline()
+        if line: # 'data\n' or '\n'
+          queue.put(line)
+        else:    # '' e.g. EOF
+          if self._eof_message:
+            sys.stdout.write(self._eof_message + '\n')
+          queue.put(self._poisonpill)
+          return
+
+    self._t = Thread(target = _populateQueue,
+            args = (self._s, self._q))
+    self._t.daemon = True
+    self._t.start()
+
+  def readline(self, timeout = None):
+    try:
+      line = self._q.get(block = timeout is not None,
+        timeout = timeout)
+      if line == self._poisonpill: 
+        raise EndOfStream
+      return line
+    except Empty:
+      return None
+
+class EndOfStream(Exception): pass
 
 # Replaces all text found using the regular expression to_replace with the supplied replacement.
 def replace_text(file, to_replace, replacement):
@@ -29,7 +83,7 @@ def replace_environ(config=None, root=None, print_result=False, command='true'):
     
         # Clean up our current environment, preserving some important items
         mini_environ = {}
-        for envname in ['HOME', 'PATH', 'USER', 'LD_LIBRARY_PATH', 'PYTHONPATH', 'FWROOT', 'TRAVIS']:
+        for envname in ['HOME', 'PATH', 'LANG', 'USER', 'LD_LIBRARY_PATH', 'PYTHONPATH', 'FWROOT', 'TRAVIS']:
           if envname in os.environ:
             mini_environ[envname] = os.environ[envname]
         for key in os.environ:


### PR DESCRIPTION
A step along the path towards #920. This prints output from `setup.sh` in real time to both the console and to the log file. Log output is much more readable, as each test gets a custom prefix. Also closes #1504 - which I think is a critical bug. Travis-CI no longer has to re-print the `err.txt` and `out.txt` files, so that is a really nice benefit as it's much easier to read. Main negative is that `framework_test#start` has become a more complex method, but that's unfortunately the nature of nonblocking IO with multiple levels of buffering and multiple levels of child processes, so I've just commented the hell out of it. If someone wants to start being awesome and throwing some unit tests against that method be my guest :+1: 

```
Setup lwan: [ 96%] Building C object techempower/CMakeFiles/techempower.dir/array.c.o
Setup lwan: [100%] Building C object techempower/CMakeFiles/techempower.dir/database.c.o
Setup lwan: Linking C executable techempower
Setup lwan: [100%] Built target techempower
Setup lwan: + cd /home/vagrant/FrameworkBenchmarks/installs/lwan/techempower
Setup lwan: + /home/vagrant/FrameworkBenchmarks/installs/lwan/build/techempower/techempower
Setup lwan: Loading configuration file: techempower.conf.
Setup lwan: Using 2 threads, maximum 32767 sockets per thread.
Setup lwan: Listening on http://0.0.0.0:8080.
Setup lwan: Ready to serve.
Setup lwan: setup.sh exited due to bound port
INFO:root:Executed setup.sh, returning 0
INFO:root:Sleeping 10 seconds to ensure framework is ready
INFO:root:Verifying framework URLs
Accessing URL http://127.0.0.1:8080/json
  Response (trimmed to 40 bytes): "{"message":"Hello, World!"}"
   WARN for http://127.0.0.1:8080/json
     Required response header missing.
Accessing URL http://127.0.0.1:8080/plaintext
  Response (trimmed to 40 bytes): "Hello, World!"
   PASS for http://127.0.0.1:8080/plaintext
lwan: Setup.sh and framework processes have terminated
Server lwan: Framework processes have terminated
verify: 100% |######################################################################################################################################################################| Rough Time: 00:00:36
```

Also includes some basic code cleanup and fixes #1171