### PR TITLE
Add dependency to java8 to startup script

### DIFF
--- a/frameworks/Java/beyondj/setup.sh
+++ b/frameworks/Java/beyondj/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends java8
+fw_depends java
 
 WORKING_DIR=beyondj-launcher/deploy
 

--- a/frameworks/Java/beyondj/setup.sh
+++ b/frameworks/Java/beyondj/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+fw_depends java8
+
 WORKING_DIR=beyondj-launcher/deploy
 
 if [ ! -d "$WORKING_DIR" ]; then


### PR DESCRIPTION
The missing dependency on java8 is why this framework failed to start in round 12