### PR TITLE
Clean up Phoenix configuration

### DIFF
--- a/frameworks/Elixir/phoenix/config/locales/en.exs
+++ b/frameworks/Elixir/phoenix/config/locales/en.exs
@@ -1,3 +1,0 @@
-[
-  hello: "Hello"
-]

--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -12,7 +12,7 @@ config :hello, Hello.Repo,
   password: "benchmarkdbpass",
   database: "hello_world",
   hostname: "localhost",
-  pool_size: 256
+  pool_size: 20
 
 # ## SSL Support
 #
@@ -29,18 +29,3 @@ config :hello, Hello.Repo,
 # disk for the key and cert.
 
 config :logger, level: :error
-
-# ## Using releases
-#
-# If you are doing OTP releases, you need to instruct Phoenix
-# to start the server for all endpoints:
-#
-#    config :phoenix, :serve_endpoints, true
-#
-# Alternatively, you can configure exactly which server to
-# start per endpoint:
-#
-#     config :hello, Hello.Endpoint, server: true
-#
-
-import_config "prod.secret.exs"

--- a/frameworks/Elixir/phoenix/config/prod.secret.exs
+++ b/frameworks/Elixir/phoenix/config/prod.secret.exs
@@ -1,7 +1,0 @@
-use Mix.Config
-
-# In this file, we keep production configuration that
-# you likely want to automate and keep it away from
-# your version control system.
-config :hello, Hello.Endpoint,
-  secret_key_base: "Z18ZjzZslFpKd8HB41IljqMavPiOKVF9y1DIQ+S2Ytg7Op0EIauwJgd7mtRStssx"

--- a/frameworks/Elixir/phoenix/setup.sh
+++ b/frameworks/Elixir/phoenix/setup.sh
@@ -12,4 +12,4 @@ mix local.rebar --force
 mix deps.get --force --only prod
 mix compile --force
 
-elixir --erl "+K true" --detached  -pa _build/prod/consolidated -S mix phoenix.server
+elixir --erl "+K true" --detached -S mix phoenix.server


### PR DESCRIPTION
We also change the pool size from 256 to 20. A high pool size does not actually improve things because we can't warm up connections, reuse caches, etc.