### PR TITLE
Replace curl usage with requests

### DIFF
--- a/frameworks/Crystal/moonshine/server.cr
+++ b/frameworks/Crystal/moonshine/server.cr
@@ -14,9 +14,9 @@ app = App.new
 
 class CONTENT
   UTF8 = "; charset=UTF-8"
-  JSON = "application/json" + UTF8
+  JSON = "application/json" #+ UTF8
   PLAIN = "text/plain"
-  HTML = "text/html" + UTF8
+  HTML = "text/html" #+ UTF8
 end
 
 ID_MAXIMUM = 10_000

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -383,9 +383,9 @@ class FrameworkTest:
         logging.warning("Verifying test %s for %s caused an exception: %s", test_type, self.name, e)
         traceback.format_exc()
 
-      test.failed = any(result is 'fail' for (result, reason, url) in results)
-      test.warned = any(result is 'warn' for (result, reason, url) in results)
-      test.passed = all(result is 'pass' for (result, reason, url) in results)
+      test.failed = any(result == 'fail' for (result, reason, url) in results)
+      test.warned = any(result == 'warn' for (result, reason, url) in results)
+      test.passed = all(result == 'pass' for (result, reason, url) in results)
       
       def output_result(result, reason, url):
         specific_rules_url = "http://frameworkbenchmarks.readthedocs.org/en/latest/Project-Information/Framework-Tests/#specific-test-requirements"

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -851,6 +851,30 @@ def test_order(type_name):
   """
   return len(type_name)
 
+
+def validate_urls(test_name, test_keys):
+  """
+  Separated from validate_test because urls are not required anywhere. We know a url is incorrect if it is
+  empty or does not start with a "/" character. There is no validation done to ensure the url conforms to
+  the suggested url specifications, although those suggestions are presented if a url fails validation here.
+  """
+  example_urls = {
+    "json_url":      "/json",
+    "db_url":        "/mysql/db",
+    "query_url":     "/mysql/queries?queries=  or  /mysql/queries/",
+    "fortune_url":   "/mysql/fortunes",
+    "update_url":    "/mysql/updates?queries=  or  /mysql/updates/",
+    "plaintext_url": "/plaintext"
+  }
+  for test_url in ["json_url","db_url","query_url","fortune_url","update_url","plaintext_url"]:
+    key_value = test_keys.get(test_url, None)
+    if key_value != None and not key_value.startswith('/'):
+      errmsg = """`%s` field in test \"%s\" does not appear to be a valid url: \"%s\"\n
+        Example `%s` url: \"%s\"
+      """ % (test_url, test_name, key_value, test_url, example_urls[test_url])
+      raise Exception(errmsg)
+ 
+
 def validate_test(test_name, test_keys, directory):
   """
   Validate benchmark config values for this test based on a schema
@@ -930,6 +954,9 @@ def validate_test(test_name, test_keys, directory):
     missingstr = (", ").join(map(str, missing))
     raise Exception("benchmark_config.json for test %s is invalid, please amend by adding the following required keys: [%s]"
       % (test_name, missingstr))
+
+  # Check the (all optional) test urls
+  validate_urls(test_name, test_keys)
 
   # Check values of keys against schema
   for key in required_keys:

--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -94,6 +94,8 @@ class DBTestType(FrameworkTestType):
                      url))
         return problems
 
+    # Prime refactor target. This method is also utilized by the multiple queries
+    # and updates tests, yet is not separated out nicely.
     def _verifyObject(self, db_object, url, max_infraction='fail'):
         '''Ensure the passed item is a JSON object with 
         keys 'id' and 'randomNumber' mapping to ints. 

--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -8,7 +8,7 @@ class DBTestType(FrameworkTestType):
     def __init__(self):
         kwargs = {
             'name': 'db',
-            'accept_header': self.accept_json,
+            'accept_header': self.accept('json'),
             'requires_db': True,
             'args': ['db_url']
         }

--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -2,133 +2,149 @@ from benchmark.test_types.framework_test_type import FrameworkTestType
 
 import json
 
+
 class DBTestType(FrameworkTestType):
-  def __init__(self):
-    kwargs = {
-      'name': 'db',
-      'accept_header': self.accept_json,
-      'requires_db': True,
-      'args': ['db_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
 
-  def get_url(self):
-    return self.db_url
+    def __init__(self):
+        kwargs = {
+            'name': 'db',
+            'accept_header': self.accept_json,
+            'requires_db': True,
+            'args': ['db_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def verify(self, base_url):
-    '''Ensures body is valid JSON with a key 'id' and a key 
-    'randomNumber', both of which must map to integers
-    '''
+    def get_url(self):
+        return self.db_url
 
-    url = base_url + self.db_url
-    headers, body = self.request_headers_and_body(url)
-    
-    # Empty response
-    if body is None:
-      return [('fail','No response', url)]
-    elif len(body) == 0:
-      return [('fail','Empty Response', url)]
+    def verify(self, base_url):
+        '''Ensures body is valid JSON with a key 'id' and a key 
+        'randomNumber', both of which must map to integers
+        '''
 
-    # Valid JSON? 
-    try: 
-      response = json.loads(body)
-    except ValueError as ve:
-      return [('fail',"Invalid JSON - %s" % ve, url)]
+        url = base_url + self.db_url
+        headers, body = self.request_headers_and_body(url)
 
-    problems = []
+        # Empty response
+        if body is None:
+            return [('fail', 'No response', url)]
+        elif len(body) == 0:
+            return [('fail', 'Empty Response', url)]
 
-    # We are allowing the single-object array 
-    # e.g. [{'id':5, 'randomNumber':10}] for now, 
-    # but will likely make this fail at some point
-    if type(response) == list:
-      response = response[0]
-      problems.append( ('warn', 'Response is a JSON array. Expected JSON object (e.g. [] vs {})', url) ) 
+        # Valid JSON?
+        try:
+            response = json.loads(body)
+        except ValueError as ve:
+            return [('fail', "Invalid JSON - %s" % ve, url)]
 
-      # Make sure there was a JSON object inside the array
-      if type(response) != dict:
-        problems.append( ('fail', 'Response is not a JSON object or an array of JSON objects', url) ) 
+        problems = []
+
+        # We are allowing the single-object array
+        # e.g. [{'id':5, 'randomNumber':10}] for now,
+        # but will likely make this fail at some point
+        if type(response) == list:
+            response = response[0]
+            problems.append(
+                ('warn', 'Response is a JSON array. Expected JSON object (e.g. [] vs {})', url))
+
+            # Make sure there was a JSON object inside the array
+            if type(response) != dict:
+                problems.append(
+                    ('fail', 'Response is not a JSON object or an array of JSON objects', url))
+                return problems
+
+        # Verify response content
+        problems += self._verifyObject(response, url)
+        problems += self._verifyHeaders(headers, url)
+
+        if len(problems) == 0:
+            return [('pass', '', url)]
+        else:
+            return problems
+
+    def _verifyHeaders(self, headers, url):
+        '''Verifies the response headers'''
+
+        problems = []
+
+        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
+            problems.append(
+                ('warn', 'Required response header missing: %s' % v, url))
+        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
+            problems.append(
+                ('warn',
+                 'Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"',
+                 url))
+        else:
+            content_type = headers.get('Content-Type', None)
+            expected_type = 'application/json'
+            includes_charset = 'application/json; charset=utf-8'
+            if content_type == includes_charset:
+                problems.append(
+                    ('warn',
+                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
+                      "Additional response bytes may negatively affect benchmark performance."
+                      % (includes_charset, expected_type)),
+                     url))
+            elif content_type != expected_type:
+                problems.append(
+                    ('warn',
+                     'Unexpected content encoding, found %s, expected %s' % (
+                         content_type, expected_type),
+                     url))
         return problems
 
-    problems += self._verifyObject(response, url)
+    def _verifyObject(self, db_object, url, max_infraction='fail'):
+        '''Ensure the passed item is a JSON object with 
+        keys 'id' and 'randomNumber' mapping to ints. 
+        Separate method allows the QueryTestType to 
+        reuse these checks'''
 
-    # Verify response headers
-    if any(v.lower() not in headers for v in ('Server','Date','Content-Type')):
-      problems.append( ('warn', 'Required response header missing: %s' % v, url) )
-    elif all(v.lower() not in headers for v in ('Content-Length','Transfer-Encoding')):
-      problems.append(
-        ('warn',
-         'Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"',
-         url))
-    else:
-      content_type = headers.get('Content-Type', None)
-      expected_type = 'application/json'
-      includes_charset = 'application/json; charset=utf-8'
-      if content_type == includes_charset:
-        problems.append(
-          ('warn',
-           ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-            "Additional response bytes may negatively affect benchmark performance."
-              % (includes_charset, expected_type)),
-           url))
-      elif content_type != expected_type:
-        problems.append(
-          ('warn',
-           'Unexpected content encoding, found %s, expected %s' % (content_type, expected_type),
-           url))
+        problems = []
 
-    if len(problems) == 0:
-      return [('pass','',url)]
-    else:
-      return problems
+        # Dict is expected, handle bytes in non-cases
+        if type(db_object) != dict:
+            got = str(db_object)[:20]
+            if len(str(db_object)) > 20:
+                got = str(db_object)[:17] + '...'
+            return [(max_infraction, "Expected a JSON object, got '%s' instead" % got, url)]
 
-  def _verifyObject(self, db_object, url, max_infraction='fail'):
-    '''Ensure the passed item is a JSON object with 
-    keys 'id' and 'randomNumber' mapping to ints. 
-    Separate method allows the QueryTestType to 
-    reuse these checks'''
+        # Make keys case insensitive
+        db_object = {k.lower(): v for k, v in db_object.iteritems()}
 
-    problems = []
+        if any(v not in db_object for v in ('id', 'randomnumber')):
+            problems.append(
+                (max_infraction, 'Response object was missing required key: %s' % v, url))
 
-    # Dict is expected, handle bytes in non-cases
-    if type(db_object) != dict:
-      got = str(db_object)[:20]
-      if len(str(db_object)) > 20:
-        got = str(db_object)[:17] + '...'
-      return [(max_infraction, "Expected a JSON object, got '%s' instead" % got, url)]
+        # All required keys must be present
+        if len(problems) > 0:
+            return problems
 
-    # Make keys case insensitive
-    db_object = {k.lower(): v for k,v in db_object.iteritems()}
+        # Assert key types and values
+        try:
+            response_id = float(db_object["id"])
+            if response_id > 10000 or response_id < 1:
+                problems.append(
+                    ('warn', "Response key 'id' should be between 1 and 10,000", url))
+            if type(db_object["id"]) != int:
+                problems.append(
+                    ('warn',
+                     ("Response key 'id' was not an integer and may result in additional response bytes.\n",
+                      "Additional response bytes may negatively affect benchmark performance."),
+                     url))
+        except ValueError as ve:
+            problems.append(
+                (max_infraction, "Response key 'id' does not map to a number - %s" % ve, url))
 
-    if any(v not in db_object for v in ('id','randomnumber')):
-      problems.append( (max_infraction, 'Response object was missing required key: %s' % v, url) )
-    
-    # All required keys must be present
-    if len(problems) > 0:
-      return problems
+        try:
+            response_rn = float(db_object["randomnumber"])
+            if response_rn > 10000:
+                problems.append(
+                    ('warn',
+                     "Response key 'randomNumber' is over 10,000. This may negatively affect performance by sending extra bytes.",
+                     url))
+        except ValueError as ve:
+            problems.append(
+                (max_infraction, "Response key 'randomNumber' does not map to a number - %s" % ve, url))
 
-    # Assert key types and values
-    try:
-      response_id = float(db_object["id"])
-      if response_id > 10000 or response_id < 1:
-        problems.append( ('warn', "Response key 'id' should be between 1 and 10,000", url) )
-      if type(db_object["id"]) != int:
-        problems.append(
-          ('warn',
-           ('%s%s' % ("Response key 'id' was not an integer and may result in additional response bytes.",
-                      "Additional response bytes may negatively affect benchmark performance.")),
-           url))
-    except ValueError as ve:
-      problems.append( (max_infraction, "Response key 'id' does not map to a number - %s" % ve, url) ) 
-
-    try:
-      response_rn = float(db_object["randomnumber"])
-      if response_rn > 10000:
-        problems.append(
-          ('warn',
-           "Response key 'randomNumber' is over 10,000. This may negatively affect performance by sending extra bytes.",
-           url))
-
-    except ValueError as ve:
-      problems.append( (max_infraction, "Response key 'randomNumber' does not map to a number - %s" % ve, url) ) 
-
-    return problems
+        return problems

--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -1,5 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.verifications import verify_headers, verify_randomnumber_object
+from benchmark.test_types.verifications import basic_body_verification, verify_headers, verify_randomnumber_object
 
 import json
 
@@ -26,19 +26,10 @@ class DBTestType(FrameworkTestType):
         url = base_url + self.db_url
         headers, body = self.request_headers_and_body(url)
 
-        # Empty response
-        if body is None:
-            return [('fail', 'No response', url)]
-        elif len(body) == 0:
-            return [('fail', 'Empty Response', url)]
+        response, problems = basic_body_verification(body)
 
-        # Valid JSON?
-        try:
-            response = json.loads(body)
-        except ValueError as ve:
-            return [('fail', "Invalid JSON - %s" % ve, url)]
-
-        problems = []
+        if len(problems) > 0:
+            return problems 
 
         # We are allowing the single-object array
         # e.g. [{'id':5, 'randomNumber':10}] for now,

--- a/toolset/benchmark/test_types/db_type.py
+++ b/toolset/benchmark/test_types/db_type.py
@@ -1,4 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
+from benchmark.test_types.verifications import verify_headers
 
 import json
 
@@ -55,44 +56,12 @@ class DBTestType(FrameworkTestType):
 
         # Verify response content
         problems += self._verifyObject(response, url)
-        problems += self._verifyHeaders(headers, url)
+        problems += verify_headers(headers, url, should_be='json')
 
         if len(problems) == 0:
             return [('pass', '', url)]
         else:
             return problems
-
-    def _verifyHeaders(self, headers, url):
-        '''Verifies the response headers'''
-
-        problems = []
-
-        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
-            problems.append(
-                ('warn', 'Required response header missing: %s' % v, url))
-        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
-            problems.append(
-                ('warn',
-                 'Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"',
-                 url))
-        else:
-            content_type = headers.get('Content-Type', None)
-            expected_type = 'application/json'
-            includes_charset = 'application/json; charset=utf-8'
-            if content_type == includes_charset:
-                problems.append(
-                    ('warn',
-                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-                      "Additional response bytes may negatively affect benchmark performance."
-                      % (includes_charset, expected_type)),
-                     url))
-            elif content_type != expected_type:
-                problems.append(
-                    ('warn',
-                     'Unexpected content encoding, found %s, expected %s' % (
-                         content_type, expected_type),
-                     url))
-        return problems
 
     # Prime refactor target. This method is also utilized by the multiple queries
     # and updates tests, yet is not separated out nicely.

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -2,12 +2,15 @@ from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.fortune_html_parser import FortuneHTMLParser
 
 class FortuneTestType(FrameworkTestType):
+
   def __init__(self):
-    args = ['fortune_url']
-    FrameworkTestType.__init__(self, name='fortune', 
-      requires_db=True, 
-      accept_header=self.accept_html, 
-      args=args)
+    kwargs = {
+      'name': 'fortune',
+      'accept_header': self.accept_html,
+      'requires_db': True,
+      'args': ['fortune_url']
+    }
+    FrameworkTestType.__init__(self, **kwargs)
 
   def get_url(self):
     return self.fortune_url
@@ -17,9 +20,9 @@ class FortuneTestType(FrameworkTestType):
     FortuneHTMLParser whether the parsed string is a 
     valid fortune response
     '''
