### PR TITLE
add default test to fasthttp

### DIFF
--- a/frameworks/Go/fasthttp/benchmark_config.json
+++ b/frameworks/Go/fasthttp/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "fasthttp",
   "tests": [{
-    "mysql": {
+    "default": {
       "setup_file": "setup-mysql",
       "json_url": "/json",
       "db_url": "/db",


### PR DESCRIPTION
fasthttp didn't have a default test set which was causing:
```bash
WARNING:root:Framework fasthttp does not define a default test in benchmark_config.json
```
on any framework test.