### PR TITLE
45216 continuousbenchmarking nuketmp 20161006 5

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -650,6 +650,19 @@ class Benchmarker:
         time.sleep(5)
 
         ##########################################################
+        # Remove contents of  /tmp folder
+        ##########################################################
+        try:
+          filelist = [ f for f in os.listdir("/tmp") ]
+	  for f in filelist:
+            try:
+	      os.remove("/tmp/" + f)
+            except OSError as err:
+              print "Failed to remove " + str(f) + " from /tmp directory: " + str(err)
+        except OSError:
+          print "Failed to remove contents of /tmp directory."
+
+        ##########################################################
         # Save results thus far into the latest results directory
         ##########################################################
 

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -652,15 +652,16 @@ class Benchmarker:
         ##########################################################
         # Remove contents of  /tmp folder
         ##########################################################
-        try:
-          filelist = [ f for f in os.listdir("/tmp") ]
-	  for f in filelist:
-            try:
-	      os.remove("/tmp/" + f)
-            except OSError as err:
-              print "Failed to remove " + str(f) + " from /tmp directory: " + str(err)
-        except OSError:
-          print "Failed to remove contents of /tmp directory."
+        if self.clear_tmp:
+          try:
+            filelist = [ f for f in os.listdir("/tmp") ]
+            for f in filelist:
+              try:
+                os.remove("/tmp/" + f)
+              except OSError as err:
+                print "Failed to remove " + str(f) + " from /tmp directory: " + str(err)
+          except OSError:
+            print "Failed to remove contents of /tmp directory."
 
         ##########################################################
         # Save results thus far into the latest results directory

--- a/toolset/run-continuously.sh
+++ b/toolset/run-continuously.sh
@@ -44,7 +44,7 @@ do
   echo Change to benchmark root
   cd $TFB_REPOPARENT/$TFB_REPONAME
   echo Run tests
-  toolset/run-tests.py --clear-tmp --test undertow
+  toolset/run-tests.py --clear-tmp
   # Handle any postprocessing
   echo Running post-test tasks
   for SCRIPT in $TFB_REPOPARENT/$TFB_REPONAME/toolset/lifecycle/post-run-tests/*

--- a/toolset/run-continuously.sh
+++ b/toolset/run-continuously.sh
@@ -44,7 +44,7 @@ do
   echo Change to benchmark root
   cd $TFB_REPOPARENT/$TFB_REPONAME
   echo Run tests
-  toolset/run-tests.py --mode verify --test undertow
+  toolset/run-tests.py
   # Handle any postprocessing
   echo Running post-test tasks
   for SCRIPT in $TFB_REPOPARENT/$TFB_REPONAME/toolset/lifecycle/post-run-tests/*

--- a/toolset/run-continuously.sh
+++ b/toolset/run-continuously.sh
@@ -44,7 +44,7 @@ do
   echo Change to benchmark root
   cd $TFB_REPOPARENT/$TFB_REPONAME
   echo Run tests
-  toolset/run-tests.py --test undertow
+  toolset/run-tests.py
   # Handle any postprocessing
   echo Running post-test tasks
   for SCRIPT in $TFB_REPOPARENT/$TFB_REPONAME/toolset/lifecycle/post-run-tests/*

--- a/toolset/run-continuously.sh
+++ b/toolset/run-continuously.sh
@@ -44,7 +44,7 @@ do
   echo Change to benchmark root
   cd $TFB_REPOPARENT/$TFB_REPONAME
   echo Run tests
-  toolset/run-tests.py
+  toolset/run-tests.py --test undertow
   # Handle any postprocessing
   echo Running post-test tasks
   for SCRIPT in $TFB_REPOPARENT/$TFB_REPONAME/toolset/lifecycle/post-run-tests/*

--- a/toolset/run-continuously.sh
+++ b/toolset/run-continuously.sh
@@ -44,7 +44,7 @@ do
   echo Change to benchmark root
   cd $TFB_REPOPARENT/$TFB_REPONAME
   echo Run tests
-  toolset/run-tests.py
+  toolset/run-tests.py --clear-tmp --test undertow
   # Handle any postprocessing
   echo Running post-test tasks
   for SCRIPT in $TFB_REPOPARENT/$TFB_REPONAME/toolset/lifecycle/post-run-tests/*

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -170,7 +170,7 @@ def main(argv=None):
     # Misc Options
     parser.add_argument('--parse', help='Parses the results of the given timestamp and merges that with the latest results')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Causes the configuration to print before any other commands are executed.')
-    parser.add_argument('--clear-tmp', action='store_true' default=False, help='Clears files written to /tmp after each framework\'s tests complete.')
+    parser.add_argument('--clear-tmp', action='store_true', default=False, help='Clears files written to /tmp after each framework\'s tests complete.')
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -170,7 +170,7 @@ def main(argv=None):
     # Misc Options
     parser.add_argument('--parse', help='Parses the results of the given timestamp and merges that with the latest results')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Causes the configuration to print before any other commands are executed.')
-    parser.add_argument('--clear-tmp', help='Clears files written to /tmp after each framework\'s tests complete.')
+    parser.add_argument('--clear-tmp', action='store_true' default=False, help='Clears files written to /tmp after each framework\'s tests complete.')
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -170,6 +170,7 @@ def main(argv=None):
     # Misc Options
     parser.add_argument('--parse', help='Parses the results of the given timestamp and merges that with the latest results')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Causes the configuration to print before any other commands are executed.')
+    parser.add_argument('--clear-tmp', help='Clears files written to /tmp after each framework\'s tests complete.')
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 


### PR DESCRIPTION
As it stands currently, many frameworks are writing to /tmp. So many, in fact, that in our testing environment the pool of inodes are exhausted which causes tests needing to write anything to fail. This commit introduces work to remove files that are generated by a test after that test is done. Note: there is no attempt to remove all files from /tmp (i.e. sudo is not used, nor is the search recursive).
