### PR TITLE
Fix Nginx as the front end tests by putting uwsgi socket in /var/tmp …

### DIFF
--- a/frameworks/C++/cutelyst/config/config_socket.ini
+++ b/frameworks/C++/cutelyst/config/config_socket.ini
@@ -3,9 +3,10 @@ master
 ; Increase listen queue used for nginx connecting to uWSGI. This matches
 ; net.ipv4.tcp_max_syn_backlog and net.core.somaxconn.
 ; for performance
+listen = 65535
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance
-socket = /tmp/uwsgi.sock
+socket = /var/tmp/uwsgi.sock
 ; allow nginx to access the UNIX socket
 chmod-socket = 666
 ; Avoid thundering herd problem http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html .

--- a/frameworks/C++/cutelyst/nginx.conf
+++ b/frameworks/C++/cutelyst/nginx.conf
@@ -41,7 +41,7 @@ http {
         server_name  localhost;
 
         location / {
-            uwsgi_pass unix:/tmp/uwsgi.sock;
+            uwsgi_pass unix:/var/tmp/uwsgi.sock;
             include /usr/local/nginx/conf/uwsgi_params;
         }
     }

--- a/frameworks/C++/cutelyst/setup.sh
+++ b/frameworks/C++/cutelyst/setup.sh
@@ -8,14 +8,12 @@ sed -i 's|SendDate=.*|SendDate=false|g' config/config.ini
 cd $IROOT
 mkdir cutelyst-benchmarks || true
 cd cutelyst-benchmarks
-rm -rf *
 
 QT_VERSION_MM=56
 export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM}:${IROOT}
 
 cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT
 
-make clean
 make -j $MAX_THREADS
 
 export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${IROOT}/lib/x86_64-linux-gnu/

--- a/frameworks/C++/cutelyst/setup_thread.sh
+++ b/frameworks/C++/cutelyst/setup_thread.sh
@@ -19,4 +19,4 @@ make -j $MAX_THREADS
 export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${IROOT}/lib/x86_64-linux-gnu/
 export CUTELYST_CONFIG=${TROOT}/config/config.ini
 
-${IROOT}/bin/cutelyst-wsgi --http-socket :8080 -a ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so -t $MAX_THREADS &
+${IROOT}/bin/cutelyst-wsgi --master --http-socket :8080 -a ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so -t $MAX_THREADS &

--- a/frameworks/C++/cutelyst/setup_thread.sh
+++ b/frameworks/C++/cutelyst/setup_thread.sh
@@ -8,14 +8,12 @@ sed -i 's|SendDate=.*|SendDate=false|g' config/config.ini
 cd $IROOT
 mkdir cutelyst-benchmarks || true
 cd cutelyst-benchmarks
-rm -rf *
 
 QT_VERSION_MM=56
 export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM}:${IROOT}
 
 cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT
 
-make clean
 make -j $MAX_THREADS
 
 export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${IROOT}/lib/x86_64-linux-gnu/

--- a/frameworks/C++/cutelyst/setup_uwsgi_nginx.sh
+++ b/frameworks/C++/cutelyst/setup_uwsgi_nginx.sh
@@ -9,14 +9,12 @@ sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_par
 cd $IROOT
 mkdir cutelyst-benchmarks || true
 cd cutelyst-benchmarks
-rm -rf *
 
 QT_VERSION_MM=56
 export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM}:${IROOT}
 
 cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT
 
-make clean
 make -j $MAX_THREADS
 
 nginx -c $TROOT/nginx.conf


### PR DESCRIPTION
Most (maybe all) frameworks using Nginx and uwsgi are failing due /tmp being privately visible to uwsgi, the "proper" fix would be to put it in /run but it isn't writable by testuser so I'm putting it in /vat/tmp
bottle and flask are two I saw that need this kind of fix