### PR TITLE
Update vibe.d setup.sh to build in release mode

### DIFF
--- a/frameworks/D/vibed/setup.sh
+++ b/frameworks/D/vibed/setup.sh
@@ -8,6 +8,6 @@ sed -i 's|127.0.0.1|'"${DBHOST}"'|g' source/app.d
 rm -f fwb
 rm -rf .dub
 
-dub build --force
+dub build --build=release --force
 
 ./fwb &


### PR DESCRIPTION
If dub is not provided with a `--build` flag it by default compiles binaries in debug mode instead of release, which might have a significant impact on performance.