### PR TITLE
Upgraded wicket to 7.1 and other deps

### DIFF
--- a/frameworks/Java/wicket/.classpath
+++ b/frameworks/Java/wicket/.classpath
@@ -1,39 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="src/test/java" output="target/test-classes"/>
-  <classpathentry kind="src" path="src/test/resources" output="target/test-classes" excluding="**/*.java"/>
-  <classpathentry kind="src" path="src/main/java"/>
-  <classpathentry kind="src" path="src/main/resources" excluding="**/*.java"/>
-  <classpathentry kind="output" path="target/classes"/>
-  <classpathentry kind="var" path="M2_REPO/javax/activation/activation/1.1/activation-1.1.jar" sourcepath="M2_REPO/javax/activation/activation/1.1/activation-1.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/javax/inject/javax.inject/1/javax.inject-1.jar" sourcepath="M2_REPO/javax/inject/javax.inject/1/javax.inject-1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/javax/mail/mail/1.4.1/mail-1.4.1.jar" sourcepath="M2_REPO/javax/mail/mail/1.4.1/mail-1.4.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar" sourcepath="M2_REPO/javax/servlet/servlet-api/2.5/servlet-api-2.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/antlr/antlr/2.7.7/antlr-2.7.7.jar"/>
-  <classpathentry kind="var" path="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0.jar" sourcepath="M2_REPO/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/asm/asm/3.1/asm-3.1.jar" sourcepath="M2_REPO/asm/asm/3.1/asm-3.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/asm/asm-commons/3.1/asm-commons-3.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/asm/asm-tree/3.1/asm-tree-3.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar" sourcepath="M2_REPO/dom4j/dom4j/1.6.1/dom4j-1.6.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/geronimo/specs/geronimo-annotation_1.0_spec/1.1.1/geronimo-annotation_1.0_spec-1.1.1.jar" sourcepath="M2_REPO/org/apache/geronimo/specs/geronimo-annotation_1.0_spec/1.1.1/geronimo-annotation_1.0_spec-1.1.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/geronimo/specs/geronimo-jaspic_1.0_spec/1.0/geronimo-jaspic_1.0_spec-1.0.jar" sourcepath="M2_REPO/org/apache/geronimo/specs/geronimo-jaspic_1.0_spec/1.0/geronimo-jaspic_1.0_spec-1.0-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/geronimo/specs/geronimo-jta_1.1_spec/1.1.1/geronimo-jta_1.1_spec-1.1.1.jar" sourcepath="M2_REPO/org/apache/geronimo/specs/geronimo-jta_1.1_spec/1.1.1/geronimo-jta_1.1_spec-1.1.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/com/google/code/gson/gson/2.1/gson-2.1.jar" sourcepath="M2_REPO/com/google/code/gson/gson/2.1/gson-2.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/com/google/inject/guice/3.0/guice-3.0.jar" sourcepath="M2_REPO/com/google/inject/guice/3.0/guice-3.0-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/hibernate/common/hibernate-commons-annotations/4.0.1.Final/hibernate-commons-annotations-4.0.1.Final.jar" sourcepath="M2_REPO/org/hibernate/common/hibernate-commons-annotations/4.0.1.Final/hibernate-commons-annotations-4.0.1.Final-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/hibernate/hibernate-core/4.1.1.Final/hibernate-core-4.1.1.Final.jar" sourcepath="M2_REPO/org/hibernate/hibernate-core/4.1.1.Final/hibernate-core-4.1.1.Final-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/hibernate/javax/persistence/hibernate-jpa-2.0-api/1.0.1.Final/hibernate-jpa-2.0-api-1.0.1.Final.jar" sourcepath="M2_REPO/org/hibernate/javax/persistence/hibernate-jpa-2.0-api/1.0.1.Final/hibernate-jpa-2.0-api-1.0.1.Final-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/javassist/javassist/3.15.0-GA/javassist-3.15.0-GA.jar" sourcepath="M2_REPO/org/javassist/javassist/3.15.0-GA/javassist-3.15.0-GA-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jboss/logging/jboss-logging/3.1.0.GA/jboss-logging-3.1.0.GA.jar" sourcepath="M2_REPO/org/jboss/logging/jboss-logging/3.1.0.GA/jboss-logging-3.1.0.GA-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/jboss/spec/javax/transaction/jboss-transaction-api_1.1_spec/1.0.0.Final/jboss-transaction-api_1.1_spec-1.0.0.Final.jar" sourcepath="M2_REPO/org/jboss/spec/javax/transaction/jboss-transaction-api_1.1_spec/1.0.0.Final/jboss-transaction-api_1.1_spec-1.0.0.Final-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/eclipse/jetty/aggregate/jetty-all-server/7.5.0.v20110901/jetty-all-server-7.5.0.v20110901.jar" sourcepath="M2_REPO/org/eclipse/jetty/aggregate/jetty-all-server/7.5.0.v20110901/jetty-all-server-7.5.0.v20110901-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/junit/junit/4.8.1/junit-4.8.1.jar" sourcepath="M2_REPO/junit/junit/4.8.1/junit-4.8.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/log4j/log4j/1.2.16/log4j-1.2.16.jar" sourcepath="M2_REPO/log4j/log4j/1.2.16/log4j-1.2.16-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/mysql/mysql-connector-java/5.1.19/mysql-connector-java-5.1.19.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/slf4j/slf4j-api/1.6.1/slf4j-api-1.6.1.jar" sourcepath="M2_REPO/org/slf4j/slf4j-api/1.6.1/slf4j-api-1.6.1-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/slf4j/slf4j-log4j12/1.6.2/slf4j-log4j12-1.6.2.jar" sourcepath="M2_REPO/org/slf4j/slf4j-log4j12/1.6.2/slf4j-log4j12-1.6.2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/wicket/wicket-core/1.5.5/wicket-core-1.5.5.jar" sourcepath="M2_REPO/org/apache/wicket/wicket-core/1.5.5/wicket-core-1.5.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/wicket/wicket-request/1.5.5/wicket-request-1.5.5.jar" sourcepath="M2_REPO/org/apache/wicket/wicket-request/1.5.5/wicket-request-1.5.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/org/apache/wicket/wicket-util/1.5.5/wicket-util-1.5.5.jar" sourcepath="M2_REPO/org/apache/wicket/wicket-util/1.5.5/wicket-util-1.5.5-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar" sourcepath="M2_REPO/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2-sources.jar"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/frameworks/Java/wicket/.project
+++ b/frameworks/Java/wicket/.project
@@ -1,13 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>hellowicket</name>
-  <comment>NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
-  <projects/>
-  <buildSpec>
-    <buildCommand>
-      <name>org.eclipse.jdt.core.javabuilder</name>
-    </buildCommand>
-  </buildSpec>
-  <natures>
-    <nature>org.eclipse.jdt.core.javanature</nature>
-  </natures>
+	<name>hellowicket</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.jsdt.core.javascriptValidator</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+	</natures>
 </projectDescription>

