### PR TITLE
45216 FIX: False (not false) is the correct python keyword.

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -115,7 +115,7 @@ class Benchmarker:
     ##########################
     # Generate metadata
     ##########################
-    self.run_list_test_metadata(false)
+    self.run_list_test_metadata(False)
     ##########################
     # Get a list of all known
     # tests that we can run.


### PR DESCRIPTION
Minor correction - False is the proper python keyword for a false value.

