### PR TITLE
Fix http headers spring

### DIFF
--- a/frameworks/Java/spring/pom.xml
+++ b/frameworks/Java/spring/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.5.RELEASE</version>
+        <version>1.3.5.RELEASE</version>
     </parent>
 
     <groupId>com.techempower</groupId>

--- a/frameworks/Java/spring/src/main/resources/application.yml
+++ b/frameworks/Java/spring/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
       naming-strategy: org.hibernate.cfg.EJB3NamingStrategy
       ddl-auto: validate
     open_in_view: false
+  http:
+    encoding:
+      enabled: false
+server:
+  server-header: Undertow
 
 ---
 spring:


### PR DESCRIPTION
Hey,

this is basically the duplicate of #2012 targeting the new branching model introduced for round 14 and beyond, but for completeness reasons here is the original content.....


....when working on a different merge request I noticed that the Spring suite doesn't include the **Server** header and sends the encoding along with the **Content-Type** header. Both result in a warning in the builds for all requests.

WARN for http://127.0.0.1:8080/json
`Required response header missing: Server`

WARN for http://127.0.0.1:8080/json
`Content encoding found in "application/json;charset=UTF-8" where "application/json" is acceptable.`

I needed to upgrade to Spring-Boot 1.3.5 to set the server header in Undertow via `server.server-header`.

Cheers,
Christoph
