### PR TITLE
Go/revel framework fix

### DIFF
--- a/frameworks/Go/revel/benchmark_config.json
+++ b/frameworks/Go/revel/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "revel",
   "tests": [{
     "default": {
-      "setup_file": "setup",
+      "setup_file": "setup_mysql",
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "port": 8080,


### PR DESCRIPTION
revel checks for a mysql connection when the server starts for all tests. added mysql setup to the default