### PR TITLE
Compojure, http-kit: Switch from c3p0 to HikariCP db pool

### DIFF
--- a/frameworks/Clojure/compojure/hello/project.clj
+++ b/frameworks/Clojure/compojure/hello/project.clj
@@ -9,7 +9,7 @@
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  [mysql/mysql-connector-java "5.1.38"]
                  [org.clojure/java.jdbc "0.3.7"]
-                 [c3p0/c3p0 "0.9.1.2"]
+                 [hikari-cp "1.5.0"]
                  [hiccup "1.0.5"]]
   :plugins [[lein-ring "0.9.7"]]
   :ring {:handler hello.handler/app}

--- a/frameworks/Clojure/http-kit/hello/project.clj
+++ b/frameworks/Clojure/http-kit/hello/project.clj
@@ -15,7 +15,7 @@
                  [ring/ring-jetty-adapter "1.4.0"]
                  [mysql/mysql-connector-java "5.1.38"]
                  [org.clojure/java.jdbc "0.3.7"]
-                 [c3p0/c3p0 "0.9.1.2"]
+                 [hikari-cp "1.5.0"]
                  [hiccup "1.0.5"]]
   :plugins [[lein-ring "0.9.7"]]
   :ring {:handler hello.handler/app}

--- a/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
@@ -1,6 +1,5 @@
 (ns hello.handler
   (:gen-class)
-  (:import com.mchange.v2.c3p0.ComboPooledDataSource)
   (:use compojure.core
         ring.middleware.json
         org.httpkit.server
@@ -13,7 +12,8 @@
   (:require [compojure.handler :as handler]
             [compojure.route :as route]
             [ring.util.response :as ring-resp]
-            [clojure.java.jdbc :as jdbc]))
+            [clojure.java.jdbc :as jdbc]
+            [hikari-cp.core :refer :all]))
 
 (defn sanitize-queries-param
   "Sanitizes the `queries` parameter. Clamps the value between 1 and 500.
@@ -38,31 +38,30 @@
     :delimiters "" ;; remove delimiters
     :maximum-pool-size 256}))
 
-;; MySQL database connection for java.jdbc "raw"
-;; https://github.com/clojure/java.jdbc/blob/master/doc/clojure/java/jdbc/ConnectionPooling.md
-(def db-spec-mysql-raw
-  {:classname "com.mysql.jdbc.Driver"
-   :subprotocol "mysql"
-   :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
-   :user "benchmarkdbuser"
-   :password "benchmarkdbpass"})
+;; MySQL database connection for java.jdbc "raw" using HikariCP
+(def datasource-options-hikaricp {:auto-commit        true
+                                  :read-only          false
+                                  :connection-timeout 30000
+                                  :validation-timeout 5000
+                                  :idle-timeout       600000
+                                  :max-lifetime       1800000
+                                  :minimum-idle       10
+                                  :maximum-pool-size  256
+                                  :pool-name          "db-pool"
+                                  :adapter            "mysql"
+                                  :username           "benchmarkdbuser"
+                                  :password           "benchmarkdbpass"
+                                  :database-name      "hello_world"
+                                  :server-name        "127.0.0.1"
+                                  :port-number        3306
+                                  :register-mbeans    false})
 
-(defn pool
-  [spec]
-  (let [cpds (doto (ComboPooledDataSource.)
-               (.setDriverClass (:classname spec))
-               (.setJdbcUrl (str "jdbc:" (:subprotocol spec) ":" (:subname spec)))
-               (.setUser (:user spec))
-               (.setPassword (:password spec))
-               ;; expire excess connections after 30 minutes of inactivity:
-               (.setMaxIdleTimeExcessConnections (* 30 60))
-               ;; expire connections after 3 hours of inactivity:
-               (.setMaxIdleTime (* 3 60 60)))]
-    {:datasource cpds}))
+;; Create HikariCP-pooled "raw" jdbc data source
+(def db-spec-mysql-raw-hikaricp
+  (make-datasource datasource-options-hikaricp))
 
-(def pooled-db (delay (pool db-spec-mysql-raw)))
-
-(defn db-mysql-raw [] @pooled-db)
+;; Get a HikariCP-pooled "raw" jdbc connection
+(defn db-mysql-raw [] {:datasource db-spec-mysql-raw-hikaricp})
 
 ;; Set up entity World and the database representation
 (defentity world


### PR DESCRIPTION
HikariCP is significantly faster in my testing (and the HikariCP published benchmarks), while still being suitable for production use.