### PR TITLE
Make minor changes to fix local test run of nodejs

### DIFF
--- a/frameworks/JavaScript/nodejs/handlers/redis.js
+++ b/frameworks/JavaScript/nodejs/handlers/redis.js
@@ -2,7 +2,10 @@ var h = require('../helper');
 var async = require('async');
 // "If hiredis [pure C library] is installed, node_redis will use it by default.
 // Otherwise, a pure JavaScript parser will be used."
-// >> hiredis is installed for these tests
+// >> Previous versions of this project installed hiredis; however, hiredis now has
+// >> installation issues and redis is no longer tested, so the hiredis dependency was taken out.
+// >> If redis tests are re-instated, try to re-add hiredis dependency; however, if it does
+// >> not install correctly, the tests will still work with the redis default JS parser
 var redis = require('redis');
 var client = redis.createClient(6379, '127.0.0.1', {});
 

--- a/frameworks/JavaScript/nodejs/package.json
+++ b/frameworks/JavaScript/nodejs/package.json
@@ -6,7 +6,6 @@
     "async": "1.5.0",
     "bluebird": "^2.9.27",
     "handlebars": "^3.0.3",
-    "hiredis": "^0.4.0",
     "mongodb": "2.1.2",
     "mongoose": "4.3.4",
     "mysql": "2.7.0",
@@ -14,7 +13,7 @@
     "pg": "^4.4.3",
     "pg-hstore": "^2.3.2",
     "redis": "^0.12.1",
-    "sequelize": "3.1.1"
+    "sequelize": "3.6.0"
   },
-  "main": "hello.js"
+  "main": "app.js"
 }

--- a/frameworks/JavaScript/nodejs/source_code
+++ b/frameworks/JavaScript/nodejs/source_code
@@ -1,1 +1,1 @@
-./nodejs/hello.js
+./nodejs/app.js

--- a/toolset/setup/linux/languages/nodejs.sh
+++ b/toolset/setup/linux/languages/nodejs.sh
@@ -5,7 +5,7 @@ RETCODE=$(fw_exists ${IROOT}/node.installed)
   source $IROOT/node.installed
   return 0; }
 
-VERSION="0.12.2"
+VERSION="0.12.12"
 
 fw_get -O http://nodejs.org/dist/v$VERSION/node-v$VERSION-linux-x64.tar.gz
 fw_untar node-v$VERSION-linux-x64.tar.gz


### PR DESCRIPTION
- Deleted hiredis from the dependencies and
  altered the comments accordingly:
  Hiredis can no longer be installed properly; however,
  redis is also no longer being tested, which makes hiredis
  unnecessary (see PR #1955). If redis test are reinstated, the code will
  still work with the redis default JavaScript parser, so
  hiredis is not necessary but would be nice to get working
  again.
- Updated sequelize to a newer version
- Updated the "main" option in package.json and in source_code
  to the actual main file, "app.js"; "hello.js" does not exist
- Updated node version to the latest in the 0.x series (released
  in March 2016)