### PR TITLE
finatra: Patch round-13 code

### DIFF
--- a/frameworks/Scala/finatra/README.md
+++ b/frameworks/Scala/finatra/README.md
@@ -12,7 +12,7 @@
 The tests are run with:
 
 * [Java Oracle 1.8.0_25](http://www.oracle.com/technetwork/java/javase)
-* [finatra 2.1.6](https://github.com/twitter/finatra/tree/v2.1.6)
+* [finatra 2.2.0](https://github.com/twitter/finatra/tree/finatra-2.2.0)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -12,10 +12,11 @@ resolvers ++= Seq(
 assemblyJarName in assembly := "finatra-benchmark.jar"
 assemblyMergeStrategy in assembly := {
   case "BUILD" => MergeStrategy.discard
+  case "META-INF/io.netty.versions.properties" => MergeStrategy.last
   case other => MergeStrategy.defaultMergeStrategy(other)
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter.finatra" %% "finatra-http" % "2.1.6",
-  "org.slf4j" % "slf4j-nop" % "1.7.7"
+  "com.twitter" %% "finatra-http" % "2.2.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.21"
 )

--- a/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
+++ b/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
@@ -1,7 +1,10 @@
 package benchmark
 
 import benchmark.controllers.Controller
+import com.twitter.finagle.Http
 import com.twitter.finagle.http.Request
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.HttpResponseFilter
 import com.twitter.finatra.http.routing.HttpRouter
@@ -9,10 +12,16 @@ import com.twitter.finatra.http.routing.HttpRouter
 object ServerMain extends Server
 
 class Server extends HttpServer {
+	override protected def configureHttpServer(server: Http.Server): Http.Server = {
+		server
+			.withCompressionLevel(0)
+			.withStatsReceiver(NullStatsReceiver)
+			.withTracer(NullTracer)
+	}
 
-  override def configureHttp(router: HttpRouter): Unit = {
-	router
-		.filter[HttpResponseFilter[Request]]
-		.add[Controller]
-  }
+	override def configureHttp(router: HttpRouter): Unit = {
+		router
+			.filter[HttpResponseFilter[Request]]
+			.add[Controller]
+	}
 }


### PR DESCRIPTION
Hi there! There are some improvements we'd like to get into the round-13 testing run for Finatra based on the released preliminary results. 

It's not clear if this patch should be done against the current [round-13](https://github.com/TechEmpower/FrameworkBenchmarks/tree/round-13) branch or the [round-14](https://github.com/TechEmpower/FrameworkBenchmarks/tree/round-14) branch. This PR is based on the current [round-14](https://github.com/TechEmpower/FrameworkBenchmarks/tree/round-14) branch. Please let me know if I need to re-do against a different branch to get this into the round-13 testing.