### PR TITLE
ffead-cpp framework fix

### DIFF
--- a/frameworks/C++/ffead-cpp/setup-apache2.sh
+++ b/frameworks/C++/ffead-cpp/setup-apache2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends apache ffead-cpp-apache
+fw_depends apache mongodb ffead-cpp-apache
 
 export FFEAD_CPP_PATH=/var/www/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/frameworks/C++/ffead-cpp/setup-nginx.sh
+++ b/frameworks/C++/ffead-cpp/setup-nginx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends ffead-cpp-nginx
+fw_depends mongodb ffead-cpp-nginx
 
 export FFEAD_CPP_PATH=$TROOT/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/frameworks/C++/ffead-cpp/setup.sh
+++ b/frameworks/C++/ffead-cpp/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends ffead-cpp
+fw_depends mongo ffead-cpp
 
 export FFEAD_CPP_PATH=$TROOT/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/frameworks/C++/ffead-cpp/setup.sh
+++ b/frameworks/C++/ffead-cpp/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends mongo ffead-cpp
+fw_depends mongodb ffead-cpp
 
 export FFEAD_CPP_PATH=$TROOT/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Attempting to fix some of the failing tests. The nginx tests will probably still fail.

@sumeetchhetri pinging you here in case you wanted to take a look at it before I remove the nginx tests. This could be a broader problem with the nginx setup after the toolset change, though some framework implementations that use nginx are still fine.