### PR TITLE
Fix #2389 apt error for MySQL in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,12 +210,12 @@ services:
   - postgresql
   - redis-server
   - mongodb
+  - mysql
 
 addons:
   postgresql: "9.3"
   apt:
     packages:
-      - mysql-server
       - redis-server
 
 before_script:


### PR DESCRIPTION
According to the Travis documentation the way to depend on mysql is

    services:
      - mysql

https://docs.travis-ci.com/user/database-setup/#MySQL