### PR TITLE
Specify perl extension version

### DIFF
--- a/frameworks/Perl/dancer/cpanfile
+++ b/frameworks/Perl/dancer/cpanfile
@@ -1,7 +1,0 @@
-requires 'Dancer', '1.3134';
-requires 'Dancer::Plugin::Database', '2.10';
-requires 'DBI', '1.633';
-requires 'DBD::mysql', '4.031';
-requires 'JSON::XS', '3.01';
-requires 'Plack', '1.0034';
-requires 'Starman', '0.4011';

--- a/frameworks/Perl/dancer/setup.sh
+++ b/frameworks/Perl/dancer/setup.sh
@@ -6,8 +6,15 @@ sed -i 's|server unix.*frameworks-benchmark.sock;|server unix:'"${TROOT}"'/frame
 
 fw_depends perl nginx
 
-carton install --cpanfile ${TROOT}/cpanfile
-
+cpanm --notest --no-man-page \
+    Dancer@1.3134 \
+    Dancer::Plugin::Database@2.10 \
+    DBI@1.633 \
+    DBD::mysql@4.033 \
+    JSON::XS@3.01 \
+    Plack@1.0034 \
+    Starman@0.4011
+    
 nginx -c ${TROOT}/nginx.conf
 
 plackup -E production -s Starman --workers=${MAX_THREADS} -l ${TROOT}/frameworks-benchmark.sock -a ./app.pl &

--- a/frameworks/Perl/kelp/setup.sh
+++ b/frameworks/Perl/kelp/setup.sh
@@ -7,14 +7,14 @@ sed -i 's|server unix.*frameworks-benchmark.sock;|server unix:'"${TROOT}"'/frame
 fw_depends perl nginx
 
 cpanm --notest --no-man-page \
-    Kelp \
-    DBI \
-    DBD::mysql \
-    MongoDB \
-    Kelp::Module::JSON::XS \
-    HTML::Escape \
-    HTTP::Parser::XS \
-    Starman
+    Kelp@0.9071 \
+    DBI@1.636 \
+    DBD::mysql@4.033 \
+    MongoDB@1.4.2 \
+    Kelp::Module::JSON::XS@0.502 \
+    HTML::Escape@1.10 \
+    HTTP::Parser::XS@0.17 \
+    Starman@0.4014
 
 nginx -c ${TROOT}/nginx.conf
 

--- a/frameworks/Perl/plack/cpanfile
+++ b/frameworks/Perl/plack/cpanfile
@@ -1,6 +1,0 @@
-requires 'JSON::XS', '3.01';
-requires 'HTTP::Parser::XS', '0.16';
-requires 'Plack', '1.0030';
-requires 'DBI', '1.631';
-requires 'DBD::mysql', '4.027';
-requires 'Starlet', '0.24';

--- a/frameworks/Perl/plack/setup.sh
+++ b/frameworks/Perl/plack/setup.sh
@@ -5,7 +5,13 @@ sed -i 's|server unix:.*/FrameworkBenchmarks/plack|server unix:'"${TROOT}"'|g' n
 
 fw_depends perl nginx
 
-cpanm --notest --no-man-page --installdeps $TROOT
-
+cpanm --notest --no-man-page \
+    JSON::XS@3.01 \
+    HTTP::Parser::XS@0.16 \
+    Plack@1.0030 \
+    DBI@1.631 \
+    DBD::mysql@4.033 \
+    Starlet@0.24
+    
 nginx -c $TROOT/nginx.conf
 start_server --backlog=16384 --pid-file=$TROOT/app.pid --path=$TROOT/app.sock -- plackup -E production -s Starlet --max-keepalive-reqs 1000 --max-reqs-per-child 50000 --min-reqs-per-child 40000 --max-workers=${MAX_THREADS} -a $TROOT/app.psgi &

--- a/frameworks/Perl/web-simple/setup.sh
+++ b/frameworks/Perl/web-simple/setup.sh
@@ -5,8 +5,14 @@ sed -i 's|server unix:.*/FrameworkBenchmarks/web-simple|server unix:'"${TROOT}"'
 
 fw_depends perl nginx
 
-cpanm --notest --no-man-page Web::Simple DBI DBD::mysql Plack Starman JSON::XS
-
+cpanm --notest --no-man-page  \
+    Web::Simple@0.031 \
+    DBI@1.636 \
+    DBD::mysql@4.033 \
+    Plack@1.0039 \
+    Starman@0.4014 \
+    JSON::XS@3.02
+    
 nginx -c $TROOT/nginx.conf
 
 plackup -E production -s Starman --workers=${MAX_THREADS} -l $TROOT/frameworks-benchmark.sock -a $TROOT/app.pl &


### PR DESCRIPTION
Fixes Perl/dancer and Perl/plack which were randomly breaking when trying to pull DBD:mysql with a cpanfile. Moved their dependencies to their respective setup.sh files and also specified version numbers for the dependencies in Perl/kelp and Perl/web-simple as well (which weren't breaking, but were just pulling the latest version of all of their dependencies).