### PR TITLE
fix crystal entry in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
     - "TESTDIR=Clojure/luminus"
     - "TESTDIR=Clojure/pedestal"
     - "TESTDIR=Clojure/aleph"
-    - "TESTDIR=Crystal/crystal-raw"
+    - "TESTDIR=Crystal/crystal"
     - "TESTDIR=Crystal/kemal"
     - "TESTDIR=D/vibed"
     - "TESTDIR=Dart/dart-raw"


### PR DESCRIPTION
travis.yml had `crystal-raw` but the test directory is now just `crystal`