### PR TITLE
Fix relative path name in create_database.py

### DIFF
--- a/frameworks/Python/pyramid/create_database.py
+++ b/frameworks/Python/pyramid/create_database.py
@@ -5,7 +5,9 @@ if __name__ == "__main__":
     """
     Initialize database
     """
-    with codecs.open('../config/create-postgres.sql', 'r', encoding='utf-8') as fp:
+    with codecs.open('../../../config/create-postgres.sql',
+                     'r',
+                     encoding='utf-8') as fp:
         sql = fp.read()
     DBSession.execute(sql)
     DBSession.commit()

--- a/frameworks/Python/pyramid/create_database.py
+++ b/frameworks/Python/pyramid/create_database.py
@@ -1,11 +1,14 @@
 import codecs
+import os
 from frameworkbenchmarks.models import DBSession
+
+FWROOT = os.environ.get('FWROOT', '../../..')
 
 if __name__ == "__main__":
     """
     Initialize database
     """
-    with codecs.open('../../../config/create-postgres.sql',
+    with codecs.open('%s/config/create-postgres.sql' % FWROOT,
                      'r',
                      encoding='utf-8') as fp:
         sql = fp.read()


### PR DESCRIPTION
The relative path name of create-postgres.sql was for an earlier layout of the repository.