### PR TITLE
Disabled bulk reading for Revenj.

### DIFF
--- a/frameworks/Java/revenj/pom.xml
+++ b/frameworks/Java/revenj/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.revenj</groupId>
 			<artifactId>revenj-core</artifactId>
-			<version>0.9.7</version>
+			<version>0.9.9</version>
 		</dependency>
                 <dependency>
                         <groupId>org.apache.commons</groupId>
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>com.dslplatform</groupId>
 				<artifactId>dsl-platform-maven-plugin</artifactId>
-				<version>0.8</version>
+				<version>0.9</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>

--- a/frameworks/Java/revenj/src/main/java/hello/Context.java
+++ b/frameworks/Java/revenj/src/main/java/hello/Context.java
@@ -57,8 +57,9 @@ class Context {
 		return random.nextInt(10000) + 1;
 	}
 
+	/* bulk loading of worlds. use such pattern for production code */
 	@SuppressWarnings("unchecked")
-	public World[] loadWorlds(final int count) throws IOException {
+	public World[] loadWorldsFast(final int count) throws IOException {
 		bulkReader.reset();
 		for (int i = 0; i < count; i++) {
 			callables[i] = bulkReader.find(World.class, Integer.toString(getRandom10k()));
@@ -70,6 +71,15 @@ class Context {
 			}
 		} catch (Exception e) {
 			throw new IOException(e);
+		}
+		return buffer;
+	}
+
+	/* multiple roundtrips loading of worlds. don't write such production code */
+	@SuppressWarnings("unchecked")
+	public World[] loadWorldsSlow(final int count) throws IOException {
+		for (int i = 0; i < count; i++) {
+			buffer[i] = worlds.find(getRandom10k(), connection).get();
 		}
 		return buffer;
 	}

--- a/frameworks/Java/revenj/src/main/java/hello/QueriesServlet.java
+++ b/frameworks/Java/revenj/src/main/java/hello/QueriesServlet.java
@@ -15,7 +15,7 @@ public class QueriesServlet extends HttpServlet {
 		final int count = Utils.parseBoundParam(req);
 		final Context ctx = Utils.getContext();
 		final JsonWriter json = ctx.json;
-		final World[] worlds = ctx.loadWorlds(count);
+		final World[] worlds = ctx.loadWorldsSlow(count);
 		json.serialize(worlds, count);
 		json.toStream(res.getOutputStream());
 	}

--- a/frameworks/Java/revenj/src/main/java/hello/UpdatesServlet.java
+++ b/frameworks/Java/revenj/src/main/java/hello/UpdatesServlet.java
@@ -18,7 +18,7 @@ public class UpdatesServlet extends HttpServlet {
 		final int count = Utils.parseBoundParam(req);
 		final Context ctx = Utils.getContext();
 		final JsonWriter json = ctx.json;
-		final World[] worlds = ctx.loadWorlds(count);
+		final World[] worlds = ctx.loadWorldsSlow(count);
 		final ArrayList<World> changed = new ArrayList<>(count);
 		for (int i = 0; i < count; i++) {
 			changed.add(worlds[i].setRandomNumber(ctx.getRandom10k()));

--- a/toolset/setup/linux/languages/dsl_platform.sh
+++ b/toolset/setup/linux/languages/dsl_platform.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-RETCODE=$(fw_exists $IROOT/dsl-compiler.exe)
+RETCODE=$(fw_exists ${IROOT}/dsl-compiler-1.6.installed)
 [ ! "$RETCODE" == 0 ] || { \
   return 0; }
 
-wget -O $IROOT/dsl-compiler.zip https://github.com/ngs-doo/revenj/releases/download/1.3.1/dsl-compiler.zip
-unzip $IROOT/dsl-compiler.zip -d $IROOT
+wget -O $IROOT/dsl-compiler.zip https://github.com/ngs-doo/revenj/releases/download/1.4.0/dsl-compiler.zip
+unzip -o $IROOT/dsl-compiler.zip -d $IROOT
 rm $IROOT/dsl-compiler.zip
+
+echo "1.6" > $IROOT/dsl-compiler-1.6.installed


### PR DESCRIPTION
Use simple loop instead of bulk reading for loading data N times from database.
Update dsl-compiler to latest version (to fix update permission).
Update Revenj.Java to 0.9.9 due to API change and sync with latest compiler.