### PR TITLE
Optimized the Undertow-Jersey tests

### DIFF
--- a/frameworks/Java/undertow-jersey-c3p0/src/main/java/hello/JerseyWebServer.java
+++ b/frameworks/Java/undertow-jersey-c3p0/src/main/java/hello/JerseyWebServer.java
@@ -5,10 +5,10 @@ import io.undertow.*;
 import io.undertow.server.handlers.*;
 import org.apache.commons.cli.*;
 import org.glassfish.hk2.utilities.binding.*;
-import org.glassfish.jersey.process.internal.*;
 import org.glassfish.jersey.server.*;
 import org.hibernate.*;
 
+import javax.inject.*;
 import java.util.*;
 
 public class JerseyWebServer
@@ -55,7 +55,7 @@ public class JerseyWebServer
       protected void configure()
       {
         bindFactory(SessionFactoryProvider.class).to(SessionFactory.class).in(
-            RequestScoped.class);
+          Singleton.class);
       }
     });
 

--- a/frameworks/Java/undertow-jersey-c3p0/src/main/java/hello/undertow/UndertowJerseyContainer.java
+++ b/frameworks/Java/undertow-jersey-c3p0/src/main/java/hello/undertow/UndertowJerseyContainer.java
@@ -102,8 +102,7 @@ public class UndertowJerseyContainer
 
     for (HeaderValues values : httpServerExchange.getRequestHeaders())
     {
-      request.getHeaders().addAll(values.getHeaderName().toString(),
-          httpServerExchange.getRequestHeaders().get(values.getHeaderName()));
+      request.headers(values.getHeaderName().toString(), values);
     }
 
     request.setEntityStream(httpServerExchange.getInputStream());

--- a/frameworks/Java/undertow-jersey-hikaricp/src/main/java/hello/JerseyWebServer.java
+++ b/frameworks/Java/undertow-jersey-hikaricp/src/main/java/hello/JerseyWebServer.java
@@ -5,10 +5,10 @@ import io.undertow.*;
 import io.undertow.server.handlers.*;
 import org.apache.commons.cli.*;
 import org.glassfish.hk2.utilities.binding.*;
-import org.glassfish.jersey.process.internal.*;
 import org.glassfish.jersey.server.*;
 import org.hibernate.*;
 
+import javax.inject.*;
 import java.util.*;
 
 public class JerseyWebServer
@@ -55,7 +55,7 @@ public class JerseyWebServer
       protected void configure()
       {
         bindFactory(SessionFactoryProvider.class).to(SessionFactory.class).in(
-            RequestScoped.class);
+          Singleton.class);
       }
     });
 

--- a/frameworks/Java/undertow-jersey-hikaricp/src/main/java/hello/undertow/UndertowJerseyContainer.java
+++ b/frameworks/Java/undertow-jersey-hikaricp/src/main/java/hello/undertow/UndertowJerseyContainer.java
@@ -102,8 +102,7 @@ public class UndertowJerseyContainer
 
     for (HeaderValues values : httpServerExchange.getRequestHeaders())
     {
-      request.getHeaders().addAll(values.getHeaderName().toString(),
-          httpServerExchange.getRequestHeaders().get(values.getHeaderName()));
+      request.headers(values.getHeaderName().toString(), values);
     }
 
     request.setEntityStream(httpServerExchange.getInputStream());


### PR DESCRIPTION
- Changed the SessionFactory to be a Singleton rather than RequestScoped. SessionFactories are thread safe by nature.
- Cleaned up the code dealing with moving request headers from Undertow to Jersey
- General import cleanup