### PR TITLE
Enable MySQL logging during verify mode

### DIFF
--- a/config/move-temp-mysql-log.sh
+++ b/config/move-temp-mysql-log.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+FROM=/tmp/tfb-temporary-mysql.log
+FINAL_DESTINATION=$1
+TEST_NAME=$2
+
+if [ -f $FROM ]
+then
+    cp /tmp/tfb-temporary-mysql.log $FINAL_DESTINATION
+    echo "Successfully moved MySQL temporary log file for $TEST_NAME" 
+else
+	echo "Expected MySQL log file at $FROM, but found none, no files copied"
+	return 1
+fi
+
+return 0

--- a/config/restart-mysql-with-logging.sh
+++ b/config/restart-mysql-with-logging.sh
@@ -1,22 +1,28 @@
 #!/bin/sh
+
+cd "$(dirname "$0")"
+
 if [ -f /etc/mysql/my.cnf ]; then
     sudo rm /etc/mysql/my.cnf
 fi
 
-# Assumes file settings are changed by this point
 
-# Incorporate this Wednesday >>
-# vagrant@TFB-all:/var/log$ sudo mkdir mysql
-# vagrant@TFB-all:/var/log$ sudo touch mysql/mysql.log
-# vagrant@TFB-all:/var/log$ sudo touch mysql/mysql.error.log
+LOG=/tmp/tfb-temporary-mysql.log
 
+if [ -f $LOG ]; then
+	sudo rm $LOG
+fi
+# Cannot initialize log in its final location because that is a synced folder, so
+touch $LOG                                   # create a log file
+sudo chown mysql:mysql $LOG                  # in a location that mysql can own
 
-# sudo chmod 0644 my.cnf
-# sudo cp my.cnf /etc/mysql/my.cnf
-# sudo service mysql restart
+cp my.cnf my.sql-logging.cnf                 # Start with my.cnf
+sed -i "s|.*general_log_file.*|general_log_file = ${LOG}|" my.sql-logging.cnf
+sed -i 's|.*general_log .*|general_log = 1|' my.sql-logging.cnf
 
-echo "Shell script ran"
-echo $0
-echo $1
+sudo mv my.sql-logging.cnf /etc/mysql/my.cnf # Move file
+sudo chmod 0644 /etc/mysql/my.cnf            # before changing modes
+
+sudo service mysql restart
 
 return 0

--- a/config/restart-mysql-with-logging.sh
+++ b/config/restart-mysql-with-logging.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+if [ -f /etc/mysql/my.cnf ]; then
+    sudo rm /etc/mysql/my.cnf
+fi
+
+# Assumes file settings are changed by this point
+
+# Incorporate this Wednesday >>
+# vagrant@TFB-all:/var/log$ sudo mkdir mysql
+# vagrant@TFB-all:/var/log$ sudo touch mysql/mysql.log
+# vagrant@TFB-all:/var/log$ sudo touch mysql/mysql.error.log
+
+
+# sudo chmod 0644 my.cnf
+# sudo cp my.cnf /etc/mysql/my.cnf
+# sudo service mysql restart
+
+echo "Shell script ran"
+echo $0
+echo $1
+
+return 0

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -522,7 +522,8 @@ class Benchmarker:
     except Exception:
       pass
     with open(os.path.join(logDir, 'out.txt'), 'w') as out, \
-         open(os.path.join(logDir, 'err.txt'), 'w') as err:
+         open(os.path.join(logDir, 'err.txt'), 'w') as err, \
+         open(os.path.join(logDir, 'mysql.log'), 'w') as mysqlLog:
 
       if test.os.lower() != self.os.lower() or test.database_os.lower() != self.database_os.lower():
         out.write("OS or Database OS specified in benchmark_config.json does not match the current environment. Skipping.\n")
