### PR TITLE
Resolves #2004: Fix broken wrk pipeline script

### DIFF
--- a/toolset/setup/linux/client.sh
+++ b/toolset/setup/linux/client.sh
@@ -33,7 +33,6 @@ cd ~
 #############################
 cat << EOF | tee pipeline.lua
 init = function(args)
-  wrk.init(args)
   local r = {}
   local depth = tonumber(args[1]) or 1
   for i=1,depth do


### PR DESCRIPTION
Delete line that prevents plaintext tests from succeeding with updated wrk(4)