### PR TITLE
Update rust

### DIFF
--- a/frameworks/Rust/hyper/Cargo.toml
+++ b/frameworks/Rust/hyper/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 
 [dependencies]
-
-hyper="0.5.2"
+hyper="0.7.2"

--- a/frameworks/Rust/hyper/src/main.rs
+++ b/frameworks/Rust/hyper/src/main.rs
@@ -20,5 +20,5 @@ fn handler(req: Request, mut res: Response) {
             res.send(HELLO_WORLD).unwrap();
         }
         _ => (),
-    };
+    }
 }

--- a/frameworks/Rust/hyper/src/main.rs
+++ b/frameworks/Rust/hyper/src/main.rs
@@ -1,24 +1,24 @@
 extern crate hyper;
 
 use hyper::server::{Server, Request, Response};
-use hyper::status::StatusCode;
 use hyper::uri::RequestUri;
 use hyper::header::ContentType;
-use hyper::header::ContentLength;
 use hyper::header;
 
 const HELLO_WORLD: &'static [u8; 14] = b"Hello, World!\n";
 
 fn main() {
-    Server::http(|req: Request, mut res: Response| {
-        match (req.method, req.uri) {
-            (hyper::Get, RequestUri::AbsolutePath(ref path)) if path == "/plaintext" => {
-                res.headers_mut().set(ContentType::plaintext());
-                res.headers_mut().set(header::Server("Hyper".to_owned()));
+    Server::http("0.0.0.0:8080").unwrap().handle(handler).unwrap();
+}
 
-                res.send(HELLO_WORLD).unwrap();
-            }
-            _ => (),
-        };
-    }).listen("0.0.0.0:8080").unwrap();
+fn handler(req: Request, mut res: Response) {
+    match (req.method, req.uri) {
+        (hyper::Get, RequestUri::AbsolutePath(ref path)) if path == "/plaintext" => {
+            res.headers_mut().set(ContentType::plaintext());
+            res.headers_mut().set(header::Server("Hyper".to_owned()));
+
+            res.send(HELLO_WORLD).unwrap();
+        }
+        _ => (),
+    };
 }

--- a/frameworks/Rust/iron/Cargo.toml
+++ b/frameworks/Rust/iron/Cargo.toml
@@ -4,6 +4,6 @@ name = "iron"
 version = "0.0.1"
 
 [dependencies]
-rustc-serialize = "0.3"
-iron = "0.1.18"
-router = "0.0.10"
+rustc-serialize = "0.3.18"
+iron = "0.2.6"
+router = "0.1.0"

--- a/frameworks/Rust/iron/setup.sh
+++ b/frameworks/Rust/iron/setup.sh
@@ -2,6 +2,6 @@
 
 fw_depends rust
 
-rm -rf target/
+cargo clean
 cargo build --release
 ./target/release/iron &

--- a/frameworks/Rust/iron/src/main.rs
+++ b/frameworks/Rust/iron/src/main.rs
@@ -4,7 +4,7 @@ extern crate rustc_serialize;
 
 use iron::{Iron, Request, Response, IronResult};
 use iron::status;
-use router::{Router};
+use router::Router;
 use rustc_serialize::json;
 
 #[derive(RustcDecodable, RustcEncodable)]
@@ -21,9 +21,7 @@ fn main() {
 }
 
 fn jsonHandler(req: &mut Request) -> IronResult<Response> {
-    let message: Message = Message{
-        message: "Hello, World!".to_string(),
-    };
+    let message: Message = Message { message: "Hello, World!".to_string() };
     Ok(Response::with((status::Ok, json::encode(&message).unwrap())))
 }
 

