### PR TITLE
Using asort instead of usort

### DIFF
--- a/frameworks/PHP/phalcon/app/controllers/BenchController.php
+++ b/frameworks/PHP/phalcon/app/controllers/BenchController.php
@@ -76,19 +76,19 @@ class BenchController extends \Phalcon\Mvc\Controller
         $this->response->send();
     }
 
-    protected function getRandomWorld()
+    private function getRandomWorld()
     {
         return Worlds::findFirst(mt_rand(1, 10000));
     }
 
-    protected function getFortunesArray()
+    private function getFortunesArray()
     {
         // since the resultset is immutable get an array instead
         // so we can add the new fortune
         return Fortunes::find()->toArray();
     }
 
-    protected function buildFortune()
+    private function buildFortune()
     {
         return array(
             'id' => 0,
@@ -96,22 +96,9 @@ class BenchController extends \Phalcon\Mvc\Controller
         );
     }
 
-    protected function sortFortunes($fortunes)
+    private function sortFortunes($fortunes)
     {
-        usort($fortunes,
-                function($left, $right) {
-                    $l = $left['message'];
-                    $r = $right['message'];
-                    if ($l === $r) {
-                        return 0;
-                    } else {
-                        if ($l > $r) {
-                            return 1;
-                        } else {
-                            return -1;
-                        }
-                    }
-                });
+        asort($fortunes);
         return $fortunes;
     }
 


### PR DESCRIPTION
Same as the case with micro-phalcon, this should be using `asort` instead of `usort`. Unless the framework provides a way to sort arrays, in which case we should be using what the Framework has to offer. But AFAIK that is not the case, hence `asort`.

Now, is not a good OOP strategy to set the visibility of methods as `protected` if there is not class that is actually inheriting this methods. Therefore, the change to `private`