### PR TITLE
fasthttp-postgresql: cleanup: removed 'synchronous_commit=off' from db setup

### DIFF
--- a/frameworks/Go/fasthttp-postgresql/server.go
+++ b/frameworks/Go/fasthttp-postgresql/server.go
@@ -291,15 +291,6 @@ func initDatabase(dbHost string, dbUser string, dbPass string, dbName string, db
 		worldSelectStmt = mustPrepare(conn, "worldSelectStmt", "SELECT id, randomNumber FROM World WHERE id = $1")
 		worldUpdateStmt = mustPrepare(conn, "worldUpdateStmt", "UPDATE World SET randomNumber = $1 WHERE id = $2")
 		fortuneSelectStmt = mustPrepare(conn, "fortuneSelectStmt", "SELECT id, message FROM Fortune")
-
-		// Disable synchronous commit for the current db connection
-		// as a performance optimization.
-		// See http://www.postgresql.org/docs/current/static/runtime-config-wal.html
-		// for details.
-		if _, err := conn.Exec("SET synchronous_commit TO OFF"); err != nil {
-			log.Fatalf("Error when disabling synchronous commit")
-		}
-
 		return nil
 	}
 


### PR DESCRIPTION
This trick became obsolete after a48ab7fa73e46de6294553d1d81566789d682415