### PR TITLE
go-raw-mongodb clean up

### DIFF
--- a/frameworks/Go/go-raw-mongodb/src/hello/hello.go
+++ b/frameworks/Go/go-raw-mongodb/src/hello/hello.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"runtime"
 	"sort"
 	"strconv"
 )
@@ -20,7 +19,8 @@ const (
 )
 
 var (
-	tmpl = template.Must(template.ParseFiles("templates/layout.html", "templates/fortune.html"))
+	tmpl            = template.Must(template.ParseFiles("templates/layout.html", "templates/fortune.html"))
+	helloWorldBytes = []byte(helloWorldString)
 
 	database *mgo.Database
 	fortunes *mgo.Collection
@@ -32,12 +32,12 @@ type Message struct {
 }
 
 type World struct {
-	Id           uint16 `bson:"id" json:"id"`
+	Id           uint16 `bson:"_id" json:"id"`
 	RandomNumber uint16 `bson:"randomNumber" json:"randomNumber"`
 }
 
 type Fortune struct {
-	Id      uint16 `bson:"id" json:"id"`
+	Id      uint16 `bson:"_id" json:"id"`
 	Message string `bson:"message" json:"message"`
 }
 
@@ -58,28 +58,21 @@ func (s ByMessage) Less(i, j int) bool {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	if session, err := mgo.Dial(connectionString); err != nil {
+	session, err := mgo.Dial(connectionString)
+	if err != nil {
 		log.Fatalf("Error opening database: %v", err)
-	} else {
-		defer session.Close()
-		session.SetPoolLimit(5)
-		database = session.DB("hello_world")
-		worlds = database.C("world")
-		fortunes = database.C("fortune")
-		http.HandleFunc("/json", jsonHandler)
-		http.HandleFunc("/db", dbHandler)
-		http.HandleFunc("/fortune", fortuneHandler)
-		http.HandleFunc("/queries", queriesHandler)
-		http.HandleFunc("/update", updateHandler)
-		http.HandleFunc("/plaintext", plaintextHandler)
-		http.ListenAndServe(":8080", nil)
 	}
-}
-
-// Helper for random numbers
-func getRandomNumber() uint16 {
-	return uint16(rand.Intn(worldRowCount) + 1)
+	defer session.Close()
+	database = session.DB("hello_world")
+	worlds = database.C("world")
+	fortunes = database.C("fortune")
+	http.HandleFunc("/json", jsonHandler)
+	http.HandleFunc("/db", dbHandler)
+	http.HandleFunc("/fortune", fortuneHandler)
+	http.HandleFunc("/queries", queriesHandler)
+	http.HandleFunc("/update", updateHandler)
+	http.HandleFunc("/plaintext", plaintextHandler)
+	http.ListenAndServe(":8080", nil)
 }
 
 // Test 1: JSON serialization
@@ -89,117 +82,97 @@ func jsonHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(&Message{helloWorldString})
 }
 
-func dbHandler(w http.ResponseWriter, r *http.Request) {
-	var world World
-	query := bson.M{"id": getRandomNumber()}
-	if worlds != nil {
-		if err := worlds.Find(query).One(&world); err != nil {
-			log.Fatalf("Error finding world with id: %s", err.Error())
-			return
-		} else {
-			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("Server", "go-mongodb")
-			json.NewEncoder(w).Encode(&world)
-			return
-		}
-	} else {
-		log.Fatal("Collection not initialized properly")
-	}
+// Helper for random numbers
+func getRandomNumber() uint16 {
+	return uint16(rand.Intn(worldRowCount) + 1)
 }
 
-func queriesHandler(w http.ResponseWriter, r *http.Request) {
+// Test 2: Single database query
+func dbHandler(w http.ResponseWriter, r *http.Request) {
+	var world World
+	query := bson.M{"_id": getRandomNumber()}
+	if err := worlds.Find(query).One(&world); err != nil {
+		log.Fatalf("Error finding world with id: %s", err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Server", "go-mongodb")
+	json.NewEncoder(w).Encode(&world)
+}
+
+// Helper for getting the "queries" parameter
+func getQueriesParam(r *http.Request) int {
 	n := 1
 	if nStr := r.URL.Query().Get("queries"); len(nStr) > 0 {
 		n, _ = strconv.Atoi(nStr)
 	}
 
-	if n > 500 {
+	if n < 1 {
+		n = 1
+	} else if n > 500 {
 		n = 500
+	}
+
+	return n
+}
+
+// Test 3: Multiple database queries
+func queriesHandler(w http.ResponseWriter, r *http.Request) {
+	n := getQueriesParam(r)
+	world := make([]World, n)
+
+	for i := 0; i < n; i++ {
+		query := bson.M{"_id": getRandomNumber()}
+		if err := worlds.Find(query).One(&world[i]); err != nil {
+			log.Fatalf("Error finding world with id: %s", err.Error())
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Server", "go-mongodb")
-	encoder := json.NewEncoder(w)
-
-	if n <= 1 {
-		result := make([]World, 1)
-		query := bson.M{"id": getRandomNumber()}
-		if err := worlds.Find(query).One(&result[0]); err != nil {
-			log.Fatalf("Error finding world with id: %s", err.Error())
-			return
-		}
-		encoder.Encode(&result)
-	} else {
-		result := make([]World, n)
-		for i := 0; i < n; i++ {
-			query := bson.M{"id": getRandomNumber()}
-			if err := worlds.Find(query).One(&result[i]); err != nil {
-				log.Fatalf("Error finding world with id: %s", err.Error())
-				return
-			}
-		}
-		encoder.Encode(&result)
-	}
+	json.NewEncoder(w).Encode(world)
 }
 
+// Test 4: Fortunes
 func fortuneHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/html")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Server", "go-mongodb")
 	f := make(Fortunes, 16)
 	if err := fortunes.Find(nil).All(&f); err == nil {
-		f = append(f, Fortune{
-			Message: "Additional fortune added at request time.",
-		})
+		f = append(f, Fortune{Message: "Additional fortune added at request time."})
 		sort.Sort(ByMessage{f})
 		if err := tmpl.Execute(w, f); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
+	} else {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-
 }
 
+// Test 5: Database updates
 func updateHandler(w http.ResponseWriter, r *http.Request) {
-	n := 1
-	if nStr := r.URL.Query().Get("queries"); len(nStr) > 0 {
-		n, _ = strconv.Atoi(nStr)
+	n := getQueriesParam(r)
+	world := make([]World, n)
+
+	for i := 0; i < n; i++ {
+		query := bson.M{"_id": getRandomNumber()}
+		if err := worlds.Find(query).One(&world[i]); err != nil {
+			log.Fatalf("Error finding world with id: %s", err.Error())
+		}
+		world[i].RandomNumber = getRandomNumber()
+		update := bson.M{"$set": bson.M{"randomNumber": world[i].RandomNumber}}
+		if err := worlds.Update(query, update); err != nil {
+			log.Fatalf("Error updating world with id: %s", err.Error())
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Server", "go-mongodb")
-	encoder := json.NewEncoder(w)
-
-	if n <= 1 {
-		result := make([]World, 1)
-		colQuery := bson.M{"id": getRandomNumber()}
-		update := bson.M{"$set": bson.M{"randomNumber": getRandomNumber()}}
-		if err := worlds.Update(colQuery, update); err != nil {
-			log.Fatalf("Error updating world with id: %s", err.Error())
-		} else {
-			result[0].Id = colQuery["id"].(uint16)
-			result[0].RandomNumber = update["$set"].(bson.M)["randomNumber"].(uint16)
-		}
-		encoder.Encode(&result)
-	} else {
-		if n > 500 {
-			n = 500
-		}
-		result := make([]World, n)
-		for i := 0; i < n; i++ {
-			colQuery := bson.M{"id": getRandomNumber()}
-			update := bson.M{"$set": bson.M{"randomNumber": getRandomNumber()}}
-			if err := worlds.Update(colQuery, update); err != nil {
-				log.Fatalf("Error updating world with id: %s", err.Error())
-			} else {
-				result[i].Id = colQuery["id"].(uint16)
-				result[i].RandomNumber = update["$set"].(bson.M)["randomNumber"].(uint16)
-			}
-		}
-		encoder.Encode(&result)
-	}
+	w.Header().Set("Server", "Go")
+	json.NewEncoder(w).Encode(&world)
 }
 
+// Test 6: Plaintext
 func plaintextHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Server", "go-mongodb")
-	w.Write([]byte(helloWorldString))
+	w.Write(helloWorldBytes)
 }


### PR DESCRIPTION
This is **not** a pull request, which improves the performance. It is meant to clean up the go-raw-mongodb implementation.
I did the following changes:
- Fix warning concerning the content-type in fortuneHandler
- Add additional error handling to fortuneHandler
- make sure that the identity column is _id (see [http://frameworkbenchmarks.readthedocs.org/en/latest/Project-Information/Framework-Tests/](url): ...except for MongoDB, wherein the identity column is _id, with the leading underscore)
- removed runtime.GOMAXPROCS(runtime.NumCPU()) (see [https://golang.org/doc/go1.5](url): By default, Go programs run with GOMAXPROCS set to the number of cores available; in prior releases it defaulted to 1.)
- removed unnecessary if/else/return (log.Fatal/log.Fatalf is equivalent to Print()/Printf() followed by a call to os.Exit(1).)
- simplified the dbHandler and queriesHandler
- In my opinion the original implementation of the Database update test violated requirement numbers 4, 5 and 6 - in my opinion the original code didn't read the original randomNumber field from the database:
 - The request handler must retrieve a set of World objects, equal in count to the queries parameter, from the World database table.
 -  Each row must be selected randomly using one query in the same fashion as the single database query test (Test #2 above). As with the read-only multiple-query test type (#3 above), use of IN clauses or similar means to consolidate multiple queries into one operation is not permitted.
 - At least the randomNumber field must be read from the database result set.