### PR TITLE
Go 1.6.2

### DIFF
--- a/toolset/setup/linux/languages/go.sh
+++ b/toolset/setup/linux/languages/go.sh
@@ -5,7 +5,7 @@ RETCODE=$(fw_exists ${IROOT}/go.installed)
   source $IROOT/go.installed
   return 0; }
 
-VERSION=1.6
+VERSION=1.6.2
 GOROOT=$IROOT/go
 
 fw_get -O https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz


### PR DESCRIPTION
Go 1.6.1 has some security fix and 1.6.2 fixes some performance regression about GC