### PR TITLE
hhvm setup service fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-colorama==0.3.1
-# Version 2.3 has a nice Counter() and other features
-# but it requires —-allow-external and -—allow-unverified
-progressbar==2.2

--- a/toolset/setup/linux/languages/hhvm.sh
+++ b/toolset/setup/linux/languages/hhvm.sh
@@ -11,7 +11,7 @@ echo deb http://dl.hhvm.com/ubuntu `lsb_release -sc` main | sudo tee /etc/apt/so
 sudo apt-get update
 sudo apt-get install -y hhvm
 
-sudo service stop hhvm
+sudo service hhvm stop
 
 echo "" > $IROOT/hhvm.installed
 

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -56,7 +56,10 @@ sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options:
   xdg-utils                         `# Needed by dlang.` \
   python-pip
 
-sudo pip install -r ../requirements.txt
+sudo pip install colorama==0.3.1
+# Version 2.3 has a nice Counter() and other features
+# but it requires —-allow-external and -—allow-unverified
+sudo pip install progressbar==2.2
 
 # Install gcc-4.8 and gcc-4.9
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -53,7 +53,10 @@ sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options:
   llvm-dev                          `# Required for correct Ruby installation` \
   libboost-dev                      `# Silicon relies on boost::lexical_cast.` \
   postgresql-server-dev-9.3         `# Needed by cpoll.` \
-  xdg-utils                         `# Needed by dlang.`
+  xdg-utils                         `# Needed by dlang.` \
+  python-pip
+
+sudo pip install -r ../requirements.txt
 
 # Install gcc-4.8 and gcc-4.9
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
The hhvm service that gets started as a part of setting up hhvm was not properly stopped in its setup script. The first commit fixes this.

In addition, some python utilities required by the tools have been added to the setup script for linux. Previously, this required a manual step to install these utilities.