--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -5,13 +5,12 @@
 	<artifactId>hellowicket</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
-	<!-- TODO project name  -->
-	<name>quickstart</name>
-	<description></description>
-	<!--
-		TODO <organization> <name>company name</name> <url>company url</url>
-		</organization>
-	-->
+	<name>Hello Wicket</name>
+	<description>Wicket project for the TechEmpower Benchmark</description>
+	<organization>
+		<name>TechEmpower</name>
+		<url>https://github.com/TechEmpower/FrameworkBenchmarks</url>
+	</organization>
 	<licenses>
 		<license>
 			<name>The Apache Software License, Version 2.0</name>
@@ -21,12 +20,12 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket.version>6.16.0</wicket.version>
-		<jetty.version>8.1.14.v20131031</jetty.version>
-		<slf4j.version>1.7.7</slf4j.version>
+		<wicket.version>7.1.0</wicket.version>
+		<jetty.version>8.1.18.v20150929</jetty.version>
+		<slf4j.version>1.7.12</slf4j.version>
 	</properties>
 	<dependencies>
-		<!--  WICKET DEPENDENCIES -->
+		<!-- WICKET DEPENDENCIES -->
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket-core</artifactId>
@@ -37,7 +36,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>1.4.0</version>
+			<version>2.4.3</version>
 			<scope>compile</scope>
 		</dependency>
 