+
     url = base_url + self.fortune_url
-    full_response = self._curl(url)
-    body = self._curl_body(url)
+    headers, body = self.request_headers_and_body(url)
     
     # Empty response
     if body is None:
@@ -30,42 +33,89 @@ class FortuneTestType(FrameworkTestType):
     parser = FortuneHTMLParser()
     parser.feed(body)
     (valid, diff) = parser.isValidFortune(self.out)
+
     if valid:
-      # Ensure required response headers are present
-      if any(v.lower() not in full_response.lower() for v in ('Server','Date','Content-Type: text/html')) \
-         or all(v.lower() not in full_response.lower() for v in ('Content-Length','Transfer-Encoding')):
-        return[('warn','Required response header missing.',url)]
+      problems = []
 
-      return [('pass','',url)]
+      problems += self._verifyHeaders(headers, url)
+
+      if len(problems) == 0:
+        return [('pass','',url)]
+      else:
+        return problems
     else:
-      failures = [('fail','Invalid according to FortuneHTMLParser',url)]
-      # Catch exceptions because we are relying on internal code
-      try:
-        # Parsing this: 
-        # --- Valid
-        # +++ Response
-        # @@ -1 +1 @@
-        #
-        # -<!doctype html><html><head><title>Fortunes</title></head><body><table>
-        # +<!doctype html><html><head><meta></meta><title>Fortunes</title></head><body><div><table>
-        # @@ -16 +16 @@
-        
-        current_neg = []
-        current_pos = []
-        for line in diff[3:]:
-          if line[0] == '+':
-            current_neg.append(line[1:])
-          elif line[0] == '-':
-            current_pos.append(line[1:])
-          elif line[0] == '@':
-            failures.append( ('fail', 
-              "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
-              url) )
-        if len(current_pos) != 0:
-          failures.append( ('fail', 
-              "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
-              url) )
-      except: 
-        pass
-      return failures 
+      failures = []
+      failures.append( ('fail','Invalid according to FortuneHTMLParser',url) )
+      failures += self._parseDiffForFailure(diff, failures, url)
+      return failures
 
+  def _parseDiffForFailure(self, diff, failures, url):
+    '''Example diff:
+
+    --- Valid
+    +++ Response
+    @@ -1 +1 @@
+    
+    -<!doctype html><html><head><title>Fortunes</title></head><body><table>
+    +<!doctype html><html><head><meta></meta><title>Fortunes</title></head><body><div><table>
+    @@ -16 +16 @@
+    '''
+
+    problems = []
+
+    # Catch exceptions because we are relying on internal code
+    try:
+      current_neg = []
+      current_pos = []
+      for line in diff[3:]:
+        if line[0] == '+':
+          current_neg.append(line[1:])
+        elif line[0] == '-':
+          current_pos.append(line[1:])
+        elif line[0] == '@':
+          problems.append( ('fail', 
+            "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
+            url) )
+      if len(current_pos) != 0:
+        problems.append( ('fail', 
+            "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
+            url) )
+    except:
+      # If there were errors reading the diff, then no diff information
+      pass
+
+    return problems
+
+  def _verifyHeaders(self, headers, url):
+    '''Verifies the response headers for the Fortunes test'''
+
+    problems = []
+
+    if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
+      problems.append(
+        ('warn', 'Required response header missing: %s' % v, url))
+    elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
+      problems.append(
+        ('warn',
+         ('Required response size header missing, '
+          'please include either "Content-Length" or "Transfer-Encoding"'),
+         url))
+    else:
+      content_type = headers.get('Content-Type', '').lower()
+      expected_type = 'text/html'
+      includes_charset = expected_type+'; charset=utf-8'
+
+      if content_type == includes_charset:
+        problems.append(
+          ('warn',
+           ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
+            "Additional response bytes may negatively affect benchmark performance."
+            % (includes_charset, expected_type)),
+           url))
+      elif content_type != expected_type:
+        problems.append(
+            ('warn',
+             'Unexpected content encoding, found %s, expected %s' % (
+                 content_type, expected_type),
+             url))
+      return problems

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -1,5 +1,6 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.fortune_html_parser import FortuneHTMLParser
+from benchmark.test_types.verifications import verify_headers
 
 
 class FortuneTestType(FrameworkTestType):
@@ -37,7 +38,7 @@ class FortuneTestType(FrameworkTestType):
 
         if valid:
             problems = []
