### PR TITLE
Fortune test in postgres causes pooling issues

### DIFF
--- a/frameworks/JavaScript/sailsjs/benchmark_config.json
+++ b/frameworks/JavaScript/sailsjs/benchmark_config.json
@@ -28,7 +28,6 @@
       "setup_file": "setup",
       "db_url": "/postgres/db",
       "query_url": "/postgres/queries?queries=",
-      "fortune_url": "/postgres/fortunes",
       "update_url": "/postgres/updates?queries=",
       "port": 8080,
       "approach": "Realistic",


### PR DESCRIPTION
Removed the fortune tests from the postgres test. It's failing due to connection pooling problems.