### PR TITLE
Set rust frameworks' database property to None type to see if that broke travis CI

### DIFF
--- a/frameworks/Rust/iron/benchmark_config.json
+++ b/frameworks/Rust/iron/benchmark_config.json
@@ -8,7 +8,7 @@
       "port": 8080,
       "approach": "Realistic",
       "classification": "Framework",
-      "database": "",
+      "database": "None",
       "framework": "iron",
       "language": "rust",
       "orm": "",

--- a/frameworks/Rust/nickel/benchmark_config.json
+++ b/frameworks/Rust/nickel/benchmark_config.json
@@ -8,7 +8,7 @@
       "port": 8080,
       "approach": "Realistic",
       "classification": "Framework",
-      "database": "",
+      "database": "None",
       "framework": "nickel",
       "language": "rust",
       "orm": "",


### PR DESCRIPTION
Travis CI broke on Rust, which may be caused by using "" rather than "None" as the database config.