### PR TITLE
Bump Finagle version in Finagle and Finch benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,10 +1,10 @@
 name := "finagle"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-version := "1.0"
+version := "1.0.1"
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "6.33.0",
+  "com.twitter" %% "finagle-http" % "6.34.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
 )

--- a/frameworks/Scala/finch/benchmark_config.json
+++ b/frameworks/Scala/finch/benchmark_config.json
@@ -17,7 +17,8 @@
       "webserver": "None",
       "os": "Linux",
       "display_name": "finch",
-      "notes": ""
+      "notes": "",
+      "versus": "finagle"
     }
   }]
 }

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,19 +1,20 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.0.2"
+version := "0.0.3"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 mainClass in (Compile, run) := Some("WebServer")
 
 libraryDependencies ++= Seq(
+  "com.twitter" %% "finagle-http" % "6.34.0",
   "com.github.finagle" %% "finch-core" % "0.10.0",
-  "com.github.finagle" %% "finch-circe" % "0.10.0"  ,
-  "io.circe" %% "circe-core" % "0.3.0",
-  "io.circe" %% "circe-generic" % "0.3.0",
-  "io.circe" %% "circe-jawn" % "0.3.0"
+  "com.github.finagle" %% "finch-circe" % "0.10.0",
+  "io.circe" %% "circe-core" % "0.4.1",
+  "io.circe" %% "circe-generic" % "0.4.1",
+  "io.circe" %% "circe-jawn" % "0.4.1"
 )
 
 resolvers += Resolver.sonatypeRepo("snapshots")


### PR DESCRIPTION
This RB bumps Finagle version to 6.34 in Finch and Finagle benchmarks. 

Also, 

- Circe version is bumped to 0.4.1 in Finch
- Scala version is bumped to 2.11.8 in both Finch and Finagle benchmarks