### PR TITLE
Add Redis as valid database

### DIFF
--- a/frameworks/Crystal/moonshine/server.cr
+++ b/frameworks/Crystal/moonshine/server.cr
@@ -104,9 +104,9 @@ app.get "/redis/fortunes", do |request|
   }
   data.push(additional_fortune)
 
-  data.sort! { |a, b|
+  data.sort! do |a, b|
     a[:message].to_s <=> b[:message].to_s
-  }
+  end
 
   # New builder for each request!
   html = HTML::Builder.new.build do

--- a/toolset/run-ci.py
+++ b/toolset/run-ci.py
@@ -34,7 +34,7 @@ class CIRunnner:
   Only verifies the first test in each directory 
   '''
 
-  SUPPORTED_DATABASES = "mysql postgres mongodb cassandra elasticsearch redis none".split()
+  SUPPORTED_DATABASES = "mysql postgres mongodb cassandra elasticsearch sqlite redis none".split()
   
   def __init__(self, mode, testdir=None):
     '''

--- a/toolset/run-ci.py
+++ b/toolset/run-ci.py
@@ -34,7 +34,7 @@ class CIRunnner:
   Only verifies the first test in each directory 
   '''
 
-  SUPPORTED_DATABASES = "mysql postgres mongodb cassandra elasticsearch sqlite none".split()
+  SUPPORTED_DATABASES = "mysql postgres mongodb cassandra elasticsearch redis none".split()
   
   def __init__(self, mode, testdir=None):
     '''


### PR DESCRIPTION
Redis was not listed as a supported database in `run-ci.py`. While making the change I also removed `sqlite` as that is not a valid database for our tests anymore.

Finally I made a trivial change in `Crystal/moonshine`. This particular test _only_ requires a redis database. This causes failures because when redis wasn't on the list of databases, it appeared as if this framework didn't require a valid database. Travis aborts in this case.

    INFO:run-ci:Found 1 usable tests (1 valid for linux, 0 valid for linux and {mysql,postgres,mongodb,cassandra,elasticsearch,sqlite,none}) in directory '$FWROOT/frameworks/Crystal/moonshine'

    CRITICAL:run-ci:Found no test that is possible to run in Travis-CI! Aborting!

So I made a change in `Crystal/moonshine` to ensure the tests will re-run on the directory (they should regardless).

Should see all tests passing, including `Crystal/moonshine` which is the litmus test.