### PR TITLE
Ur/urweb framework fix

### DIFF
--- a/frameworks/Ur/urweb/benchmark_config.json
+++ b/frameworks/Ur/urweb/benchmark_config.json
@@ -3,23 +3,9 @@
   "tests": [{
     "default": {
       "display_name": "urweb",
-      "setup_file": "setup",
+      "setup_file": "setup-postgresql",
       "json_url": "/json",
       "plaintext_url": "/plaintext",
-      "port": 8080,
-      "approach": "Realistic",
-      "classification": "Fullstack",
-      "database": "None",
-      "framework": "urweb",
-      "language": "Ur",
-      "orm": "Micro",
-      "platform": "Ur/Web",
-      "webserver": "None",
-      "os": "Linux",
-      "database_os": "Linux"
-    },
-    "postgres": {
-      "setup_file": "setup-postgresql",
       "db_url": "/db",
       "query_url": "/queries/",
       "fortune_url": "/fortunes",

--- a/frameworks/Ur/urweb/setup.sh
+++ b/frameworks/Ur/urweb/setup.sh
@@ -1,26 +1,6 @@
 #!/bin/bash
 
-VERSION=20160621
-COMPILER=${IROOT}/urweb
-
-RETCODE=$(fw_exists ${COMPILER}.installed)
-[ "$RETCODE" == 0 ] || { \
-  sudo apt-get --assume-yes install mlton
-  cd $IROOT
-  fw_get -O http://www.impredicative.com/ur/urweb-$VERSION.tgz
-  fw_untar urweb-$VERSION.tgz
-  cd urweb-$VERSION
-  ./configure --prefix=$IROOT/urweb
-  make
-  make install
-
-  echo "export URWEB_HOME=${COMPILER}" > $COMPILER.installed
-  echo "export LD_LIBRARY_PATH=${COMPILER}/lib" >> $COMPILER.installed
-  echo -e "export PATH=${COMPILER}/bin:\$PATH" >> $COMPILER.installed
-  cd $TROOT
-}
-
-source $IROOT/urweb.installed
+fw_depends urweb
 
 urweb -db "dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass host=${DBHOST}" bench
 

--- a/frameworks/Ur/urweb/setup_mysql.sh
+++ b/frameworks/Ur/urweb/setup_mysql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends mysql
+fw_depends urweb mysql
 
 export URWEB_HOME=${IROOT}/urweb
 export LD_LIBRARY_PATH=${URWEB_HOME}/lib

--- a/toolset/setup/linux/frameworks/urweb.sh
+++ b/toolset/setup/linux/frameworks/urweb.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+VERSION=20160621
+COMPILER=${IROOT}/urweb
+
+RETCODE=$(fw_exists ${COMPILER}.installed)
+[ "$RETCODE" == 0 ] || { \
+  sudo apt-get --assume-yes install mlton
+  cd $IROOT
+  fw_get -O http://www.impredicative.com/ur/urweb-$VERSION.tgz
+  fw_untar urweb-$VERSION.tgz
+  cd urweb-$VERSION
+  sudo ./configure --prefix=$IROOT/urweb
+  sudo make
+  sudo make install
+
+  echo "export URWEB_HOME=${COMPILER}" > $COMPILER.installed
+  echo "export LD_LIBRARY_PATH=${COMPILER}/lib" >> $COMPILER.installed
+  echo -e "export PATH=${COMPILER}/bin:\$PATH" >> $COMPILER.installed
+  cd $TROOT
+}
+
+source $IROOT/urweb.installed
+


### PR DESCRIPTION
urweb's default test relied on testing a postgresql connection, so I've combined the default and postgresql tests in to 1. The mysql test would only work after the default test was run, and would not work on it's own. It was relying on urweb already being installed. I've moved the installation of the framework to `toolset/setup/linux/frameworks/urweb.sh` so it can be `fw_depends` by both setup files that need it. All tests pass now.