### PR TITLE
Luminus: Add routes to pass benchmark verification tests

### DIFF
--- a/frameworks/Clojure/luminus/hello/src/hello/routes/home.clj
+++ b/frameworks/Clojure/luminus/hello/src/hello/routes/home.clj
@@ -2,7 +2,7 @@
   (:require [hello.layout :as layout]
             [hello.db.core :as db]
             [compojure.core :refer [defroutes GET]]
-            [ring.util.response :refer [response]]
+            [ring.util.response :refer [response content-type]]
             [clojure.java.io :as io]))
 
 (def json-serialization
@@ -35,15 +35,18 @@
 
 (def plaintext
   "Test 6: Plaintext"
-  {:status 200
-   :headers {"Content-Type" "text/plain"}
-   :body "Hello, World!"})
+  (->
+    (response "Hello, World!")
+    (content-type "text/plain")))
+
 
 (defroutes home-routes
   (GET "/"                 [] "Hello, World!")
   (GET "/plaintext"        [] plaintext)
   (GET "/json"             [] json-serialization)
   (GET "/db"               [] (single-query-test))
+  (GET "/queries/"         [] (multiple-query-test 1))
   (GET "/queries/:queries" [queries] (multiple-query-test queries))
   (GET "/fortunes"         [] (fortunes))
-  (GET "/updates/:queries"  [queries] (db-update queries)))
+  (GET "/updates/"         [] (db-update 1))
+  (GET "/updates/:queries" [queries] (db-update queries)))


### PR DESCRIPTION
The verify script tries /queries/ and /updates/ with no count param, and
the Luminus test implementation needs to treat this the same as if a 1 
was passed in.

Also use ring.util.response to set the Content-Type header for plaintext.