### PR TITLE
aleph/compojure/http-kit: Use defn instead of def for handler functions

### DIFF
--- a/frameworks/Clojure/aleph/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/aleph/hello/src/hello/handler.clj
@@ -7,21 +7,23 @@
     [clj-tuple :as t])
   (:gen-class))
 
-(def plaintext-response
+(defn plaintext-response
+  []
   (t/hash-map
     :status 200
     :headers (t/hash-map "content-type" "text/plain; charset=utf-8")
     :body (bs/to-byte-array "Hello, World!")))
 
-(def json-response
+(defn json-response
+  []
   (t/hash-map
     :status 200
     :headers (t/hash-map "content-type" "application/json")))
 
 (defn handler [{:keys [uri] :as req}]
   (cond
-    (= "/plaintext" uri) plaintext-response
-    (= "/json" uri) (assoc json-response
+    (= "/plaintext" uri) (plaintext-response)
+    (= "/json" uri) (assoc (json-response)
                       :body (json/encode (t/hash-map :message "Hello, World!")))
     :else {:status 404}))
 

--- a/frameworks/Clojure/aleph/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/aleph/hello/src/hello/handler.clj
@@ -7,23 +7,21 @@
     [clj-tuple :as t])
   (:gen-class))
 
-(defn plaintext-response
-  []
+(def plaintext-response
   (t/hash-map
     :status 200
     :headers (t/hash-map "content-type" "text/plain; charset=utf-8")
     :body (bs/to-byte-array "Hello, World!")))
 
-(defn json-response
-  []
+(def json-response
   (t/hash-map
     :status 200
     :headers (t/hash-map "content-type" "application/json")))
 
 (defn handler [{:keys [uri] :as req}]
   (cond
-    (= "/plaintext" uri) (plaintext-response)
-    (= "/json" uri) (assoc (json-response)
+    (= "/plaintext" uri) plaintext-response
+    (= "/json" uri) (assoc json-response
                       :body (json/encode (t/hash-map :message "Hello, World!")))
     :else {:status 404}))
 

--- a/frameworks/Clojure/compojure/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/hello/src/hello/handler.clj
@@ -231,9 +231,8 @@
       (update-and-persist-raw)
       (ring-resp/response)))
 
-(defn plaintext
+(def plaintext
   "Test 6: Plaintext"
-  []
   (->
     (ring-resp/response "Hello, World!")
     (ring-resp/content-type "text/plain")))
@@ -241,7 +240,7 @@
 ;; Define route handlers
 (defroutes app-routes
   (GET "/"                     [] "Hello, World!")
-  (GET "/plaintext"            [] (plaintext))
+  (GET "/plaintext"            [] plaintext)
   (GET "/json"                 [] (json-serialization))
   (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))

--- a/frameworks/Clojure/compojure/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/hello/src/hello/handler.clj
@@ -161,12 +161,14 @@
         (jdbc/update! (db-mysql-raw) :world {:randomNumber (:randomNumber w)} ["id = ?" (:id w)])))
     results))
 
