### PR TITLE
Added Erlang/misultin framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ env:
     - "TESTDIR=Erlang/chicagoboss"
     - "TESTDIR=Erlang/cowboy"
     - "TESTDIR=Erlang/elli"
+    - "TESTDIR=Erlang/misultin"
     - "TESTDIR=Go/beego"
     - "TESTDIR=Go/falcore"
     - "TESTDIR=Go/fasthttp"

--- a/frameworks/Erlang/misultin/.gitignore
+++ b/frameworks/Erlang/misultin/.gitignore
@@ -1,0 +1,7 @@
+.eunit
+deps
+ebin
+*.o
+*.beam
+*.plt
+erl_crash.dump

--- a/frameworks/Erlang/misultin/Makefile
+++ b/frameworks/Erlang/misultin/Makefile
@@ -1,0 +1,13 @@
+REBAR=./rebar
+
+all:
+	@$(REBAR) -r get-deps compile
+
+clean:
+	@$(REBAR) clean
+
+run:
+	@./start.sh
+
+stop:
+	@killall beam.smp

--- a/frameworks/Erlang/misultin/benchmark_config.json
+++ b/frameworks/Erlang/misultin/benchmark_config.json
@@ -1,0 +1,23 @@
+{
+  "framework": "misultin",
+  "tests": [{
+    "default": {
+      "setup_file": "setup",
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
+      "framework": "Misultin",
+      "language": "Erlang",
+      "orm": "Raw",
+      "platform": "Erlang",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "misultin",
+      "notes": "",
+      "versus": ""
+  }}]
+}

--- a/frameworks/Erlang/misultin/priv/app.config
+++ b/frameworks/Erlang/misultin/priv/app.config
@@ -1,0 +1,9 @@
+%% -*- erlang -*-
+[{misultin_bench, [{http_port, 8080}]},
+
+ {erl_bench, [{db_pool, 256},
+              {db_user, "benchmarkdbuser"},
+              {db_password, "benchmarkdbpass"},
+              {db_host, "localhost"},
+              {db_port, 3306},
+              {db_name, "hello_world"}]}].

--- a/frameworks/Erlang/misultin/rebar.config
+++ b/frameworks/Erlang/misultin/rebar.config
@@ -1,0 +1,5 @@
+%% -*- erlang -*-
+{deps, [
+  {erl_bench, "0.0.1", {git, "git://github.com/b0oh/erl_bench.git", {tag, "v0.0.1"}}},
+  {misultin, "0.9", {git, "git://github.com/ostinelli/misultin.git", {tag, "misultin-0.9"}}}
+]}.

--- a/frameworks/Erlang/misultin/setup.sh
+++ b/frameworks/Erlang/misultin/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sed -i 's|"benchmarkdbpass", ".*", 3306|"benchmarkdbpass", "'"${DBHOST}"'", 3306|g' src/misultin_bench_sup.erl
+
+fw_depends erlang
+
+rm -rf deps/* ebin/*
+rebar get-deps
+rebar compile
+
+erl +K true +sbwt very_long +swt very_low -pa ebin deps/*/ebin -boot start_sasl -config priv/app.config -s misultin_bench_app -noshell -detached

--- a/frameworks/Erlang/misultin/src/misultin_bench.app.src
+++ b/frameworks/Erlang/misultin/src/misultin_bench.app.src
@@ -1,0 +1,9 @@
+%% -*- erlang -*-
+{application, misultin_bench,
+ [{description, ""},
+  {vsn, "0.1"},
+  {modules, []},
+  {registered, []},
+  {mod, {misultin_bench_app, []}},
+  {env, []},
+  {applications, [kernel, stdlib, crypto, erl_bench]}]}.

