### PR TITLE
Fix Java/wildfly-ee7 travis-ci build fail issue

### DIFF
--- a/frameworks/Java/wildfly-ee7/setup.sh
+++ b/frameworks/Java/wildfly-ee7/setup.sh
@@ -2,7 +2,7 @@
 
 fw_depends java7 maven
 
-export JAVA_OPTS="-Xms2g -Xmx2g -XX:MaxPermSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=25 -verbosegc -Xloggc:/tmp/wildfly_gc.log"
+export JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Xms2g -Xmx2g -XX:MaxPermSize=256m -XX:+UseG1GC -XX:MaxGCPauseMillis=25 -verbosegc -Xloggc:/tmp/wildfly_gc.log"
 
 mvn clean initialize package -Pbenchmark -Ddatabase.host=${DBHOST}
 target/wildfly-9.0.1.Final/bin/standalone.sh -b 0.0.0.0 &


### PR DESCRIPTION
Fix build fail issue. 
The error occurs because of Java 7. 
Java 7 trying to use IPv6 to connect, but this framework uses IPv4.  
So telling java to use IPv4 is developer's role. 
After I explicitly indicate this using java option, problem disappeared magically.

Sounds simple, but this kind of error is super hard to debug. So keep in mind. 