### PR TITLE
update express to use latest jade

### DIFF
--- a/frameworks/JavaScript/express/package.json
+++ b/frameworks/JavaScript/express/package.json
@@ -7,9 +7,9 @@
     , "body-parser": "1.12.3"
     , "method-override": "2.3.2"
     , "errorhandler": "1.3.5"
-    , "mongoose": "4.0.1" 
+    , "mongoose": "4.0.1"
     , "async": "0.9.0"
-    , "jade": "0.29.0"
+    , "jade": "1.10.0"
     , "sequelize": "2.0.6"
     , "mysql": "2.6.2"
   }

--- a/frameworks/JavaScript/express/views/fortunes/index.jade
+++ b/frameworks/JavaScript/express/views/fortunes/index.jade
@@ -5,7 +5,7 @@ block content
     tr
       th id
       th message
-    for fortune in fortunes
+    each fortune in fortunes
       tr
         td= fortune.id
         td= fortune.message

--- a/frameworks/JavaScript/express/views/layout.jade
+++ b/frameworks/JavaScript/express/views/layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype
 html
   head
     title Fortunes


### PR DESCRIPTION
the old version of jade had a debug flag that was still enabled by default in production which this newer version disabled, so the performance increases quite significantly.