### PR TITLE
Fix shadowed test name

### DIFF
--- a/frameworks/Python/pyramid/frameworkbenchmarks/tests.py
+++ b/frameworks/Python/pyramid/frameworkbenchmarks/tests.py
@@ -56,7 +56,7 @@ class FunctionalTests(unittest.TestCase):
         res = self._get('/queries?queries=999')
         self.assertEqual(len(json.loads(self._str_compat(res.body))), 500)
 
-    def test_queries_999(self):
+    def test_queries_10(self):
         """
         /queries?queries=10 objects
         """


### PR DESCRIPTION
test_queries_999 was actually test_queries_10, shadowing a prior test_queries_999