### PR TITLE
Using later maven version (for Aether support)

### DIFF
--- a/toolset/setup/linux/systools/maven.sh
+++ b/toolset/setup/linux/systools/maven.sh
@@ -2,11 +2,18 @@
 
 RETCODE=$(fw_exists ${IROOT}/maven.installed)
 [ ! "$RETCODE" == 0 ] || { \
-  source $IROOT/maven.installed
-  return 0; }
+source $IROOT/maven.installed
+return 0; }
 
-# TODO: Someday remove apt-get
-sudo apt-get -y install maven
+sudo add-apt-repository "deb http://ppa.launchpad.net/natecarlson/maven3/ubuntu precise main"
+sudo apt-get update
+sudo apt-get -y --force-yes install maven3
+if [ -e /usr/bin/mvn ]
+then
+    sudo rm -f /usr/bin/mvn
+fi
+sudo ln -s /usr/share/maven3/bin/mvn /usr/bin/mvn
+
 mvn -version
 
 touch $IROOT/maven.installed


### PR DESCRIPTION
Maven was bumped to 3.1.x with the move to Eclipse and the Aether functionality.  Plug-ins built for 3.1.x using the lower level Maven functionality are not backwards compatible, as is the case with the OfficeFloor plugins.  Given Maven 3.0.5 is more than 3 years old this is not unreasonable to have users upgrade to 3.1.x or higher.

This upgrade is necessary as OfficeFloor failed to start in round 12 due to this problem.

Note: for other projects that use maven it should not create any impacts as I believe the Travis environment is already running this later version.  Need this PR to have the production environment use the later Maven version.

Some references:
 - https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
 - http://stackoverflow.com/questions/22074117/maven-3-0-5-vs-3-1-1-vs-3-2-1
 - https://github.com/allure-framework/allure-core/issues/577