### PR TITLE
Java/play2 framework fix

### DIFF
--- a/frameworks/Java/play2-java/setup_java_ebean_hikaricp.sh
+++ b/frameworks/Java/play2-java/setup_java_ebean_hikaricp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_dependsmysql java sbt
+fw_depends mysql java sbt
 
 sed -i 's|127.0.0.1|'${DBHOST}'|g' play2-java-ebean-hikaricp/conf/application.conf
 


### PR DESCRIPTION
Fixes a typo in the `play2-ebean-hikaricp` test that was causing failure.