### PR TITLE
Round-14 (Fintrospect): Fix interpretation of empty "queries" parameter in db tests

### DIFF
--- a/frameworks/Scala/fintrospect/src/main/scala/DatabaseRoutes.scala
+++ b/frameworks/Scala/fintrospect/src/main/scala/DatabaseRoutes.scala
@@ -10,12 +10,12 @@ import io.fintrospect.RouteSpec.RequestValidation.none
 import io.fintrospect.formats.Json4sJackson.JsonFormat.{array, number, obj}
 import io.fintrospect.formats.Json4sJackson.ResponseBuilder.implicits._
 import io.fintrospect.parameters.ParameterSpec.int
-import io.fintrospect.parameters.Query
+import io.fintrospect.parameters.{ParameterSpec, Query}
 import io.fintrospect.{RouteSpec, ServerRoutes}
 import org.json4s.JValue
 
 import scala.language.reflectiveCalls
-import scala.util.Random
+import scala.util.{Random, Try}
 
 object DatabaseRoutes {
 
@@ -41,7 +41,9 @@ object DatabaseRoutes {
         .map(_.map(Ok(_)).getOrElse(NotFound()).build())
     }
 
-    val numberOfQueries = Query.optional(int("queries").map(_.max(1).min(500)))
+    val numberOfQueries = Query.optional(ParameterSpec.string("queries").map {
+      i => Try(i.toInt).getOrElse(1).max(1).min(500)
+    })
 
     val multipleRoute = RouteSpec()
       .taking(numberOfQueries)

--- a/frameworks/Scala/fintrospect/src/main/scala/FintrospectBenchmarkServer.scala
+++ b/frameworks/Scala/fintrospect/src/main/scala/FintrospectBenchmarkServer.scala
@@ -15,7 +15,7 @@ import scala.util.Properties
 
 object FintrospectBenchmarkServer extends App {
 
-  val dateFormat = getInstance("EEE, dd MMM yyyy HH:mm:ss 'GMT'", getTimeZone("GMT"))
+  val dateFormat = getInstance("EEE, d MMM yyyy HH:mm:ss 'GMT'", getTimeZone("GMT"))
 
   val addServerAndDate = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
     svc(req).map(resp => {
@@ -28,7 +28,7 @@ object FintrospectBenchmarkServer extends App {
   val dbHost = Properties.envOrNone("DBHOST").map(Host(_)).getOrElse(Host.localhost)
   val database = Database(dbHost)
 
-  val module = ModuleSpec(Root, SimpleJson(), addServerAndDate)
+  val module = ModuleSpec(Root, SimpleJson())
     .withRoute(JsonRoute())
     .withRoute(PlainTextRoute())
     .withRoute(FortunesRoute(database))
@@ -40,6 +40,6 @@ object FintrospectBenchmarkServer extends App {
       .withStatsReceiver(NullStatsReceiver)
       .withTracer(NullTracer)
       .withMonitor(NullMonitor)
-      .serve(":9000", module.toService)
+      .serve(":9000", addServerAndDate.andThen(module.toService))
   )
 }


### PR DESCRIPTION
An empty "queries" param now defaults to a value of 1 instead of returning a 400 Bad Request.


<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->

…nstead of returning a 400 (Bad request)