### PR TITLE
Make Colossus building a response object on each request

### DIFF
--- a/frameworks/Scala/colossus/src/main/scala/example/Main.scala
+++ b/frameworks/Scala/colossus/src/main/scala/example/Main.scala
@@ -17,7 +17,7 @@ object BenchmarkService {
     def encode(json: JValue)  = new HttpBody(compact(render(json)).getBytes("UTF-8"), Some(jsonHeader))
   }
 
-  val json : JValue     = ("message" -> "Hello, World!")
+  def json: JValue      = ("message" -> "Hello, World!")
   val plaintext         = HttpBody("Hello, World!")
   val serverHeader      = HttpHeader("Server", "Colossus")
 


### PR DESCRIPTION
This addresses #2221 and changes the way Colossus responds a JSON payload. The response object is now allocated on each request as per benchmark rules.