### PR TITLE
Fix compilation of Scala unfiltered

### DIFF
--- a/frameworks/Scala/unfiltered/project/Build.scala
+++ b/frameworks/Scala/unfiltered/project/Build.scala
@@ -1,13 +1,22 @@
 import sbt._
 import Keys._
+import sbtassembly._
 import sbtassembly.AssemblyPlugin._
-//import AssemblyKeys._
+import sbtassembly.AssemblyKeys._
 
 object Bench extends Build {
+
+  val projectAssemblySettings = (assemblySettings: Seq[Setting[_]]) ++ Seq(
+    assemblyMergeStrategy in assembly := {
+      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+      case x => MergeStrategy.first
+    }
+  )
+  
   lazy val project = Project(
     "bench", 
     file("."),
-    settings = Defaults.defaultSettings ++ assemblySettings ++ Seq(
+    settings = Defaults.defaultSettings ++ projectAssemblySettings ++ Seq(
       scalaVersion := "2.11.7",
       version := "1.0.0",
       name := "bench",

--- a/frameworks/Scala/unfiltered/setup_unfiltered.sh
+++ b/frameworks/Scala/unfiltered/setup_unfiltered.sh
@@ -2,10 +2,10 @@
 
 fw_depends java scala sbt
 
-sed -i 's|jdbc:mysql://.*:3306|jdbc:mysql://'"${DBHOST}"':3306|g' src/main/resources/application.conf
-sed -i 's|maxThreads = .*|maxThreads = '"${MAX_THREADS}"'|g' src/main/resources/application.conf
+sed -ie 's|jdbc:mysql://.*:3306|jdbc:mysql://'"${DBHOST}"':3306|g' src/main/resources/application.conf
+sed -ie 's|maxThreads = .*|maxThreads = '"${MAX_THREADS}"'|g' src/main/resources/application.conf
 
 sbt assembly -batch
 
-cd target/scala-2.10
+cd target/scala-2.11
 java -jar bench-assembly-1.0.0.jar &

--- a/frameworks/Scala/unfiltered/src/main/resources/application.conf
+++ b/frameworks/Scala/unfiltered/src/main/resources/application.conf
@@ -1,8 +1,8 @@
 db.default.driver=""com.mysql.jdbc.Driver""
-db.default.url = "jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
+db.default.url = "jdbc:mysql://:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
 db.default.user = "benchmarkdbuser"
 db.default.password = "benchmarkdbpass"
 db.default.minConnections = 4
 db.default.maxConnections = 125
 
-unfiltered.maxThreads = 16
+unfiltered.maxThreads = 

--- a/frameworks/Scala/unfiltered/src/main/scala/DatabaseAccess.scala
+++ b/frameworks/Scala/unfiltered/src/main/scala/DatabaseAccess.scala
@@ -2,7 +2,7 @@ package bench
 
 import scala.collection.immutable.Map
 import scala.util.Try
-import scala.slick.driver.SQLServerDriver.simple._
+import slick.driver.MySQLDriver.api._
 import java.util.Map.Entry
 import com.typesafe.config._
 import com.jolbox.bonecp.{ BoneCP, BoneCPConfig, BoneCPDataSource }

--- a/frameworks/Scala/unfiltered/src/main/scala/Plans.scala
+++ b/frameworks/Scala/unfiltered/src/main/scala/Plans.scala
@@ -9,15 +9,19 @@ import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.{read, write}
 import org.json4s.JsonDSL.WithBigDecimal._
 import scala.util.Random
-import scala.slick.driver.MySQLDriver.simple._
-import scala.slick.jdbc.{ GetResult, StaticQuery => Q }
+import slick.driver.MySQLDriver.api._
+import slick.jdbc.{ GetResult }
+import slick.lifted.{Query => Q}
 import java.util.concurrent.ThreadLocalRandom
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 case class World(id: Long, randomNumber: Long)
 
 /** unfiltered plan */
-object Plans extends cycle.Plan
+object Plans extends future.Plan
   with cycle.DeferralExecutor with cycle.DeferredIntent with ServerErrorResponse {
+  implicit def executionContext = ExecutionContext.Implicits.global
 
   private val TEST_DATABASE_ROWS = 9999
   implicit val getWorld = GetResult(r => World(r.<<, r.<<))
@@ -25,17 +29,22 @@ object Plans extends cycle.Plan
   val db = DatabaseAccess.databases("db.default")
 
   def intent = {
-    case GET(Path("/json")) => JsonContent ~> ResponseString(compact(render("message" -> "Hello, World!")))
+    case GET(Path("/json")) => Future.successful(JsonContent ~> ResponseString(compact(render("message" -> "Hello, World!"))))
     case GET(Path("/db") & Params(params)) =>
       val random = ThreadLocalRandom.current()
       val queries = params.get("queries").flatMap(_.headOption).getOrElse("1").toInt
-      JsonContent ~> ResponseString(
-        write(
-          db.withSession { implicit session: Session =>
-            (0 until queries).map { _ =>
-              (Q[Int, World] + "select id, randomNumber from World where id = ?")(random.nextInt(TEST_DATABASE_ROWS) + 1).first
-            }
+      db.run(
+        DBIO.sequence {
+          (0 until queries).map { _ =>
+            val next = 1 + random.nextInt(TEST_DATABASE_ROWS)
+            sql"select id, randomNumber from World where id = $next".as[World].head
           }
+        }
+      ).map( result =>
+        JsonContent ~> ResponseString(
+          write(
+            result
+          )
         )
       )
   }


### PR DESCRIPTION
```
  * frameworks/Scala/unfiltered/setup_unfiltered.sh:
  Build is Scala 2.11, not 2.10

  * frameworks/Scala/unfiltered/src/main/scala/DatabaseAccess.scala:
  Use MySQL driver, not SQL Server

  * frameworks/Scala/unfiltered/src/main/scala/Plans.scala (Plans):
  Convert netty.cycle.Plan to netty.future.Plan
  (intent): Use new DBIO async facility of Slick 3
```