### PR TITLE
Fix cutelyst threaded tests

### DIFF
--- a/frameworks/C++/cutelyst/setup_thread.sh
+++ b/frameworks/C++/cutelyst/setup_thread.sh
@@ -17,6 +17,5 @@ cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT
 make -j $MAX_THREADS
 
 export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${IROOT}/lib/x86_64-linux-gnu/
-export CUTELYST_CONFIG=${TROOT}/config/config.ini
 
-${IROOT}/bin/cutelyst-wsgi --master --http-socket :8080 -a ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so -t $MAX_THREADS &
+${IROOT}/bin/cutelyst-wsgi --ini ${TROOT}/config/config.ini --http-socket :8080 -a ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so -t $MAX_THREADS &

--- a/toolset/setup/linux/frameworks/cutelyst.sh
+++ b/toolset/setup/linux/frameworks/cutelyst.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CUTELYST_VER=0.13.3
+CUTELYST_VER=r1.0.0
 RETCODE=$(fw_exists ${IROOT}/cutelyst.installed)
 [ ! "$RETCODE" == 0 ] || { \
   source $IROOT/cutelyst.installed
@@ -18,10 +18,10 @@ sudo apt-get install -qqy clearsilver-dev
 sudo apt-get install -qqy qt${QT_VERSION_MM}base qt${QT_VERSION_MM}script qt${QT_VERSION_MM}tools
 export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM};
 
-fw_get -O https://github.com/cutelyst/cutelyst/archive/r$CUTELYST_VER.tar.gz
-fw_untar r$CUTELYST_VER.tar.gz
+fw_get -O https://github.com/cutelyst/cutelyst/archive/$CUTELYST_VER.tar.gz
+fw_untar $CUTELYST_VER.tar.gz
 
-cd cutelyst-r$CUTELYST_VER
+cd cutelyst-$CUTELYST_VER
 mkdir build && cd build
 
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT


### PR DESCRIPTION
The preview runs raised a segfault when running
cutelyst in threaded mode, an unsafe use of atribution
of a static object, the fix got included in the 1.0.0 release