### PR TITLE
Fixes --clean --clean-all options in toolset

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -964,14 +964,14 @@ class Benchmarker:
 
     # setup results and latest_results directories 
     self.result_directory = os.path.join("results", self.name)
-    if args['clean'] or args['clean_all']:
+    if (args['clean'] or args['clean_all']) and os.path.exists(os.path.join(self.fwroot, "results")):
         shutil.rmtree(os.path.join(self.fwroot, "results"))
     self.latest_results_directory = self.latest_results_directory()
   
     # remove installs directories if --clean-all provided
     self.install_root = "%s/%s" % (self.fwroot, "installs")
     if args['clean_all']:
-        os.system("rm -rf " + self.install_root)
+        os.system("sudo rm -rf " + self.install_root)
         os.mkdir(self.install_root)
 
     if hasattr(self, 'parse') and self.parse != None:


### PR DESCRIPTION
--clean was not working when there was no results directory
--clean-all does not work without sudo as installation files are made by different users

closes issue #1934 