### PR TITLE
PHP-Phalcon-Micro fix

### DIFF
--- a/frameworks/PHP/phalcon-micro/.gitignore
+++ b/frameworks/PHP/phalcon-micro/.gitignore
@@ -1,2 +1,2 @@
-/compiled-templates/
+/compiled-templates/*.c
 /deploy/php-fpm.pid


### PR DESCRIPTION
Creates a compiled-templates directory to avoid permission error.