@@ -53,32 +52,32 @@
 			<version>1.2.17</version>
 		</dependency>
 
-		<!--  JUNIT DEPENDENCY FOR TESTING -->
+		<!-- JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 
-		<!--  JETTY DEPENDENCIES FOR TESTING  -->
+		<!-- JETTY DEPENDENCIES FOR TESTING -->
 		<dependency>
 			<groupId>org.eclipse.jetty.aggregate</groupId>
 			<artifactId>jetty-all-server</artifactId>
 			<version>${jetty.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		
-		 <dependency>
+
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.3.2</version>
+			<version>2.7.0</version>
 		</dependency>
 
 		<dependency>
-		  <groupId>mysql</groupId>
-		  <artifactId>mysql-connector-java</artifactId>
-		  <version>5.1.31</version>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>5.1.38</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -137,13 +136,9 @@
 							<port>8080</port>
 							<maxIdleTime>3600000</maxIdleTime>
 						</connector>
-						<!--connector implementation="org.eclipse.jetty.server.ssl.SslSocketConnector">
-							<port>8443</port>
-							<maxIdleTime>3600000</maxIdleTime>
-							<keystore>${project.build.directory}/test-classes/keystore</keystore>
-							<password>wicket</password>
-							<keyPassword>wicket</keyPassword>
-						</connector-->
+						<!--connector implementation="org.eclipse.jetty.server.ssl.SslSocketConnector"> 
+							<port>8443</port> <maxIdleTime>3600000</maxIdleTime> <keystore>${project.build.directory}/test-classes/keystore</keystore> 
+							<password>wicket</password> <keyPassword>wicket</keyPassword> </connector -->
 					</connectors>
 				</configuration>
 			</plugin>
@@ -162,5 +157,4 @@
 			</snapshots>
 		</repository>
 	</repositories>
-
-	</project>
+</project>

--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -147,14 +147,6 @@
 					</connectors>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.9</version>
-				<configuration>
-					<downloadSources>true</downloadSources>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/frameworks/Java/wicket/src/main/java/hellowicket/BasePage.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/BasePage.java
@@ -4,5 +4,5 @@ import org.apache.wicket.markup.html.WebPage;
 
 public class BasePage extends WebPage
 {
-  
+  private static final long serialVersionUID = 1L;
 }

--- a/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
@@ -4,7 +4,7 @@ import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
 import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.settings.IRequestCycleSettings;
+import org.apache.wicket.settings.RequestCycleSettings;
 
 import com.zaxxer.hikari.HikariDataSource;
 
@@ -42,7 +42,7 @@ public class WicketApplication extends WebApplication
 
 		// disable response caching to be more close to other
 		// test applications' behavior
-		IRequestCycleSettings requestCycleSettings = getRequestCycleSettings();
+		RequestCycleSettings requestCycleSettings = getRequestCycleSettings();
 		requestCycleSettings.setBufferResponse(false);
 
 		// set UTF-8 for /fortunes test
@@ -85,17 +85,17 @@ public class WicketApplication extends WebApplication
 				InitialContext jndiContext = new InitialContext();
 				dataSource = (DataSource) jndiContext.lookup("java:comp/env/jdbc/hello_world");
 			}
-			else
+			else try(HikariDataSource ds = new HikariDataSource();)
 			{
 				// use faster DataSource impl
-				HikariDataSource ds = new HikariDataSource();
 				ds.setJdbcUrl("jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true");
 				ds.setDriverClassName("com.mysql.jdbc.Driver");
 				ds.setUsername("benchmarkdbuser");
 				ds.setPassword("benchmarkdbpass");
 				dataSource = ds;
 			}