-            problems += self._verifyHeaders(headers, url)
+            problems += verify_headers(headers, url, should_be='html')
 
             if len(problems) == 0:
                 return [('pass', '', url)]
@@ -87,38 +88,4 @@ class FortuneTestType(FrameworkTestType):
         except:
             # If there were errors reading the diff, then no diff information
             pass
-        return problems
-
-    def _verifyHeaders(self, headers, url):
-        '''Verifies the response headers for the Fortunes test'''
-
-        problems = []
-
-        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
-            problems.append(
-                ('warn', 'Required response header missing: %s' % v, url))
-        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
-            problems.append(
-                ('warn',
-                 ('Required response size header missing, '
-                  'please include either "Content-Length" or "Transfer-Encoding"'),
-                    url))
-        else:
-            content_type = headers.get('Content-Type', '')
-            expected_type = 'text/html'
-            includes_charset = expected_type + '; charset=utf-8'
-
-            if content_type.lower() == includes_charset:
-                problems.append(
-                    ('warn',
-                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-                      "Additional response bytes may negatively affect benchmark performance."
-                      % (includes_charset, expected_type)),
-                     url))
-            elif content_type != expected_type:
-                problems.append(
-                    ('warn',
-                     'Unexpected content encoding, found %s, expected %s' % (
-                         content_type, expected_type),
-                     url))
         return problems

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -7,7 +7,7 @@ class FortuneTestType(FrameworkTestType):
     def __init__(self):
         kwargs = {
             'name': 'fortune',
-            'accept_header': self.accept_html,
+            'accept_header': self.accept('html'),
             'requires_db': True,
             'args': ['fortune_url']
         }

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -1,121 +1,124 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.fortune_html_parser import FortuneHTMLParser
 
+
 class FortuneTestType(FrameworkTestType):
 
