### PR TITLE
fix warning: historical needs default

### DIFF
--- a/frameworks/Python/historical/benchmark_config.json
+++ b/frameworks/Python/historical/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "historical",
   "tests": [{
-    "webware": {
+    "default": {
       "setup_file": "webware/setup",
       "json_url": "/json2",
       "plaintext_url": "/plaintext",


### PR DESCRIPTION
builds are complaining that historical does not have a `"default"` test

```
WARNING:root:Framework historical does not define a default test in benchmark_config.json
```