### PR TITLE
Attempting to fix Java installation in Travis-CI

### DIFF
--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -10,7 +10,7 @@ RETCODE=$(fw_exists java.installed)
 sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt-get update
 echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-sudo apt-get install -y oracle-java8-installer
+sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y oracle-java8-installer
 
 # Setup environment variables
 JAVA_HOME=/usr/lib/jvm/java-8-oracle


### PR DESCRIPTION
In Travis-CI, the Java installation was hanging on waiting for user input; this **should** avoid that problem.