### PR TITLE
Issue #1546: Update Node version to 5.10.0 which includes io.js

### DIFF
--- a/toolset/setup/linux/languages/nodejs.sh
+++ b/toolset/setup/linux/languages/nodejs.sh
@@ -5,7 +5,7 @@ RETCODE=$(fw_exists ${IROOT}/node.installed)
   source $IROOT/node.installed
   return 0; }
 
-VERSION="0.12.12"
+VERSION="5.10.0"
 
 fw_get -O http://nodejs.org/dist/v$VERSION/node-v$VERSION-linux-x64.tar.gz
 fw_untar node-v$VERSION-linux-x64.tar.gz


### PR DESCRIPTION
Beginning with Node 4.0, Node and io.js have merged together so there is no need to check performance between Node and io.js. Updated Node version to 5.10.0, which is the latest stable.

Resolves Issue #1546 