### PR TITLE
Phoenix is a Fullstack framework - and its overhead should be compare…

### DIFF
--- a/frameworks/Elixir/phoenix/benchmark_config.json
+++ b/frameworks/Elixir/phoenix/benchmark_config.json
@@ -11,7 +11,7 @@
             "plaintext_url": "/plaintext",
             "port": 8080,
             "approach": "Realistic",
-            "classification": "Micro",
+            "classification": "Fullstack",
             "database": "Postgres",
             "framework": "Phoenix",
             "language": "Elixir",
@@ -23,7 +23,7 @@
             "database_os": "Linux",
             "display_name": "Phoenix",
             "notes": "",
-            "versus": ""
+            "versus": "Cowboy"
         }
     }]
 }


### PR DESCRIPTION
…d to Cowboy.

I believe that Phoenix should not be classified as Micro, but should be instead classified as Fullstack, since:

> Fullstack, meaning a framework that provides wide feature coverage including server-side templates, database connectivity, form processing, and so on.

* server-side templates: check, using EEx
* database-connectivity: check, using Ecto & Phoenix-Ecto
* form-processing: check

It also provides session tracking, CRSF protection, WebSocket support etc etc so by no means it should be consider a "Micro" framework.