### PR TITLE
Kelp framework fix

### DIFF
--- a/frameworks/Perl/kelp/benchmark_config.json
+++ b/frameworks/Perl/kelp/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "kelp",
   "tests": [{
     "default": {
-      "setup_file": "setup-mysql",
+      "setup_file": "setup",
       "json_url": "/json",
       "db_url": "/db",
       "query_url": "/queries?queries=",
@@ -24,7 +24,7 @@
       "versus": ""
     },
     "mongodb": {
-      "setup_file": "setup-mongodb",
+      "setup_file": "setup",
       "json_url": "/json",
       "db_url": "/db",
       "query_url": "/queries/mongo?queries=",

--- a/frameworks/Perl/kelp/setup-mongodb.sh
+++ b/frameworks/Perl/kelp/setup-mongodb.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mongodb
-
-source ./setup.sh

--- a/frameworks/Perl/kelp/setup-mysql.sh
+++ b/frameworks/Perl/kelp/setup-mysql.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mysql
-
-source ./setup.sh

--- a/frameworks/Perl/kelp/setup.sh
+++ b/frameworks/Perl/kelp/setup.sh
@@ -4,7 +4,7 @@ sed -i 's|localhost|'"${DBHOST}"'|g' app.pl
 sed -i 's|user .*;|user '"$(id -u -n)"';|g' nginx.conf
 sed -i 's|server unix.*frameworks-benchmark.sock;|server unix:'"${TROOT}"'/frameworks-benchmark.sock;|g' nginx.conf
 
-fw_depends perl nginx
+fw_depends perl nginx mysql mongodb
 
 cpanm --notest --no-man-page \
     Kelp@0.9071 \


### PR DESCRIPTION
Kelp's two tests use the same `app.pl` file which configures both databases. Because of this the mysql tests are failing without a mongo installation there. A quick fix here is to use one setup file that installs both db's. Would like to separate this out at some point.