### PR TITLE
moves phalcon download from php setup script to its own file

### DIFF
--- a/frameworks/PHP/phalcon-micro/setup.sh
+++ b/frameworks/PHP/phalcon-micro/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends php nginx
+fw_depends php phalcon nginx
 
 sed -i 's|localhost|'"${DBHOST}"'|g' public/index.php
 sed -i 's|root .*/FrameworkBenchmarks/php-phalcon-micro|root '"${TROOT}"'|g' deploy/nginx.conf

--- a/frameworks/PHP/phalcon/setup.sh
+++ b/frameworks/PHP/phalcon/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends php nginx
+fw_depends php phalcon nginx
 
 sed -i 's|mongodb://localhost|mongodb://'"${DBHOST}"'|g' app/config/config.php
 sed -i 's|localhost|'"${DBHOST}"'|g' app/config/config.php

--- a/toolset/setup/linux/frameworks/phalcon.sh
+++ b/toolset/setup/linux/frameworks/phalcon.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+RETCODE=$(fw_exists ${IROOT}/phalcon.installed)
+[ ! "$RETCODE" == 0 ] || { \
+  source $IROOT/phalcon.installed
+  return 0; }
+
+PHP_VERSION="5.5.17"
+PHP_HOME=$IROOT/php-$PHP_VERSION
+
+fw_get -O https://github.com/phalcon/cphalcon/archive/phalcon-v1.3.2.tar.gz
+fw_untar phalcon-v1.3.2.tar.gz
+cd cphalcon-phalcon-v1.3.2/build/64bits 
+$PHP_HOME/bin/phpize
+# For some reason we have to point to php-config 
+# explicitly, it's not found by the prefix settings
+./configure --prefix=$PHP_HOME --exec-prefix=$PHP_HOME \
+  --with-php-config=$PHP_HOME/bin/php-config \
+  --enable-phalcon --quiet
+make --quiet
+make install
+
+echo "export PHP_HOME=${PHP_HOME}" > $IROOT/phalcon.installed
+echo -e "export PATH=\$PHP_HOME/bin:\$PHP_HOME/sbin:\$PATH" >> $IROOT/phalcon.installed
+
+echo "export PHALCON_HOME=${PHALCON_HOME}" > $IROOT/phalcon.installed
+echo -e "export PATH=\$PHALCON_HOME:\$PATH" >> $IROOT/phalcon.installed
+
+
+source $IROOT/phalcon.installed

--- a/toolset/setup/linux/frameworks/phalcon.sh
+++ b/toolset/setup/linux/frameworks/phalcon.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
+fw_depends php
+
 RETCODE=$(fw_exists ${IROOT}/phalcon.installed)
 [ ! "$RETCODE" == 0 ] || { \
   source $IROOT/phalcon.installed
   return 0; }
-
-PHP_VERSION="5.5.17"
-PHP_HOME=$IROOT/php-$PHP_VERSION
 
 fw_get -O https://github.com/phalcon/cphalcon/archive/phalcon-v1.3.2.tar.gz
 fw_untar phalcon-v1.3.2.tar.gz

--- a/toolset/setup/linux/frameworks/phalcon.sh
+++ b/toolset/setup/linux/frameworks/phalcon.sh
@@ -19,11 +19,6 @@ $PHP_HOME/bin/phpize
 make --quiet
 make install
 
-echo "export PHP_HOME=${PHP_HOME}" > $IROOT/phalcon.installed
-echo -e "export PATH=\$PHP_HOME/bin:\$PHP_HOME/sbin:\$PATH" >> $IROOT/phalcon.installed
-
-echo "export PHALCON_HOME=${PHALCON_HOME}" > $IROOT/phalcon.installed
-echo -e "export PATH=\$PHALCON_HOME:\$PATH" >> $IROOT/phalcon.installed
-
+echo "" > $IROOT/phalcon.installed
 
 source $IROOT/phalcon.installed

--- a/toolset/setup/linux/languages/php.sh
+++ b/toolset/setup/linux/languages/php.sh
@@ -49,22 +49,6 @@ printf "\n" | $PHP_HOME/bin/pecl -q install -f redis
 # yaf.so
 # printf "\n" | $PHP_HOME/bin/pecl -q install -f yaf
 
-# phalcon.so
-#   The configure seems broken, does not respect prefix. If you 
-#   update the value of PATH then it finds the prefix from `which php`
-
-fw_get -O https://github.com/phalcon/cphalcon/archive/phalcon-v1.3.2.tar.gz
-fw_untar phalcon-v1.3.2.tar.gz
-cd cphalcon-phalcon-v1.3.2/build/64bits 
-$PHP_HOME/bin/phpize
-# For some reason we have to point to php-config 
-# explicitly, it's not found by the prefix settings
-./configure --prefix=$PHP_HOME --exec-prefix=$PHP_HOME \
-  --with-php-config=$PHP_HOME/bin/php-config \
-  --enable-phalcon --quiet
-make --quiet
-make install
-
 # mongodb.so
 printf "\n" | $PHP_HOME/bin/pecl -q install -f mongodb
 


### PR DESCRIPTION
the `php.sh` setup script is currently installing phalcon. This is an issue for two reasons:

1. Most PHP frameworks do not need phalcon (it is only used by php-phalcon and php-phalcon-micro)
2. If you are trying to test a PHP framework as testrunner line-by-line, you will end up with a phalcon directory in that framework  (e.g. `frameworks/php/cakephp/phalcon-v1.3.2/`)

I would advise waiting until #2119 and #2120 are merged before testing this.