### PR TITLE
Reflect undertow in benchmark config for Spring

### DIFF
--- a/frameworks/Java/spring/benchmark_config.json
+++ b/frameworks/Java/spring/benchmark_config.json
@@ -17,7 +17,7 @@
       "language": "Java",
       "orm": "Full",
       "platform": "Servlet",
-      "webserver": "Tomcat",
+      "webserver": "Undertow",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "spring",


### PR DESCRIPTION
Hey,

the benchmark config for the Spring test doesn't reflect its usage of Undertow as a webserver. I quickly added that.

Cheers,
Christoph
