### PR TITLE
travis: sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Now Travis's default build environment is container and sudo is
prohibited. We should use `sudo: required`.

http://blog.travis-ci.com/2015-04-09-this-week-in-travis-ci/