### PR TITLE
Cakephp fix

### DIFF
--- a/frameworks/PHP/cakephp/app/Config/core.php
+++ b/frameworks/PHP/cakephp/app/Config/core.php
@@ -263,24 +263,24 @@ $prefix = 'myapp_';
  * Configure the cache used for general framework caching.  Path information,
  * object listings, and translation cache files are stored with this configuration.
  */
-Cache::config('_cake_core_', array(
-	'engine' => $engine,
-	'server' => 'REDISSERVER',
-	'prefix' => $prefix . 'cake_core_',
-	'path' => CACHE . 'persistent' . DS,
-	'serialize' => ($engine === 'File'),
-	'duration' => $duration
-));
+//Cache::config('_cake_core_', array(
+//	'engine' => $engine,
+//	'server' => 'REDISSERVER',
+//	'prefix' => $prefix . 'cake_core_',
+//	'path' => CACHE . 'persistent' . DS,
+//	'serialize' => ($engine === 'File'),
+//	'duration' => $duration
+//));
 
 /**
  * Configure the cache for model and datasource caches.  This cache configuration
  * is used to store schema descriptions, and table listings in connections.
  */
-Cache::config('_cake_model_', array(
-	'engine' => $engine,
-	'server' => 'REDISSERVER',
-	'prefix' => $prefix . 'cake_model_',
-	'path' => CACHE . 'models' . DS,
-	'serialize' => ($engine === 'File'),
-	'duration' => $duration
-));
+//Cache::config('_cake_model_', array(
+//	'engine' => $engine,
+//	'server' => 'REDISSERVER',
+//	'prefix' => $prefix . 'cake_model_',
+//	'path' => CACHE . 'models' . DS,
+//	'serialize' => ($engine === 'File'),
+//	'duration' => $duration
+//));

--- a/frameworks/PHP/cakephp/app/Config/core.php
+++ b/frameworks/PHP/cakephp/app/Config/core.php
@@ -259,6 +259,9 @@ if (Configure::read('debug') >= 1) {
 // Prefix each application on the same server with a different string, to avoid Memcache and APC conflicts.
 $prefix = 'myapp_';
 
+// NOTE: There is currently no implementation of redis so commenting out this configuration for now. This
+// *may* have also been in violation of the rules of some of the database tests.
+
 /**
  * Configure the cache used for general framework caching.  Path information,
  * object listings, and translation cache files are stored with this configuration.


### PR DESCRIPTION
Cakephp was using redis (which is no longer implemented) but was also using it as an in memory cache for some of the database endpoints which is not permitted.