### PR TITLE
Yesod to use stack

### DIFF
--- a/frameworks/Haskell/yesod/bench/bench.cabal
+++ b/frameworks/Haskell/yesod/bench/bench.cabal
@@ -18,17 +18,17 @@ executable         bench
                 EmptyDataDecls
                 CPP
 
-    build-depends: base                          >= 4.7        && < 5
-                 , yesod-core                    >= 1.4.2      && < 1.4.6
-                 , text                          >= 0.11       && < 1.3
-                 , persistent                    >= 2.1        && < 2.2
-                 , persistent-mysql              >= 2.1        && < 2.2
-                 , persistent-template           >= 2.1        && < 2.2
-                 , warp                          >= 3.0.2.2    && < 3.1
-                 , auto-update                   >= 0.1.1.4    && < 0.2
-                 , primitive                     >= 0.5
-                 , mwc-random                    >= 0.12
-                 , pool-conduit                  >= 0.1.2
+    build-depends: base
+                 , yesod-core
+                 , text
+                 , persistent
+                 , persistent-mysql
+                 , persistent-template
+                 , warp
+                 , auto-update
+                 , primitive
+                 , mwc-random
+                 , pool-conduit
                  , network
                  , mongoDB
                  , monad-logger
@@ -38,7 +38,7 @@ executable         bench
                  , aeson
                  , blaze-builder
                  , blaze-html
-                 , bytestring                    >= 0.10
+                 , bytestring
                  , resource-pool
                  , resourcet
                  , shakespeare

--- a/frameworks/Haskell/yesod/bench/stack.yaml
+++ b/frameworks/Haskell/yesod/bench/stack.yaml
@@ -1,0 +1,7 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- pool-conduit-0.1.2.3
+- monad-control-0.3.3.1
+resolver: lts-3.19

--- a/frameworks/Haskell/yesod/bench/stack.yaml
+++ b/frameworks/Haskell/yesod/bench/stack.yaml
@@ -4,4 +4,4 @@ packages:
 extra-deps:
 - pool-conduit-0.1.2.3
 - monad-control-0.3.3.1
-resolver: lts-3.19
+resolver: lts-5.0

--- a/frameworks/Haskell/yesod/setup.sh
+++ b/frameworks/Haskell/yesod/setup.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-fw_depends haskell
+fw_depends stack
 
 cd bench
 
-cabal update
-cabal sandbox init
-cabal --bindir=${TROOT}/bench/dist/build/bench install
+${IROOT}/stack setup
+${IROOT}/stack build
 
-dist/build/bench/bench ${MAX_THREADS} ${DBHOST} +RTS -A32m -N${MAX_THREADS} &
+${IROOT}/stack exec bench ${MAX_THREADS} ${DBHOST} +RTS -A32m -N${MAX_THREADS} &

--- a/toolset/setup/linux/systools/stack.sh
+++ b/toolset/setup/linux/systools/stack.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+RETCODE=$(fw_exists ${IROOT}/stack.installed)
+[ ! "$RETCODE" == 0 ] || { \
+  source $IROOT/stack.installed
+  return 0; }
+
+fw_get -o $IROOT/stack.tar.gz https://www.stackage.org/stack/linux-x86_64
+tar xzf $IROOT/stack.tar.gz
+mv $IROOT/stack-1.0.2-linux-x86_64/stack $IROOT
+sudo apt-get -y install perl make automake gcc libgmp3-dev
+
+touch $IROOT/stack.installed
+
+source $IROOT/stack.installed

--- a/toolset/setup/linux/systools/stack.sh
+++ b/toolset/setup/linux/systools/stack.sh
@@ -7,7 +7,9 @@ RETCODE=$(fw_exists ${IROOT}/stack.installed)
 
 fw_get -o $IROOT/stack.tar.gz https://www.stackage.org/stack/linux-x86_64
 tar xzf $IROOT/stack.tar.gz
-mv $IROOT/stack-1.0.2-linux-x86_64/stack $IROOT
+pushd $IROOT/stack-*
+mv stack $IROOT
+popd
 sudo apt-get -y install perl make automake gcc libgmp3-dev
 
 touch $IROOT/stack.installed


### PR DESCRIPTION
This PR updates the Yesod (Haskell) framework to be built using Stack, a build tool built on top of the usual Haskell build tools with an emphasis on reproducible builds. This should both fix the currently broken Yesod tests as well as hopefully make the Yesod tests more resistant to future changes of Hackage packages.