### PR TITLE
Remove Go/Gorail from Travis Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ env:
     - "TESTDIR=Go/gin"
     - "TESTDIR=Go/go"
     - "TESTDIR=Go/go-mongodb"
-    - "TESTDIR=Go/gorail"
     - "TESTDIR=Go/revel"
     - "TESTDIR=Go/revel-jet"
     - "TESTDIR=Go/revel-qbs"


### PR DESCRIPTION
- Gorails framework was removed from TFB, Go/Gorail test was accidentally re-added. Remove Gorails from .travis.yml