### PR TITLE
Dancer framework fix

### DIFF
--- a/frameworks/Perl/dancer/benchmark_config.json
+++ b/frameworks/Perl/dancer/benchmark_config.json
@@ -2,25 +2,8 @@
   "framework": "dancer",
   "tests": [{
     "default": {
-      "setup_file": "setup",
-      "json_url": "/json",
-      "port": 8080,
-      "approach": "Realistic",
-      "classification": "Fullstack",
-      "database": "None",
-      "framework": "dancer",
-      "language": "Perl",
-      "orm": "Full",
-      "platform": "Plack",
-      "webserver": "Starman",
-      "os": "Linux",
-      "database_os": "Linux",
-      "display_name": "dancer",
-      "notes": "",
-      "versus": ""
-    },
-    "raw": {
       "setup_file": "setup-mysql",
+      "json_url": "/json",
       "db_url": "/db",
       "query_url": "/db?queries=",
       "port": 8080,


### PR DESCRIPTION
Dancer's default test was also looking for a mysql connection. Since the only difference between the two tests were the json route, I combined it into one default test.