### PR TITLE
Fix creating AWS environment from scratch

### DIFF
--- a/deployment/vagrant-aws/setup_aws.py
+++ b/deployment/vagrant-aws/setup_aws.py
@@ -101,8 +101,12 @@ def run_aws(command, prefix=True, load=True):
   log.debug("Request : %s", command)
   result = subprocess.check_output(command, shell=True)
   log.debug("Response: %s", result)
-  if load:
-    return json.loads(result)
+  if load and result != '':
+    try:
+      return json.loads(result)
+    except ValueError:
+      log.error("Could not parse result '%s' as JSON for command '%s'", result, command)
+      raise
   else:
     return result
 


### PR DESCRIPTION
modify-vpc-attribute does not produce any output, which caused a problem when
trying to parse an empty string as JSON.

Added some more error handling/reporting, as well as just returning an empty
result in that particular case.
