### PR TITLE
Silex orm fix

### DIFF
--- a/frameworks/PHP/silex-orm/setup.sh
+++ b/frameworks/PHP/silex-orm/setup.sh
@@ -2,7 +2,7 @@
 
 fw_depends php nginx composer
 
-sed -i 's|192.168.100.102|'"${DBHOST}"'|g' web/index.php
+sed -i 's|mysql:host=[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+|'"mysql:host=${DBHOST}"'|g' web/index.php
 sed -i 's|".*/FrameworkBenchmarks/php-silex-orm|"'"${TROOT}"'|g' deploy/php-silex-orm
 sed -i 's|Directory .*/FrameworkBenchmarks/php-silex-orm|Directory '"${TROOT}"'|g' deploy/php-silex-orm
 sed -i 's|root .*/FrameworkBenchmarks/php-silex-orm|root '"${TROOT}"'|g' deploy/nginx.conf

--- a/frameworks/PHP/silex-orm/setup.sh
+++ b/frameworks/PHP/silex-orm/setup.sh
@@ -2,7 +2,7 @@
 
 fw_depends php nginx composer
 
-sed -i 's|mysql:host=[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+|'"mysql:host=${DBHOST}"'|g' web/index.php
+sed -i 's|127.0.0.1|'"${DBHOST}"'|g' web/index.php
 sed -i 's|".*/FrameworkBenchmarks/php-silex-orm|"'"${TROOT}"'|g' deploy/php-silex-orm
 sed -i 's|Directory .*/FrameworkBenchmarks/php-silex-orm|Directory '"${TROOT}"'|g' deploy/php-silex-orm
 sed -i 's|root .*/FrameworkBenchmarks/php-silex-orm|root '"${TROOT}"'|g' deploy/nginx.conf

--- a/frameworks/PHP/silex-orm/web/index.php
+++ b/frameworks/PHP/silex-orm/web/index.php
@@ -14,7 +14,7 @@ $loader = require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Silex\Application();
 
-$dbh = new PDO('mysql:host=192.168.100.102;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$dbh = new PDO('mysql:host=127.0.0.1;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
     PDO::ATTR_PERSISTENT => true
 ));
 
@@ -34,8 +34,7 @@ $app->register(new DoctrineOrmServiceProvider, array(
                 'path' => __DIR__.'/../src/Entity',
                 'use_simple_annotation_reader' => false,
             ),
-        ),
-        'metadata_cache' => 'redis'
+        )
     ),
 ));
 

--- a/frameworks/PHP/silex-orm/web/index.php
+++ b/frameworks/PHP/silex-orm/web/index.php
@@ -14,7 +14,7 @@ $loader = require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Silex\Application();
 
-$dbh = new PDO('mysql:host=127.0.0.1;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$dbh = new PDO('mysql:host=192.168.100.102;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
     PDO::ATTR_PERSISTENT => true
 ));
 

--- a/frameworks/PHP/silex-orm/web/index.php
+++ b/frameworks/PHP/silex-orm/web/index.php
@@ -14,7 +14,7 @@ $loader = require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Silex\Application();
 
-$dbh = new PDO('mysql:host=192.168.100.102;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$dbh = new PDO('mysql:host=127.0.0.1;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
     PDO::ATTR_PERSISTENT => true
 ));
 


### PR DESCRIPTION
Removes the redis header caching that was breaking silex-orm tests, and also fixes the sed command in the setup.sh files for silex-orm to replace 127.0.0.1 rather than 192.168.100.102.