### PR TITLE
Benchmark config warnings 2

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -851,6 +851,30 @@ def test_order(type_name):
   """
   return len(type_name)
 
+
+def validate_urls(test_name, test_keys):
+  """
+  Separated from validate_test because urls are not required anywhere. We know a url is incorrect if it is
+  empty or does not start with a "/" character. There is no validation done to ensure the url conforms to
+  the suggested url specifications, although those suggestions are presented if a url fails validation here.
+  """
+  example_urls = {
+    "json_url":      "/json",
+    "db_url":        "/mysql/db",
+    "query_url":     "/mysql/queries?queries=  or  /mysql/queries/",
+    "fortune_url":   "/mysql/fortunes",
+    "update_url":    "/mysql/updates?queries=  or  /mysql/updates/",
+    "plaintext_url": "/plaintext"
+  }
+  for test_url in ["json_url","db_url","query_url","fortune_url","update_url","plaintext_url"]:
+    key_value = test_keys.get(test_url, None)
+    if key_value != None and not key_value.startswith('/'):
+      errmsg = """`%s` field in test \"%s\" does not appear to be a valid url: \"%s\"\n
+        Example `%s` url: \"%s\"
+      """ % (test_url, test_name, key_value, test_url, example_urls[test_url])
+      raise Exception(errmsg)
+ 
+
 def validate_test(test_name, test_keys, directory):
   """
   Validate benchmark config values for this test based on a schema
@@ -930,6 +954,9 @@ def validate_test(test_name, test_keys, directory):
     missingstr = (", ").join(map(str, missing))
     raise Exception("benchmark_config.json for test %s is invalid, please amend by adding the following required keys: [%s]"
       % (test_name, missingstr))
+
+  # Check the (all optional) test urls
+  validate_urls(test_name, test_keys)
 
   # Check values of keys against schema
   for key in required_keys:


### PR DESCRIPTION
_Changes prompted by conversation in the [previous pull request](https://github.com/TechEmpower/FrameworkBenchmarks/pull/1658#issuecomment-111344061)_

Changes:
- [x] Improve the Python of the area I was working on, make it conform more closely with PEP8, clean up comments, improve variable names in some cases
- [x] Use a schema dict to define required fields and help messages in the event that they are absent or non-conforming (main motivation for changes)
- [x] Break `parse_config` into smaller functions
- [ ] Improve quality of help messages (not fully done, some are still `"..."`, others can be improved with some feedback)

To test:
1.  Pick a couple `benchmark_config.json` files to use, different languages with more than one test type is ideal.
2.  The validation is done on the whole project from what I've seen, so if the `benchmark_config.json` for `Java/gemini` is broken, you will still get errors if you are running `toolset/run-tests.py --mode verify --test sailsjs`. This is nice and can save some typing.
3.  The test urls `["json_url", "db_url", "query_url", "fortune_url", "update_url", "plaintext_url"]` must begin with a `/` character, some nice test cases are `"."`, `""`, `"db"`, `"queries/"`. See that an exception and suggested url is generated. Omitting these fields is not a test case as they are never required.
4.  The `["language", "webserver", "platform"]` fields are required, but free-entry, so they must be any string that is non-empty. So cases like `"JavaSScript"` and `"Pyton"` will work. Test will empty string to ensure that error and help message come up.
5.1.  The `["classification", "database", "approach", "orm", "os", "database_os"]` fields are required but only accept a set of options. In several `benchmark_configs` of choice, set these keys to values that are clearly not apart of set e.g.:
    * `"classification": "quite superb"`
    * `"database": "HoldsStuffDB"`
    * `"orm": ""`
    * `"os": "Yosemite"`
See that a list of possible values plus short descriptors for each are presented.
5.2.  These fields are not case-sensitive, try some acceptable, un-acceptably cased values and see that they work e.g.:
    * `"database": "PoSTGRES"`
    * `"os": "LiNuX"`
6.  Finally take a look at the `schema` dict in `framework_test.py` (look through files changed) and examine it. I have done my best with the help comments so far but I plan for another commit of improvements before this gets merged.

Starting this PR now to let travis have at it over the weeked. Best-case scenario is I only need to complete the help strings.