### PR TITLE
Fixed maven installation

### DIFF
--- a/toolset/setup/linux/systools/ant.sh
+++ b/toolset/setup/linux/systools/ant.sh
@@ -10,6 +10,6 @@ sudo apt-get -y --force-yes install ant
 
 echo "export PATH=/usr/share/ant/bin:\$PATH" > $IROOT/ant.installed
 
-ant -version
-
 source $IROOT/ant.installed
+
+ant -version

--- a/toolset/setup/linux/systools/maven.sh
+++ b/toolset/setup/linux/systools/maven.sh
@@ -11,6 +11,6 @@ sudo apt-get -y --force-yes install maven3
 
 echo "export PATH=/usr/share/maven3/bin:\$PATH" > $IROOT/maven.installed
 
-mvn -version
-
 source $IROOT/maven.installed
+
+mvn -version


### PR DESCRIPTION
Hey,

while waiting on my latest Travis build I recognized that the currently running builds are failing in almost every Java related build.

I guess the root-cause for this was introduced some days ago when the installation of Ant and Maven were changed to don't use symlinks anymore ( #1993 ). 

```
Setup spring: +++ mvn -version
Setup spring: /home/travis/build/TechEmpower/FrameworkBenchmarks/toolset/setup/linux/systools/maven.sh: line 14: mvn: command not found
```

Since the symlinks are not setup anymore, accessing mvn -version won't work directly. The file needs to be sourced beforehand. 

**Note:** Ant seems to work despite this, which I guess is related to a previous installation of Ant somewhere else. Nevertheless, I changed the order for Ant as well.

Cheers,
Christoph 