### PR TITLE
Update Finatra to 2.3.0

### DIFF
--- a/frameworks/Scala/finatra/README.md
+++ b/frameworks/Scala/finatra/README.md
@@ -12,7 +12,7 @@
 The tests are run with:
 
 * [Java Oracle 1.8.0_25](http://www.oracle.com/technetwork/java/javase)
-* [finatra 2.1.6](https://github.com/twitter/finatra/tree/v2.1.6)
+* [finatra 2.3.0](https://github.com/twitter/finatra/tree/finatra-2.3.0)
 
 ## Test URLs
 ### JSON Encoding Test
@@ -26,4 +26,4 @@ http://localhost:8888/plaintext
 ## How to run
 sbt 'assembly'
 
-`java -jar target/scala-2.11/finatra-benchmark.jar -log.level=ERROR`
+`java -Dcom.twitter.util.events.sinkEnabled=false -Xmx2000M -Xms2000M -Xmn1750M -XX:MetaspaceSize=128M -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:TargetSurvivorRatio=90 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -XX:TargetSurvivorRatio=60 -jar target/scala-2.11/finatra-benchmark.jar -log.level=ERROR -http.response.charset.enabled=false`

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -12,10 +12,11 @@ resolvers ++= Seq(
 assemblyJarName in assembly := "finatra-benchmark.jar"
 assemblyMergeStrategy in assembly := {
   case "BUILD" => MergeStrategy.discard
+  case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.discard
   case other => MergeStrategy.defaultMergeStrategy(other)
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter.finatra" %% "finatra-http" % "2.1.6",
-  "org.slf4j" % "slf4j-nop" % "1.7.7"
+  "com.twitter" %% "finatra-http" % "2.3.0",
+  "org.slf4j" % "slf4j-nop" % "1.7.21"
 )

--- a/frameworks/Scala/finatra/setup.sh
+++ b/frameworks/Scala/finatra/setup.sh
@@ -4,4 +4,4 @@ fw_depends java sbt
 
 sbt clean assembly -batch
 
-java -jar target/scala-2.11/finatra-benchmark.jar -log.level=ERROR
+java -Dcom.twitter.util.events.sinkEnabled=false -Xmx2000M -Xms2000M -Xmn1750M -XX:MetaspaceSize=128M -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:TargetSurvivorRatio=90 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -XX:TargetSurvivorRatio=60 -jar target/scala-2.11/finatra-benchmark.jar -log.level=ERROR -http.response.charset.enabled=false

--- a/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
+++ b/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
@@ -1,18 +1,30 @@
 package benchmark
 
 import benchmark.controllers.Controller
+import com.twitter.finagle.Http
 import com.twitter.finagle.http.Request
+import com.twitter.finagle.stats.NullStatsReceiver
+import com.twitter.finagle.tracing.NullTracer
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.HttpResponseFilter
 import com.twitter.finatra.http.routing.HttpRouter
+import com.twitter.util.NullMonitor
 
 object ServerMain extends Server
 
 class Server extends HttpServer {
 
+  override protected def configureHttpServer(server: Http.Server): Http.Server = {
+    server
+      .withCompressionLevel(0)
+      .withStatsReceiver(NullStatsReceiver)
+      .withTracer(NullTracer)
+      .withMonitor(NullMonitor)
+  }
+
   override def configureHttp(router: HttpRouter): Unit = {
-	router
-		.filter[HttpResponseFilter[Request]]
-		.add[Controller]
+    router
+      .filter[HttpResponseFilter[Request]]
+      .add[Controller]
   }
 }

--- a/frameworks/Scala/finatra/src/main/scala/benchmark/controllers/Controller.scala
+++ b/frameworks/Scala/finatra/src/main/scala/benchmark/controllers/Controller.scala
@@ -4,11 +4,13 @@ import com.twitter.finagle.http.Request
 import com.twitter.finatra.http.{Controller => HttpController}
 
 class Controller extends HttpController {
+  private[this] val helloWorldText = "Hello, World!"
+
   get("/json") { request: Request =>
-    Map("message" -> "Hello, World!")
+    Map("message" -> helloWorldText)
   }
 
   get("/plaintext") { request: Request =>
-    "Hello, World!"
+    helloWorldText
   }
 }


### PR DESCRIPTION
This PR updates Finatra to 2.3.0 and also makes some minor changes:
- Set Finagle server defaults appropriately
- Set JVM args appropriately

Please let me know if there's anything else I need to do to get this into the current Round 13.

This is in place of #2210 cc @knewmanTE.

Thanks!