### PR TITLE
"Fixed" C# frameworks

### DIFF
--- a/frameworks/CSharp/aspnet/benchmark_config.json
+++ b/frameworks/CSharp/aspnet/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "aspnet",
   "tests": [{
-    "default": {
+    "windows": {
       "setup_file": "setup_iis",
       "json_url": "/json/default",
       "plaintext_url": "/plaintext",
@@ -203,7 +203,7 @@
       "notes": "",
       "versus": ""
     },
-    "mono": {
+    "default": {
       "setup_file": "setup_nginx",
       "json_url": "/json/default",
       "plaintext_url": "/plaintext",

--- a/frameworks/CSharp/nancy/benchmark_config.json
+++ b/frameworks/CSharp/nancy/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "nancy",
   "tests": [{
-    "default": {
+    "windows": {
       "setup_file": "setup_iis",
       "plaintext_url":"/plaintext",
       "json_url": "/json",
@@ -22,7 +22,7 @@
       "notes": "",
       "versus": ""
     },
-    "mono": {
+    "default": {
       "setup_file": "setup_nginx",
       "plaintext_url":"/plaintext",
       "json_url": "/json",

--- a/frameworks/CSharp/servicestack/benchmark_config.json
+++ b/frameworks/CSharp/servicestack/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "servicestack",
   "tests": [{
-    "default": {
+    "windows": {
       "setup_file": "setup_iis",
       "json_url": "/json",
       "plaintext_url": "/plaintext",
@@ -105,7 +105,7 @@
       "notes": "",
       "versus": ""
     },
-    "nginx-default": {
+    "default": {
       "setup_file": "setup_nginx",
       "json_url": "/json",
       "plaintext_url": "/plaintext",

--- a/toolset/setup/linux/languages/xsp.sh
+++ b/toolset/setup/linux/languages/xsp.sh
@@ -7,18 +7,6 @@ RETCODE=$(fw_exists ${IROOT}/xsp.installed)
   source $IROOT/xsp.installed
   return 0; }
 
-# get
-git clone git://github.com/mono/xsp
-cd xsp
-git checkout e272a2c006211b6b03be2ef5bbb9e3f8fefd0768
-
-# build
-./autogen.sh --prefix=$MONO_HOME --disable-docs
-make
-sudo make install
-
-# cleanup
-cd ..
-rm -rf xsp
+sudo apt-get install -y mono-fastcgi-server
 
 echo "" > $IROOT/xsp.installed


### PR DESCRIPTION
Install XSP through apt-get

Tooling fails if "default" targets "Windows"
Renamed config names as a workaround