### PR TITLE
Update grizzly and jackson versions, change compiling to Java 8 bytecode

### DIFF
--- a/frameworks/Java/grizzly-bm/pom.xml
+++ b/frameworks/Java/grizzly-bm/pom.xml
@@ -29,8 +29,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <optimize>true</optimize>
                     <debug>false</debug>
                 </configuration>
@@ -68,13 +68,13 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
-            <version>2.3.11</version>
+            <version>2.3.28</version>
             <!--<version>3.0-SNAPSHOT</version>-->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.0</version>
+            <version>2.8.5</version>
         </dependency>
     </dependencies>
     <!-- <repositories>

--- a/frameworks/Java/grizzly-jersey/pom.xml
+++ b/frameworks/Java/grizzly-jersey/pom.xml
@@ -14,10 +14,10 @@
   </prerequisites>
 
   <properties>
-    <grizzly.version>2.3.23</grizzly.version>
+    <grizzly.version>2.3.28</grizzly.version>
     <jersey.version>1.19</jersey.version>
     <jersey-mustache.version>1.0.0</jersey-mustache.version>
-    <jackson.version>2.7.0</jackson.version>
+    <jackson.version>2.8.5</jackson.version>
     <mustache.version>0.9.1</mustache.version>
     <hibernate.version>4.3.11.Final</hibernate.version>
     <mysql-connector.version>5.1.38</mysql-connector.version>
@@ -103,8 +103,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <optimize>true</optimize>
           <debug>false</debug>
         </configuration>


### PR DESCRIPTION
Fixes #2377
Please note that the current implementation of `grizzly-jersey` for `Plaintext` is **unstable** - i.e. the log is flooded with `Connection reset` and `Broken pipe` exceptions under higher request count. The result of Round 13 on physical hardware seems to be affected too: https://www.techempower.com/benchmarks/#section=data-r13&hw=ph&test=plaintext&l=4fti0v&p=zik0zb-zik0zj-13bwfz&f=3c3l-70u8-0-mha9-hra0hs-0-0