### PR TITLE
Fix Elixir for round 13.

### DIFF
--- a/toolset/setup/linux/languages/elixir.sh
+++ b/toolset/setup/linux/languages/elixir.sh
@@ -8,9 +8,9 @@ RETCODE=$(fw_exists ${IROOT}/elixir.installed)
   return 0; }
 
 ELIXIR_HOME=$IROOT/elixir
-VERSION="1.3.2-1"
+VERSION="1.3.3-1"
 RELEASE="trusty"
-ARCH="amd64"
+ARCH="all"
 
 fw_get -O http://packages.erlang-solutions.com/debian/pool/elixir_${VERSION}~ubuntu~${RELEASE}_${ARCH}.deb
 dpkg -x elixir_${VERSION}~ubuntu~${RELEASE}_${ARCH}.deb $IROOT/elixir


### PR DESCRIPTION
At the moment the Phoenix test is failing with the following error:

> Setup phoenix: dpkg-deb: error: `elixir_1.3.2-1\~ubuntu\~trusty_amd64.deb' is not a debian format archive

I believe that's because it depends on elixir_**1.3.2-1**\~ubuntu\~trusty_**amd64**.deb (version 1.3.2-1, arch amd64) being available at http://packages.erlang-solutions.com/debian/pool/. This change updates it to use elixir_**1.3.3-1**\~ubuntu\~trusty_**all**.deb (version 1.3.3-1, arch all).