### PR TITLE
Fixing host bind

### DIFF
--- a/frameworks/Scala/scruffy/src/main/scala/scruffy/examples/Main.scala
+++ b/frameworks/Scala/scruffy/src/main/scala/scruffy/examples/Main.scala
@@ -16,7 +16,7 @@ object Main extends App {
 
   val server = Undertow
     .builder()
-    .addHttpListener(port, "localhost")
+    .addHttpListener(port, "0.0.0.0")
     .setHandler(handler)
     .setServerOption(UndertowOptions.ALWAYS_SET_KEEP_ALIVE, java.lang.Boolean.FALSE)
     .setServerOption(UndertowOptions.ALWAYS_SET_DATE, java.lang.Boolean.TRUE)


### PR DESCRIPTION
Scruffy was binding to localhost, when it should bind to all network interfaces.
This PR addresses an error in preview 11.