### PR TITLE
Upgrade CPython + PyPy2 and add PyPy3

### DIFF
--- a/toolset/setup/linux/languages/pypy.sh
+++ b/toolset/setup/linux/languages/pypy.sh
@@ -6,11 +6,11 @@ RETCODE=$(fw_exists ${IROOT}/pypy.installed)
   return 0; }
   
 PYPY_ROOT=$IROOT/pypy
-PYPY_VERSION=5.0.1
+PYPY_VERSION=5.4.1
 
-fw_get -o pypy-${PYPY_VERSION}-linux64.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy-${PYPY_VERSION}-linux64.tar.bz2
-fw_untar pypy-${PYPY_VERSION}-linux64.tar.bz2
-mv pypy-${PYPY_VERSION}-linux64 pypy
+fw_get -o pypy2-v${PYPY_VERSION}-linux64.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy2-v${PYPY_VERSION}-linux64.tar.bz2
+fw_untar pypy2-v${PYPY_VERSION}-linux64.tar.bz2
+mv pypy2-v${PYPY_VERSION}-linux64 pypy
 
 $PYPY_ROOT/bin/pypy -m ensurepip
 $PYPY_ROOT/bin/pip install -U pip setuptools wheel

--- a/toolset/setup/linux/languages/pypy3.sh
+++ b/toolset/setup/linux/languages/pypy3.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+RETCODE=$(fw_exists ${IROOT}/pypy3.installed)
+[ ! "$RETCODE" == 0 ] || { \
+  source $IROOT/pypy3.installed
+  return 0; }
+  
+PYPY3_ROOT=$IROOT/pypy3
+PYPY3_VERSION=5.5.0-alpha
+
+fw_get -o pypy3-v${PYPY_VERSION}-linux64.tar.bz2 https://bitbucket.org/pypy/pypy/downloads/pypy3-v${PYPY_VERSION}-linux64.tar.bz2
+fw_untar pypy3-v${PYPY_VERSION}-linux64.tar.bz2
+mv pypy3-v${PYPY_VERSION}-linux64 pypy3
+
+$PYPY_ROOT/bin/pypy3 -m ensurepip
+$PYPY_ROOT/bin/pip install -U pip setuptools wheel
+
+echo "export PYPY3_ROOT=${PYPY3_ROOT}" > $IROOT/pypy3.installed
+echo "export PYTHONHOME=${PYPY3_ROOT}" >> $IROOT/pypy3.installed
+echo -e "export PATH=${PYPY3_ROOT}/bin:\$PATH" >> $IROOT/pypy3.installed
+  
+source $IROOT/pypy3.installed

--- a/toolset/setup/linux/languages/python3.sh
+++ b/toolset/setup/linux/languages/python3.sh
@@ -6,7 +6,7 @@ RETCODE=$(fw_exists ${IROOT}/py3.installed)
   return 0; }
   
 PY3_ROOT=$IROOT/py3
-PY3_VERSION=3.5.1
+PY3_VERSION=3.5.2
 
 fw_get -O http://www.python.org/ftp/python/${PY3_VERSION}/Python-${PY3_VERSION}.tar.xz
 fw_untar Python-${PY3_VERSION}.tar.xz


### PR DESCRIPTION
Hi,

This PR upgrades CPython + PyPy2 and add PyPy3, because PyPy3 becomes useable to launch benchmarks.

Have a nice day.