### PR TITLE
Updated PostgreSQL JDBC driver to 9.4.1208

### DIFF
--- a/frameworks/Clojure/luminus/hello/project.clj
+++ b/frameworks/Clojure/luminus/hello/project.clj
@@ -24,7 +24,7 @@
                  [luminus-nrepl "0.1.2"]
                  [migratus "0.8.8"]
                  [conman "0.2.9"]
-                 [org.postgresql/postgresql "9.4-1206-jdbc4"]
+                 [org.postgresql/postgresql "9.4.1208"]
                  [org.webjars/webjars-locator-jboss-vfs "0.1.0"]
                  [luminus-immutant "0.1.0"]]
 

--- a/frameworks/Clojure/luminus/hello/src/hello/db/core.clj
+++ b/frameworks/Clojure/luminus/hello/src/hello/db/core.clj
@@ -6,7 +6,7 @@
     [environ.core :refer [env]]
     [mount.core :refer [defstate]])
   (:import org.postgresql.util.PGobject
-           org.postgresql.jdbc4.Jdbc4Array
+           org.postgresql.jdbc.PgArray
            clojure.lang.IPersistentMap
            clojure.lang.IPersistentVector
            [java.sql
@@ -48,7 +48,7 @@
   Timestamp
   (result-set-read-column [v _ _] (to-date v))
 
-  Jdbc4Array
+  PgArray
   (result-set-read-column [v _ _] (vec (.getArray v)))
 
   PGobject

--- a/frameworks/Java/dropwizard/pom.xml
+++ b/frameworks/Java/dropwizard/pom.xml
@@ -13,7 +13,7 @@
         <dropwizard.version>0.8.1</dropwizard.version>
         <mysql-connector-java.version>5.1.35</mysql-connector-java.version>
         <mongojack.version>2.3.0</mongojack.version>
-        <postgres-jdbc.version>9.4-1201-jdbc41</postgres-jdbc.version>
+        <postgres-jdbc.version>9.4.1208</postgres-jdbc.version>
         <dropwizard.java8.version>0.8.0-1</dropwizard.java8.version>
 
         <main.class>com.example.helloworld.HelloWorldService</main.class>

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -20,7 +20,7 @@
 	<dependency>
 	    <groupId>org.postgresql</groupId>
 	    <artifactId>postgresql</artifactId>
-	    <version>9.4-1200-jdbc41</version>
+	    <version>9.4.1208</version>
 	</dependency>
             
 

--- a/frameworks/Java/undertow-edge/pom.xml
+++ b/frameworks/Java/undertow-edge/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>undertow-edge</artifactId>
     <version>0.1</version>
 
+    <properties>
+        <postgres-jdbc.version>9.4.1208</postgres-jdbc.version>
+    </properties>
+
     <dependencies>
         <!-- Web server -->
         <dependency>
@@ -45,7 +49,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
 	    <artifactId>postgresql</artifactId>
-            <version>9.4-1200-jdbc41</version>
+            <version>${postgres-jdbc.version}</version>
 	</dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
 	    <artifactId>postgresql</artifactId>
-            <version>9.4-1200-jdbc41</version>
+            <version>9.4.1208</version>
 	</dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/frameworks/Scala/http4s/build.sbt
+++ b/frameworks/Scala/http4s/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
 	"org.scalaz" %% "scalaz-core" % scalazVersion,
 	"org.scalaz" %% "scalaz-concurrent" % scalazVersion,
 	"com.github.alexarchambault" %% "argonaut-shapeless_6.1" % "0.3.1",
-	"org.postgresql" % "postgresql" % "9.4-1204-jdbc4"
+	"org.postgresql" % "postgresql" % "9.4.1208"
 )
 
 mainClass in oneJar := Some("http4s.techempower.benchmark.WebServer")


### PR DESCRIPTION
PostgreSQL JDBC driver is updated to the latest release version. [Changelog](https://jdbc.postgresql.org/documentation/changelog.html#version_9.4-1208)
It has some speed improvements - my quick test (with `dropwizard-postgres`) shows at least 15% increase in total requests and lower average request times.
**Important note:** I've tried to upgrade `gemini`. On local machine it works fine with the new `jar` but the `WEB-INF/lib` folder is not under version control and I'm not familiar with the setup scripts. [This is the older](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Java/gemini/Docroot/WEB-INF/lib/postgresql-9.4-1200.jdbc41.jar) jdbc driver.