### PR TITLE
avoid Content encoding warning with tests

### DIFF
--- a/frameworks/C++/ULib/README.md
+++ b/frameworks/C++/ULib/README.md
@@ -45,7 +45,7 @@ HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:11:10 GMT
 Server: ULib 
 Content-Length: 27
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 {"message":"Hello, World!"}
 ```
@@ -57,7 +57,7 @@ HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:14:51 GMT
 Server: ULib 
 Content-Length: 31
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 {"id":6227,"randomNumber":8489}
 ```
@@ -69,7 +69,7 @@ HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:14:51 GMT
 Server: ULib 
 Content-Length: 320
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 [{"id":6851,"randomNumber":7598},{"id":3968,"randomNumber":7325},{"id":8159,"randomNumber":348},{"id":9560,"randomNumber":7333},{"id":9938,"randomNumber":9080},{"id":1598,"randomNumber":1623},{"id":3280,"randomNumber":8707},{"id":4521,"randomNumber":6063},{"id":8173,"randomNumber":3690},{"id":3648,"randomNumber":8803}]
 ```
@@ -80,7 +80,7 @@ Content-Type: application/json; charset=UTF-8
 HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:14:51 GMT
 Server: ULib 
-Content-Type: text/html; charset=UTF-8
+Content-Type: text/html
 Content-Length: 1227
 
 <!doctype html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr><tr><td>11</td><td>&lt;script&gt;alert(&quot;This should not be displayed in a browser alert box.&quot;);&lt;/script&gt;</td></tr><tr><td>4</td><td>A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1</td></tr><tr><td>5</td><td>A computer program does what you tell it to do, not what you want it to do.</td></tr><tr><td>2</td><td>A computer scientist is someone who fixes things that aren&apos;t broken.</td></tr><tr><td>8</td><td>A list is only as strong as its weakest link. — Donald Knuth</td></tr><tr><td>0</td><td>Additional fortune added at request time.</td></tr><tr><td>3</td><td>After enough decimal places, nobody gives a damn.</td></tr><tr><td>7</td><td>Any program that runs right is obsolete.</td></tr><tr><td>10</td><td>Computers make very fast, very accurate mistakes.</td></tr><tr><td>6</td><td>Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen</td></tr><tr><td>9</td><td>Feature: A bug with seniority.</td></tr><tr><td>1</td><td>fortune: No such file or directory</td></tr><tr><td>12</td><td>フレームワークのベンチマーク</td></tr></table></body></html>
@@ -93,7 +93,7 @@ HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:14:51 GMT
 Server: ULib 
 Content-Length: 319
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 
 [{"id":7171,"randomNumber":351},{"id":6019,"randomNumber":9725},{"id":8118,"randomNumber":4023},{"id":7965,"randomNumber":1388},{"id":7797,"randomNumber":2249},{"id":112,"randomNumber":1108},{"id":6127,"randomNumber":4323},{"id":2597,"randomNumber":7509},{"id":2978,"randomNumber":7883},{"id":1111,"randomNumber":2228}]
 ```
@@ -104,7 +104,7 @@ Content-Type: application/json; charset=UTF-8
 HTTP/1.1 200 OK
 Date: Thu, 03 Jul 2014 10:14:51 GMT
 Server: ULib 
-Content-Type: text/plain; charset=UTF-8
+Content-Type: text/plain
 Content-Length: 13
 
 Hello, World!

--- a/frameworks/C++/ULib/src/db.usp
+++ b/frameworks/C++/ULib/src/db.usp
@@ -55,7 +55,7 @@ static void usp_end_db()
 #endif
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 pworld_db->id = u_get_num_random(10000);

--- a/frameworks/C++/ULib/src/json.usp
+++ b/frameworks/C++/ULib/src/json.usp
@@ -36,7 +36,7 @@ static void usp_end_json()
 #endif
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 #ifndef AS_cpoll_cppsp_DO

--- a/frameworks/C++/ULib/src/query.usp
+++ b/frameworks/C++/ULib/src/query.usp
@@ -64,7 +64,7 @@ static void usp_end_query()
 queries;
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 int i = 0, num_queries;

--- a/frameworks/C++/ULib/src/rdb.usp
+++ b/frameworks/C++/ULib/src/rdb.usp
@@ -51,7 +51,7 @@ static void usp_end_rdb()
 #endif
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 UStringRep* rep;

--- a/frameworks/C++/ULib/src/rquery.usp
+++ b/frameworks/C++/ULib/src/rquery.usp
@@ -54,7 +54,7 @@ static void usp_end_rquery()
 queries;
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 World* pworld;

--- a/frameworks/C++/ULib/src/rupdate.usp
+++ b/frameworks/C++/ULib/src/rupdate.usp
@@ -54,7 +54,7 @@ static void usp_end_rupdate()
 queries;
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 World* pworld;

--- a/frameworks/C++/ULib/src/update.usp
+++ b/frameworks/C++/ULib/src/update.usp
@@ -72,7 +72,7 @@ static void usp_end_update()
 queries;
 -->
 <!--#header
-Content-Type: application/json; charset=UTF-8
+Content-Type: application/json
 -->
 <!--#code
 int i = 0, num_queries;


### PR DESCRIPTION
Hi,

this patch is to avoid Content encoding warning when we test ULib.

There is a problem with the name of the directory for the framework 'ULib' and the name used for travis test 'ulib' and also Ulib is disappearance from the result of Round 10 results...

Greeting
Stefano