### PR TITLE
Update Finatra framework version to release 2.7.0

### DIFF
--- a/frameworks/Scala/finatra/README.md
+++ b/frameworks/Scala/finatra/README.md
@@ -12,7 +12,7 @@
 The tests are run with:
 
 * [Java Oracle 1.8.0_25](http://www.oracle.com/technetwork/java/javase)
-* [finatra 2.3.0](https://github.com/twitter/finatra/tree/finatra-2.3.0)
+* [finatra 2.7.0](https://github.com/twitter/finatra/tree/finatra-2.7.0)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -17,6 +17,6 @@ assemblyMergeStrategy in assembly := {
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "2.3.0",
+  "com.twitter" %% "finatra-http" % "2.7.0",
   "org.slf4j" % "slf4j-nop" % "1.7.21"
 )

--- a/frameworks/Scala/finatra/src/main/scala/benchmark/controllers/Controller.scala
+++ b/frameworks/Scala/finatra/src/main/scala/benchmark/controllers/Controller.scala
@@ -1,16 +1,22 @@
 package benchmark.controllers
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finatra.http.{Controller => HttpController}
+import com.twitter.io.Buf
+import com.twitter.util.Future
 
 class Controller extends HttpController {
   private[this] val helloWorldText = "Hello, World!"
+  private[this] val helloWorldBuf: Buf = Buf.Utf8(helloWorldText)
 
   get("/json") { request: Request =>
     Map("message" -> helloWorldText)
   }
 
   get("/plaintext") { request: Request =>
-    helloWorldText
+    val resp = Response()
+    resp.content = helloWorldBuf
+    resp.contentType = response.plainTextContentType
+    Future.value(resp)
   }
 }


### PR DESCRIPTION
Problem

We'd like to update the Finatra framework version and
also bring the /plaintext test inline with the Finagle
version for consistency between the frameworks.

Solution

Update the Finatra dependency and the test Controller.

<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->
