### PR TITLE
Clean zend warnings on db calls

### DIFF
--- a/frameworks/PHP/zend/module/FrameworkBenchmarks/src/FrameworkBenchmarks/Entity/World.php
+++ b/frameworks/PHP/zend/module/FrameworkBenchmarks/src/FrameworkBenchmarks/Entity/World.php
@@ -27,8 +27,8 @@ class World extends ArrayObject
      */
     public function exchangeArray($data)
     {
-        $this->id           = $data['id'];
-        $this->randomNumber = $data['randomNumber'];
+        $this->id           = (int) $data['id'];
+        $this->randomNumber = (int) $data['randomNumber'];
     }
 
     /**

--- a/frameworks/PHP/zend/setup.sh
+++ b/frameworks/PHP/zend/setup.sh
@@ -8,3 +8,6 @@ sed -i 's|/usr/local/nginx/|'"${IROOT}"'/nginx/|g' deploy/nginx.conf
 
 php-fpm --fpm-config $FWROOT/config/php-fpm.conf -g $TROOT/deploy/php-fpm.pid
 nginx -c $TROOT/deploy/nginx.conf 
+
+mkdir -p data/cache
+chmod 777 data/cache


### PR DESCRIPTION
Adds in data type-casting to zend in order to clean up test warnings and return proper integer types instead of string types.