### PR TITLE
Fixed failing ffead-cpp framework nginx tests Attempt 1

### DIFF
--- a/frameworks/C++/ffead-cpp/setup-apache2.sh
+++ b/frameworks/C++/ffead-cpp/setup-apache2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends apache ffead-cpp-apache
+fw_depends apache mongodb ffead-cpp-apache
 
 export FFEAD_CPP_PATH=/var/www/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/frameworks/C++/ffead-cpp/setup-nginx.sh
+++ b/frameworks/C++/ffead-cpp/setup-nginx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends ffead-cpp-nginx
+fw_depends mongodb ffead-cpp-nginx
 
 export FFEAD_CPP_PATH=$TROOT/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/frameworks/C++/ffead-cpp/setup.sh
+++ b/frameworks/C++/ffead-cpp/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends ffead-cpp
+fw_depends mongodb ffead-cpp
 
 export FFEAD_CPP_PATH=$TROOT/ffead-cpp-2.0
 export LD_LIBRARY_PATH=$IROOT:$FFEAD_CPP_PATH/lib:$LD_LIBRARY_PATH

--- a/toolset/setup/linux/frameworks/ffead-cpp-nginx.sh
+++ b/toolset/setup/linux/frameworks/ffead-cpp-nginx.sh
@@ -20,6 +20,12 @@ cp -R ffead-cpp-2.0-bin/ ${TROOT}
 mv ${TROOT}/ffead-cpp-2.0-bin ${TROOT}/ffead-cpp-2.0
 rm -rf ffead-cpp-2.0/
 
+fw_get -o mongo-c-driver-1.4.0.tar.gz https://github.com/mongodb/mongo-c-driver/releases/download/1.4.0/mongo-c-driver-1.4.0.tar.gz
+fw_untar mongo-c-driver-1.4.0.tar.gz
+cd mongo-c-driver-1.4.0/
+./configure --prefix=${IROOT} --libdir=${IROOT} --disable-automatic-init-and-cleanup
+make && sudo make install
+
 fw_get -o nginx-1.11.3.tar.gz http://nginx.org/download/nginx-1.11.3.tar.gz
 fw_untar nginx-1.11.3.tar.gz
 sudo rm -rf ${IROOT}/nginxfc
@@ -36,12 +42,6 @@ sudo cp ${TROOT}/ffead-cpp-2.0/resources/sample-odbcinst.ini /etc/odbcinst.ini
 sudo cp ${TROOT}/ffead-cpp-2.0/resources/sample-odbc.ini /etc/odbc.ini
 
 sudo sed -i 's|localhost|'${DBHOST}'|g' /etc/odbc.ini
-
-fw_get -o mongo-c-driver-1.4.0.tar.gz https://github.com/mongodb/mongo-c-driver/releases/download/1.4.0/mongo-c-driver-1.4.0.tar.gz
-fw_untar mongo-c-driver-1.4.0.tar.gz
-cd mongo-c-driver-1.4.0/
-./configure --prefix=${IROOT} --libdir=${IROOT} --disable-automatic-init-and-cleanup
-make && sudo make install
 
 cp ${TROOT}/ffead-cpp-2.0/ngx_mod/nginx.conf ${IROOT}/nginxfc/conf/
 sed -i 's|FFEAD_PATH|'${TROOT}/ffead-cpp-2.0'|g' ${IROOT}/nginxfc/conf/nginx.conf


### PR DESCRIPTION
Copied changes from https://github.com/TechEmpower/FrameworkBenchmarks/pull/2458
nginx was getting built before mongo c driver was installed and hence the failing tests, reordered the sequence of installation of mongo c driver and nginx
