### PR TITLE
Fixed some Java frameworks that were still depending on 'java8'

### DIFF
--- a/frameworks/Java/curacao/setup.sh
+++ b/frameworks/Java/curacao/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends java8 resin maven
+fw_depends java resin maven
 
 mvn clean compile war:war
 rm -rf $RESIN_HOME/webapps/*

--- a/frameworks/Java/undertow-jersey-c3p0/setup.sh
+++ b/frameworks/Java/undertow-jersey-c3p0/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends java8 maven
+fw_depends java maven
 
 mvn clean package
 

--- a/frameworks/Java/undertow-jersey-hikaricp/setup.sh
+++ b/frameworks/Java/undertow-jersey-hikaricp/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends java8 maven
+fw_depends java maven
 
 mvn clean package
 

--- a/frameworks/Java/vertx-web/setup.sh
+++ b/frameworks/Java/vertx-web/setup.sh
@@ -2,7 +2,7 @@
 
 sed -i 's|localhost|'"${DBHOST}"'|g' src/main/conf/config.json
 
-fw_depends java8 maven
+fw_depends java maven
 
 mvn clean package
 


### PR DESCRIPTION
A couple of Java frameworks were still depending on `java8` instead of just `java`. This PR fixes those frameworks.