### PR TITLE
Added MongoDB client to PHP install scripts. Fixes #1401

### DIFF
--- a/config/php.ini
+++ b/config/php.ini
@@ -870,6 +870,7 @@ zend_extension=opcache.so
 extension=redis.so
 extension=phalcon.so
 extension=yaf.so
+extension=mongo.so
 ;extension=php_bz2.dll
 ;extension=php_curl.dll
 ;extension=php_fileinfo.dll

--- a/frameworks/PHP/php-phalcon/app/views/layouts/mongobench.volt
+++ b/frameworks/PHP/php-phalcon/app/views/layouts/mongobench.volt
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>Fortunes</title></head><body>{{ content() }}</body></html>

--- a/toolset/setup/linux/languages/php.sh
+++ b/toolset/setup/linux/languages/php.sh
@@ -49,6 +49,8 @@ printf "\n" | $IROOT/php-${VERSION}/bin/pecl -q install -f redis
 # yaf.so
 printf "\n" | $IROOT/php-${VERSION}/bin/pecl -q install -f yaf
 
+printf "\n" | $IROOT/php-${VERSION}/bin/pecl -q install -f mongo
+
 # phalcon.so
 #   The configure seems broken, does not respect prefix. If you 
 #   update the value of PATH then it finds the prefix from `which php`


### PR DESCRIPTION
The MongoDB PHP extension wasn't installed. Fixes #1401. This involves changes to PHP's install scripts, so if there's an existing PHP installation on your test box it'll have to be wiped and rebuilt.