-(def json-serialization
+(defn json-serialization
   "Test 1: JSON serialization"
+  []
   (ring-resp/response {:message "Hello, World!"}))
 
-(def single-query-test
+(defn single-query-test
   "Test 2: Single database query"
+  []
   (ring-resp/response (first (run-queries 1))))
 
 (defn multiple-queries-test
@@ -177,8 +179,9 @@
       (run-queries)
       (ring-resp/response)))
 
-(def single-query-test-raw
+(defn single-query-test-raw
   "Test 2: Single database query (raw)"
+  []
   (-> 1
       (run-queries-raw)
       (first)
@@ -192,8 +195,9 @@
       (run-queries-raw)
       (ring-resp/response)))
 
-(def fortune-test
+(defn fortune-test
   "Test 4: Fortunes"
+  []
   (->
     (get-fortunes get-all-fortunes-korma)
     (fortunes-hiccup)
@@ -201,8 +205,9 @@
     (ring-resp/content-type "text/html")
     (ring-resp/charset "utf-8")))
 
-(def fortune-test-raw
+(defn fortune-test-raw
   "Test 4: Fortunes Raw"
+  []
   (->
     (get-fortunes get-all-fortunes-raw)
     (fortunes-hiccup)
@@ -226,8 +231,9 @@
       (update-and-persist-raw)
       (ring-resp/response)))
 
-(def plaintext
+(defn plaintext
   "Test 6: Plaintext"
+  []
   (->
     (ring-resp/response "Hello, World!")
     (ring-resp/content-type "text/plain")))
@@ -235,20 +241,20 @@
 ;; Define route handlers
 (defroutes app-routes
   (GET "/"                     [] "Hello, World!")
-  (GET "/plaintext"            [] plaintext)
-  (GET "/json"                 [] json-serialization)
-  (GET "/db"                   [] single-query-test)
+  (GET "/plaintext"            [] (plaintext))
+  (GET "/json"                 [] (json-serialization))
+  (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))
-  (GET "/queries/"             [] (multiple-queries-test queries)) ; When param is omitted
+  (GET "/queries/"             [] (multiple-queries-test)) ; When param is omitted
   (GET "/fortunes"             [] fortune-test)
   (GET "/updates/:queries"     [queries] (db-updates queries))
-  (GET "/updates/"             [] (db-updates queries)) ; When param is omitted
-  (GET "/raw/db"               [] single-query-test-raw)
+  (GET "/updates/"             [] (db-updates)) ; When param is omitted
+  (GET "/raw/db"               [] (single-query-test-raw))
   (GET "/raw/queries/:queries" [queries] (multiple-queries-test-raw queries))
-  (GET "/raw/queries/"         [] (multiple-queries-test-raw queries)) ; When param is omitted
-  (GET "/raw/fortunes"         [] fortune-test-raw)
+  (GET "/raw/queries/"         [] (multiple-queries-test-raw)) ; When param is omitted
+  (GET "/raw/fortunes"         [] (fortune-test-raw))
   (GET "/raw/updates/:queries" [queries] (db-updates-raw queries))
-  (GET "/raw/updates/"         [] (db-updates-raw queries)) ; When param is omitted
+  (GET "/raw/updates/"         [] (db-updates-raw)) ; When param is omitted
   (route/not-found "Not Found"))
 
 (def app

--- a/frameworks/Clojure/compojure/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/hello/src/hello/handler.clj
@@ -245,16 +245,16 @@
   (GET "/json"                 [] (json-serialization))
   (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))
-  (GET "/queries/"             [] (multiple-queries-test)) ; When param is omitted
-  (GET "/fortunes"             [] fortune-test)
+  (GET "/queries/"             [] (multiple-queries-test 1)) ; When param is omitted
+  (GET "/fortunes"             [] (fortune-test))
   (GET "/updates/:queries"     [queries] (db-updates queries))
-  (GET "/updates/"             [] (db-updates)) ; When param is omitted
+  (GET "/updates/"             [] (db-updates 1)) ; When param is omitted
   (GET "/raw/db"               [] (single-query-test-raw))
   (GET "/raw/queries/:queries" [queries] (multiple-queries-test-raw queries))
-  (GET "/raw/queries/"         [] (multiple-queries-test-raw)) ; When param is omitted
+  (GET "/raw/queries/"         [] (multiple-queries-test-raw 1)) ; When param is omitted
   (GET "/raw/fortunes"         [] (fortune-test-raw))
   (GET "/raw/updates/:queries" [queries] (db-updates-raw queries))
-  (GET "/raw/updates/"         [] (db-updates-raw)) ; When param is omitted
+  (GET "/raw/updates/"         [] (db-updates-raw 1)) ; When param is omitted
   (route/not-found "Not Found"))
 
 (def app

--- a/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
@@ -247,16 +247,16 @@
   (GET "/json"                 [] (json-serialization))
   (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))
-  (GET "/queries/"             [] (multiple-queries-test)) ; When param is omitted
-  (GET "/fortunes"             [] fortune-test)
+  (GET "/queries/"             [] (multiple-queries-test 1)) ; When param is omitted
+  (GET "/fortunes"             [] (fortune-test))
   (GET "/updates/:queries"     [queries] (db-updates queries))
-  (GET "/updates/"             [] (db-updates)) ; When param is omitted
+  (GET "/updates/"             [] (db-updates 1)) ; When param is omitted
   (GET "/raw/db"               [] (single-query-test-raw))
   (GET "/raw/queries/:queries" [queries] (multiple-queries-test-raw queries))
-  (GET "/raw/queries/"         [] (multiple-queries-test-raw)) ; When param is omitted
+  (GET "/raw/queries/"         [] (multiple-queries-test-raw 1)) ; When param is omitted
   (GET "/raw/fortunes"         [] (fortune-test-raw))
   (GET "/raw/updates/:queries" [queries] (db-updates-raw queries))
-  (GET "/raw/updates/"         [] (db-updates-raw)) ; When param is omitted
+  (GET "/raw/updates/"         [] (db-updates-raw 1)) ; When param is omitted
   (route/not-found "Not Found"))
 
 (defn parse-port [s] 

--- a/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
@@ -233,9 +233,8 @@
       (update-and-persist-raw)
       (ring-resp/response)))
 
-(defn plaintext
+(def plaintext
   "Test 6: Plaintext"
-  []
   (->
     (ring-resp/response "Hello, World!")
     (ring-resp/content-type "text/plain")))
@@ -243,7 +242,7 @@
 ;; Define route handlers
 (defroutes app-routes
   (GET "/"                     [] "Hello, World!")
-  (GET "/plaintext"            [] (plaintext))
+  (GET "/plaintext"            [] plaintext)
   (GET "/json"                 [] (json-serialization))
   (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))

--- a/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
@@ -163,12 +163,14 @@
         (jdbc/update! (db-mysql-raw) :world {:randomNumber (:randomNumber w)} ["id = ?" (:id w)])))
     results))
 
