### PR TITLE
set the DB host for nodejs-postgres

### DIFF
--- a/frameworks/JavaScript/nodejs/setup.sh
+++ b/frameworks/JavaScript/nodejs/setup.sh
@@ -7,6 +7,7 @@ sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/mongoose.js
 sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/mysql-raw.js
 sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/redis.js
 sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/sequelize.js
+sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/sequelize-postgres.js
 
 npm install
 node app.js &


### PR DESCRIPTION
nodejs-postgres tests were failing because we weren't changing the database IP address from 127.0.0.1 to ${DBHOST}.