### PR TITLE
Dlang version updates and new test variant

### DIFF
--- a/frameworks/D/vibed/README.md
+++ b/frameworks/D/vibed/README.md
@@ -12,7 +12,7 @@ This is the Vibe.D portion of a [benchmarking test suite](../) comparing a varie
 
 ## Infrastructure Software Versions
 The tests were run with:
-* [Vibe.D v0.7.19](http://vibed.org/)
+* [Vibe.D v0.7.29](http://vibed.org/)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/D/vibed/benchmark_config.json
+++ b/frameworks/D/vibed/benchmark_config.json
@@ -23,6 +23,29 @@
       "display_name": "vibe.d",
       "notes": "",
       "versus": "vibed"
+    },
+    "ldc": {
+      "setup_file": "setup_ldc",
+      "json_url": "/json",
+      "db_url": "/db",
+      "query_url": "/queries?queries=",
+      "plaintext_url": "/plaintext",
+      "fortune_url": "/fortunes",
+      "update_url": "/updates?queries=",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MongoDB",
+      "framework": "vibed",
+      "language": "D",
+      "orm": "Micro",
+      "platform": "D",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "vibe.d-ldc",
+      "notes": "",
+      "versus": "vibed"
     }
   }]
 }

--- a/frameworks/D/vibed/dub.selections.json
+++ b/frameworks/D/vibed/dub.selections.json
@@ -1,11 +1,10 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"memutils": "0.4.4",
-		"vibe-d": "0.7.28",
+		"libasync": "0.7.9",
 		"libevent": "2.0.1+2.0.16",
+		"memutils": "0.4.6",
 		"openssl": "1.1.4+1.0.1g",
-		"libasync": "0.7.8",
-		"libev": "5.0.0+4.04"
+		"vibe-d": "0.7.29"
 	}
 }

--- a/frameworks/D/vibed/setup_ldc.sh
+++ b/frameworks/D/vibed/setup_ldc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+fw_depends dlang dub
+
+# Clean any files from last run
+rm -f fwb
+rm -rf .dub
+
+dub build -b release --compiler=ldc2
+
+./fwb &

--- a/frameworks/D/vibed/source/mongodb.d
+++ b/frameworks/D/vibed/source/mongodb.d
@@ -5,7 +5,7 @@ import vibe.web.web;
 
 import std.conv : ConvException, to;
 import std.random : uniform;
-
+import std.array;
 
 enum worldSize = 10000;
 

--- a/toolset/setup/linux/languages/dlang.sh
+++ b/toolset/setup/linux/languages/dlang.sh
@@ -6,10 +6,17 @@ RETCODE=$(fw_exists ${IROOT}/dlang.installed)
   return 0; }
   
 DLANG=$IROOT/dlang
+DMDVER="2.071.1"
+LDCVER="1.0.0"
 
 mkdir -p $DLANG
-fw_get -O http://downloads.dlang.org/releases/2.x/2.069.2/dmd_2.069.2-0_amd64.deb
-dpkg-deb -x dmd_2.069.2-0_amd64.deb $DLANG
+fw_get -O http://downloads.dlang.org/releases/2.x/$DMDVER/dmd_$DMDVER-0_amd64.deb
+dpkg-deb -x dmd_$DMDVER-0_amd64.deb $DLANG
+
+cd $DLANG
+fw_get -O https://github.com/ldc-developers/ldc/releases/download/v$LDCVER/ldc2-$LDCVER-linux-x86_64.tar.xz
+fw_untar ldc2-$LDCVER-linux-x86_64.tar.xz
+ln -s $DLANG/ldc2-$LDCVER-linux-x86_64/bin/ldc2 $DLANG/usr/bin/ldc2
 
 # According to this file (dmd.conf) dmd will, upon execution, look for
 # a dmd.conf in 1) the current working directory [bad], 2) the directory

--- a/toolset/setup/linux/systools/dub.sh
+++ b/toolset/setup/linux/systools/dub.sh
@@ -7,8 +7,8 @@ RETCODE=$(fw_exists ${IROOT}/dub.installed)
 
 mkdir dub
 cd dub
-fw_get -O http://code.dlang.org/files/dub-0.9.24-linux-x86_64.tar.gz
-fw_untar dub-0.9.24-linux-x86_64.tar.gz
+fw_get -O http://code.dlang.org/files/dub-1.0.0-linux-x86_64.tar.gz
+fw_untar dub-1.0.0-linux-x86_64.tar.gz
 
 echo -e "export PATH=${IROOT}/dub:\$PATH" > $IROOT/dub.installed
 


### PR DESCRIPTION
DUB 0.9.24 -> 1.0.0
DMD 2.069.2 -> 2.071.1
LDC2 1.0.0 as an alternative (more performant) compiler
vibe-d 0.7.28 -> 0.7.29
Fix of warning in mongodb.d due to changes in compiler.