### PR TITLE
Hexagon

### DIFF
--- a/frameworks/Kotlin/hexagon/benchmark_config.json
+++ b/frameworks/Kotlin/hexagon/benchmark_config.json
@@ -1,60 +1,51 @@
 {
-    "framework" : "hexagon",
-    "tests" : [
-        {
-            "default" : {
-                "json_url" : "/json",
-                "db_url" : "/db",
-                "query_url" : "/query?queries=",
-                "fortune_url" : "/fortunes",
-                "update_url" : "/update?queries=",
-                "plaintext_url" : "/plaintext",
-                "port" : 9090,
-
-                "approach" : "Realistic",
-                "classification" : "Micro",
-                "database" : "MongoDB",
-                "framework" : "Hexagon",
-                "language" : "Kotlin",
-                "orm" : "Raw",
-                "platform" : "Servlet",
-                "webserver" : "None",
-                "os" : "Linux",
-                "database_os" : "Linux",
-                "display_name" : "Hexagon MongoDB",
-                "notes" : "http://there4.co/hexagon",
-
-                "setup_file" : "setup",
-                "versus" : "servlet"
-            }
-        },
-        {
-            "resin" : {
-                "json_url" : "/json",
-                "db_url" : "/db",
-                "query_url" : "/query?queries=",
-                "fortune_url" : "/fortunes",
-                "update_url" : "/update?queries=",
-                "plaintext_url" : "/plaintext",
-
-                "port" : 8080,
-
-                "approach" : "Realistic",
-                "classification" : "Micro",
-                "database" : "MongoDB",
-                "framework" : "Hexagon",
-                "language" : "Kotlin",
-                "orm" : "Raw",
-                "platform" : "Servlet",
-                "webserver" : "None",
-                "os" : "Linux",
-                "database_os" : "Linux",
-                "display_name" : "Hexagon Resin",
-                "notes" : "http://there4.co/hexagon",
-
-                "setup_file" : "setup_resin",
-                "versus" : "servlet"
-            }
-        }
-    ]
+  "framework" : "hexagon",
+  "tests" : [{
+    "default" : {
+      "setup_file" : "setup",
+      "json_url" : "/json",
+      "db_url" : "/db",
+      "query_url" : "/query?queries=",
+      "fortune_url" : "/fortunes",
+      "update_url" : "/update?queries=",
+      "plaintext_url" : "/plaintext",
+      "port" : 9090,
+      "approach" : "Realistic",
+      "classification" : "Micro",
+      "database" : "MongoDB",
+      "framework" : "Hexagon",
+      "language" : "Kotlin",
+      "orm" : "Raw",
+      "platform" : "Servlet",
+      "webserver" : "None",
+      "os" : "Linux",
+      "database_os" : "Linux",
+      "display_name" : "Hexagon MongoDB",
+      "notes" : "http://there4.co/hexagon",
+      "versus" : "servlet"
+    },
+    "resin" : {
+      "setup_file" : "setup_resin",
+      "json_url" : "/json",
+      "db_url" : "/db",
+      "query_url" : "/query?queries=",
+      "fortune_url" : "/fortunes",
+      "update_url" : "/update?queries=",
+      "plaintext_url" : "/plaintext",
+      "port" : 8080,
+      "approach" : "Realistic",
+      "classification" : "Micro",
+      "database" : "MongoDB",
+      "framework" : "Hexagon",
+      "language" : "Kotlin",
+      "orm" : "Raw",
+      "platform" : "Servlet",
+      "webserver" : "None",
+      "os" : "Linux",
+      "database_os" : "Linux",
+      "display_name" : "Hexagon Resin",
+      "notes" : "http://there4.co/hexagon",
+      "versus" : "servlet"
+    }
+  }]
 }

--- a/frameworks/Kotlin/hexagon/gradle.properties
+++ b/frameworks/Kotlin/hexagon/gradle.properties
@@ -4,7 +4,7 @@ group=co.there4.hexagon
 description=Hexagon web framework's benchmark
 
 wrapperGradleVersion=3.2.1
-gradleScripts=https://raw.githubusercontent.com/jaguililla/hexagon/master/gradle
+gradleScripts=https://raw.githubusercontent.com/jaguililla/hexagon/a1a489ba2e0a512c7012028a5e7b079f1aea345f/gradle
 
 dokkaVersion=0.9.11
 kotlinVersion=1.0.5-2


### PR DESCRIPTION
Fixed the malformed benchmark_config file so that hexagon isn't being reported as not having a default test.

Tied down `gradle.properties` to a specific commit. Recent pushes to master are breaking tests.

@jaguililla The resin tests are no longer working. Would you be able to explore?