### PR TITLE
Delete ant from prerequisites and move to its own script file

### DIFF
--- a/frameworks/Java/gemini/start.sh
+++ b/frameworks/Java/gemini/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends java resin maven
+fw_depends java resin maven ant
 
 sed -i 's|db.ConnectString = .*/|db.ConnectString = '"$DBHOST"':3306/|g' Docroot/WEB-INF/GeminiHello.conf
 sed -i 's|root-directory=".*/FrameworkBenchmarks/frameworks/Java/gemini|root-directory="'"$TROOT"'|g' Docroot/WEB-INF/resin.xml

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -54,8 +54,7 @@ sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options:
   libboost-dev                      `# Silicon relies on boost::lexical_cast.` \
   postgresql-server-dev-9.3         `# Needed by cpoll.` \
   xdg-utils                         `# Needed by dlang.` \
-  python-pip \
-  ant
+  python-pip
 
 sudo pip install colorama==0.3.1
 # Version 2.3 has a nice Counter() and other features

--- a/toolset/setup/linux/systools/ant.sh
+++ b/toolset/setup/linux/systools/ant.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+RETCODE=$(fw_exists ${IROOT}/ant.installed)
+[ ! "$RETCODE" == 0 ] || { \
+source $IROOT/ant.installed
+return 0; }
+
+sudo apt-get update
+sudo apt-get -y --force-yes install ant
+
+if [ -e /usr/bin/ant ]
+then
+    sudo rm -f /usr/bin/ant
+fi
+sudo ln -s /usr/share/ant/bin/ant /usr/bin/ant
+
+ant -version
+
+touch $IROOT/ant.installed
+
+source $IROOT/ant.installed

--- a/toolset/setup/linux/systools/ant.sh
+++ b/toolset/setup/linux/systools/ant.sh
@@ -8,14 +8,8 @@ return 0; }
 sudo apt-get update
 sudo apt-get -y --force-yes install ant
 
-if [ -e /usr/bin/ant ]
-then
-    sudo rm -f /usr/bin/ant
-fi
-sudo ln -s /usr/share/ant/bin/ant /usr/bin/ant
+echo "export PATH=/usr/share/ant/bin:\$PATH" > $IROOT/ant.installed
 
 ant -version
-
-touch $IROOT/ant.installed
 
 source $IROOT/ant.installed

--- a/toolset/setup/linux/systools/maven.sh
+++ b/toolset/setup/linux/systools/maven.sh
@@ -8,14 +8,9 @@ return 0; }
 sudo add-apt-repository "deb http://ppa.launchpad.net/natecarlson/maven3/ubuntu precise main"
 sudo apt-get update
 sudo apt-get -y --force-yes install maven3
-if [ -e /usr/bin/mvn ]
-then
-    sudo rm -f /usr/bin/mvn
-fi
-sudo ln -s /usr/share/maven3/bin/mvn /usr/bin/mvn
+
+echo "export PATH=/usr/share/maven3/bin:\$PATH" > $IROOT/maven.installed
 
 mvn -version
-
-touch $IROOT/maven.installed
 
 source $IROOT/maven.installed


### PR DESCRIPTION
- Delete ant from the prerequisites file
- Create separate file for ant script (format based off the maven script)
- Depend on the ant script in Gemini's start script