### PR TITLE
Replacing the manual usort with the native asort. 

### DIFF
--- a/frameworks/PHP/phalcon-micro/public/index.php
+++ b/frameworks/PHP/phalcon-micro/public/index.php
@@ -75,19 +75,7 @@ try {
             'message' => 'Additional fortune added at request time.'
         );
 
-        usort($fortunes, function($left, $right) {
-            $l = $left['message'];
-            $r = $right['message'];
-            if ($l === $r) {
-                return 0;
-            } else {
-                if ($l > $r) {
-                    return 1;
-                } else {
-                    return -1;
-                }
-            }
-        });
+        asort($fortunes);
 
         header("Content-Type: text/html; charset=utf-8");
 


### PR DESCRIPTION
This should be done same as the naked PHP benchmark or use framework resources. The manual implementation of usort bring this logic to the PHP scope, while asort is implemented using C native code.