### PR TITLE
Update Rust benchmark configs to get through Travis

### DIFF
--- a/frameworks/Rust/iron/benchmark_config.json
+++ b/frameworks/Rust/iron/benchmark_config.json
@@ -8,17 +8,17 @@
       "port": 8080,
       "approach": "Realistic",
       "classification": "Framework",
-      "database": "",
+      "database": "None",
       "framework": "iron",
       "language": "rust",
-      "orm": "",
+      "orm": "raw",
       "platform": "Rust",
       "webserver": "hyper",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "iron",
       "notes": "",
-      "versus": ""
+      "versus": "rust"
     }
   }]
 }

--- a/frameworks/Rust/nickel/benchmark_config.json
+++ b/frameworks/Rust/nickel/benchmark_config.json
@@ -8,17 +8,17 @@
       "port": 8080,
       "approach": "Realistic",
       "classification": "Framework",
-      "database": "",
+      "database": "None",
       "framework": "nickel",
       "language": "rust",
-      "orm": "",
+      "orm": "raw",
       "platform": "Rust",
       "webserver": "hyper",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "nickel",
       "notes": "",
-      "versus": ""
+      "versus": "rust"
     }
   }]
 }


### PR DESCRIPTION
As [commented](https://github.com/TechEmpower/FrameworkBenchmarks/pull/1649#issuecomment-110096958) in #1649, there were some tests that were failing to make it through travis due to their benchmark configs.

Adding Redis has already been put into a PR #1653 . These tests were failing because they specified the empty string as the database rather than `"None"`. I have updated the configs to have None specified as well as to be compared against other `rust` frameworks.