### PR TITLE
Express framework fix

### DIFF
--- a/frameworks/JavaScript/express/app.js
+++ b/frameworks/JavaScript/express/app.js
@@ -27,6 +27,14 @@ var WorldSchema = new mongoose.Schema({
   }),
   MWorld = conn.model('World', WorldSchema);
 
+var FortuneSchema = new mongoose.Schema({
+    id          : Number,
+    message     : String
+  }, {
+    collection: 'fortune'
+  }),
+  MFortune = conn.model('Fortune', FortuneSchema);
+
 var sequelize = new Sequelize('hello_world', 'benchmarkdbuser', 'benchmarkdbpass', {
   host: 'localhost',
   dialect: 'mysql',

--- a/frameworks/JavaScript/express/benchmark_config.json
+++ b/frameworks/JavaScript/express/benchmark_config.json
@@ -26,7 +26,7 @@
       "db_url": "/mongoose",
       "query_url": "/mongoose?queries=",
       "update_url": "/mongoose-update?queries=",
-      "fortune_url": "/mysql-orm-fortune",
+      "fortune_url": "/mongoose-fortune",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Micro",


### PR DESCRIPTION
The mongo fortune tests for express were using a mysql endpoint. This was picked up after ensuring that tests use fw_depends for the databases they need. There was no schema set for for the /mongoose-fortune endpoint so I made one in the original author's style.