### PR TITLE
Remove keepalive from PHP frameworks using fastcgi

### DIFF
--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -17,7 +17,6 @@ http {
 
 	upstream fastcgi_backend {
 		server 127.0.0.1:9001;
-		keepalive 32;
 	}
 
 	server {
@@ -34,7 +33,6 @@ http {
 		location ~ \.php$ {
 			try_files $uri =404;
 			fastcgi_pass   fastcgi_backend;
-			fastcgi_keep_conn on;
 			fastcgi_index  index.php;
 			fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
 			include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/codeigniter/deploy/nginx.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
     
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -81,7 +80,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/cygnite-php-framework/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite-php-framework/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
     
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -81,7 +80,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -32,7 +32,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -75,7 +74,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -54,7 +53,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /home/vagrant/FrameworkBenchmarks/installs/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -15,7 +15,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -36,7 +35,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -15,7 +15,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
     server {
         listen       8080;
@@ -31,7 +30,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/micromvc/deploy/nginx.conf
+++ b/frameworks/PHP/micromvc/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/phalcon-micro/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon-micro/deploy/nginx.conf
@@ -34,7 +34,6 @@ http {
     #gzip  on;
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
     server {
         listen       8080;
@@ -79,7 +78,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
     
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -81,7 +80,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-	    fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/php/deploy/nginx.conf
+++ b/frameworks/PHP/php/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -75,7 +74,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -75,7 +74,6 @@ http {
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            fastcgi_keep_conn on;
             include        /usr/local/nginx/conf/fastcgi_params;
         }
 

--- a/frameworks/PHP/pimf/deploy/nginx.conf
+++ b/frameworks/PHP/pimf/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/silex-orm/deploy/nginx.conf
+++ b/frameworks/PHP/silex-orm/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/slim/deploy/nginx.conf
+++ b/frameworks/PHP/slim/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/symfony2-stripped/deploy/nginx.conf
+++ b/frameworks/PHP/symfony2-stripped/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/symfony2/deploy/nginx.conf
+++ b/frameworks/PHP/symfony2/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/yaf/deploy/nginx.conf
+++ b/frameworks/PHP/yaf/deploy/nginx.conf
@@ -14,7 +14,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -36,7 +35,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             include        /usr/local/nginx/conf/fastcgi_params;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/yii2/deploy/nginx.conf
+++ b/frameworks/PHP/yii2/deploy/nginx.conf
@@ -30,7 +30,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -49,7 +48,6 @@ http {
         location ~ \.php$ {
             fastcgi_split_path_info  ^(.+\.php)(.*)$;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             set $fsn /index.php;
             if (-f $document_root$fastcgi_script_name){
                 set $fsn $fastcgi_script_name;

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/zend1/deploy/nginx.conf
+++ b/frameworks/PHP/zend1/deploy/nginx.conf
@@ -35,7 +35,6 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
     }
 
     server {
@@ -78,7 +77,6 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
-            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;


### PR DESCRIPTION
A few years ago I have added a keepalive option to nginx configuration for PHP frameworks and since then almost all of them started getting a lot of failed request.

I finally decided to fix it, and judging by the tests I did on the Symfony2 framework it looks like it works now.