### PR TITLE
Lowercase postgres db names

### DIFF
--- a/frameworks/JavaScript/hapi/handlers/sequelize-postgres.js
+++ b/frameworks/JavaScript/hapi/handlers/sequelize-postgres.js
@@ -16,7 +16,8 @@ var Worlds = sequelize.define('World', {
   randomnumber: { type: 'Sequelize.INTEGER' }
 }, {
   timestamps: false,
-  freezeTableName: true
+  freezeTableName: true,
+  tableName: 'world'
 });
 
 var Fortunes = sequelize.define('Fortune', {
@@ -24,7 +25,8 @@ var Fortunes = sequelize.define('Fortune', {
   message:      { type: 'Sequelize.STRING' }
 }, {
   timestamps: false,
-  freezeTableName: true
+  freezeTableName: true,
+  tableName: 'fortune'
 });
 
 var randomWorldPromise = function() {
@@ -74,7 +76,7 @@ module.exports = {
         .header('Server', 'hapi');
     }).catch(function (err) {
       process.exit(1);
-    }); 
+    });
   },
 
   Updates: function (req, reply) {

--- a/frameworks/JavaScript/nodejs/handlers/sequelize-postgres.js
+++ b/frameworks/JavaScript/nodejs/handlers/sequelize-postgres.js
@@ -13,7 +13,8 @@ var Worlds = sequelize.define('World', {
   randomnumber: { type: 'Sequelize.INTEGER' }
 }, {
   timestamps: false,
-  freezeTableName: true
+  freezeTableName: true,
+  tableName: 'world'
 });
 
 var Fortunes = sequelize.define('Fortune', {
@@ -21,7 +22,8 @@ var Fortunes = sequelize.define('Fortune', {
   message: { type: 'Sequelize.STRING' }
 }, {
   timestamps: false,
-  freezeTableName: true
+  freezeTableName: true,
+  tableName: 'fortune'
 });
 
 var randomWorldPromise = function() {
@@ -48,7 +50,7 @@ module.exports = {
 
     for (var i = 0; i < queries; i++) {
       worldPromises.push(randomWorldPromise());
-    } 
+    }
 
     Promise.all(worldPromises).then(function (worlds) {
       h.addTfbHeaders(res, 'json');

--- a/frameworks/Python/pyramid/frameworkbenchmarks/models.py
+++ b/frameworks/Python/pyramid/frameworkbenchmarks/models.py
@@ -49,7 +49,7 @@ class SQLAlchemyEncoder(json.JSONEncoder):
 
 
 class World(DatabaseBase):
-    __tablename__ = 'World'
+    __tablename__ = 'world'
 
     id = Column('id', Integer, primary_key=True)
     randomNumber = Column('randomnumber', Integer, nullable=False, server_default='0')
@@ -59,7 +59,7 @@ class World(DatabaseBase):
 
 
 class Fortune(DatabaseBase):
-    __tablename__ = 'Fortune'
+    __tablename__ = 'fortune'
 
     id = Column('id', Integer, primary_key=True)
     message = Column('message', String, nullable=False)


### PR DESCRIPTION
A couple frameworks (Javascript/hapi and Python/pyramid) were failing on their Postgres Fortune tests because the uppercase `Fortune` table has been removed in favor of exclusively using the lowercase `fortune` table. This PR should fix that problem.