### PR TITLE
Fix and update Erlang/elli

### DIFF
--- a/frameworks/Erlang/elli/benchmark_config.json
+++ b/frameworks/Erlang/elli/benchmark_config.json
@@ -3,9 +3,9 @@
   "tests": [{
     "default": {
       "setup_file": "setup",
+      "plaintext_url":"/plaintext",
       "json_url": "/json",
       "db_url": "/db",
-      "query_url": "/query?queries=",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Platform",

--- a/frameworks/Erlang/elli/src/elli_bench_cb.erl
+++ b/frameworks/Erlang/elli/src/elli_bench_cb.erl
@@ -8,11 +8,19 @@ handle(Req, _Args) ->
     %% Delegate to our handler function
     handle(Req#req.method, elli_request:path(Req), Req).
 
+%% Plaintext test route 
+handle('GET', [<<"plaintext">>], _Req) ->
+    %% Reply with a normal response. 'ok' can be used instead of '200'
+    %% to signal success.
+    {ok,[{<<"Content-Type">>, <<"text/plain">>}], <<"Hello, World!">>};
+
+%% Json test route
 handle('GET',[<<"json">>], _Req) ->
     %% Reply with a normal response. 'ok' can be used instead of '200'
     %% to signal success.
     {ok, [{<<"Content-Type">>, <<"application/json">>}], jiffy:encode({[{<<"message">>, <<"Hello, World!">>}]})};
 
+%% db test route (Single Database Query)
 handle('GET',[<<"db">>], Req) ->
         random:seed(erlang:now()),
         JSON = case elli_request:get_arg(<<"queries">>, Req) of
@@ -27,19 +35,22 @@ handle('GET',[<<"db">>], Req) ->
 		end,
     {ok, [{<<"Content-Type">>, <<"application/json">>}], jiffy:encode(lists:nth(1,JSON))};
 
-handle('GET',[<<"query">>], Req) ->
-        random:seed(erlang:now()),
-        JSON = case elli_request:get_arg(<<"queries">>, Req) of
-        undefined ->
-            {result_packet, _, _, [[ID, Rand]], _} = emysql:execute(test_pool, db_stmt, [random:uniform(10000)]),
-            [{[{<<"id">>, ID}, {<<"randomNumber">>, Rand}]}];
-        N ->
-            I = list_to_integer(binary_to_list(N)),
-            Res = [ {[{<<"id">>, ID}, {<<"randomNumber">>, Rand}]} || 
-                    {result_packet, _, _, [[ID, Rand]], _} <- [emysql:execute(test_pool, db_stmt, [random:uniform(10000)]) || _ <- lists:seq(1, I) ]],
-            Res
-        end,
-    {ok, [{<<"Content-Type">>, <<"application/json">>}], jiffy:encode(JSON)};
+%% TODO : Finish this function with correct logic.
+%%        Please check TFB document
+%% Multiple query test route
+% handle('GET',[<<"query">>], Req) ->
+%         random:seed(erlang:now()),
+%         JSON = case elli_request:get_arg(<<"queries">>, Req) of
+%         undefined ->
+%             {result_packet, _, _, [[ID, Rand]], _} = emysql:execute(test_pool, db_stmt, [random:uniform(10000)]),
+%             [{[{<<"id">>, ID}, {<<"randomNumber">>, Rand}]}];
+%         N ->
+%             I = list_to_integer(binary_to_list(N)),
+%             Res = [ {[{<<"id">>, ID}, {<<"randomNumber">>, Rand}]} || 
+%                     {result_packet, _, _, [[ID, Rand]], _} <- [emysql:execute(test_pool, db_stmt, [random:uniform(10000)]) || _ <- lists:seq(1, I) ]],
+%             Res
+%         end,
+%     {ok, [{<<"Content-Type">>, <<"application/json">>}], jiffy:encode(JSON)};
 
 handle(_, _, _Req) ->
     {404, [], <<"Not Found">>}.

--- a/frameworks/Erlang/elli/src/elli_bench_sup.erl
+++ b/frameworks/Erlang/elli/src/elli_bench_sup.erl
@@ -22,10 +22,14 @@ start_link() ->
 %% Supervisor callbacks
 %% ===================================================================
 
+%% CAUTION : Assign big number to db pool will fail travis ci.
+%%           Original value was 5000, too big! Even 512 crashes! keep 256
+%%           till travis-ci environment accepts bigger size of db pool. 
+
 init([]) ->
     crypto:start(),
     application:start(emysql),
-    emysql:add_pool(test_pool, 5000,
+    emysql:add_pool(test_pool, 256,
        "benchmarkdbuser", "benchmarkdbpass", "localhost", 3306,
        "hello_world", utf8),
     emysql:prepare(db_stmt, <<"SELECT * FROM World where id = ?">>),
@@ -34,7 +38,7 @@ init([]) ->
         fancy_http,
         {elli, start_link, [ElliOpts]},
         permanent,
-        5000,
+        256,
         worker,
         [elli]},
 


### PR DESCRIPTION
- No more build fail on travis-ci test.
- Reduced db pool size. Assigning large db pool size is a main reason of failing travis-ci test.
- Add plaintext route.
- Disable multi query test temporarily. Even this framework has multi query test route, the logic is not correct. For this reason, I just disable it for now. This can be added later by Erlang expert.