### PR TITLE
JSON Tests to Fail Gracefully Fixes #2146

### DIFF
--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -125,7 +125,7 @@ def verify_helloworld_object(json_object, url):
         message = json_object['message']
 
         if message != 'hello, world!':
-            return [('fail', "Expected message of 'hello, world!', got '%s'" % message)]
+            return [('fail', "Expected message of 'hello, world!', got '%s'" % message, url)]
         return problems
 
 


### PR DESCRIPTION
When "hello, world!" is not matched, the `problem` returned was missing the url parameter.