--- a/frameworks/Erlang/misultin/src/misultin_bench_app.erl
+++ b/frameworks/Erlang/misultin/src/misultin_bench_app.erl
@@ -1,0 +1,16 @@
+-module(misultin_bench_app).
+-behaviour(application).
+-export([start/0]).
+-export([start/2, stop/1]).
+
+start() ->
+    application:ensure_all_started(misultin_bench).
+
+start(_Type, _StartArgs) ->
+    {ok, Port} = application:get_env(misultin_bench, http_port),
+    Options = [{loop, fun(Req) -> web_handler:dispatch(Req) end},
+               {port, Port}],
+    misultin_bench_sup:start_link(Options).
+
+stop(_State) ->
+    ok.

--- a/frameworks/Erlang/misultin/src/misultin_bench_sup.erl
+++ b/frameworks/Erlang/misultin/src/misultin_bench_sup.erl
@@ -1,0 +1,18 @@
+-module(misultin_bench_sup).
+-behaviour(supervisor).
+-export([start_link/1]).
+-export([init/1]).
+
+start_link(Options) ->
+    supervisor:start_link(?MODULE, [Options]).
+
+init([Options]) ->
+    Misultin = supervisor(misultin, Options),
+    Processes = [Misultin],
+    Strategy = {one_for_one, 5, 30},
+    {ok, {Strategy, Processes}}.
+
+supervisor(Mod, Options) ->
+    {Mod,
+     {Mod, start_link, [Options]},
+     permanent, infinity, supervisor, [Mod]}.

--- a/frameworks/Erlang/misultin/src/web_handler.erl
+++ b/frameworks/Erlang/misultin/src/web_handler.erl
@@ -1,0 +1,53 @@
+-module(web_handler).
+-export([dispatch/1]).
+
+dispatch(Req) ->
+    Method = Req:get(method),
+    {_UriType, Uri} = Req:get(uri),
+    Path = string:tokens(Uri, "/"),
+    handle(Method, Path, Req).
+
+%% handle
+
+handle('GET', ["json"], Req) ->
+    json(Req, erl_bench:hello_json());
+
+handle('GET', ["plaintext"], Req) ->
+    plain(Req, erl_bench:hello_plain());
+
+handle('GET', ["db"], Req) ->
+    json(Req, erl_bench:random_json());
+
+handle('GET', ["queries"], Req) ->
+    Queries = queries(Req),
+    json(Req, erl_bench:randoms_json(Queries));
+
+handle('GET', ["updates"], Req) ->
+    Queries = queries(Req),
+    json(Req, erl_bench:update_randoms_json(Queries));
+
+handle('GET', ["fortunes"], Req) ->
+    html(Req, erl_bench:fortunes_html());
+
+handle(_Method, _Path, Req) ->
+    Req:respond(404, [{"Content-Type", "text/plain"}], "Not Found").
+
+%% private
+
+json(Req, Json) ->
+    Req:ok([{"Content-Type", "application/json"}], Json).
+
+plain(Req, Text) ->
+    Req:ok([{"Content-Type", "text/plain"}], Text).
+
+html(Req, Html) ->
+    Req:ok([{"Content-Type", "text/html"}], Html).
+
+queries(Req) ->
+    Params = Req:parse_qs(),
+    Queries = (catch list_to_integer(proplists:get_value("queries", Params, "1"))),
+    case {is_number(Queries), Queries > 500} of
+        {true, true} -> 500;
+        {false, _}   -> 1;
+        _ -> Queries
+    end.

--- a/frameworks/Erlang/misultin/start-dev.sh
+++ b/frameworks/Erlang/misultin/start-dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+exec erl \
+     +K true +sbwt very_long +swt very_low \
+     -pa ebin deps/*/ebin \
+     -boot start_sasl \
+     -config priv/app.config \
+     -s misultin_bench_app


### PR DESCRIPTION
I will be adding the 3 frameworks from #938 over time, as I fix them to meet the correct structure. This is the misultin framework. Passes all tests locally for plaintext and json. It seems there are issues with db connections for all the erlang frameworks so I will look into that as well, while updating these.