### PR TITLE
Update Finagle to 6.36

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -2,9 +2,11 @@ name := "finagle"
 
 scalaVersion := "2.11.8"
 
-version := "1.0.1"
+version := "1.0.2"
+
+com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "6.34.0",
+  "com.twitter" %% "finagle-http" % "6.36.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
 )

--- a/frameworks/Scala/finagle/project/plugins.sbt
+++ b/frameworks/Scala/finagle/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")

--- a/frameworks/Scala/finagle/setup.sh
+++ b/frameworks/Scala/finagle/setup.sh
@@ -2,6 +2,6 @@
 
 fw_depends java sbt
 
-sbt update compile -batch
+sbt 'oneJar' -batch
 
-sbt run &
+java -jar target/scala-2.11/*finagle*one-jar.jar &

--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -1,4 +1,3 @@
-import java.text.{DateFormat, SimpleDateFormat}
 import java.util.Date
 
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -13,14 +12,13 @@ import com.twitter.io.Buf
 object Main extends App {
 
   val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
-  val dateFormat: DateFormat = new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss z")
 
   val helloWorld: Buf = Buf.Utf8("Hello, World!")
 
   val muxer: HttpMuxer = new HttpMuxer()
     .withHandler("/json", Service.mk { req: Request =>
       val rep = Response()
-      rep.content = Buf.Utf8(mapper.writeValueAsString(Map("message" -> "Hello, World!")))
+      rep.content = Buf.ByteArray.Owned(mapper.writeValueAsBytes(Map("message" -> "Hello, World!")))
       rep.contentType = "application/json"
 
       Future.value(rep)
@@ -34,13 +32,16 @@ object Main extends App {
     })
 
   val serverAndDate: SimpleFilter[Request, Response] = new SimpleFilter[Request, Response] {
-    def apply(req: Request, s: Service[Request, Response]): Future[Response] =
-      s(req).map { rep =>
-        rep.headerMap.set("Server", "Finagle")
-        rep.headerMap.set("Date", dateFormat.format(new Date()))
+
+    private[this] val addServerAndDate: Response => Response = { rep =>
+        rep.server = "Finagle"
+        rep.date = new Date()
 
         rep
-      }
+    }
+
+    def apply(req: Request, s: Service[Request, Response]): Future[Response] =
+      s(req).map(addServerAndDate)
   }
 
   Await.ready(Http.server


### PR DESCRIPTION
This PR updates Finagle to 6.36 and also makes some misc changes:

1. Make `DateTimeFormat` a thread-local since it's not thread-safe and it's not fair to share it
2. Use one-jar plugin to run the program instead of reusing the sbt's JVM instance

Please let me know if there anything I can do/change to make this PR make it to the Round 13.