### PR TITLE
Fix broken Round 13 PHP tests (clancats, lumen, yii2, yii2-hhvm) 

### DIFF
--- a/frameworks/PHP/clancats/setup.sh
+++ b/frameworks/PHP/clancats/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sed -i 's|localhost|'"${DBHOST}"'|g' index.php
+sed -i 's|localhost|'"${DBHOST}"'|g' app/config/database.config.php
 sed -i 's|root /home/ubuntu/FrameworkBenchmarks|root '"${TROOT}"'|g' deploy/nginx.conf
 sed -i 's|/usr/local/nginx/|'"${IROOT}"'/nginx/|g' deploy/nginx.conf
 

--- a/frameworks/PHP/lumen/setup.sh
+++ b/frameworks/PHP/lumen/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sed -i 's|localhost|'"${DBHOST}"'|g' index.php
+sed -i 's|localhost|'"${DBHOST}"'|g' .env
 sed -i 's|root .*/FrameworkBenchmarks/lumen|root '"${TROOT}"'|g' deploy/nginx.conf
 sed -i 's|/usr/local/nginx/|'"${IROOT}"'/nginx/|g' deploy/nginx.conf
 

--- a/frameworks/PHP/yii2/app/index.php
+++ b/frameworks/PHP/yii2/app/index.php
@@ -14,7 +14,7 @@ $config = [
     'components' => [
         'db' => [
             'class' => 'yii\db\Connection',
-            'dsn' => 'mysql:host=127.0.0.1;dbname=hello_world',
+            'dsn' => 'mysql:host=localhost;dbname=hello_world',
             'username' => 'benchmarkdbuser',
             'password' => 'benchmarkdbpass',
             'charset' => 'utf8',


### PR DESCRIPTION
4 PHP tests (clancats, lumen, yii2, yii2-hhvm) were failing on the preview run. This is because we weren't properly setting the IP address for the database. Because local and Travis tests are only on 1 machine, this error won't show up and the test will pass fine, but as soon as we moved to one of our production setups where the database and application server are on separate machines, the tests failed.

Anyway, this fixes that.