### PR TITLE
Update duda install to not depend on http://duda.io

### DIFF
--- a/frameworks/C/duda/install.sh
+++ b/frameworks/C/duda/install.sh
@@ -3,10 +3,9 @@
 RETCODE=$(fw_exists ${IROOT}/duda-0.23.installed)
 [ ! "$RETCODE" == 0 ] || { return 0; }
 
-fw_get http://duda.io/releases/duda-client/dudac-0.23.tar.gz -O dudac-0.23.tar.gz
-fw_untar dudac-0.23.tar.gz
+git clone https://github.com/monkey/dudac.git
 
-cd dudac-0.23
+cd dudac/
 
 ./dudac -r
 ./dudac -s

--- a/frameworks/C/duda/setup.sh
+++ b/frameworks/C/duda/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export DUDA_HOME=${IROOT}/dudac-0.23
+export DUDA_HOME=${IROOT}/dudac
 export PATH=${DUDA_HOME}:$PATH
 
 dudac -w $TROOT/webservice -p 2001 &


### PR DESCRIPTION
Was causing a fail in #1658 

http://duda.io is completely down. I was able to find the project on github and get the install working. All tests run and pass smoothly.