### PR TITLE
Switch Go version from 1.6 to 1.7

### DIFF
--- a/toolset/setup/linux/languages/go.sh
+++ b/toolset/setup/linux/languages/go.sh
@@ -5,7 +5,7 @@ RETCODE=$(fw_exists ${IROOT}/go.installed)
   source $IROOT/go.installed
   return 0; }
 
-VERSION=1.6.2
+VERSION=1.7
 GOROOT=$IROOT/go
 
 fw_get -O https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz


### PR DESCRIPTION
Go 1.7 [is out](https://blog.golang.org/go1.7). Let's use it in benchmarks.