### PR TITLE
update elixir version (to fix benchmark)

### DIFF
--- a/toolset/setup/linux/languages/elixir.sh
+++ b/toolset/setup/linux/languages/elixir.sh
@@ -8,7 +8,7 @@ RETCODE=$(fw_exists ${IROOT}/elixir.installed)
   return 0; }
 
 ELIXIR_HOME=$IROOT/elixir
-VERSION="1.2.6-1"
+VERSION="1.3.2-0"
 RELEASE="trusty"
 ARCH="amd64"
 

--- a/toolset/setup/linux/languages/elixir.sh
+++ b/toolset/setup/linux/languages/elixir.sh
@@ -8,7 +8,7 @@ RETCODE=$(fw_exists ${IROOT}/elixir.installed)
   return 0; }
 
 ELIXIR_HOME=$IROOT/elixir
-VERSION="1.3.2-0"
+VERSION="1.3.2-1"
 RELEASE="trusty"
 ARCH="amd64"
 

--- a/toolset/setup/linux/languages/elixir.sh
+++ b/toolset/setup/linux/languages/elixir.sh
@@ -8,7 +8,7 @@ RETCODE=$(fw_exists ${IROOT}/elixir.installed)
   return 0; }
 
 ELIXIR_HOME=$IROOT/elixir
-VERSION="1.1.0-1"
+VERSION="1.2.6-1"
 RELEASE="trusty"
 ARCH="amd64"
 


### PR DESCRIPTION
Latest preview run for Phoenix is failing due to outdated elixir version. 
This pull request updates elixir version to prevent issue with compiling phoenix

http://tfb-logs.techempower.com/round-13/preview-1/latest/logs/phoenix/