### PR TITLE
Verification change for charset

### DIFF
--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -66,19 +66,36 @@ def verify_headers(headers, url, should_be='json'):
              'No content encoding found, expected \"%s\"' % (
                  expected_type),
              url))
-    elif content_type.lower() == includes_charset:
-        problems.append(
-            ('warn',
-             ("Content encoding found \"%s\" where \"%s\" is acceptable.\n"
-              "Additional response bytes may negatively affect benchmark performance."
-              % (includes_charset, expected_type)),
-             url))
-    elif content_type != expected_type:
-        problems.append(
-            ('warn',
-             'Unexpected content encoding, found \"%s\", expected \"%s\"' % (
-                 content_type, expected_type),
-             url))
+    else:
+    	content_type = content_type.lower()
+        # "text/html" requires charset to be set. The others do not
+        if expected_type == types['html']:
+            if content_type == expected_type:
+                problems.append(
+                    ('warn',
+                     ('The \"%s\" content type requires \"charset=utf-8\" to be specified.'
+                      % content_type),
+                     url))
+            elif content_type != includes_charset:
+                problems.append(
+                    ('warn',
+                     'Unexpected content encoding, found \"%s\", expected \"%s\".' % (
+                         content_type, expected_type),
+                     url))
+        else:
+            if content_type == includes_charset:
+                problems.append(
+                    ('warn',
+                     ("Content encoding found \"%s\" where \"%s\" is acceptable.\n"
+                      "Additional response bytes may negatively affect benchmark performance."
+                      % (content_type, expected_type)),
+                     url))
+            elif content_type != expected_type:
+                problems.append(
+                    ('warn',
+                     'Unexpected content encoding, found \"%s\", expected \"%s\"' % (
+                         content_type, expected_type),
+                     url))
     return problems
 
 

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -82,7 +82,7 @@ def verify_headers(headers, url, should_be='json'):
                      'Unexpected content encoding, found \"%s\", expected \"%s\".' % (
                          content_type, expected_type),
                      url))
-        else:
+        elif expected_type == types['json']:
             if content_type == includes_charset:
                 problems.append(
                     ('warn',
@@ -96,6 +96,12 @@ def verify_headers(headers, url, should_be='json'):
                      'Unexpected content encoding, found \"%s\", expected \"%s\"' % (
                          content_type, expected_type),
                      url))
+        elif content_type != expected_type and content_type != includes_charset:
+            problems.append(
+                ('warn',
+                 'Unexpected content encoding, found \"%s\", expected \"%s\"' % (
+                     content_type, expected_type),
+                 url))
     return problems
 
 


### PR DESCRIPTION
Previously, we would flag responses that set a `charset` as warnings as this extra header data was unnecessary and may impact performance. After some internal discussions, it's been decided that the `charset` should be considered mandatory for `text/html`, which is the content type for the fortunes test. This PR changes the verification script to reflect this. Failure to include `charset` for `text/html` or including `charset` for other content types is flagged as a warning.