### PR TITLE
set the DB host for jooby

### DIFF
--- a/frameworks/Java/jooby/setup.sh
+++ b/frameworks/Java/jooby/setup.sh
@@ -2,6 +2,8 @@
 
 fw_depends java maven
 
+sed -i 's|localhost|'"${DBHOST}"'|g' conf/application.conf
+
 mvn clean package
 
 cd target


### PR DESCRIPTION
jooby tests were failing because we weren't changing the database IP address from localhost to ${DBHOST}.