### PR TITLE
activeweb fix

### DIFF
--- a/frameworks/Java/activeweb/src/main/webapp/WEB-INF/views/queries/index.html
+++ b/frameworks/Java/activeweb/src/main/webapp/WEB-INF/views/queries/index.html
@@ -1,1 +1,1 @@
-[<#list worlds as w >{"id":${w.id},"randomNumber":${w.randomNumber}}<#if w_has_next >,</#if></#list>]
+ [<#list worlds as w >{"id":${w.id},"randomNumber":${w.randomNumber}}<#if w_has_next >,</#if></#list>]


### PR DESCRIPTION
The update and queries tests for activeweb were breaking, throwing the following error:
```
org.javalite.templator.TemplateException: java.lang.StringIndexOutOfBoundsException: String index out of range: -1; java.lang.StringIndexOutOfBoundsException: String index out of range: -1
```

This may be indicative of a larger issue with the javalite template rendering engine, but in the meantime, adding a space to the beginning of the queries template seems to fix the problem.

Full stack trace for the exception:

```
org.javalite.activeweb.ViewException: org.javalite.templator.TemplateException: java.lang.StringIndexOutOfBoundsException: String index out of range: -1; java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at org.javalite.activeweb.RenderTemplateResponse.doProcess(RenderTemplateResponse.java:91)
	at org.javalite.activeweb.ControllerResponse.process(ControllerResponse.java:64)
	at org.javalite.activeweb.ControllerRunner.renderResponse(ControllerRunner.java:141)
	at org.javalite.activeweb.ControllerRunner.run(ControllerRunner.java:73)
	at org.javalite.activeweb.RequestDispatcher.doFilter(RequestDispatcher.java:202)
	at com.caucho.server.dispatch.FilterFilterChain.doFilter(FilterFilterChain.java:89)
	at com.caucho.server.webapp.WebAppFilterChain.doFilter(WebAppFilterChain.java:156)
	at com.caucho.server.dispatch.ServletInvocation.service(ServletInvocation.java:289)
	at com.caucho.server.http.HttpRequest.handleRequest(HttpRequest.java:838)
	at com.caucho.network.listen.TcpSocketLink.dispatchRequest(TcpSocketLink.java:1348)
	at com.caucho.network.listen.TcpSocketLink.handleRequest(TcpSocketLink.java:1304)
	at com.caucho.network.listen.TcpSocketLink.handleRequestsImpl(TcpSocketLink.java:1288)
	at com.caucho.network.listen.TcpSocketLink.handleRequests(TcpSocketLink.java:1196)
	at com.caucho.network.listen.TcpSocketLink.handleAcceptTaskImpl(TcpSocketLink.java:993)
	at com.caucho.network.listen.ConnectionTask.runThread(ConnectionTask.java:117)
	at com.caucho.network.listen.ConnectionTask.run(ConnectionTask.java:93)
	at com.caucho.network.listen.SocketLinkThreadLauncher.handleTasks(SocketLinkThreadLauncher.java:169)
	at com.caucho.network.listen.TcpSocketAcceptThread.run(TcpSocketAcceptThread.java:61)
	at com.caucho.env.thread2.ResinThread2.runTasks(ResinThread2.java:173)
	at com.caucho.env.thread2.ResinThread2.run(ResinThread2.java:118)
Caused by: org.javalite.templator.TemplateException: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at org.javalite.templator.Template.<init>(Template.java:24)
	at org.javalite.activeweb.templator.TemplatorManager.merge(TemplatorManager.java:29)
	at org.javalite.activeweb.RenderTemplateResponse.doProcess(RenderTemplateResponse.java:82)
	... 19 more
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1960)
	at org.javalite.templator.AbstractTag.matchEndTag(AbstractTag.java:124)
	at org.javalite.templator.Template.parse(Template.java:69)
	at org.javalite.templator.Template.<init>(Template.java:20)
	... 21 more
```