### PR TITLE
Disable kernel polling

### DIFF
--- a/frameworks/Elixir/phoenix/setup.sh
+++ b/frameworks/Elixir/phoenix/setup.sh
@@ -12,4 +12,4 @@ mix local.rebar --force
 mix deps.get --force --only prod
 mix compile --force
 
-elixir --erl "+K true" --detached -S mix phoenix.server
+elixir --detached -S mix phoenix.server


### PR DESCRIPTION
Because the pollset is single core, on benchmarks that are mostly
waiting on the pollset (almost no CPU work), it may reduce throughput.

Therefore we are disabling the pollset and see how it will affect
future results.