### PR TITLE
Fix instructions output

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -244,8 +244,8 @@ class FrameworkTest:
         self.database_host,
         logDir,
         self.benchmarker.threads, 
-        self.directory,
         max(self.benchmarker.concurrency_levels),
+        self.directory,
         command)
     logging.info("To run %s manually, copy/paste this:\n%s", self.name, debug_command)
 


### PR DESCRIPTION
It was yielding `cd 256`, see excerpt from the ouput below:

```
INFO:root: To run phoenix manually, copy/paste this:
  export FWROOT=/home/vagrant/FrameworkBenchmarks          &&  \
  export TROOT=/home/vagrant/FrameworkBenchmarks/frameworks/Elixir/phoenix           &&  \
  export IROOT=/home/vagrant/FrameworkBenchmarks/installs           &&  \
  export DBHOST=127.0.0.1          &&  \
  export LOGDIR=/home/vagrant/FrameworkBenchmarks/results/latest/logs/phoenix          &&  \
  export MAX_THREADS=2     &&  \
  export MAX_CONCURRENCY=/home/vagrant/FrameworkBenchmarks/frameworks/Elixir/phoenix && \
  cd 256 && \
  sudo -u testrunner -E -H stdbuf -o0 -e0 bash -exc "source /home/vagrant/FrameworkBenchmarks/toolset/setup/linux/bash_functions.sh && source /home/vagrant/FrameworkBenchmarks/frameworks/Elixir/phoenix/setup.sh"
```