### PR TITLE
add plaintext and json tests for Aleph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - "TESTDIR=Clojure/http-kit"
     - "TESTDIR=Clojure/luminus"
     - "TESTDIR=Clojure/pedestal"
+    - "TESTDIR=Clojure/aleph"
     - "TESTDIR=Dart/dart"
     - "TESTDIR=Dart/dart-redstone"
     - "TESTDIR=Dart/dart-start"

--- a/frameworks/Clojure/aleph/README.md
+++ b/frameworks/Clojure/aleph/README.md
@@ -1,0 +1,24 @@
+# Compojure Benchmarking Test
+
+This is the [Aleph](https;//github.com/ztellman/aleph) portion of a [benchmarking test suite](../) comparing a variety of web development platforms.
+
+### JSON Encoding Test
+
+* [JSON test source](hello/src/hello/handler.clj)
+
+## Infrastructure Software Versions
+The dependencies are documented in [project.clj](hello/project.clj),
+but the main ones are:
+
+* [Aleph 0.4.0](https://github.com/ztellman/aleph)
+* [Clojure 1.7.0-beta2](http://clojure.org/)
+* [Cheshire 5.4.0](https://github.com/dakrone/cheshire), which in turn uses [Jackson](http://jackson.codehaus.org/)
+
+## Test URLs
+### JSON Encoding Test
+
+http://localhost/json
+
+### Plaintext Test
+
+http://localhost/plaintext

--- a/frameworks/Clojure/aleph/benchmark_config.json
+++ b/frameworks/Clojure/aleph/benchmark_config.json
@@ -12,7 +12,7 @@
       "framework": "aleph",
       "language": "Clojure",
       "orm": "Raw",
-      "platform": "aleph",
+      "platform": "Netty",
       "webserver": "None",
       "os": "Linux",
       "database_os": "Linux",

--- a/frameworks/Clojure/aleph/benchmark_config.json
+++ b/frameworks/Clojure/aleph/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework": "aleph",
+  "tests": [{
+    "default": {
+      "setup_file": "setup",
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "aleph",
+      "language": "Clojure",
+      "orm": "Raw",
+      "platform": "aleph",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "aleph",
+      "notes": "",
+      "versus": "netty"
+    }
+  }]
+}

--- a/frameworks/Clojure/aleph/hello/.gitignore
+++ b/frameworks/Clojure/aleph/hello/.gitignore
@@ -1,0 +1,11 @@
+/target
+/lib
+/classes
+/checkouts
+pom.xml
+*.jar
+*.class
+.lein-deps-sum
+.lein-failures
+.lein-plugins
+.lein-env

--- a/frameworks/Clojure/aleph/hello/project.clj
+++ b/frameworks/Clojure/aleph/hello/project.clj
@@ -1,0 +1,9 @@
+(defproject hello "aleph"
+  :description "JSON/plaintext tests"
+  :dependencies [[org.clojure/clojure "1.7.0-beta2"]
+                 [clj-tuple "0.2.1"]
+                 [org.clojure/tools.cli "0.3.1"]
+                 [aleph "0.4.0"]
+                 [cheshire "5.4.0"]]
+  :main hello.handler
+  :aot :all)

--- a/frameworks/Clojure/aleph/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/aleph/hello/src/hello/handler.clj
@@ -1,0 +1,44 @@
+(ns hello.handler
+  (:require
+    [byte-streams :as bs]
+    [clojure.tools.cli :as cli]
+    [aleph.http :as http]
+    [cheshire.core :as json]
+    [clj-tuple :as t])
+  (:gen-class))
+
+(def plaintext-response
+  (t/hash-map
+    :status 200
+    :headers (t/hash-map "content-type" "text/plain; charset=utf-8")
+    :body (bs/to-byte-array "Hello, World!")))
+
+(def json-response
+  (t/hash-map
+    :status 200
+    :headers (t/hash-map "content-type" "application/json")))
+
+(defn handler [{:keys [uri] :as req}]
+  (cond
+    (= "/plaintext" uri) plaintext-response
+    (= "/json" uri) (assoc json-response
+                      :body (json/encode (t/hash-map :message "Hello, World!")))
+    :else {:status 404}))
+
+;;;
+
+(defn -main [& args]
+
+  (let [[{:keys [help port]} _ banner]
+        (cli/cli args
+          ["-p" "--port" "Server port"
+           :default 8080
+           :parse-fn #(Integer/parseInt %)]
+          ["-h" "--[no-]help"])]
+
+    (when help
+      (println banner)
+      (System/exit 0))
+
+    (aleph.netty/leak-detector-level! :disabled)
+    (http/start-server handler {:port port, :executor :none})))

--- a/frameworks/Clojure/aleph/hello/src/log4j.xml
+++ b/frameworks/Clojure/aleph/hello/src/log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <logger name="com.mchange">
+    <level value="WARN"/>
+  </logger>
+</log4j:configuration>

--- a/frameworks/Clojure/aleph/install.sh
+++ b/frameworks/Clojure/aleph/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+fw_depends java7 leiningen

--- a/frameworks/Clojure/aleph/setup.sh
+++ b/frameworks/Clojure/aleph/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source $IROOT/java7.installed
+
+source $IROOT/lein.installed
+
+cd hello
+lein clean
+lein uberjar
+java -server -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -jar target/*-standalone.jar &

--- a/frameworks/Clojure/aleph/source_code
+++ b/frameworks/Clojure/aleph/source_code
@@ -1,0 +1,2 @@
+./aleph/hello/src/hello/handler.clj
+./aleph/hello/project.clj


### PR DESCRIPTION
Ran tests in the vagrant VM, everything seems fine:

```
INFO:root:Sleeping 60 seconds to ensure framework is ready
INFO:root:Verifying framework URLs
Accessing URL http://127.0.0.1:8080/json:
  Response (trimmed to 40 bytes): "{"message":"Hello, World!"}"
   PASS for http://127.0.0.1:8080/json

Accessing URL http://127.0.0.1:8080/plaintext:
  Response (trimmed to 40 bytes): "Hello, World!"
   PASS for http://127.0.0.1:8080/plaintext
```