-		} catch (Exception x)
+		}
+        catch (Exception x)
 		{
 			throw new RuntimeException("Cannot create the data source", x);
 		}

--- a/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
@@ -85,8 +85,12 @@ public class WicketApplication extends WebApplication
 				InitialContext jndiContext = new InitialContext();
 				dataSource = (DataSource) jndiContext.lookup("java:comp/env/jdbc/hello_world");
 			}
-			else try(HikariDataSource ds = new HikariDataSource();)
+			else 
 			{
+				// allocating a resource for future use should not (auto) close the resource 
+				@SuppressWarnings("resource")
+				HikariDataSource ds = new HikariDataSource();
+
 				// use faster DataSource impl
 				ds.setJdbcUrl("jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true");
 				ds.setDriverClassName("com.mysql.jdbc.Driver");

--- a/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
@@ -16,48 +16,42 @@ import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 
 /**
- * A page that loads all fortune cookies
+ * A page that loads all fortune cookies. This mimics the Servlet example
+ * exactly, without any further optimizations that one could do such as sorting
+ * in the database, or not sorting at all.
  */
-public class FortunePage extends WebPage
-{
-  public FortunePage() throws Exception
-  {
-    List<Fortune> fortunes = new ArrayList<>(10000);
+public class FortunePage extends WebPage {
+	private static final long serialVersionUID = 1L;
 
-    Fortune newFortune = new Fortune(0, "Additional fortune added at request time.");
-    fortunes.add(newFortune);
+	public FortunePage() throws Exception {
+		List<Fortune> fortunes = new ArrayList<>(10000);
 
-    DataSource dataSource = WicketApplication.get().getDataSource();
-    try (Connection connection = dataSource.getConnection())
-    {
-      try (PreparedStatement statement = connection.prepareStatement("SELECT * FROM Fortune",
-              ResultSet.TYPE_FORWARD_ONLY,
-              ResultSet.CONCUR_READ_ONLY))
-      {
-          try (ResultSet resultSet = statement.executeQuery())
-          {
-              while (resultSet.next())
-              {
-                  fortunes.add(new Fortune(
-                          resultSet.getInt("id"),
-                          resultSet.getString("message")));
-              }
-          }
-      }
-    }
+		DataSource dataSource = WicketApplication.get().getDataSource();
+		try ( //
+				Connection connection = dataSource.getConnection();
+				PreparedStatement statement = connection.prepareStatement("SELECT id, message FROM Fortune",
+						ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+				ResultSet resultSet = statement.executeQuery();) {
 
-    Collections.sort(fortunes);
+			while (resultSet.next()) {
+				fortunes.add(new Fortune(resultSet.getInt("id"), resultSet.getString("message")));
+			}
+		}
 
-    ListView<Fortune> listView = new ListView<Fortune>("fortunes", fortunes)
-    {
-      @Override
-      protected void populateItem(ListItem<Fortune> item)
-      {
-        Fortune fortune = item.getModelObject();
-        item.add(new Label("id", fortune.id));
-        item.add(new Label("message", fortune.message));
-      }
-    };
-    add(listView);
-  }
+		fortunes.add(new Fortune(0, "Additional fortune added at request time."));
+
+		Collections.sort(fortunes);
+
+		ListView<Fortune> listView = new ListView<Fortune>("fortunes", fortunes) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void populateItem(ListItem<Fortune> item) {
+				Fortune fortune = item.getModelObject();
+				item.add(new Label("id", fortune.id));
+				item.add(new Label("message", fortune.message));
+			}
+		};
+		add(listView);
+	}
 }


### PR DESCRIPTION
This PR upgrades wicket to 7.1 and upgrades other dependencies to their latest counterparts as well.
It also removes the Eclipse meta-data, which gets in the way when you use Eclipse 4.4 or newer to
import the project as a Maven project, which is the preferred way of managing your projects when they
are based on a Maven POM.