### PR TITLE
update haywire setup to use a specific commit

### DIFF
--- a/toolset/setup/linux/frameworks/haywire.sh
+++ b/toolset/setup/linux/frameworks/haywire.sh
@@ -10,6 +10,7 @@ HAYWIRE_HOME=$IROOT/Haywire
  
 git clone https://github.com/kellabyte/Haywire.git
 cd $HAYWIRE_HOME
+git checkout e4d23b533c15ddc51966e439fa455eb764e0f555
 ./build.sh -c release
 
 echo "export HAYWIRE_HOME=${HAYWIRE_HOME}" >> $IROOT/haywire.installed


### PR DESCRIPTION
Currently, haywire is pulling the latest from its git repo and the framework is failing to start when running tests. I've switched it to pull from the last commit before haywire was originally merged into TFB master.

@kellabyte the commit I'm pulling from is fairly old (June 4, 2015). It works, but I realize there may be a more recent commit that still works with the framework benchmark. If there's a newer commit you'd like to use instead, feel free to let us know or open a new pull request with the updated commit.