### PR TITLE
Fixes #2047 Ruby tests fail in vagrant box due to RVM wrong install

### DIFF
--- a/toolset/setup/linux/languages/rvm.sh
+++ b/toolset/setup/linux/languages/rvm.sh
@@ -9,12 +9,14 @@ RETCODE=$(fw_exists ${IROOT}/rvm.installed)
 
 export SHELL=/bin/bash
 gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
-\curl -sSL https://get.rvm.io | sudo bash -s stable
+RVM_INSTALLER="curl -sSL https://get.rvm.io"
 
 if [ "$TRAVIS" = "true" ]
 then
+  $RVM_INSTALLER | sudo bash -s stable
   echo "source /usr/local/rvm/scripts/rvm" > $IROOT/rvm.installed
 else
+  $RVM_INSTALLER | bash -s stable
   echo "source ~/.rvm/scripts/rvm" > $IROOT/rvm.installed
 fi
 


### PR DESCRIPTION
Recreated for **round-14** from closed  https://github.com/TechEmpower/FrameworkBenchmarks/pull/2048 for **master**