### PR TITLE
Revert phalcon to use php5

### DIFF
--- a/frameworks/PHP/phalcon-micro/setup.sh
+++ b/frameworks/PHP/phalcon-micro/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends php7 phalcon nginx
+fw_depends php5 phalcon nginx
 
 sed -i 's|localhost|'"${DBHOST}"'|g' public/index.php
 sed -i 's|root .*/FrameworkBenchmarks/php-phalcon-micro|root '"${TROOT}"'|g' deploy/nginx.conf

--- a/frameworks/PHP/phalcon/setup.sh
+++ b/frameworks/PHP/phalcon/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends php7 phalcon nginx
+fw_depends php5 phalcon nginx
 
 sed -i 's|mongodb://localhost|mongodb://'"${DBHOST}"'|g' app/config/config.php
 sed -i 's|localhost|'"${DBHOST}"'|g' app/config/config.php

--- a/toolset/setup/linux/languages/php7.sh
+++ b/toolset/setup/linux/languages/php7.sh
@@ -25,6 +25,11 @@ echo "Installing PHP quietly"
 make --quiet install
 cd ..
 
+# Disable yaf and phalcon, for most PHP frameworks
+# (there is a similar line to enable the frameworks in their respective setup files)
+sed -i 's|^extension=yaf.so|;extension=yaf.so|g' $FWROOT/config/php.ini
+sed -i 's|^extension=phalcon.so|;extension=phalcon.so|g' $FWROOT/config/php.ini
+
 # Enable the correct Mongo DB plugin for PHP 7
 sed -i 's|^extension=mongo.so|;extension=mongo.so|g' $FWROOT/config/php.ini
 sed -i 's|;extension=mongodb.so|extension=mongodb.so|g' $FWROOT/config/php.ini
@@ -44,8 +49,7 @@ $PHP_HOME/bin/pecl channel-update pecl.php.net
 # Apc.so
 $PHP_HOME/bin/pecl config-set php_ini $PHP_HOME/lib/php.ini
 
-#redis not available in pecl for php7 - find alternative install
-#printf "\n" | $PHP_HOME/bin/pecl -q install -f redis
+printf "\n" | $PHP_HOME/bin/pecl -q install -f redis-3.0.0
 
 #removed phalcon install - separate to toolset/setup/linux/frameworks
 


### PR DESCRIPTION
I originally thought Phalcon was running on PHP 7, but as it turns out, it was installing PHP 7 in `php7.sh` and then switching to PHP 5 in the separate `phalcon.sh` file.

I also noticed and fixed a couple minor discrepancies between the PHP 7 and PHP 5 install scripts. We weren't disabling yaf or phalcon, and the redis download was commented out (possibly because, the last time someone was working on `php7.sh`, there wasn't a redis version that was compatible with PHP 7).