### PR TITLE
Do not iterate by reference

### DIFF
--- a/frameworks/PHP/php/fortune.php
+++ b/frameworks/PHP/php/fortune.php
@@ -30,7 +30,7 @@ asort($arr);
 <th>message</th>
 </tr>
 <?php
-foreach ( $arr as $id => &$fortune ) {
+foreach ( $arr as $id => $fortune ) {
 ?>
 <tr>
 <td><?php echo htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?></td>  


### PR DESCRIPTION
Iteration by reference is generally only used when the variable is changed and that change should be reflected in the array.

Whether this is faster or not is irrelevant since this is a realistic implementation.