### PR TITLE
add a benchmark for s-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -189,6 +189,7 @@ env:
     - "TESTDIR=Scala/scruffy"
     - "TESTDIR=Scala/spray"
     - "TESTDIR=Scala/spray-es"
+    - "TESTDIR=Scala/s-server-tfb"
     - "TESTDIR=Scala/unfiltered"
     - "TESTDIR=Scala/http4s"
     - "TESTDIR=Scala/finch"

--- a/frameworks/Scala/s-server-tfb/.gitignore
+++ b/frameworks/Scala/s-server-tfb/.gitignore
@@ -1,0 +1,7 @@
+/project/.*
+/project/target
+/target
+/.project
+/.classpath
+/.cache
+/.cache-main

--- a/frameworks/Scala/s-server-tfb/README.md
+++ b/frameworks/Scala/s-server-tfb/README.md
@@ -1,0 +1,3 @@
+# S-server Benchmarking Test
+
+This is the s-server portion of a [benchmarking test suite](../) comparing a variety of web development platforms.

--- a/frameworks/Scala/s-server-tfb/benchmark_config.json
+++ b/frameworks/Scala/s-server-tfb/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework" : "s-server",
+  "tests" : [{
+    "default" : {
+      "setup_file" : "setup",
+      "json_url" : "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "s-server",
+      "language": "Scala",
+      "orm": "Raw",
+      "platform": "s-server",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "s-server",
+      "notes": "",
+      "versus": "s-server"
+    }
+  }]
+}

