### PR TITLE
WIP: Upgrade hapiJS

### DIFF
--- a/frameworks/JavaScript/hapi/create-server.js
+++ b/frameworks/JavaScript/hapi/create-server.js
@@ -1,14 +1,16 @@
 var Hapi = require('hapi');
+var Vision = require('vision');
 var server = new Hapi.Server();
 server.connection({port: 8080});
-server.views({
-  engines: {
-    hbs: require('handlebars')
-  },
-  path: __dirname + '/views',
-  compileOptions: {
-    pretty: false
-  }
+server.register(Vision, (err) => {
+    if (err) {
+        throw err;
+    }
+
+    server.views({
+        engines: { html: require('handlebars') },
+        path: __dirname + '/views/'
+    });
 });
 
 var Promise = require('bluebird');

--- a/frameworks/JavaScript/hapi/handlers/sequelize.js
+++ b/frameworks/JavaScript/hapi/handlers/sequelize.js
@@ -74,7 +74,7 @@ module.exports = {
         .header('Server', 'hapi');
     }).catch(function (err) {
       process.exit(1);
-    }); 
+    });
   },
 
   Updates: function (req, reply) {

--- a/frameworks/JavaScript/hapi/package.json
+++ b/frameworks/JavaScript/hapi/package.json
@@ -3,16 +3,17 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "async": "1.2.0",
+    "async": "1.5.2",
     "bluebird": "^2.9.27",
-    "handlebars": "3.0.3",
-    "hapi": "8.6.0",
-    "hiredis": "^0.4.0",
-    "mongoose": "4.0.4",
-    "mysql": "2.7.0",
-    "pg": "^4.3.0",
+    "handlebars": "4.0.5",
+    "hapi": "13.5.0",
+    "vision":"4.1.0",
+    "hiredis": "^0.5.0",
+    "mongoose": "4.5.3",
+    "mysql": "2.11.1",
+    "pg": "^6.0.2",
     "pg-hstore": "^2.3.2",
-    "redis": "^0.12.1",
+    "redis": "^2.6.2",
     "sequelize": "3.1.1"
   }
 }

--- a/frameworks/JavaScript/hapi/views/fortunes.hbs
+++ b/frameworks/JavaScript/hapi/views/fortunes.hbs
@@ -1,1 +1,0 @@
-<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>{{#fortunes}}<tr><td>{{id}}</td><td>{{message}}</td></tr>{{/fortunes}}</table></body></html>

--- a/frameworks/JavaScript/hapi/views/fortunes.html
+++ b/frameworks/JavaScript/hapi/views/fortunes.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>{{#fortunes}}<tr><td>{{id}}</td><td>{{message}}</td></tr>{{/fortunes}}</table></body></html>


### PR DESCRIPTION
Upgrades hapiJS to its newest release (13.5.0). Also upgrades most of its dependencies to their newest releases as well.

WIP: While I'm at it, I'm upgrading the dependencies for all of the other JS frameworks to as high as they can go, so hold off on merging this until then.