### PR TITLE
add mongodb to travis services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,6 +212,7 @@ before_install:
 services:
   - postgresql
   - redis-server
+  - mongodb
 
 addons:
   postgresql: "9.3"


### PR DESCRIPTION
MongoDB was failing to start up on Travis, which was causing about 20 tests to fail that should otherwise be passing. This change should fix that.

I'd like to get this merged in ASAP, as it will make everyone's lives easier when trying to assess the influx of merge requests and determining what is a broken framework and what is just a Travis bug.

For comparison:
-  [results with mongodb line added to .travis.yml](https://travis-ci.org/knewmanTE/FrameworkBenchmarks/builds/154611017) (22 failing tests)
- [results currently on master with mongodb failing to start](https://travis-ci.org/TechEmpower/FrameworkBenchmarks/builds/154511835) (45 failing tests)