--- a/frameworks/Scala/s-server-tfb/build.sbt
+++ b/frameworks/Scala/s-server-tfb/build.sbt
@@ -12,6 +12,8 @@ javacOptions ++= Seq("-Xlint:deprecation", "-Xlint:unchecked", "-source", "1.8",
 
 enablePlugins(JavaAppPackaging)
 
+resolvers += "Woshilaiceshide Releases" at "http://dl.bintray.com/woshilaiceshide/maven/"
+
 libraryDependencies += "woshilaiceshide" %% "s-server" % "2.1"
 
 //libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.7.4"

--- a/frameworks/Scala/s-server-tfb/build.sbt
+++ b/frameworks/Scala/s-server-tfb/build.sbt
@@ -1,0 +1,21 @@
+name := "s-server-tfb"
+
+organization := "woshilaiceshide"
+
+scalaVersion := "2.11.8"
+
+version := "1.0"
+
+scalacOptions := Seq("-unchecked", "-deprecation","-optimise", "-encoding", "utf8", "-Yno-adapted-args", "-target:jvm-1.8")
+
+javacOptions ++= Seq("-Xlint:deprecation", "-Xlint:unchecked", "-source", "1.8", "-target", "1.8")
+
+enablePlugins(JavaAppPackaging)
+
+libraryDependencies += "woshilaiceshide" %% "s-server" % "2.1"
+
+//libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.7.4"
+
+//libraryDependencies += "com.fasterxml.jackson.module" % "jackson-module-afterburner" % "2.7.4"
+
+libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.7.4"

--- a/frameworks/Scala/s-server-tfb/project/build.properties
+++ b/frameworks/Scala/s-server-tfb/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/frameworks/Scala/s-server-tfb/project/plugins.sbt
+++ b/frameworks/Scala/s-server-tfb/project/plugins.sbt
@@ -1,0 +1,9 @@
+// Comment to get more information during initialization
+logLevel := Level.Warn
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
+

--- a/frameworks/Scala/s-server-tfb/setup.sh
+++ b/frameworks/Scala/s-server-tfb/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+fw_depends java scala sbt
+
+sbt stage
+
+./target/universal/stage/bin/s-server-tfb -J-XX:+UseBiasedLocking -J-XX:+UseParallelGC -J-XX:+AggressiveOpts &

--- a/frameworks/Scala/s-server-tfb/source_code
+++ b/frameworks/Scala/s-server-tfb/source_code
@@ -1,0 +1,1 @@
+./s-server-tfb/src/main/scala/woshilaiceshide/sserver/tfb/Server.scala

--- a/frameworks/Scala/s-server-tfb/src/main/resources/logback.xml
+++ b/frameworks/Scala/s-server-tfb/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date{MM/dd HH:mm:ss.SSS} %-5level[%.15thread] %logger{1} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/frameworks/Scala/s-server-tfb/src/main/scala/woshilaiceshide/sserver/tfb/Server.scala
+++ b/frameworks/Scala/s-server-tfb/src/main/scala/woshilaiceshide/sserver/tfb/Server.scala
@@ -1,0 +1,125 @@
+package woshilaiceshide.sserver.tfb
+
+import woshilaiceshide.sserver.http._
+import woshilaiceshide.sserver.nio._
+import spray.http._
+import spray.http.HttpEntity.apply
+import spray.http.StatusCode.int2StatusCode
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala._
+
+object Server extends App {
+
+  val log = org.slf4j.LoggerFactory.getLogger(Server.getClass);
+
+  val mapper = new ObjectMapper()
+  mapper.registerModule(DefaultScalaModule)
+  final case class Message(message: String)
+
+  import scala.concurrent._
+  val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+  implicit val ec = ExecutionContext.fromExecutor(executor)
+
+  val handler = new HttpChannelHandler {
+
+    private val ping = new HttpResponse(200, HttpEntity(ContentTypes.`text/plain`, "Hello World"))
+    private def write_ping(channel: HttpChannel) = {
+      channel.writeResponse(ping)
+      ResponseAction.responseNormally
+    }
+    private val path_ping = Uri.Path("/ping")
+
+    private val phelloworld = new HttpResponse(200, HttpEntity(ContentTypes.`text/plain`, "Hello, World!"))
+    private def write_phelloworld(channel: HttpChannel) = {
+      channel.writeResponse(phelloworld)
+      ResponseAction.responseNormally
+    }
+    private val path_plaintext = Uri.Path("/plaintext")
+
+    //JsObject("message" -> JsString("Hello, World!"))
+    private val path_json = Uri.Path("/json")
+    private def jhelloworld = new HttpResponse(200, HttpEntity(ContentTypes.`application/json`, mapper.writeValueAsBytes(Message("Hello, World!"))))
+    private def write_jhelloworld(channel: HttpChannel) = {
+      channel.writeResponse(jhelloworld)
+      ResponseAction.responseNormally
+    }
+
+    private def write_404(channel: HttpChannel) = {
+      channel.writeResponse { new HttpResponse(404) }
+      ResponseAction.responseNormally
+    }
+
+    private def write_400(channel: HttpChannel) = {
+      channel.writeResponse { new HttpResponse(400) }
+      ResponseAction.responseNormally
+    }
+
+    private val ping_asynchronously = new HttpResponse(200, HttpEntity(ContentTypes.`text/plain`, "Hello World Asynchronously"))
+    private def write_ping_asynchronously(channel: HttpChannel) = {
+      //channel.post_to_io_thread { channel.writeResponse(ping_asynchronously) }
+      Future { channel.writeResponse(ping_asynchronously) }
+      ResponseAction.responseNormally
+    }
+
+    def requestReceived(request: HttpRequest, channel: HttpChannel, classifier: RequestClassifier): ResponseAction = request match {
+
+      case HttpRequest(HttpMethods.GET, uri, _, _, _) if uri.path == path_json => write_jhelloworld(channel)
+
+      case HttpRequest(HttpMethods.GET, uri, _, _, _) if uri.path == path_plaintext => write_phelloworld(channel)
+
+      case HttpRequest(HttpMethods.GET, uri, _, _, _) if uri.path == path_ping => write_ping(channel)
+
+      case HttpRequest(HttpMethods.GET, Uri.Path("/ping_asynchronously"), _, _, _) => write_ping_asynchronously(channel)
+
+      case _: HttpRequest => write_404(channel)
+    }
+
+  }
+
+  val http_configurator = new HttpConfigurator(max_request_in_pipeline = 8, use_direct_byte_buffer_for_cached_bytes_rendering = false)
+
+  val factory = new HttpChannelHandlerFactory(handler, http_configurator)
+
+  val listening_channel_configurator: ServerSocketChannelWrapper => Unit = wrapper => {
+    wrapper.setOption[java.lang.Boolean](java.net.StandardSocketOptions.SO_REUSEADDR, true)
+    wrapper.setBacklog(1024 * 8)
+  }
+
+  val accepted_channel_configurator: SocketChannelWrapper => Unit = wrapper => {
+    wrapper.setOption[java.lang.Boolean](java.net.StandardSocketOptions.TCP_NODELAY, true)
+  }
+
+  /*
+  val threadFactory = new java.util.concurrent.ThreadFactory() {
+    def newThread(r: Runnable) = {
+      new Thread(r)
+    }
+  }
+  val mt = new MultipleThreadHandlerFactory(1, threadFactory, Integer.MAX_VALUE, factory)
+  */
+
+  val configurator = XNioConfigurator(count_for_reader_writers = Runtime.getRuntime().availableProcessors() - 1, //2,
+    listening_channel_configurator = listening_channel_configurator,
+    accepted_channel_configurator = accepted_channel_configurator,
+    //buffer_pool_factory = DefaultByteBufferPoolFactory(1, 1, true),
+    //buffer_pool_factory = DefaultByteBufferPoolFactory(512, 64, true),
+    //more i/o, more asynchronously, then make it bigger
+    buffer_pool_factory = DefaultByteBufferPoolFactory(512, 64, true),
+    io_thread_factory = new woshilaiceshide.sserver.http.AuxThreadFactory())
+
+  val port = 8080
+
+  val server = NioSocketServer(
+    "0.0.0.0",
+    port,
+    factory,
+    configurator)
+
+  server.register_on_termination {
+    executor.shutdown()
+  }
+
+  server.start(false)
+
+}


### PR DESCRIPTION
S-server are Some Small & Smart Servers written in Scala, including a nio server and a small httpd, which also supports websocket(v13 only). it's shown on https://github.com/woshilaiceshide/s-server .

This pr is adding a benchmark for s-server, including "/plaintext" and "/json".

thanks.