--- a/frameworks/Rust/iron/src/main.rs
+++ b/frameworks/Rust/iron/src/main.rs
@@ -14,17 +14,17 @@ struct Message {
 
 fn main() {
     let mut router = Router::new();
-    router.get("/json", jsonHandler);
-    router.get("/plaintext", plaintextHandler);
+    router.get("/json", json_handler);
+    router.get("/plaintext", plaintext_handler);
 
     Iron::new(router).http("0.0.0.0:8080").unwrap();
 }
 
-fn jsonHandler(req: &mut Request) -> IronResult<Response> {
+fn json_handler(_: &mut Request) -> IronResult<Response> {
     let message: Message = Message { message: "Hello, World!".to_string() };
     Ok(Response::with((status::Ok, json::encode(&message).unwrap())))
 }
 
-fn plaintextHandler(req: &mut Request) -> IronResult<Response> {
+fn plaintext_handler(_: &mut Request) -> IronResult<Response> {
     Ok(Response::with((status::Ok, "Hello, World!")))
 }

--- a/frameworks/Rust/nickel/Cargo.toml
+++ b/frameworks/Rust/nickel/Cargo.toml
@@ -4,6 +4,6 @@ name = "nickel"
 version = "0.0.1"
 
 [dependencies]
-rustc-serialize = "0.3"
-nickel = "0.5.0"
+rustc-serialize = "0.3.18"
+nickel = "0.7.3"
 nickel_macros = "0.1.0"

--- a/frameworks/Rust/nickel/setup.sh
+++ b/frameworks/Rust/nickel/setup.sh
@@ -2,6 +2,6 @@
 
 fw_depends rust
 
-rm -rf target/
+cargo clean
 cargo build --release
 ./target/release/nickel &

--- a/frameworks/Rust/nickel/src/main.rs
+++ b/frameworks/Rust/nickel/src/main.rs
@@ -1,7 +1,8 @@
-#[macro_use] extern crate nickel;
+#[macro_use]
+extern crate nickel;
 extern crate rustc_serialize;
 
-use nickel::{ Nickel, HttpRouter, MediaType };
+use nickel::{Nickel, HttpRouter, MediaType};
 use rustc_serialize::json;
 
 #[derive(RustcDecodable, RustcEncodable)]
@@ -13,7 +14,8 @@ fn main() {
     let mut server = Nickel::new();
     let mut router = Nickel::router();
 
-    router.get("/json", middleware!{ |_, mut response|
+    router.get("/json",
+               middleware!{ |_, mut response|
         response.set(MediaType::Json);
         let message: Message = Message{
             message: "Hello, World!".to_string(),
@@ -21,7 +23,8 @@ fn main() {
         json::encode(&message).unwrap()
     });
 
-    router.get("/plaintext", middleware! { |_, mut response|
+    router.get("/plaintext",
+               middleware! { |_, mut response|
         response.set(MediaType::Txt);
         "Hello, World!"
     });

--- a/toolset/setup/linux/languages/rust.sh
+++ b/toolset/setup/linux/languages/rust.sh
@@ -5,10 +5,10 @@ RETCODE=$(fw_exists $IROOT/rust.installed)
   source $IROOT/rust.installed;
   return 0; }
 
-fw_get -O https://static.rust-lang.org/dist/rust-1.0.0-x86_64-unknown-linux-gnu.tar.gz
-fw_untar rust-1.0.0-x86_64-unknown-linux-gnu.tar.gz
+fw_get -O https://static.rust-lang.org/dist/rust-1.6.0-x86_64-unknown-linux-gnu.tar.gz
+fw_untar rust-1.6.0-x86_64-unknown-linux-gnu.tar.gz
 (
-	cd rust-1.0.0-x86_64-unknown-linux-gnu
+	cd rust-1.6.0-x86_64-unknown-linux-gnu
 	./install.sh --prefix=$IROOT/rust
 )
 


### PR DESCRIPTION
I tried to keep these in small commits in case you didn't want any of these changes.

This PR:

1. Updates Rust from 1.0.0 to 1.6.0. It would be nice if we could have a "latest stable", but that would require infrastructure work I can't do right now.
2. Update the various frameworks and their versions. There was also breaking changes to one of the libraries, so the code was updated.
3. Various style/formatting fixes. They are now in line with the standard Rust style, and are formatted according to `rustfmt`, the automatic formatting tool.
4. A small fix to use 'cargo clean' rather than 'rm' to remove cached builds.