### PR TITLE
Revenj update bugfix for Round 13.

### DIFF
--- a/frameworks/CSharp/revenj/Revenj.Bench/RestService.cs
+++ b/frameworks/CSharp/revenj/Revenj.Bench/RestService.cs
@@ -129,6 +129,8 @@ namespace Revenj.Bench
 			return cms;
 		}
 
+		private static readonly Comparison<World> ASC = (l, r) => l.id - r.id;
+
 		public Stream Updates(string count)
 		{
 			int repeat;
@@ -141,6 +143,7 @@ namespace Revenj.Bench
 			Array.Copy(ctx.Worlds, result, repeat);
 			for (int i = 0; i < result.Length; i++)
 				result[i].randomNumber = Random.Next(10000) + 1;
+			Array.Sort(result, ASC);
 			ctx.Repository.Update(result);
 			var cms = ctx.Stream;
 			result.Serialize(cms);

--- a/frameworks/Java/revenj/src/main/java/hello/UpdatesServlet.java
+++ b/frameworks/Java/revenj/src/main/java/hello/UpdatesServlet.java
@@ -6,9 +6,11 @@ import dsl.FrameworkBench.World;
 import javax.servlet.ServletException;
 import javax.servlet.http.*;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.*;
 
 public class UpdatesServlet extends HttpServlet {
+
+	private static final Comparator<World> ASC = (l, r) -> l.getId() - r.getId();
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
@@ -22,6 +24,7 @@ public class UpdatesServlet extends HttpServlet {
 		for (int i = 0; i < count; i++) {
 			changed.add(worlds[i].setRandomNumber(ctx.getRandom10k()));
 		}
+		Collections.sort(changed, ASC);
 		ctx.repository.update(changed);
 		json.serialize(worlds, count);
 		json.toStream(res.getOutputStream());


### PR DESCRIPTION
Due to usage of random Revenj can fail on highly concurrent updates.
Avoid failure by sorting data before update.