### PR TITLE
Fix rvm.sh

### DIFF
--- a/toolset/setup/linux/languages/rvm.sh
+++ b/toolset/setup/linux/languages/rvm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RETCODE=$(fw_exists rvm.installed)
+RETCODE=$(fw_exists ${IROOT}/rvm.installed)
 [ ! "$RETCODE" == 0 ] || { \
   # Assume single-user installation
   source $IROOT/rvm.installed


### PR DESCRIPTION
While I was investigating why most Ruby related framework are broken,
I notice that one problem at 'rvm.sh'. It does not solve current problem,
but it seems that RETCODE variable would have nonexisting value, so I change
it to have right value. 