### PR TITLE
revel-qbs directory left behind

### DIFF
--- a/frameworks/Go/revel-qbs/.gitignore
+++ b/frameworks/Go/revel-qbs/.gitignore
@@ -1,1 +1,0 @@
-/src/github.com/


### PR DESCRIPTION
revel-qbs directory was accidentally left behind when merged into revel tests