### PR TITLE
add force-confdef flag to apt-get Dpkg::Options

### DIFF
--- a/toolset/setup/linux/bash_functions.sh
+++ b/toolset/setup/linux/bash_functions.sh
@@ -136,7 +136,7 @@ fw_depends() {
       . $FWROOT/toolset/setup/linux/databases/${depend}.sh
     else
       echo WARN: No installer found for $depend, attempting to install with 'apt-get'...
-      sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes ${depend}
+      sudo apt-get install -o Dpkg::Options::="--force-confold --force-confdef" --force-yes ${depend}
       # Return whence you came.
       popd
       continue


### PR DESCRIPTION
Adds an additional Dpkg::Options value to the `fw_depends` apt-get call we make. This is in response to @msmith-techempower's request [here](https://github.com/TechEmpower/FrameworkBenchmarks/pull/2384#discussion_r92847216).