### PR TITLE
Improve the Elixir Phoenix benchmark

### DIFF
--- a/frameworks/Elixir/phoenix/lib/hello/repo.ex
+++ b/frameworks/Elixir/phoenix/lib/hello/repo.ex
@@ -1,3 +1,3 @@
 defmodule Hello.Repo do
-    use Ecto.Repo, otp_app: :hello
+  use Ecto.Repo, otp_app: :hello
 end

--- a/frameworks/Elixir/phoenix/mix.exs
+++ b/frameworks/Elixir/phoenix/mix.exs
@@ -3,8 +3,8 @@ defmodule Hello.Mixfile do
 
   def project do
    [app: :hello,
-    version: "0.0.1",
-    elixir: "~> 1.1",
+    version: "0.1.0",
+    elixir: "~> 1.3",
     elixirc_paths: elixirc_paths(Mix.env),
     compilers: [:phoenix] ++ Mix.compilers,
     build_embedded: Mix.env == :prod,
@@ -26,12 +26,11 @@ defmodule Hello.Mixfile do
   #
   # Type `mix help deps` for examples and options
   defp deps do
-    [{:phoenix, "~> 1.0.3"},
-     {:phoenix_ecto, "~> 1.1"},
+    [{:phoenix, "~> 1.2"},
+     {:phoenix_ecto, "~> 3.0"},
      {:postgrex, ">= 0.0.0"},
      {:cowboy, "~> 1.0.0"},
-     {:phoenix_html, "~> 2.1"},
-     {:phoenix_live_reload, "~> 1.0", only: :dev},
-     {:exrm, "~> 0.19.8"}]
+     {:phoenix_html, "~> 2.6"},
+     {:phoenix_live_reload, "~> 1.0", only: :dev}]
   end
 end

--- a/frameworks/Elixir/phoenix/setup.sh
+++ b/frameworks/Elixir/phoenix/setup.sh
@@ -8,7 +8,8 @@ rm -rf _build deps
 
 export MIX_ENV=prod
 mix local.hex --force
-mix deps.get --force
+mix local.rebar --force
+mix deps.get --force --only prod
 mix compile --force
 
 elixir --detached -S mix phoenix.server

--- a/frameworks/Elixir/phoenix/setup.sh
+++ b/frameworks/Elixir/phoenix/setup.sh
@@ -12,4 +12,4 @@ mix local.rebar --force
 mix deps.get --force --only prod
 mix compile --force
 
-elixir --detached -S mix phoenix.server
+elixir --erl "+K true" --detached  -pa _build/prod/consolidated -S mix phoenix.server

--- a/frameworks/Elixir/phoenix/web/models/fortune.ex
+++ b/frameworks/Elixir/phoenix/web/models/fortune.ex
@@ -6,11 +6,11 @@ defmodule Hello.Fortune do
     field :message, :string
   end
 
-  @required_fields ~w(message)
+  @required_fields ~w(message)a
   @optional_fields ~w()
 
-  def changeset(model, params \\ nil) do
+  def changeset(model, params \\ %{}) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields)
   end
 end

--- a/frameworks/Elixir/phoenix/web/models/world.ex
+++ b/frameworks/Elixir/phoenix/web/models/world.ex
@@ -6,11 +6,11 @@ defmodule Hello.World do
     field :randomnumber, :integer
   end
 
-  @required_fields ~w(randomnumber)
+  @required_fields ~w(randomnumber)a
   @optional_fields ~w()
 
-  def changeset(model, params \\ nil) do
+  def changeset(model, params \\ %{}) do
     model
-    |> cast(params, @required_fields, @optional_fields)
+    |> cast(params, @required_fields)
   end
 end

--- a/frameworks/Elixir/phoenix/web/templates/layout/app.html.eex
+++ b/frameworks/Elixir/phoenix/web/templates/layout/app.html.eex
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html lang="en"><head><title>Fortunes</title></head><body><%= @inner %></body></html>
+<!DOCTYPE html><html lang="en"><head><title>Fortunes</title></head><body><%= render @view_module, @view_template, assigns %></body></html>

--- a/frameworks/Elixir/phoenix/web/web.ex
+++ b/frameworks/Elixir/phoenix/web/web.ex
@@ -14,7 +14,11 @@ defmodule Hello.Web do
 
   def model do
     quote do
-      use Ecto.Model
+      use Ecto.Schema
+
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
     end
   end
 
@@ -24,7 +28,7 @@ defmodule Hello.Web do
 
       # Alias the data repository and import query/model functions
       alias Hello.Repo
-      import Ecto.Model
+      import Ecto
       import Ecto.Query
 
       # Import URL helpers from the router
@@ -40,11 +44,11 @@ defmodule Hello.Web do
       import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2,
                                         action_name: 1, controller_module: 1]
 
-      # Import URL helpers from the router
-      import Hello.Router.Helpers
 
       # Import all HTML functions (forms, tags, etc)
       use Phoenix.HTML
+
+      import Hello.Router.Helpers
     end
   end
 
@@ -60,8 +64,8 @@ defmodule Hello.Web do
       use Phoenix.Channel
       # Alias the data repository and import query/model functions
       alias Hello.Repo
-      import Ecto.Model
-      import Ecto.Query, only: [from: 2]
+      import Ecto
+      import Ecto.Query
     end
   end
 

--- a/toolset/setup/linux/languages/elixir.sh
+++ b/toolset/setup/linux/languages/elixir.sh
@@ -8,11 +8,11 @@ RETCODE=$(fw_exists ${IROOT}/elixir.installed)
   return 0; }
 
 ELIXIR_HOME=$IROOT/elixir
-VERSION="1.1.0-1"
+VERSION="1.3.2-1"
 RELEASE="trusty"
 ARCH="amd64"
 
-fw_get -O http://packages.erlang-solutions.com/site/esl/elixir/FLAVOUR_2_download/elixir_${VERSION}~ubuntu~${RELEASE}_${ARCH}.deb
+fw_get -O http://packages.erlang-solutions.com/debian/pool/elixir_${VERSION}~ubuntu~${RELEASE}_${ARCH}.deb
 dpkg -x elixir_${VERSION}~ubuntu~${RELEASE}_${ARCH}.deb $IROOT/elixir
 $IROOT/erlang/usr/lib/erlang/Install -minimal $IROOT/erlang/usr/lib/erlang
 


### PR DESCRIPTION
Hi there!

This PR does a few things to update the Elixir Phoenix framework benchmark:

- ~~Bumps the Erlang runtime from `18.2` to `19.0`~~, and changes random number generation to use the newer Erlang `:rand` library over `:random`, which was emitting deprecation warnings.
- Bumps the Elixir language from `1.1` to `1.3`
- Bumps the Phoenix framework from `1.0` to `1.2`, along with related dependencies, and fixes application code that broke as a result of these dependency upgrades
- Modifies the build process to:
  1. Enable kernel polling (more info here: https://stackoverflow.com/questions/1182025/what-do-the-erlang-emulator-info-statements-mean)
  2. Explicitly use consolidated protocols when starting the application (more info here: http://learningelixir.joekain.com/optmizing-elixir/)

This is all enumerated in the commit log as well :)

I have run the framework benchmark locally with these changes using the described vagrant setup and seen both faster numbers and lower error counts.

Thanks for your consideration!

PS: Please let me know if this should be reopened against another branch, happy to do so.