### PR TITLE
Update resin to 4.0.48

### DIFF
--- a/toolset/setup/linux/webservers/resin.sh
+++ b/toolset/setup/linux/webservers/resin.sh
@@ -7,7 +7,7 @@ RETCODE=$(fw_exists ${IROOT}/resin.installed)
   source $IROOT/resin.installed
   return 0; }
 
-RVER=4.0.41
+RVER=4.0.48
 RESIN=resin-$RVER
 RESIN_HOME=$IROOT/$RESIN
 


### PR DESCRIPTION
The current version [4.0.41](http://www.caucho.com/resin-4.0/changes/changes.xtp) is quite old. My local tests show some small improvement in performance.