### PR TITLE
http4s: Fix DB connections, bump versions, use circe JSON library

### DIFF
--- a/frameworks/Scala/http4s/build.sbt
+++ b/frameworks/Scala/http4s/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 	"org.tpolecat" %% "doobie-contrib-hikari" % doobieVersion exclude("com.zaxxer", "HikariCP-java6"),
 	"com.zaxxer" %  "HikariCP" % "2.4.1",
 	"org.postgresql" % "postgresql" % "9.4.1208",
-	"org.slf4j" % "slf4j-nop" % "1.7.18"
+	"ch.qos.logback" % "logback-classic" % "1.1.6"
 )
 
 mainClass in oneJar := Some("http4s.techempower.benchmark.WebServer")

--- a/frameworks/Scala/http4s/build.sbt
+++ b/frameworks/Scala/http4s/build.sbt
@@ -10,27 +10,24 @@ TwirlKeys.templateImports += "http4s.techempower.benchmark._"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
-val http4sVersion = "0.10.1"
-val doobieVersion = "0.2.3-RC2"
-val scalazVersion = "7.1.3"
+val http4sVersion = "0.11.3"
+val circeVersion = "0.3.0"
+val doobieVersion = "0.2.3"
 
 libraryDependencies ++= Seq(
 	"org.http4s" %% "http4s-blaze-server" % http4sVersion,
 	"org.http4s" %% "http4s-dsl" % http4sVersion,
-	"org.http4s" %% "http4s-argonaut" % http4sVersion,
+	"org.http4s" %% "http4s-circe" % http4sVersion,
 	"org.http4s" %% "http4s-twirl" % http4sVersion,
+	"io.circe" %% "circe-core" % circeVersion,
+	"io.circe" %% "circe-generic" % circeVersion,
+	"io.circe" %% "circe-parser" % circeVersion,
 	"org.tpolecat" %% "doobie-core" % doobieVersion,
-	"org.tpolecat" %% "doobie-contrib-hikari" % doobieVersion,
+	"org.tpolecat" %% "doobie-contrib-hikari" % doobieVersion exclude("com.zaxxer", "HikariCP-java6"),
 	"com.zaxxer" %  "HikariCP" % "2.4.1",
-	"org.scalaz" %% "scalaz-core" % scalazVersion,
-	"org.scalaz" %% "scalaz-concurrent" % scalazVersion,
-	"com.github.alexarchambault" %% "argonaut-shapeless_6.1" % "0.3.1",
-	"org.postgresql" % "postgresql" % "9.4.1208"
+	"org.postgresql" % "postgresql" % "9.4.1208",
+	"org.slf4j" % "slf4j-nop" % "1.7.18"
 )
 
 mainClass in oneJar := Some("http4s.techempower.benchmark.WebServer")
 
-resolvers ++= Seq(
-  "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
-  "tpolecat" at "http://dl.bintray.com/tpolecat/maven"
-)

--- a/frameworks/Scala/http4s/project/plugins.sbt
+++ b/frameworks/Scala/http4s/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.0.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1")

--- a/frameworks/Scala/http4s/setup.sh
+++ b/frameworks/Scala/http4s/setup.sh
@@ -4,4 +4,4 @@ fw_depends java sbt
 
 sbt 'oneJar' -batch
 
-java -jar target/scala-2.11/http4s*one-jar.jar &
+java -jar target/scala-2.11/http4s*one-jar.jar "${DBHOST}" &

--- a/frameworks/Scala/http4s/src/main/resources/logback.xml
+++ b/frameworks/Scala/http4s/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="error">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/frameworks/Scala/http4s/src/main/scala/WebServer.scala
+++ b/frameworks/Scala/http4s/src/main/scala/WebServer.scala
@@ -159,10 +159,9 @@ object WebServer extends TaskApp {
   }
 
   // Entry point when starting service
-  override val runc: Task[Unit] = {
+  override def runl(args: List[String]): Task[Unit] = {
     for {
-      dbHost <- Task.delay(System.getProperty("DBHOST", "localhost"))
-      xa <- xaTask(dbHost)
+      xa <- xaTask(args.head)
       server <- startServer(Middleware.addHeaders(service(xa)))
     } yield ()
   }


### PR DESCRIPTION
Update libraries, read DBHOST from environment, set DB pool size to 256.

Version changes: 
http4s: 0.10.1 -> 0.11.3
argonaut -> circe 0.3.0
doobie: 0.2.3-RC2 -> 0.2.3
postgresql: 9.4-1204-jdbc4 -> 9.4.1208
twirl: 1.0.4 -> 1.1.1
hikari: 2.2.5 -> 2.4.1