### PR TITLE
Fix web2py compile and race condition bugs

### DIFF
--- a/frameworks/Python/web2py/README.md
+++ b/frameworks/Python/web2py/README.md
@@ -8,7 +8,7 @@ review the [documentation](http://frameworkbenchmarks.readthedocs.org/en/latest/
 Also note that there is additional information provided in
 the [Python README](../).
 
-There are two sets of web2py tests, "web2py-standard" (the default) and "web2py-optimized". The former set is implemented via standard web2py production code. The latter involves several special optimizations that would not be typical of a web2py application but could be implemented in cases were performance is critical.
+There are two sets of web2py tests, "web2py-standard" (the default) and "web2py-optimized". The former set is implemented via standard web2py production code. The latter involves several special optimizations that would not be typical of a web2py application but could be implemented in cases where performance is critical.
 
 ## Web Server and Database Client Software
 

--- a/frameworks/Python/web2py/app/standard/modules/controller.py
+++ b/frameworks/Python/web2py/app/standard/modules/controller.py
@@ -34,8 +34,6 @@ def updates():
     update_world = db.update_world
     r10k = partial(randint, 1, 10000)
     worlds = []
-    #ids = [r10k() for _ in xrange(num_queries)]
-    #ids.sort() # To avoid deadlock
     for wid in (r10k() for _ in xrange(num_queries(current.request.vars.queries))):
         world = get_world(wid)
         newNumber = r10k()

--- a/frameworks/Python/web2py/app/standard/modules/database.py
+++ b/frameworks/Python/web2py/app/standard/modules/database.py
@@ -16,6 +16,9 @@ class Dal(object):
             self.db.define_table('Fortune', Field('message'))
 
     def get_world(self, wid):
+        # Setting `cacheable=True` improves performance by foregoing the creation
+        # of some non-essential attributes. It does *not* actually cache the
+        # database results (it simply produces a Rows object that *could be* cached).
         return self.db(self.db.World.id == wid).select(cacheable=True)[0].as_dict()
 
     def update_world(self, wid, randomNumber):

--- a/frameworks/Python/web2py/setup.sh
+++ b/frameworks/Python/web2py/setup.sh
@@ -7,6 +7,9 @@ pip install --install-option="--prefix=${PY2_ROOT}" -r $TROOT/requirements.txt
 rm -fr web2py
 git clone --recursive --branch master https://github.com/web2py/web2py.git
 cd web2py
+# The following commit is checked out in order to take advantage of a particular
+# bug fix that was made after the latest stable release. This can be changed
+# in future rounds once a new stable release has been made.
 git checkout 326335c3cd027a97b9c2b83d880b2b1f8f62321d
 cd ..
 cp -r app/standard/ web2py/applications/
@@ -14,6 +17,6 @@ cp -r app/optimized/ web2py/applications/
 cp app/wsgi.py web2py/
 cp app/routes.py web2py/
 touch web2py/__init__.py
-python compile_apps.py
+$PY2_ROOT/bin/python compile_apps.py
 
 gunicorn web2py.wsgi:application -c gunicorn_conf.py &

--- a/frameworks/Python/web2py/setup.sh
+++ b/frameworks/Python/web2py/setup.sh
@@ -17,6 +17,6 @@ cp -r app/optimized/ web2py/applications/
 cp app/wsgi.py web2py/
 cp app/routes.py web2py/
 touch web2py/__init__.py
-$PY2_ROOT/bin/python compile_apps.py
+python compile_apps.py
 
 gunicorn web2py.wsgi:application -c gunicorn_conf.py &

--- a/frameworks/Python/web2py/setup.sh
+++ b/frameworks/Python/web2py/setup.sh
@@ -7,10 +7,10 @@ pip install --install-option="--prefix=${PY2_ROOT}" -r $TROOT/requirements.txt
 rm -fr web2py
 git clone --recursive --branch master https://github.com/web2py/web2py.git
 cd web2py
-# The following commit is checked out in order to take advantage of a particular
-# bug fix that was made after the latest stable release. This can be changed
+# The following commit is checked out in order to take advantage of several
+# bug fixes that were made after the latest stable release. This can be changed
 # in future rounds once a new stable release has been made.
-git checkout 326335c3cd027a97b9c2b83d880b2b1f8f62321d
+git checkout 44362aa42948dca08ddf1b2f86ac03c69b0d48e4
 cd ..
 cp -r app/standard/ web2py/applications/
 cp -r app/optimized/ web2py/applications/


### PR DESCRIPTION
Ensure web2py applications are compiled with the same version of Python used to execute the tests. Also, update web2py to a more recent commit from "master" in order to take advantage of a fix for a possible framework-level race condition (which occurred once during a test run of the benchmarks).

Also includes some clarifying comments in the code.