-(def json-serialization
+(defn json-serialization
   "Test 1: JSON serialization"
+  []
   (ring-resp/response {:message "Hello, World!"}))
 
-(def single-query-test
+(defn single-query-test
   "Test 2: Single database query"
+  []
   (ring-resp/response (first (run-queries 1))))
 
 (defn multiple-queries-test
@@ -179,8 +181,9 @@
       (run-queries)
       (ring-resp/response)))
 
-(def single-query-test-raw
+(defn single-query-test-raw
   "Test 2: Single database query (raw)"
+  []
   (-> 1
       (run-queries-raw)
       (first)
@@ -194,8 +197,9 @@
       (run-queries-raw)
       (ring-resp/response)))
 
-(def fortune-test
+(defn fortune-test
   "Test 4: Fortunes"
+  []
   (->
     (get-fortunes get-all-fortunes-korma)
     (fortunes-hiccup)
@@ -203,8 +207,9 @@
     (ring-resp/content-type "text/html")
     (ring-resp/charset "utf-8")))
 
-(def fortune-test-raw
+(defn fortune-test-raw
   "Test 4: Fortunes Raw"
+  []
   (->
     (get-fortunes get-all-fortunes-raw)
     (fortunes-hiccup)
@@ -228,8 +233,9 @@
       (update-and-persist-raw)
       (ring-resp/response)))
 
-(def plaintext
+(defn plaintext
   "Test 6: Plaintext"
+  []
   (->
     (ring-resp/response "Hello, World!")
     (ring-resp/content-type "text/plain")))
@@ -237,20 +243,20 @@
 ;; Define route handlers
 (defroutes app-routes
   (GET "/"                     [] "Hello, World!")
-  (GET "/plaintext"            [] plaintext)
-  (GET "/json"                 [] json-serialization)
-  (GET "/db"                   [] single-query-test)
+  (GET "/plaintext"            [] (plaintext))
+  (GET "/json"                 [] (json-serialization))
+  (GET "/db"                   [] (single-query-test))
   (GET "/queries/:queries"     [queries] (multiple-queries-test queries))
-  (GET "/queries/"             [] (multiple-queries-test queries)) ; When param is omitted
+  (GET "/queries/"             [] (multiple-queries-test)) ; When param is omitted
   (GET "/fortunes"             [] fortune-test)
   (GET "/updates/:queries"     [queries] (db-updates queries))
-  (GET "/updates/"             [] (db-updates queries)) ; When param is omitted
-  (GET "/raw/db"               [] single-query-test-raw)
+  (GET "/updates/"             [] (db-updates)) ; When param is omitted
+  (GET "/raw/db"               [] (single-query-test-raw))
   (GET "/raw/queries/:queries" [queries] (multiple-queries-test-raw queries))
-  (GET "/raw/queries/"         [] (multiple-queries-test-raw queries)) ; When param is omitted
-  (GET "/raw/fortunes"         [] fortune-test-raw)
+  (GET "/raw/queries/"         [] (multiple-queries-test-raw)) ; When param is omitted
+  (GET "/raw/fortunes"         [] (fortune-test-raw))
   (GET "/raw/updates/:queries" [queries] (db-updates-raw queries))
-  (GET "/raw/updates/"         [] (db-updates-raw queries)) ; When param is omitted
+  (GET "/raw/updates/"         [] (db-updates-raw)) ; When param is omitted
   (route/not-found "Not Found"))
 
 (defn parse-port [s] 


### PR DESCRIPTION
This is intended to address #1894 

They were mistakenly using def and using a value set at compile time. This
contradicts the intention of the benchmark test.