### PR TITLE
python: Use /var/tmp instead of /tmp for unix socket.

### DIFF
--- a/frameworks/Python/bottle/nginx.conf
+++ b/frameworks/Python/bottle/nginx.conf
@@ -41,7 +41,7 @@ http {
         server_name  localhost;
 
         location / {
-            uwsgi_pass unix:/tmp/uwsgi.sock;
+            uwsgi_pass unix:/var/tmp/uwsgi.sock;
             include /usr/local/nginx/conf/uwsgi_params;
         }
     }

--- a/frameworks/Python/bottle/uwsgi.ini
+++ b/frameworks/Python/bottle/uwsgi.ini
@@ -6,7 +6,7 @@ listen = 16384
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance
-socket = /tmp/uwsgi.sock
+socket = /var/tmp/uwsgi.sock
 ; allow nginx to access the UNIX socket
 chmod-socket = 666
 ; Avoid thundering herd problem http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html .
@@ -16,4 +16,4 @@ chmod-socket = 666
 ; disabling this caused bottle to get ~13% faster.
 ;thunder-lock
 ; used by uwsgi_stop.ini
-pidfile = /tmp/uwsgi.pid
+pidfile = /var/tmp/uwsgi.pid

--- a/frameworks/Python/flask/nginx.conf
+++ b/frameworks/Python/flask/nginx.conf
@@ -41,7 +41,7 @@ http {
         server_name  localhost;
 
         location / {
-            uwsgi_pass unix:/tmp/uwsgi.sock;
+            uwsgi_pass unix:/var/tmp/uwsgi.sock;
             include /usr/local/nginx/conf/uwsgi_params;
         }
     }

--- a/frameworks/Python/flask/uwsgi.ini
+++ b/frameworks/Python/flask/uwsgi.ini
@@ -6,7 +6,7 @@ listen = 16384
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance
-socket = /tmp/uwsgi.sock
+socket = /var/tmp/uwsgi.sock
 ; allow nginx to access the UNIX socket
 chmod-socket = 666
 ; Avoid thundering herd problem http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html .
@@ -16,4 +16,4 @@ chmod-socket = 666
 ; disabling this caused bottle to get ~13% faster.
 ;thunder-lock
 ; used by uwsgi_stop.ini
-pidfile = /tmp/uwsgi.pid
+pidfile = /var/tmp/uwsgi.pid

--- a/frameworks/Python/uwsgi/nginx.conf
+++ b/frameworks/Python/uwsgi/nginx.conf
@@ -41,7 +41,7 @@ http {
         server_name  localhost;
 
         location / {
-            uwsgi_pass unix:/tmp/uwsgi.sock;
+            uwsgi_pass unix:/var/tmp/uwsgi.sock;
             include /usr/local/nginx/conf/uwsgi_params;
         }
     }

--- a/frameworks/Python/uwsgi/uwsgi.ini
+++ b/frameworks/Python/uwsgi/uwsgi.ini
@@ -6,7 +6,7 @@ listen = 16384
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance
-socket = /tmp/uwsgi.sock
+socket = /var/tmp/uwsgi.sock
 ; allow nginx to access the UNIX socket
 chmod-socket = 666
 ; Avoid thundering herd problem http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html .
@@ -16,4 +16,4 @@ chmod-socket = 666
 ; disabling this caused bottle to get ~13% faster.
 ;thunder-lock
 ; used by uwsgi_stop.ini
-pidfile = /tmp/uwsgi.pid
+pidfile = /var/tmp/uwsgi.pid


### PR DESCRIPTION
ref #2332 