-  def __init__(self):
-    kwargs = {
-      'name': 'fortune',
-      'accept_header': self.accept_html,
-      'requires_db': True,
-      'args': ['fortune_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
+    def __init__(self):
+        kwargs = {
+            'name': 'fortune',
+            'accept_header': self.accept_html,
+            'requires_db': True,
+            'args': ['fortune_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def get_url(self):
-    return self.fortune_url
+    def get_url(self):
+        return self.fortune_url
 
-  def verify(self, base_url):
-    '''Parses the given HTML string and asks the 
-    FortuneHTMLParser whether the parsed string is a 
-    valid fortune response
-    '''
+    def verify(self, base_url):
+        '''Parses the given HTML string and asks the 
+        FortuneHTMLParser whether the parsed string is a 
+        valid fortune response
+        '''
 
-    url = base_url + self.fortune_url
-    headers, body = self.request_headers_and_body(url)
-    
-    # Empty response
-    if body is None:
-      return [('fail','No response', url)]
-    elif len(body) == 0:
-      return [('fail','Empty Response', url)]
+        url = base_url + self.fortune_url
+        headers, body = self.request_headers_and_body(url)
 
-    parser = FortuneHTMLParser()
-    parser.feed(body)
-    (valid, diff) = parser.isValidFortune(self.out)
+        # Empty response
+        if body is None:
+            return [('fail', 'No response', url)]
+        elif len(body) == 0:
+            return [('fail', 'Empty Response', url)]
 
-    if valid:
-      problems = []
+        parser = FortuneHTMLParser()
+        parser.feed(body)
+        (valid, diff) = parser.isValidFortune(self.out)
 
-      problems += self._verifyHeaders(headers, url)
+        if valid:
+            problems = []
+            problems += self._verifyHeaders(headers, url)
 
-      if len(problems) == 0:
-        return [('pass','',url)]
-      else:
+            if len(problems) == 0:
+                return [('pass', '', url)]
+            else:
+                return problems
+        else:
+            failures = []
+            failures.append(
+                ('fail', 'Invalid according to FortuneHTMLParser', url))
+            failures += self._parseDiffForFailure(diff, failures, url)
+            return failures
+
+    def _parseDiffForFailure(self, diff, failures, url):
+        '''Example diff:
+
+        --- Valid
+        +++ Response
+        @@ -1 +1 @@
+
+        -<!doctype html><html><head><title>Fortunes</title></head><body><table>
+        +<!doctype html><html><head><meta></meta><title>Fortunes</title></head><body><div><table>
+        @@ -16 +16 @@
+        '''
+
+        problems = []
+
+        # Catch exceptions because we are relying on internal code
+        try:
+            current_neg = []
+            current_pos = []
+            for line in diff[3:]:
+                if line[0] == '+':
+                    current_neg.append(line[1:])
+                elif line[0] == '-':
+                    current_pos.append(line[1:])
+                elif line[0] == '@':
+                    problems.append(('fail',
+                                     "`%s` should be `%s`" % (
+                                         ''.join(current_neg), ''.join(current_pos)),
+                                     url))
+            if len(current_pos) != 0:
+                problems.append(
+                    ('fail',
+                     "`%s` should be `%s`" % (
+                         ''.join(current_neg), ''.join(current_pos)),
+                     url))
+        except:
+            # If there were errors reading the diff, then no diff information
+            pass
         return problems
-    else:
-      failures = []
-      failures.append( ('fail','Invalid according to FortuneHTMLParser',url) )
-      failures += self._parseDiffForFailure(diff, failures, url)
-      return failures
 
-  def _parseDiffForFailure(self, diff, failures, url):
-    '''Example diff:
+    def _verifyHeaders(self, headers, url):
+        '''Verifies the response headers for the Fortunes test'''
 
-    --- Valid
-    +++ Response
-    @@ -1 +1 @@
-    
-    -<!doctype html><html><head><title>Fortunes</title></head><body><table>
-    +<!doctype html><html><head><meta></meta><title>Fortunes</title></head><body><div><table>
-    @@ -16 +16 @@
-    '''
+        problems = []
 
-    problems = []
+        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
+            problems.append(
+                ('warn', 'Required response header missing: %s' % v, url))
+        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
+            problems.append(
+                ('warn',
+                 ('Required response size header missing, '
+                  'please include either "Content-Length" or "Transfer-Encoding"'),
+                    url))
+        else:
+            content_type = headers.get('Content-Type', '')
+            expected_type = 'text/html'
+            includes_charset = expected_type + '; charset=utf-8'
 
-    # Catch exceptions because we are relying on internal code
-    try:
-      current_neg = []
-      current_pos = []
-      for line in diff[3:]:
-        if line[0] == '+':
-          current_neg.append(line[1:])
-        elif line[0] == '-':
-          current_pos.append(line[1:])
-        elif line[0] == '@':
-          problems.append( ('fail', 
-            "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
-            url) )
-      if len(current_pos) != 0:
-        problems.append( ('fail', 
-            "`%s` should be `%s`" % (''.join(current_neg), ''.join(current_pos)),
-            url) )
-    except:
-      # If there were errors reading the diff, then no diff information
-      pass
-
-    return problems
-
-  def _verifyHeaders(self, headers, url):
-    '''Verifies the response headers for the Fortunes test'''
-
-    problems = []
-
-    if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
-      problems.append(
-        ('warn', 'Required response header missing: %s' % v, url))
-    elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
-      problems.append(
-        ('warn',
-         ('Required response size header missing, '
-          'please include either "Content-Length" or "Transfer-Encoding"'),
-         url))
-    else:
-      content_type = headers.get('Content-Type', '').lower()
-      expected_type = 'text/html'
-      includes_charset = expected_type+'; charset=utf-8'
-
-      if content_type == includes_charset:
-        problems.append(
-          ('warn',
-           ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-            "Additional response bytes may negatively affect benchmark performance."
-            % (includes_charset, expected_type)),
-           url))
-      elif content_type != expected_type:
-        problems.append(
-            ('warn',
-             'Unexpected content encoding, found %s, expected %s' % (
-                 content_type, expected_type),
-             url))
-      return problems
+            if content_type.lower() == includes_charset:
+                problems.append(
+                    ('warn',
+                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
+                      "Additional response bytes may negatively affect benchmark performance."
+                      % (includes_charset, expected_type)),
+                     url))
+            elif content_type != expected_type:
+                problems.append(
+                    ('warn',
+                     'Unexpected content encoding, found %s, expected %s' % (
+                         content_type, expected_type),
+                     url))
+        return problems

--- a/toolset/benchmark/test_types/fortune_type.py
+++ b/toolset/benchmark/test_types/fortune_type.py
@@ -1,6 +1,6 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.fortune_html_parser import FortuneHTMLParser
-from benchmark.test_types.verifications import verify_headers
+from benchmark.test_types.verifications import basic_body_verification, verify_headers
 
 
 class FortuneTestType(FrameworkTestType):
@@ -26,18 +26,16 @@ class FortuneTestType(FrameworkTestType):
         url = base_url + self.fortune_url
         headers, body = self.request_headers_and_body(url)
 
-        # Empty response
-        if body is None:
-            return [('fail', 'No response', url)]
-        elif len(body) == 0:
-            return [('fail', 'Empty Response', url)]
+        _, problems = basic_body_verification(body, is_json_check=False)
+
+        if len(problems) > 0:
+            return problems
 
         parser = FortuneHTMLParser()
         parser.feed(body)
         (valid, diff) = parser.isValidFortune(self.out)
 
         if valid:
-            problems = []
             problems += verify_headers(headers, url, should_be='html')
 
             if len(problems) == 0:

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -21,23 +21,27 @@ class FrameworkTestType:
   exist a member `X.spam = 'foobar'`. 
   '''
 
-  accept_json = "Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7"
-  accept_html = "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-  accept_plaintext = "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7"
-
-  def __init__(self, name, requires_db = False, accept_header = None, args = []):
+  def __init__(self, name, requires_db=False, accept_header=None, args=[]):
     self.name = name
     self.requires_db = requires_db
     self.args = args
     self.out = sys.stdout
     self.err = sys.stderr
-    self.accept_header = accept_header
     if accept_header is None:
-      self.accept_header = self.accept_plaintext
+      self.accept_header = self.accept('json')
+    else:
+      self.accept_header = accept_header
 
     self.passed = None
     self.failed = None
     self.warned = None
+
+  def accept(self, content_type):
+    return {
+      'json': 'application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7',
+      'html': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'plaintext': 'text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7'
+    }[content_type]
 
   def setup_out_err(self, out, err):
     '''Sets up file-like objects for logging. Used in 

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -79,6 +79,10 @@ class FrameworkTestType:
       body = r.content
       self.out.write(str(headers))
       self.out.write(body)
+      
+      b = 40
+      print "  Response (trimmed to %d bytes): \"%s\"" % (b, body.strip()[:b])
+      
       return headers, body
     except requests.HTTPError as err:
       self.err.write(err + '\n')

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -76,17 +76,17 @@ class FrameworkTestType:
     self.err.write("Accessing URL %s \n" % url)
     self.out.write("Accessing URL %s \n" % url)
 
-    r = requests.get(url, timeout=15)
+    headers = { 'Accept': self.accept_header}
+    r = requests.get(url, timeout=15, headers=headers)
+
     try:
       r.raise_for_status() # Throws on non-200
       headers = r.headers
       body = r.content
       self.out.write(str(headers))
       self.out.write(body)
-      
       b = 40
       print "  Response (trimmed to %d bytes): \"%s\"" % (b, body.strip()[:b])
-      
       return headers, body
     except requests.HTTPError as err:
       self.err.write(err + '\n')

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -11,115 +11,124 @@ logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 
 from pprint import pprint
 
+
 class FrameworkTestType:
-  '''Interface between a test type (json, query, plaintext, etc) and 
-  the rest of TFB. A test type defines a number of keys it expects
-  to find in the benchmark_config.json, and this base class handles extracting
-  those keys and injecting them into the test. For example, if 
-  benchmark_config.json contains a line `"spam" : "foobar"` and a subclasses X
-  passes an argument list of ['spam'], then after parsing there will 
-  exist a member `X.spam = 'foobar'`. 
-  '''
 
-  def __init__(self, name, requires_db=False, accept_header=None, args=[]):
-    self.name = name
-    self.requires_db = requires_db
-    self.args = args
-    self.out = sys.stdout
-    self.err = sys.stderr
-    if accept_header is None:
-      self.accept_header = self.accept('json')
-    else:
-      self.accept_header = accept_header
-
-    self.passed = None
-    self.failed = None
-    self.warned = None
-
-  def accept(self, content_type):
-    return {
-      'json': 'application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7',
-      'html': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'plaintext': 'text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7'
-    }[content_type]
-
-  def setup_out_err(self, out, err):
-    '''Sets up file-like objects for logging. Used in 
-    cases where it is hard just return the output. Any
-    output sent to these file objects is also printed to 
-    the console
-
-    NOTE: I detest this. It would be much better to use
-    logging like it's intended
     '''
-    self.out = out
-    self.err = err
-  
-  def parse(self, test_keys):
-    '''Takes the dict of key/value pairs describing a FrameworkTest 
-    and collects all variables needed by this FrameworkTestType
-
-    Raises AttributeError if required keys are missing
+    Interface between a test type (json, query, plaintext, etc) and 
+    the rest of TFB. A test type defines a number of keys it expects
+    to find in the benchmark_config.json, and this base class handles extracting
+    those keys and injecting them into the test. For example, if 
+    benchmark_config.json contains a line `"spam" : "foobar"` and a subclasses X
+    passes an argument list of ['spam'], then after parsing there will 
+    exist a member `X.spam = 'foobar'`. 
     '''
-    if all (arg in test_keys for arg in self.args):
-      self.__dict__.update({ arg:test_keys[arg] for arg in self.args})
-      return self
-    else: # This is quite common - most tests don't support all types
-      raise AttributeError("A %s requires the benchmark_config.json to contain %s"%(self.name,self.args))
 
-  def request_headers_and_body(self, url):
-    '''
-    Downloads a URL and returns the HTTP response headers
-    and body content as a tuple
-    '''
-    print "Accessing URL %s:" % url
-    self.err.write("Accessing URL %s \n" % url)
-    self.out.write("Accessing URL %s \n" % url)
+    def __init__(self, name, requires_db=False, accept_header=None, args=[]):
+        self.name = name
+        self.requires_db = requires_db
+        self.args = args
+        self.out = sys.stdout
+        self.err = sys.stderr
 
-    headers = { 'Accept': self.accept_header}
-    r = requests.get(url, timeout=15, headers=headers)
+        if accept_header is None:
+            self.accept_header = self.accept('json')
+        else:
+            self.accept_header = accept_header
 
-    try:
-      r.raise_for_status() # Throws on non-200
-      headers = r.headers
-      body = r.content
-      self.out.write(str(headers))
-      self.out.write(body)
-      b = 40
-      print "  Response (trimmed to %d bytes): \"%s\"" % (b, body.strip()[:b])
-      return headers, body
-    except requests.HTTPError as err:
-      self.err.write(err + '\n')
-      return None, None
-  
-  def verify(self, base_url):
-    '''Accesses URL used by this test type and checks the return 
-    values for correctness. Most test types run multiple checks,
-    so this returns a list of results. Each result is a 3-tuple
-    of (String result, String reason, String urlTested).
+        self.passed = None
+        self.failed = None
+        self.warned = None
 
-    - result : 'pass','warn','fail'
-    - reason : Short human-readable reason if result was 
-        warn or fail. Please do not print the response as part of this, 
-        other parts of TFB will do that based upon the current logging 
-        settings if this method indicates a failure happened
-    - urlTested: The exact URL that was queried
+    def accept(self, content_type):
+        return {
+            'json': 'application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7',
+            'html': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'plaintext': 'text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7'
+        }[content_type]
 
-    Subclasses should make a best-effort attempt to report as many
-    failures and warnings as they can to help users avoid needing 
-    to run TFB repeatedly while debugging
-    '''
-    # TODO make String result into an enum to enforce
-    raise NotImplementedError("Subclasses must provide verify")
+    def setup_out_err(self, out, err):
+        '''
+        Sets up file-like objects for logging. Used in 
+        cases where it is hard just return the output. Any
+        output sent to these file objects is also printed to 
+        the console
 
-  def get_url(self):
-    '''Returns the URL for this test, like '/json'''
-    # This is a method because each test type uses a different key
-    # for their URL so the base class can't know which arg is the URL
-    raise NotImplementedError("Subclasses must provide verify")
+        NOTE: I detest this. It would be much better to use
+        logging like it's intended
+        '''
+        self.out = out
+        self.err = err
 
-  def copy(self):
-    '''Returns a copy that can be safely modified. Use before calling 
-    parse'''
-    return copy.copy(self)
+    def parse(self, test_keys):
+        '''
+        Takes the dict of key/value pairs describing a FrameworkTest 
+        and collects all variables needed by this FrameworkTestType
 
+        Raises AttributeError if required keys are missing
+        '''
+        if all(arg in test_keys for arg in self.args):
+            self.__dict__.update({arg: test_keys[arg] for arg in self.args})
+            return self
+        else:  # This is quite common - most tests don't support all types
+            raise AttributeError(
+                "A %s requires the benchmark_config.json to contain %s" % (self.name, self.args))
+
+    def request_headers_and_body(self, url):
+        '''
+        Downloads a URL and returns the HTTP response headers
+        and body content as a tuple
+        '''
+        print "Accessing URL %s:" % url
+        self.err.write("Accessing URL %s \n" % url)
+        self.out.write("Accessing URL %s \n" % url)
+
+        headers = {'Accept': self.accept_header}
+        r = requests.get(url, timeout=15, headers=headers)
+
+        try:
+            r.raise_for_status()  # Throws on non-200
+            headers = r.headers
+            body = r.content
+            self.out.write(str(headers))
+            self.out.write(body)
+            b = 40
+            print "  Response (trimmed to %d bytes): \"%s\"" % (b, body.strip()[:b])
+            return headers, body
+        except requests.HTTPError as err:
+            self.err.write(err + '\n')
+            return None, None
+
+    def verify(self, base_url):
+        '''
+        Accesses URL used by this test type and checks the return 
+        values for correctness. Most test types run multiple checks,
+        so this returns a list of results. Each result is a 3-tuple
+        of (String result, String reason, String urlTested).
+
+        - result : 'pass','warn','fail'
+        - reason : Short human-readable reason if result was 
+            warn or fail. Please do not print the response as part of this, 
+            other parts of TFB will do that based upon the current logging 
+            settings if this method indicates a failure happened
+        - urlTested: The exact URL that was queried
+
+        Subclasses should make a best-effort attempt to report as many
+        failures and warnings as they can to help users avoid needing 
+        to run TFB repeatedly while debugging
+        '''
+        # TODO make String result into an enum to enforce
+        raise NotImplementedError("Subclasses must provide verify")
+
+    def get_url(self):
+        '''Returns the URL for this test, like '/json'''
+        # This is a method because each test type uses a different key
+        # for their URL so the base class can't know which arg is the URL
+        raise NotImplementedError("Subclasses must provide verify")
+
+    def copy(self):
+        '''
+        Returns a copy that can be safely modified.
+        Use before calling parse
+        '''
+        return copy.copy(self)

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -1,5 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.verifications import verify_headers, verify_helloworld_object
+from benchmark.test_types.verifications import basic_body_verification, verify_headers, verify_helloworld_object
 
 import json
 
@@ -27,19 +27,11 @@ class JsonTestType(FrameworkTestType):
         url = base_url + self.json_url
         headers, body = self.request_headers_and_body(url)
 
-        # Empty response
-        if body is None:
-            return [('fail', 'No response', url)]
-        elif len(body) == 0:
-            return [('fail', 'Empty Response', url)]
+        response, problems = basic_body_verification(body)
 
-        # Valid JSON?
-        try:
-            response = json.loads(body)
-        except ValueError as ve:
-            return [('fail', "Invalid JSON - %s" % ve, url)]
+        if len(problems) > 0:
+            return problems
 
-        problems = []
         problems += verify_helloworld_object(response, url)
         problems += verify_headers(headers, url, should_be='json')
 

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -1,5 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.verifications import verify_headers
+from benchmark.test_types.verifications import verify_headers, verify_helloworld_object
 
 import json
 
@@ -40,37 +40,10 @@ class JsonTestType(FrameworkTestType):
             return [('fail', "Invalid JSON - %s" % ve, url)]
 
         problems = []
-        problems += self._verifyObject(response, url)
+        problems += verify_helloworld_object(response, url)
         problems += verify_headers(headers, url, should_be='json')
 
         if len(problems) > 0:
             return problems
         else:
             return [('pass', '', url)]
-
-    def _verifyObject(self, json_object, url):
-        '''
-        Ensure that the JSON object closely resembles
-        { 'message': 'Hello, World!' }
-        '''
-
-        problems = []
-
-        # Make everything case insensitive
-        json_object = {k.lower(): v.lower()
-                       for k, v in json_object.iteritems()}
-
-        if 'message' not in json_object:
-            return [('fail', "Missing required key 'message'", url)]
-        else:
-            if len(json_object) != 1:
-                additional = (', ').join(
-                    [k for k in json_object.keys() if k != 'message'])
-                problems.append(
-                    ('warn', "Too many JSON key/value pairs, consider removing: %s" % additional, url))
-
-            message = json_object['message']
-            if message != 'hello, world!':
-                return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
-
-        return problems

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -8,7 +8,7 @@ class JsonTestType(FrameworkTestType):
     def __init__(self):
         kwargs = {
             'name': 'json',
-            'accept_header': self.accept_json,
+            'accept_header': self.accept('json'),
             'requires_db': False,
             'args': ['json_url']
         }

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -1,5 +1,9 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.verifications import basic_body_verification, verify_headers, verify_helloworld_object
+from benchmark.test_types.verifications import (
+    basic_body_verification,
+    verify_headers,
+    verify_helloworld_object
+)
 
 import json
 

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -1,4 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
+from benchmark.test_types.verifications import verify_headers
 
 import json
 
@@ -40,7 +41,7 @@ class JsonTestType(FrameworkTestType):
 
         problems = []
         problems += self._verifyObject(response, url)
-        problems += self._verifyHeaders(headers, url)
+        problems += verify_headers(headers, url, should_be='json')
 
         if len(problems) > 0:
             return problems
@@ -72,36 +73,4 @@ class JsonTestType(FrameworkTestType):
             if message != 'hello, world!':
                 return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
 
-        return problems
-
-    def _verifyHeaders(self, headers, url):
-        '''Verifies the response headers'''
-
-        problems = []
-
-        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
-            problems.append(
-                ('warn', 'Required response header missing: %s' % v, url))
-        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
-            problems.append(
-                ('warn',
-                 'Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"',
-                 url))
-        else:
-            content_type = headers.get('Content-Type', None)
-            expected_type = 'application/json'
-            includes_charset = 'application/json; charset=utf-8'
-            if content_type == includes_charset:
-                problems.append(
-                    ('warn',
-                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-                      "Additional response bytes may negatively affect benchmark performance."
-                      % (includes_charset, expected_type)),
-                     url))
-            elif content_type != expected_type:
-                problems.append(
-                    ('warn',
-                     'Unexpected content encoding, found %s, expected %s' % (
-                         content_type, expected_type),
-                     url))
         return problems

--- a/toolset/benchmark/test_types/json_type.py
+++ b/toolset/benchmark/test_types/json_type.py
@@ -2,76 +2,79 @@ from benchmark.test_types.framework_test_type import FrameworkTestType
 
 import json
 
+
 class JsonTestType(FrameworkTestType):
 
-  def __init__(self):
-    kwargs = {
-      'name': 'json',
-      'accept_header': self.accept_json,
-      'requires_db': False,
-      'args': ['json_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
+    def __init__(self):
+        kwargs = {
+            'name': 'json',
+            'accept_header': self.accept_json,
+            'requires_db': False,
+            'args': ['json_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def get_url(self):
-    return self.json_url
+    def get_url(self):
+        return self.json_url
 
-  def verify(self, base_url):
-    '''Validates the response is a JSON object of 
-    { 'message' : 'hello, world!' }. Case insensitive and 
-    quoting style is ignored
-    '''
+    def verify(self, base_url):
+        '''Validates the response is a JSON object of 
+        { 'message' : 'hello, world!' }. Case insensitive and 
+        quoting style is ignored
+        '''
 
-    url = base_url + self.json_url
-    headers, body = self.request_headers_and_body(url)
-    
-    # Empty response
-    if body is None:
-      return [('fail','No response', url)]
-    elif len(body) == 0:
-      return [('fail','Empty Response', url)]
+        url = base_url + self.json_url
+        headers, body = self.request_headers_and_body(url)
 
-    # Valid JSON? 
-    try: 
-      response = json.loads(body)
-    except ValueError as ve:
-      return [('fail',"Invalid JSON - %s" % ve, url)]
-    
-    problems = []
-    problems += self._verifyObject(response, url)
-    problems += self._verifyHeaders(headers, url)
+        # Empty response
+        if body is None:
+            return [('fail', 'No response', url)]
+        elif len(body) == 0:
+            return [('fail', 'Empty Response', url)]
 
-    if len(problems) > 0:
-      return problems
-    else:
-      return [('pass','',url)]
+        # Valid JSON?
+        try:
+            response = json.loads(body)
+        except ValueError as ve:
+            return [('fail', "Invalid JSON - %s" % ve, url)]
 
-  def _verifyObject(self, json_object, url):
-    '''
-    Ensure that the JSON object closely resembles
-    { 'message': 'Hello, World!' }
-    '''
+        problems = []
+        problems += self._verifyObject(response, url)
+        problems += self._verifyHeaders(headers, url)
 
-    problems = []
+        if len(problems) > 0:
+            return problems
+        else:
+            return [('pass', '', url)]
 
-    # Make everything case insensitive
-    json_object = {k.lower(): v.lower() for k,v in json_object.iteritems()}
+    def _verifyObject(self, json_object, url):
+        '''
+        Ensure that the JSON object closely resembles
+        { 'message': 'Hello, World!' }
+        '''
 
-    if 'message' not in json_object:
-      return [('fail',"Missing required key 'message'",url)]
-    else:
-      if len(json_object) != 1:
-        additional = (', ').join([k for k in json_object.keys() if k != 'message'])
-        problems.append(
-          ('warn',"Too many JSON key/value pairs, consider removing: %s" % additional,url))
+        problems = []
 
-      message = json_object['message']
-      if message != 'hello, world!':
-        return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
+        # Make everything case insensitive
+        json_object = {k.lower(): v.lower()
+                       for k, v in json_object.iteritems()}
 
-    return problems
+        if 'message' not in json_object:
+            return [('fail', "Missing required key 'message'", url)]
+        else:
+            if len(json_object) != 1:
+                additional = (', ').join(
+                    [k for k in json_object.keys() if k != 'message'])
+                problems.append(
+                    ('warn', "Too many JSON key/value pairs, consider removing: %s" % additional, url))
 
-  def _verifyHeaders(self, headers, url):
+            message = json_object['message']
+            if message != 'hello, world!':
+                return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
+
+        return problems
+
+    def _verifyHeaders(self, headers, url):
         '''Verifies the response headers'''
 
         problems = []

--- a/toolset/benchmark/test_types/plaintext_type.py
+++ b/toolset/benchmark/test_types/plaintext_type.py
@@ -1,86 +1,86 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 
+
 class PlaintextTestType(FrameworkTestType):
 
-  def __init__(self):
-    kwargs = {
-      'name': 'plaintext',
-      'requires_db': False,
-      'accept_header': self.accept_plaintext,
-      'args': ['plaintext_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
+    def __init__(self):
+        kwargs = {
+            'name': 'plaintext',
+            'requires_db': False,
+            'accept_header': self.accept_plaintext,
+            'args': ['plaintext_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def verify(self, base_url):
-    url = base_url + self.plaintext_url
-    headers, body = self.request_headers_and_body(url)
+    def verify(self, base_url):
+        url = base_url + self.plaintext_url
+        headers, body = self.request_headers_and_body(url)
 
-    # Empty response
-    if body is None:
-      return [('fail','No response', url)]
-    elif len(body) == 0:
-      return [('fail','Empty Response', url)]
+        # Empty response
+        if body is None:
+            return [('fail', 'No response', url)]
+        elif len(body) == 0:
+            return [('fail', 'Empty Response', url)]
 
-    # Case insensitive
-    orig = body
-    body = body.lower()
-    expected = "hello, world!"
-    extra_bytes = len(body) - len(expected)
+        # Case insensitive
+        orig = body
+        body = body.lower()
+        expected = "hello, world!"
+        extra_bytes = len(body) - len(expected)
 
-    if expected not in body:
-      return [('fail', "Could not find 'Hello, World!' in response.", url)]
+        if expected not in body:
+            return [('fail', "Could not find 'Hello, World!' in response.", url)]
 
-    problems = []
+        problems = []
 
-    if extra_bytes > 0:
-      problems.append(
-        ('warn',
-         ("Server is returning %s more bytes than are required. "
-          "This may negatively affect benchmark performance."
-          % (extra_bytes)),
-         url))
+        if extra_bytes > 0:
+            problems.append(
+                ('warn',
+                 ("Server is returning %s more bytes than are required. "
+                  "This may negatively affect benchmark performance."
+                  % (extra_bytes)),
+                 url))
 
-    problems += self._verifyHeaders(headers, url)
+        problems += self._verifyHeaders(headers, url)
 
-    if len(problems) == 0:
-      return [('pass', '', url)]
-    else:
-      return problems
+        if len(problems) == 0:
+            return [('pass', '', url)]
+        else:
+            return problems
 
-  def get_url(self):
-    return self.plaintext_url
+    def get_url(self):
+        return self.plaintext_url
 
-  def _verifyHeaders(self, headers, url):
-    '''Verifies the response headers for the Plaintext test'''
+    def _verifyHeaders(self, headers, url):
+        '''Verifies the response headers for the Plaintext test'''
 
-    problems = []
+        problems = []
 
-    if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
-      problems.append(
-        ('warn', 'Required response header missing: %s' % v, url))
-    elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
-      problems.append(
-        ('warn',
-         ('Required response size header missing, '
-          'please include either "Content-Length" or "Transfer-Encoding"'),
-         url))
-    else:
-      content_type = headers.get('Content-Type', '')
-      expected_type = 'text/plain'
-      includes_charset = expected_type + '; charset=utf-8'
+        if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
+            problems.append(
+                ('warn', 'Required response header missing: %s' % v, url))
+        elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
+            problems.append(
+                ('warn',
+                 ('Required response size header missing, '
+                  'please include either "Content-Length" or "Transfer-Encoding"'),
+                 url))
+        else:
+            content_type = headers.get('Content-Type', '')
+            expected_type = 'text/plain'
+            includes_charset = expected_type + '; charset=utf-8'
 
-      if content_type.lower() == includes_charset:
-        problems.append(
-            ('warn',
-             ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
-              "Additional response bytes may negatively affect benchmark performance."
-              % (includes_charset, expected_type)),
-             url))
-      elif content_type != expected_type:
-        problems.append(
-            ('warn',
-             'Unexpected content encoding, found %s, expected %s' % (
-                 content_type, expected_type),
-             url))
-    return problems
-
+            if content_type.lower() == includes_charset:
+                problems.append(
+                    ('warn',
+                     ("Content encoding \"%s\" found where \"%s\" is acceptable.\n"
+                      "Additional response bytes may negatively affect benchmark performance."
+                      % (includes_charset, expected_type)),
+                     url))
+            elif content_type != expected_type:
+                problems.append(
+                    ('warn',
+                     'Unexpected content encoding, found %s, expected %s' % (
+                         content_type, expected_type),
+                     url))
+        return problems

--- a/toolset/benchmark/test_types/plaintext_type.py
+++ b/toolset/benchmark/test_types/plaintext_type.py
@@ -1,5 +1,5 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.verifications import verify_headers
+from benchmark.test_types.verifications import basic_body_verification, verify_headers
 
 
 class PlaintextTestType(FrameworkTestType):
@@ -17,11 +17,10 @@ class PlaintextTestType(FrameworkTestType):
         url = base_url + self.plaintext_url
         headers, body = self.request_headers_and_body(url)
 
-        # Empty response
-        if body is None:
-            return [('fail', 'No response', url)]
-        elif len(body) == 0:
-            return [('fail', 'Empty Response', url)]
+        _, problems = basic_body_verification(body, is_json_check=False)
+
+        if len(problems) > 0:
+            return problems
 
         # Case insensitive
         orig = body
@@ -31,8 +30,6 @@ class PlaintextTestType(FrameworkTestType):
 
         if expected not in body:
             return [('fail', "Could not find 'Hello, World!' in response.", url)]
-
-        problems = []
 
         if extra_bytes > 0:
             problems.append(

--- a/toolset/benchmark/test_types/plaintext_type.py
+++ b/toolset/benchmark/test_types/plaintext_type.py
@@ -7,7 +7,7 @@ class PlaintextTestType(FrameworkTestType):
         kwargs = {
             'name': 'plaintext',
             'requires_db': False,
-            'accept_header': self.accept_plaintext,
+            'accept_header': self.accept('plaintext'),
             'args': ['plaintext_url']
         }
         FrameworkTestType.__init__(self, **kwargs)

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -3,148 +3,152 @@ from benchmark.test_types.db_type import DBTestType
 
 import json
 
+
 class QueryTestType(DBTestType):
-  '''
-  This test type is used for the multiple queries test
-  Inherits from DBTestType
-  Both tests deal with the same objects;
-  this test just expects a list of them
-  '''
 
-  def __init__(self):
-    kwargs = {
-      'name': 'query',
-      'accept_header': self.accept_json,
-      'requires_db': True,
-      'args': ['query_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
-
-  def get_url(self):
-    return self.query_url
-
-  def verify(self, base_url):
-    '''Validates the response is a JSON array of 
-    the proper length, each JSON Object in the array 
-    has keys 'id' and 'randomNumber', and these keys 
-    map to integers. Case insensitive and 
-    quoting style is ignored
+    '''
+    This test type is used for the multiple queries test
+    Inherits from DBTestType
+    Both tests deal with the same objects; this test just expects a list of them
     '''
 
-    url = base_url + self.query_url
-    cases = ('2', '0', 'foo', '501', '')
-    problems = self._verifyQueryCases(url, cases)
-    
-    if len(problems) == 0:
-      return [('pass','',url + case) for case in cases]
-    else:
-      return problems
+    def __init__(self):
+        kwargs = {
+            'name': 'query',
+            'accept_header': self.accept_json,
+            'requires_db': True,
+            'args': ['query_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def _verifyQueryCases(self, url, cases):
-    '''
-    The queries tests accepts a `queries` parameter that should be between 1-500
-    This method execises a framework with different `queries` parameter values
-    then verifies the framework's response.
-    '''
-    problems = []
-    Q_MAX = 500
-    Q_MIN = 1
+    def get_url(self):
+        return self.query_url
 
-    for q in cases:
-      case_url = url + q
-      headers, body = self.request_headers_and_body(case_url)
+    def verify(self, base_url):
+        '''Validates the response is a JSON array of 
+        the proper length, each JSON Object in the array 
+        has keys 'id' and 'randomNumber', and these keys 
+        map to integers. Case insensitive and 
+        quoting style is ignored
+        '''
 
-      try:
-        queries = int(q) # drops down for 'foo' and ''
-        
-        if queries > Q_MAX:
-          expected_len = Q_MAX
-        elif queries < Q_MIN:
-          expected_len = Q_MIN
+        url = base_url + self.query_url
+        cases = ('2', '0', 'foo', '501', '')
+
+        problems = self._verifyQueryCases(url, cases)
+
+        if len(problems) == 0:
+            return [('pass', '', url + case) for case in cases]
         else:
-          expected_len = queries
+            return problems
 
-        problems += self._verifyBodyList(expected_len, headers, body, case_url)
-        problems += self._verifyHeaders(headers, case_url)
-      
-      except ValueError:
-        warning = (
-          '%s given for stringy `queries` parameter %s\n'
-          'Suggestion: modify your /queries route to handle this case '
-          '(this will be a failure in future rounds, please fix)')
+    def _verifyQueryCases(self, url, cases):
+        '''
+        The queries tests accepts a `queries` parameter that should be between 1-500
+        This method execises a framework with different `queries` parameter values
+        then verifies the framework's response.
+        '''
+        problems = []
+        Q_MAX = 500
+        Q_MIN = 1
 
+        for q in cases:
+            case_url = url + q
+            headers, body = self.request_headers_and_body(case_url)
+
+            try:
+                queries = int(q)  # drops down for 'foo' and ''
+
+                if queries > Q_MAX:
+                    expected_len = Q_MAX
+                elif queries < Q_MIN:
+                    expected_len = Q_MIN
+                else:
+                    expected_len = queries
+
+                problems += self._verifyBodyList(
+                    expected_len, headers, body, case_url)
+                problems += self._verifyHeaders(headers, case_url)
+
+            except ValueError:
+                warning = (
+                    '%s given for stringy `queries` parameter %s\n'
+                    'Suggestion: modify your /queries route to handle this case '
+                    '(this will be a failure in future rounds, please fix)')
+
+                if body is None:
+                    problems.append(
+                        ('warn',
+                         warning % ('No response', q),
+                         case_url))
+                elif len(body) == 0:
+                    problems.append(
+                        ('warn',
+                         warning % ('Empty response', q),
+                         case_url))
+                else:
+                    expected_len = 1
+                    # Strictness will be upped in a future round, i.e. Frameworks currently do not have
+                    # to gracefully handle absent, or non-intlike `queries`
+                    # parameter input
+                    kwargs = {'max_infraction': 'warn'}
+                    problems += self._verifyBodyList(
+                        expected_len, headers, body, case_url, **kwargs)
+                    problems += self._verifyHeaders(headers, case_url)
+
+        return problems
+
+    def _verifyBodyList(self, expectedLen, headers, body, url, max_infraction='fail'):
+        '''
+        Validates high-level structure (array length, object types, etc),
+        then verifies the inner objects of the list for correctness
+        '''
         if body is None:
-          problems.append(
-            ('warn',
-             warning % ('No response', q),
-             case_url))
+            return [(max_infraction, 'No response', url)]
         elif len(body) == 0:
-          problems.append(
-            ('warn',
-             warning % ('Empty response', q),
-             case_url))
-        else:
-          expected_len = 1
-          # Strictness will be upped in a future round, i.e. Frameworks currently do not have
-          # to gracefully handle absent, or non-intlike `queries` parameter input
-          kwargs = { 'max_infraction': 'warn'}
-          problems += self._verifyBodyList(expected_len, headers, body, case_url, **kwargs)
-          problems += self._verifyHeaders(headers, case_url)
+            return [(max_infraction, 'Empty Response', url)]
 
-    return problems
+        try:
+            response = json.loads(body)
+        except ValueError as ve:
+            return [(max_infraction, "Invalid JSON - %s" % ve, url)]
 
+        problems = []
 
-  def _verifyBodyList(self, expectedLen, headers, body, url, max_infraction='fail'):
-    '''
-    Validates high-level structure (array length, object types, etc),
-    then verifies the inner objects of the list for correctness
-    '''
-    if body is None:
-      return [(max_infraction,'No response', url)]
-    elif len(body) == 0:
-      return [(max_infraction,'Empty Response', url)]
-  
-    try: 
-      response = json.loads(body)
-    except ValueError as ve:
-      return [(max_infraction,"Invalid JSON - %s" % ve, url)]
+        # This path will be hit when the framework returns a single JSON object
+        # rather than a list containing one element. We allow this with a warn,
+        # then verify the supplied object
+        if type(response) is not list:
+            problems.append(
+                ('warn', 'Top-level JSON is an object, not an array', url))
+            problems += self._verifyObject(response, url, max_infraction)
+            return problems
 
-    problems = []
+        if any(type(item) is not dict for item in response):
+            problems.append(
+                (max_infraction, 'Not all items in the JSON array were JSON objects', url))
 
-    # This path will be hit when the framework returns a single JSON object
-    # rather than a list containing one element. We allow this with a warn,
-    # then verify the supplied object
-    if type(response) != list:
-      problems.append(
-        ('warn','Top-level JSON is an object, not an array', url))
-      problems += self._verifyObject(response, url, max_infraction)
-      return problems
+        if len(response) != expectedLen:
+            problems.append(
+                (max_infraction,
+                 "JSON array length of %s != expected length of %s" % (
+                     len(response), expectedLen),
+                 url))
 
-    if any(type(item) != dict for item in response):
-      problems.append(
-        (max_infraction,'Not all items in the JSON array were JSON objects', url))
+        # Verify individual objects, arbitrarily stop after 5 bad ones are found
+        # i.e. to not look at all 500
+        badObjectsFound = 0
+        i = iter(response)
 
-    if len(response) != expectedLen:
-      problems.append( 
-        (max_infraction,
-         "JSON array length of %s != expected length of %s" % (
-            len(response), expectedLen), 
-         url))
+        try:
+            while badObjectsFound < 5:
+                obj = next(i)
+                findings = self._verifyObject(obj, url, max_infraction)
 
-    # Verify individual objects, arbitrarily stop after 5 bad ones are found
-    # i.e. to not look at all 500
-    badObjectsFound = 0
-    i = iter(response)
+                if len(findings) > 0:
+                    problems += findings
+                    badObjectsFound += 1
+        except StopIteration:
+            pass
 
-    try:
-      while badObjectsFound < 5:
-        obj = next(i)
-        findings = self._verifyObject(obj, url, max_infraction)      
-
-        if len(findings) > 0:
-          problems += findings
-          badObjectsFound += 1
-    except StopIteration:
-      pass
-
-    return problems
+        return problems

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -15,7 +15,7 @@ class QueryTestType(DBTestType):
     def __init__(self):
         kwargs = {
             'name': 'query',
-            'accept_header': self.accept_json,
+            'accept_header': self.accept('json'),
             'requires_db': True,
             'args': ['query_url']
         }

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -1,17 +1,15 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.db_type import DBTestType
-from benchmark.test_types.verifications import verify_headers, verify_randomnumber_list, verify_query_cases
+from benchmark.test_types.verifications import (
+    verify_headers,
+    verify_randomnumber_list,
+    verify_query_cases
+)
+
 
 import json
 
 
-class QueryTestType(DBTestType):
-
-    '''
-    This test type is used for the multiple queries test
-    Inherits from DBTestType
-    Both tests deal with the same objects; this test just expects a list of them
-    '''
+class QueryTestType(FrameworkTestType):
 
     def __init__(self):
         kwargs = {

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -1,5 +1,6 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.test_types.db_type import DBTestType
+from benchmark.test_types.verifications import verify_headers
 
 import json
 
@@ -74,7 +75,7 @@ class QueryTestType(DBTestType):
 
                 problems += self._verifyBodyList(
                     expected_len, headers, body, case_url, max_infraction)
-                problems += self._verifyHeaders(headers, case_url)
+                problems += verify_headers(headers, case_url)
 
             except ValueError:
                 warning = (
@@ -99,7 +100,7 @@ class QueryTestType(DBTestType):
                     # parameter input
                     problems += self._verifyBodyList(
                         expected_len, headers, body, case_url, max_infraction)
-                    problems += self._verifyHeaders(headers, case_url)
+                    problems += verify_headers(headers, case_url)
 
         return problems
 

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -1,6 +1,6 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.test_types.db_type import DBTestType
-from benchmark.test_types.verifications import verify_headers, verify_randomnumber_list
+from benchmark.test_types.verifications import verify_headers, verify_randomnumber_list, verify_query_cases
 
 import json
 
@@ -26,7 +26,8 @@ class QueryTestType(DBTestType):
         return self.query_url
 
     def verify(self, base_url):
-        '''Validates the response is a JSON array of 
+        '''
+        Validates the response is a JSON array of 
         the proper length, each JSON Object in the array 
         has keys 'id' and 'randomNumber', and these keys 
         map to integers. Case insensitive and 
@@ -42,64 +43,9 @@ class QueryTestType(DBTestType):
             ('',    'warn')
         ]
 
-        problems = self._verifyQueryCases(url, cases)
+        problems = verify_query_cases(self, cases, url)
 
         if len(problems) == 0:
             return [('pass', '', url + case) for case, _ in cases]
         else:
             return problems
-
-    def _verifyQueryCases(self, url, cases):
-        '''
-        The queries tests accepts a `queries` parameter that should be between 1-500
-        This method execises a framework with different `queries` parameter values
-        then verifies the framework's response.
-        '''
-        problems = []
-        Q_MAX = 500
-        Q_MIN = 1
-
-        for q, max_infraction in cases:
-            case_url = url + q
-            headers, body = self.request_headers_and_body(case_url)
-
-            try:
-                queries = int(q)  # drops down for 'foo' and ''
-
-                if queries > Q_MAX:
-                    expected_len = Q_MAX
-                elif queries < Q_MIN:
-                    expected_len = Q_MIN
-                else:
-                    expected_len = queries
-
-                problems += verify_randomnumber_list(
-                    expected_len, headers, body, case_url, max_infraction)
-                problems += verify_headers(headers, case_url)
-
-            except ValueError:
-                warning = (
-                    '%s given for stringy `queries` parameter %s\n'
-                    'Suggestion: modify your /queries route to handle this case '
-                    '(this will be a failure in future rounds, please fix)')
-
-                if body is None:
-                    problems.append(
-                        (max_infraction,
-                         warning % ('No response', q),
-                         case_url))
-                elif len(body) == 0:
-                    problems.append(
-                        (max_infraction,
-                         warning % ('Empty response', q),
-                         case_url))
-                else:
-                    expected_len = 1
-                    # Strictness will be upped in a future round, i.e. Frameworks currently do not have
-                    # to gracefully handle absent, or non-intlike `queries`
-                    # parameter input
-                    problems += verify_randomnumber_list(
-                        expected_len, headers, body, case_url, max_infraction)
-                    problems += verify_headers(headers, case_url)
-
-        return problems

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -9,7 +9,7 @@ class UpdateTestType(QueryTestType):
     def __init__(self):
         kwargs = {
             'name': 'update',
-            'accept_header': self.accept_json,
+            'accept_header': self.accept('json'),
             'requires_db': True,
             'args': ['update_url']
         }

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -1,11 +1,8 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
-from benchmark.test_types.query_type import QueryTestType
 from benchmark.test_types.verifications import verify_query_cases
 
-from pprint import pprint
 
-
-class UpdateTestType(QueryTestType):
+class UpdateTestType(FrameworkTestType):
 
     def __init__(self):
         kwargs = {

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -1,5 +1,6 @@
 from benchmark.test_types.framework_test_type import FrameworkTestType
 from benchmark.test_types.query_type import QueryTestType
+from benchmark.test_types.verifications import verify_query_cases
 
 from pprint import pprint
 
@@ -34,7 +35,7 @@ class UpdateTestType(QueryTestType):
             ('501', 'warn'),
             ('',    'warn')
         ]
-        problems = self._verifyQueryCases(url, cases)
+        problems = verify_query_cases(self, cases, url)
 
         if len(problems) == 0:
             return [('pass', '', url + case) for (case, _) in cases]

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -3,44 +3,40 @@ from benchmark.test_types.query_type import QueryTestType
 
 from pprint import pprint
 
+
 class UpdateTestType(QueryTestType):
 
-  def __init__(self):
-    kwargs = {
-      'name': 'update',
-      'accept_header': self.accept_json,
-      'requires_db': True,
-      'args': ['update_url']
-    }
-    FrameworkTestType.__init__(self, **kwargs)
+    def __init__(self):
+        kwargs = {
+            'name': 'update',
+            'accept_header': self.accept_json,
+            'requires_db': True,
+            'args': ['update_url']
+        }
+        FrameworkTestType.__init__(self, **kwargs)
 
-  def get_url(self):
-    return self.update_url
+    def get_url(self):
+        return self.update_url
 
-  def verify(self, base_url):
-    '''Validates the response is a JSON array of 
-    the proper length, each JSON Object in the array 
-    has keys 'id' and 'randomNumber', and these keys 
-    map to integers. Case insensitive and 
-    quoting style is ignored
-    '''
+    def verify(self, base_url):
+        '''Validates the response is a JSON array of 
+        the proper length, each JSON Object in the array 
+        has keys 'id' and 'randomNumber', and these keys 
+        map to integers. Case insensitive and 
+        quoting style is ignored
+        '''
 
-    url = base_url + self.update_url
-    cases = [
-      ('2',   'fail'),
-      ('0',   'warn'),
-      ('foo', 'warn'),
-      ('501', 'warn'),
-      ('',    'warn')
-    ]
-    problems = self._verifyQueryCases(url, cases)
+        url = base_url + self.update_url
+        cases = [
+            ('2',   'fail'),
+            ('0',   'warn'),
+            ('foo', 'warn'),
+            ('501', 'warn'),
+            ('',    'warn')
+        ]
+        problems = self._verifyQueryCases(url, cases)
 
-    if len(problems) == 0:
-      return [('pass','',url + '2'),
-              ('pass','',url + '0'),
-              ('pass','',url + 'foo'),
-              ('pass','',url + '501')]
-    else:
-      return problems
-
-
+        if len(problems) == 0:
+            return [('pass', '', url + case) for (case, _) in cases]
+        else:
+            return problems

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -4,10 +4,15 @@ from benchmark.test_types.query_type import QueryTestType
 from pprint import pprint
 
 class UpdateTestType(QueryTestType):
+
   def __init__(self):
-    args = ['update_url']
-    FrameworkTestType.__init__(self, name='update', requires_db=True, 
-      accept_header=self.accept_json, args=args)
+    kwargs = {
+      'name': 'update',
+      'accept_header': self.accept_json,
+      'requires_db': True,
+      'args': ['update_url']
+    }
+    FrameworkTestType.__init__(self, **kwargs)
 
   def get_url(self):
     return self.update_url
@@ -21,23 +26,14 @@ class UpdateTestType(QueryTestType):
     '''
 
     url = base_url + self.update_url
-    problems = []
-    
-    response = self._curl(url + '2')
-    body = self._curl_body(url + '2')
-    problems += self._verifyQueryList(2, response, body, url + '2')
-
-    response = self._curl(url + '0')
-    body = self._curl_body(url + '0')
-    problems += self._verifyQueryList(1, response, body, url + '0', 'warn')
-
-    response = self._curl(url + 'foo')
-    body = self._curl_body(url + 'foo')
-    problems += self._verifyQueryList(1, response, body, url + 'foo', 'warn')
-
-    response = self._curl(url + '501')
-    body = self._curl_body(url + '501')
-    problems += self._verifyQueryList(500, response, body, url + '501', 'warn')
+    cases = [
+      ('2',   'fail'),
+      ('0',   'warn'),
+      ('foo', 'warn'),
+      ('501', 'warn'),
+      ('',    'warn')
+    ]
+    problems = self._verifyQueryCases(url, cases)
 
     if len(problems) == 0:
       return [('pass','',url + '2'),

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -1,3 +1,6 @@
+import json
+
+
 def verify_headers(headers, url, should_be='json'):
     '''
     Verifies the headers of a framework response
@@ -40,6 +43,7 @@ def verify_headers(headers, url, should_be='json'):
                  url))
     return problems
 
+
 def verify_helloworld_object(json_object, url):
     '''
     Ensure that the JSON object closely resembles
@@ -60,9 +64,133 @@ def verify_helloworld_object(json_object, url):
                 [k for k in json_object.keys() if k != 'message'])
             problems.append(
                 ('warn', "Too many JSON key/value pairs, consider removing: %s" % additional, url))
-        
+
         message = json_object['message']
 
         if message != 'hello, world!':
             return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
         return problems
+
+
+def verify_randomnumber_object(db_object, url, max_infraction='fail'):
+    '''
+    Ensures that `db_object` is a JSON object with 
+    keys 'id' and 'randomNumber' that both map to ints. 
+    Should closely resemble:
+    { "id": 2354, "randomNumber": 8952 }
+    '''
+
+    problems = []
+
+    # Dict is expected
+    # Produce error for bytes in non-cases
+    if type(db_object) is not dict:
+        got = str(db_object)[:20]
+        if len(str(db_object)) > 20:
+            got = str(db_object)[:17] + '...'
+        return [(max_infraction, "Expected a JSON object, got '%s' instead" % got, url)]
+
+    # Make keys case insensitive
+    db_object = {k.lower(): v for k, v in db_object.iteritems()}
+    required_keys = set(['id', 'randomnumber'])
+
+    if any(v not in db_object for v in required_keys):
+        problems.append(
+            (max_infraction, 'Response object was missing required key: %s' % v, url))
+
+    if len(db_object) > len(required_keys):
+        extras = db_object.keys() - required_keys
+        problems.append(
+            ('warn',
+             'An extra key(s) is being included with the db object: %s' % ', '.join(
+                 extras),
+             url))
+
+    # All required keys must be present
+    if len(problems) > 0:
+        return problems
+
+    # Assert key types and values
+    try:
+        o_id = int(db_object['id'])
+
+        if o_id > 10000 or o_id < 1:
+            problems.append(
+                ('warn',
+                 'Response key id should be between 1 and 10,000: ' +
+                 str(o_id),
+                 url))
+    except TypeError as e:
+        problems.append(
+            (max_infraction, "Response key 'id' does not map to an integer - %s" % e, url))
+
+    try:
+        o_rn = int(db_object['randomnumber'])
+
+        if o_rn > 10000:
+            problems.append(
+                ('warn',
+                 'Response key `randomNumber` is over 10,000. This may negatively affect performance by sending extra bytes',
+                 url))
+    except TypeError as e:
+        problems.append(
+            (max_infraction, "Response key 'randomnumber' does not map to an integer - %s" % e, url))
+
+    return problems
+
+
+def verify_randomnumber_list(expected_len, headers, body, url, max_infraction='fail'):
+    '''
+    Validates that the object is a list containing a number of 
+    randomnumber object. Should closely resemble:
+    [{ "id": 2354, "randomNumber": 8952 }, { id: }]
+    '''
+    if body is None:
+        return [(max_infraction, 'No response', url)]
+    elif len(body) == 0:
+        return [(max_infraction, 'Empty Response', url)]
+
+    try:
+        response = json.loads(body)
+    except ValueError as ve:
+        return [(max_infraction, "Invalid JSON - %s" % ve, url)]
+
+    problems = []
+
+    # This path will be hit when the framework returns a single JSON object
+    # rather than a list containing one element. We allow this with a warn,
+    # then verify the supplied object
+    if type(response) is not list:
+        problems.append(
+            ('warn', 'Top-level JSON is an object, not an array', url))
+        problems += verify_randomnumber_object(response, url, max_infraction)
+        return problems
+
+    if any(type(item) is not dict for item in response):
+        problems.append(
+            (max_infraction, 'Not all items in the JSON array were JSON objects', url))
+
+    if len(response) != expected_len:
+        problems.append(
+            (max_infraction,
+             "JSON array length of %s != expected length of %s" % (
+                 len(response), expected_len),
+             url))
+
+    # Verify individual objects, arbitrarily stop after 5 bad ones are found
+    # i.e. to not look at all 500
+    badObjectsFound = 0
+    inner_objects = iter(response)
+
+    try:
+        while badObjectsFound < 5:
+            obj = next(inner_objects)
+            findings = verify_randomnumber_object(obj, url, max_infraction)
+
+            if len(findings) > 0:
+                problems += findings
+                badObjectsFound += 1
+    except StopIteration:
+        pass
+
+    return problems

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -1,0 +1,41 @@
+def verify_headers(headers, url, should_be='json'):
+    '''
+    Verifies the headers of a framework response
+    param `should_be` is a switch for the three acceptable content types
+    '''
+
+    types = {
+        'json': 'application/json',
+        'html': 'text/html',
+        'plaintext': 'text/plain'
+    }
+    expected_type = types[should_be]
+    includes_charset = expected_type + '; charset=utf-8'
+
+    problems = []
+
+    if any(v.lower() not in headers for v in ('Server', 'Date', 'Content-Type')):
+        problems.append(
+            ('warn', 'Required response header missing: %s' % v, url))
+    elif all(v.lower() not in headers for v in ('Content-Length', 'Transfer-Encoding')):
+        problems.append(
+            ('warn',
+             'Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"',
+             url))
+    else:
+        content_type = headers.get('Content-Type', None)
+
+        if content_type.lower() == includes_charset:
+            problems.append(
+                ('warn',
+                 ("Content encoding found \"%s\" where \"%s\" is acceptable.\n"
+                  "Additional response bytes may negatively affect benchmark performance."
+                  % (includes_charset, expected_type)),
+                 url))
+        elif content_type != expected_type:
+            problems.append(
+                ('warn',
+                 'Unexpected content encoding, found \"%s\", expected \"%s\"' % (
+                     content_type, expected_type),
+                 url))
+    return problems

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -39,3 +39,30 @@ def verify_headers(headers, url, should_be='json'):
                      content_type, expected_type),
                  url))
     return problems
+
+def verify_helloworld_object(json_object, url):
+    '''
+    Ensure that the JSON object closely resembles
+    { 'message': 'Hello, World!' }
+    '''
+
+    problems = []
+
+    # Make everything case insensitive
+    json_object = {k.lower(): v.lower()
+                   for k, v in json_object.iteritems()}
+
+    if 'message' not in json_object:
+        return [('fail', "Missing required key 'message'", url)]
+    else:
+        if len(json_object) > 1:
+            additional = (', ').join(
+                [k for k in json_object.keys() if k != 'message'])
+            problems.append(
+                ('warn', "Too many JSON key/value pairs, consider removing: %s" % additional, url))
+        
+        message = json_object['message']
+
+        if message != 'hello, world!':
+            return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
+        return problems

--- a/toolset/setup/linux/languages/crystal-0.7.1.sh
+++ b/toolset/setup/linux/languages/crystal-0.7.1.sh
@@ -11,4 +11,4 @@ fw_get -O $SAVE_AS $URL
 
 fw_untar crystal-0.7.1-1-linux-x86_64.tar.gz
 
-echo "export PATH=$IROOT/crystal-0.7.1-1/bin/:$PATH" >> ${IROOT}/crystal-0.7.1.installed
+echo "export PATH=$IROOT/crystal-0.7.1-1/bin/:$PATH" > ${IROOT}/crystal-0.7.1.installed


### PR DESCRIPTION
_Early PR for a chunk of in-progress work_

These changes are centered around addressing #1568 which aims to use the native, and excellent Python [requests](http://docs.python-requests.org/en/latest/) package which prevents the need of using `curl` through Python. Notably this will improve Windows compatibility by removing the curl requirement. These changes touch the framework test types and their super class `framework_test_type` (which previously had the `_curl` and `_curl_response_body` methods). I have taken the liberty to improve the formatting of the files that I touch to be more closely in line with PEP8 in the interest of a cleaner TFB toolset.

- May fix #1600, I am checking that url's are correctly formed, and I am working in that area of files
- Fixes #1625 
- Will help address #1511 by breaking verification functionality into smaller and easier-to-test chunks. I have been keeping unit testing in mind as I've been working through this.
- Addresses #1534 by giving better warning messages. I have addressed concerns about [frameworks including charset in `Content-Type` field](https://github.com/TechEmpower/FrameworkBenchmarks/issues/1534#issuecomment-95766652) by adding an explicit check for the case. This makes the toolset `WARN`-city for certain frameworks that always append the charset.

- [x] Replace `_curl` and `_curl_response_body` with a similar method that utilizes the `requests` module
- [x] Go through test type files and:
    - Change their header checks for `requests`
    - Change their body checks for `requests`
    - Refactor checking logic to be more informative (mostly for `WARN`'s) and helpful to developers trying to add a framework
    - PEP 8 them, 4 space indentation, formatting, break into smaller functions
- [x] Refactor repeated/shared code
- [x] Refactor verification functions to be more grouped together
- [x] All test types inherit from `FrameworkTestType` directly (previously queries and updates were inheriting from `DBTestType` in order to share validation functions)
- [ ] Implement unit tests for the verification of headers and response bodies

This is Windows Compatibility / Round 12 work