### PR TITLE
Remove claim vagrant from apt-get is too old

### DIFF
--- a/deployment/vagrant-aws/README.md
+++ b/deployment/vagrant-aws/README.md
@@ -17,8 +17,7 @@ production setup costs about TODO.
 
 ## Prerequisites
 
-* **A recent version of Vagrant**, like 1.6.3 (NOTE: `apt-get` is 
-too old, download the newest `deb` directly). See 
+* **A recent version of Vagrant**, like 1.6.3. See 
 [here](https://www.vagrantup.com/downloads.html) for downloads
 
 * **Vagrant AWS Plugin** from [here](https://github.com/mitchellh/vagrant-aws)


### PR DESCRIPTION
On recent versions of Ubuntu (Xenial, Yakkety) and Debian (Testing, Unstable) vagrant 1.8.x is available which AFAICT should be fine
