### PR TITLE
Updating vert.x to the latest release 2.1.5

### DIFF
--- a/frameworks/Java/vertx/README.md
+++ b/frameworks/Java/vertx/README.md
@@ -12,7 +12,7 @@ This is the vertx portion of a [benchmarking test suite](../) comparing a variet
 ## Versions
 
 * [Java OpenJDK 1.7.0_09](http://openjdk.java.net/)
-* [vertx 1.3.1](http://vertx.io/)
+* [vertx 2.1.5](http://vertx.io/)
 
 
 ## Test URLs

--- a/frameworks/Java/vertx/app.js
+++ b/frameworks/Java/vertx/app.js
@@ -3,7 +3,8 @@ var container = require('vertx/container')
 var persistorConf = {
   address: 'hello.persistor',
   db_name: 'hello_world',
-  host: 'localhost'
+  host: '127.0.0.1',
+  pool_size: 20
 }
 
 container.deployModule('io.vertx~mod-mongo-persistor~2.1.1', persistorConf, function (err, dep_id) {

--- a/frameworks/Java/vertx/install.sh
+++ b/frameworks/Java/vertx/install.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-fw_depends java7 vertx 
+fw_depends java7
+
+RETCODE=$(fw_exists ${IROOT}/vert.x-2.1.5.installed)
+[ ! "$RETCODE" == 0 ] || { return 0; }
+
+fw_get http://dl.bintray.com/vertx/downloads/vert.x-2.1.5.tar.gz?direct=true -O vert.x-2.1.5.tar.gz
+fw_untar vert.x-2.1.5.tar.gz
+
+touch ${IROOT}/vert.x-2.1.5.installed

--- a/frameworks/Java/vertx/setup.sh
+++ b/frameworks/Java/vertx/setup.sh
@@ -4,4 +4,4 @@ source $IROOT/java7.installed
 
 sed -i 's|host: \x27.*\x27|host: \x27'"${DBHOST}"'\x27|g' app.js
 
-${IROOT}/vert.x-2.1.1/bin/vertx run app.js &
+${IROOT}/vert.x-2.1.5/bin/vertx run app.js &

--- a/frameworks/Java/vertx/source_code
+++ b/frameworks/Java/vertx/source_code
@@ -1,2 +1,2 @@
-./vertx/App.groovy
+./vertx/app.js
 ./vertx/WebServer.java

--- a/toolset/setup/linux/frameworks/vertx.sh
+++ b/toolset/setup/linux/frameworks/vertx.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-RETCODE=$(fw_exists ${IROOT}/vert.x-2.1.1.installed)
+RETCODE=$(fw_exists ${IROOT}/vert.x-2.1.5.installed)
 [ ! "$RETCODE" == 0 ] || { return 0; }
 
-fw_get http://dl.bintray.com/vertx/downloads/vert.x-2.1.1.tar.gz?direct=true -O vert.x-2.1.1.tar.gz
-fw_untar vert.x-2.1.1.tar.gz
+fw_get http://dl.bintray.com/vertx/downloads/vert.x-2.1.5.tar.gz?direct=true -O vert.x-2.1.5.tar.gz
+fw_untar vert.x-2.1.5.tar.gz
 
-touch ${IROOT}/vert.x-2.1.1.installed
+touch ${IROOT}/vert.x-2.1.5.installed


### PR DESCRIPTION
Maintainer of vert.x seems to like to have vert.x back in FrameworkBenchmarks, maybe for Round 11?
https://groups.google.com/forum/#!msg/vertx/kism9YHbpTo/zSwWhs952dwJ
It is also important for us, developers who is using vert.x to have it in FrameworkBenchmarks.