### PR TITLE
Updated readme to make changing dir clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ required.
 
         $ vagrant ssh
 
-5. Run a test.
+5. Move into the FrameworkBenchmarks directory in the vm.
 
         vagrant@TFB-all:~$ cd ~/FrameworkBenchmarks
+        
+6. Run a test.
+
         vagrant@TFB-all:~/FrameworkBenchmarks$ toolset/run-tests.py --install server --mode verify --test beego
 
 _Note: `--install server` only needs to be added the first time that a tests is run. 


### PR DESCRIPTION
Updated readme to make it clearer to move into the FrameworkBenchmarks directory in the vagrant machine before running the first test.