@@ -563,6 +564,15 @@ class Benchmarker:
             /opt/elasticsearch/elasticsearch restart
           """)
           time.sleep(10)
+
+          if self.mode == "verify":
+            enable = os.path.join('config', 'restart-mysql-with-logging.sh')
+            print enable
+            try:
+              x = subprocess.call([enable, 'first arg', 'second arg'])
+              print x
+            except Exception as e:
+              print e
 
           st = verify_database_connections([
             ("mysql", self.database_host, 3306),

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -567,7 +567,7 @@ class Benchmarker:
           if self.mode == "verify":
             with_logging = os.path.join('config', 'restart-mysql-with-logging.sh')
             try:
-              print 'Mode was verify, restarting MySQL with logging enabled'
+              print 'Mode was verify, restarting MySQL with logging enabled for %s' % test.name
               # Creates a temp db log and restarts MySQL to write to it for this test
               subprocess.call([with_logging])
             except Exception as e:
@@ -636,6 +636,15 @@ class Benchmarker:
         self.__stop_test(out, err)
         out.flush()
         err.flush()
+        if test.mode == "verify":
+          # this path is w.r.t. move-temp-mysql-log.sh
+          final_dest = os.path.join('../', logDir, 'mysql.log')
+          mv_db_logging = os.path.join('config', 'move-temp-mysql-log.sh')
+          try:
+            print "Mode was verify, moving MySQL test log to %s's results directory" % test.name
+            subprocess.call([mv_db_logging, final_dest, test.name])
+          except Exception as e:
+            print e
         time.sleep(15)
 
         if self.__is_port_bound(test.port):

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -522,8 +522,7 @@ class Benchmarker:
     except Exception:
       pass
     with open(os.path.join(logDir, 'out.txt'), 'w') as out, \
-         open(os.path.join(logDir, 'err.txt'), 'w') as err, \
-         open(os.path.join(logDir, 'mysql.log'), 'w') as mysqlLog:
+         open(os.path.join(logDir, 'err.txt'), 'w') as err:
 
       if test.os.lower() != self.os.lower() or test.database_os.lower() != self.database_os.lower():
         out.write("OS or Database OS specified in benchmark_config.json does not match the current environment. Skipping.\n")
@@ -566,11 +565,11 @@ class Benchmarker:
           time.sleep(10)
 
           if self.mode == "verify":
-            enable = os.path.join('config', 'restart-mysql-with-logging.sh')
-            print enable
+            with_logging = os.path.join('config', 'restart-mysql-with-logging.sh')
             try:
-              x = subprocess.call([enable, 'first arg', 'second arg'])
-              print x
+              print 'Mode was verify, restarting MySQL with logging enabled'
+              # Creates a temp db log and restarts MySQL to write to it for this test
+              subprocess.call([with_logging])
             except Exception as e:
               print e
 


### PR DESCRIPTION
These changes allow MySQL to log during verify mode. One script creates a temporary log file that mysql can access, and restarts MySQL to log to that file. Once the test is complete the log is moved into the results directory for the test, the same one with the respective `err.txt` and `out.txt` of the test:

    $ ls -la results/ec2/latest/logs/sailsjs
    total 372
    drwxrwxrwx 1 vagrant vagrant   4096 Jun 10 21:21 .
    drwxrwxrwx 1 vagrant vagrant   4096 Jun 10 21:17 ..
    -rwxrwxrwx 1 vagrant vagrant    687 Jun 10 21:21 err.txt
    -rwxrwxrwx 1 vagrant vagrant 265576 Jun 10 21:21 mysql.log
    -rwxrwxrwx 1 vagrant vagrant  99660 Jun 10 21:21 out.txt

This change will allow a closer audit to be made on the database activities of a framework tests.

This change works if multiple tests are run at the same time, the results will be organized nicely in the same way as `err.txt` and `out.txt`.

Tasks:
- [x] Do initial work, get MySQL to log to a specific location then move that log to a test-specific place at the end of test
- [x] First round of feedback
- [ ] Ensure that the logic for doing the logging is `in_verify_mode && !in_travis_ci`