### PR TITLE
Move root password set to reliable location

### DIFF
--- a/toolset/setup/linux/database.sh
+++ b/toolset/setup/linux/database.sh
@@ -68,10 +68,7 @@ sudo useradd benchmarkdbuser -p benchmarkdbpass
 # MySQL
 ##############################
 echo "Setting up MySQL database"
-sudo sh -c "echo mysql-server mysql-server/root_password_again select secret | debconf-set-selections"
-sudo sh -c "echo mysql-server mysql-server/root_password select secret | debconf-set-selections"
-
-sudo apt-get -y install mysql-server
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-server
 
 sudo stop mysql
 # disable checking of disk size
@@ -90,6 +87,8 @@ sudo cp usr.sbin.mysqld /etc/apparmor.d/
 sudo /etc/init.d/apparmor reload
 sudo start mysql
 
+# Set root password
+sudo mysqladmin -u root password secret
 # Insert data
 mysql -uroot -psecret < create.sql
 rm create.sql


### PR DESCRIPTION
When set in the previous way, the root password was not being
reliably set for me in Ubuntu 14.04. This technique moves the
password reset into the configuation tools that are a part of
MySQL itself.