### PR TITLE
Specify php5 Redis Version

### DIFF
--- a/toolset/setup/linux/languages/php.sh
+++ b/toolset/setup/linux/languages/php.sh
@@ -44,7 +44,7 @@ echo PHP compilation finished, installing extensions
 $PHP_HOME/bin/pecl channel-update pecl.php.net
 # Apc.so
 $PHP_HOME/bin/pecl config-set php_ini $PHP_HOME/lib/php.ini
-printf "\n" | $PHP_HOME/bin/pecl -q install -f redis
+printf "\n" | $PHP_HOME/bin/pecl -q install -f redis-2.2.5
 
 # yaf.so
 # printf "\n" | $PHP_HOME/bin/pecl -q install -f yaf


### PR DESCRIPTION
Currently, we're just pulling the most recent version of redis from pecl when `php.sh` is run. However, some of the more recent versions are only compatible with php7:

https://pecl.php.net/package/redis

This branch fixes that, downloading version 2.2.5 (the last stable release compatible with php5) when you're using php5.