### PR TITLE
fix warnings for sabina

### DIFF
--- a/frameworks/Java/sabina/benchmark_config.json
+++ b/frameworks/Java/sabina/benchmark_config.json
@@ -24,8 +24,7 @@
       "display_name": "Sabina Undertow MongoDB",
       "notes": "",
       "versus": "servlet"
-    }
-  }, {
+    },
     "undertow-mysql": {
       "json_url": "/json",
       "db_url": "/db",
@@ -49,8 +48,7 @@
       "display_name": "Sabina Undertow MySQL",
       "notes": "",
       "versus": "servlet"
-    }
-  }, {
+    },
     "jetty-mysql": {
       "json_url": "/json",
       "db_url": "/db",
@@ -74,8 +72,7 @@
       "display_name": "Sabina Jetty MySQL",
       "notes": "",
       "versus": "servlet"
-    }
-  }, {
+    },
     "jetty-mongodb": {
       "json_url": "/json",
       "db_url": "/db",


### PR DESCRIPTION
This this is what the benchmark json should look like for sabina.

```
WARNING:root:Framework sabina does not define a default test in benchmark_config.json
```
I noticed the warning and it looked different from others.

I may be way off on this one.