### PR TITLE
Update clang compilers

### DIFF
--- a/toolset/setup/linux/systools/clang-3.8.sh
+++ b/toolset/setup/linux/systools/clang-3.8.sh
@@ -7,7 +7,9 @@ RETCODE=$(fw_exists ${IROOT}/clang-3.8.installed)
   return 0; }
 
 sudo add-apt-repository -s "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-3.8 main"
+wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get -yq update
 sudo apt-get install -qqy clang-3.8 lldb-3.8
 
 touch $IROOT/clang-3.8.installed
+

--- a/toolset/setup/linux/systools/clang-3.8.sh
+++ b/toolset/setup/linux/systools/clang-3.8.sh
@@ -7,8 +7,7 @@ RETCODE=$(fw_exists ${IROOT}/clang-3.8.installed)
   return 0; }
 
 sudo add-apt-repository -s "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-3.8 main"
-wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get -yq update
-sudo apt-get install -qqy clang-3.8
+sudo apt-get install -qqy clang-3.8 lldb-3.8
 
 touch $IROOT/clang-3.8.installed

--- a/toolset/setup/linux/systools/clang-3.9.sh
+++ b/toolset/setup/linux/systools/clang-3.9.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+
+RETCODE=$(fw_exists ${IROOT}/clang-3.9.installed)
+[ ! "$RETCODE" == 0 ] || { \
+  source $IROOT/clang-3.9.installed
+  return 0; }
+
+sudo add-apt-repository -s "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-3.9 main"
+sudo apt-get -yq update
+sudo apt-get install -qqy clang-3.9 lldb-3.9
+
+touch $IROOT/clang-3.9.installed
+

--- a/toolset/setup/linux/systools/clang-3.9.sh
+++ b/toolset/setup/linux/systools/clang-3.9.sh
@@ -7,6 +7,7 @@ RETCODE=$(fw_exists ${IROOT}/clang-3.9.installed)
   return 0; }
 
 sudo add-apt-repository -s "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-3.9 main"
+wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get -yq update
 sudo apt-get install -qqy clang-3.9 lldb-3.9
 


### PR DESCRIPTION
Adds a missing tool in clang-3.8 and adds clang-3.9 to the toolset.

The latter will be used in an upcoming C++/silicon fix.