### PR TITLE
Fix Erlang/cowboy travis-ci test fail issue

### DIFF
--- a/frameworks/Erlang/cowboy/setup.sh
+++ b/frameworks/Erlang/cowboy/setup.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Caution: "line 11 has flaw." reported by 'blee@techempower.com'
+#   Below sed command can cause travis-ci test failing.
+#   Please be aware of testing this on local machine.
+#   If you perform a local test, please apply inverse of   
+#   below command. (hint: ${DBHOST} value must be rollback to
+#   localhost.
+#
+#   I will fix this problem later with better solution. 
+#
 sed -i 's|"benchmarkdbpass", ".*", 3306|"benchmarkdbpass", "'"${DBHOST}"'", 3306|g' src/hello_world_app.erl
 
 fw_depends erlang

--- a/frameworks/Erlang/cowboy/src/hello_world_app.erl
+++ b/frameworks/Erlang/cowboy/src/hello_world_app.erl
@@ -10,10 +10,16 @@
 
 %% API.
 
+%% NOTE: 
+%%   If size of db testpool is too big (e.g: 5000), 
+%%   it will fail travis ci test. So I shrink this to 256.
+%%   blee@techempower.com
+
+
 start(_Type, _Args) ->
         crypto:start(),
         application:start(emysql),
-        emysql:add_pool(test_pool, 5000,
+        emysql:add_pool(test_pool, 256,
           "benchmarkdbuser", "benchmarkdbpass", "localhost", 3306,
           "hello_world", utf8),
 	emysql:prepare(db_stmt, <<"SELECT * FROM World where id = ?">>),
@@ -24,7 +30,7 @@ start(_Type, _Args) ->
       {"/query", query_handler, []}
 		]}
 	]),
-	{ok, _} = cowboy:start_http(http, 5000, [{port, 8080}], [
+	{ok, _} = cowboy:start_http(http, 256, [{port, 8080}], [
 		{env, [{dispatch, Dispatch}]}
 	]),
 	hello_world_sup:start_link().


### PR DESCRIPTION
Fix Travis-CI test failing issue. 
- Indicated 'dangerous' code to prevent problems that can be occurred by contributors or testers.
- Shrink size of db pool which causes problem on the travis-ci environment. Minimizing database pool size was a perfect solution. After shrinking the size of db pool, travis test stop failing. 

