### PR TITLE
Decrease backlog to 128

### DIFF
--- a/frameworks/Python/bottle/uwsgi.ini
+++ b/frameworks/Python/bottle/uwsgi.ini
@@ -2,7 +2,7 @@
 master
 ; Increase listen queue used for nginx connecting to uWSGI. This matches
 ; net.ipv4.tcp_max_syn_backlog and net.core.somaxconn.
-listen = 65535
+listen = 128
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance

--- a/frameworks/Python/flask/uwsgi.ini
+++ b/frameworks/Python/flask/uwsgi.ini
@@ -2,7 +2,7 @@
 master
 ; Increase listen queue used for nginx connecting to uWSGI. This matches
 ; net.ipv4.tcp_max_syn_backlog and net.core.somaxconn.
-listen = 65535
+listen = 128
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance

--- a/frameworks/Python/uwsgi/uwsgi.ini
+++ b/frameworks/Python/uwsgi/uwsgi.ini
@@ -2,7 +2,7 @@
 master
 ; Increase listen queue used for nginx connecting to uWSGI. This matches
 ; net.ipv4.tcp_max_syn_backlog and net.core.somaxconn.
-listen = 65535
+listen = 128
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance


### PR DESCRIPTION
uwsgi tests were failed again and again because of this issue.
All other frameworks run with 128 backlog.  So just decrease it. 
fixes #2213 