### PR TITLE
Fixed setup script for Luminus

### DIFF
--- a/frameworks/Clojure/luminus/setup.sh
+++ b/frameworks/Clojure/luminus/setup.sh
@@ -3,7 +3,7 @@
 fw_depends java resin leiningen
 
 # Update db host in the source file
-sed -i 's|:jdbc-uri   "jdbc:postgresql://.*/hello_world|:jdbc-uri   "jdbc:postgresql://'"${DBHOST}"':5432/hello_world|g' hello/src/hello/db/core.clj
+sed -i 's|:jdbc-url   "jdbc:postgresql://.*/hello_world|:jdbc-url   "jdbc:postgresql://'"${DBHOST}"':5432/hello_world|g' hello/src/hello/db/core.clj
 
 cd hello
 lein clean


### PR DESCRIPTION
Luminus's setup script had a mistake in the `sed` command which caused the DB host to not be updated. Since the DB host defaults to localhost this error only manifested on the Peak servers and not on Travis or when run locally with everything on the same machine.