### PR TITLE
Silicon Framework fix

### DIFF
--- a/toolset/setup/linux/frameworks/silicon.sh
+++ b/toolset/setup/linux/frameworks/silicon.sh
@@ -5,12 +5,13 @@ RETCODE=$(fw_exists ${IROOT}/silicon.installed)
   # Load environment variables
   source $IROOT/silicon.installed
   return 0; }
-  
+
 SILICON=$IROOT/silicon
 
 git clone https://github.com/matt-42/silicon.git
 cd silicon;
-git checkout a2b930696a72aa963056f21b1605adfe8ec1a8a7
+# May 18th, 2016
+git checkout 73dac7f3c8dcd4f9c53713456e8b73165006e968
 CXX=clang++-3.5 ./install.sh $IROOT
 
 echo "" > $IROOT/silicon.installed


### PR DESCRIPTION
The most recent version of silicon at matt-42@73dac7f3c8dcd4f9c53713456e8b73165006e968 fixes the recent gcc compiler errors. Tied that version down.