### PR TITLE
Symfony2 hhvm update test removal

### DIFF
--- a/frameworks/PHP/symfony2/benchmark_config.json
+++ b/frameworks/PHP/symfony2/benchmark_config.json
@@ -70,7 +70,6 @@
       "setup_file": "setup_hhvm",
       "plaintext_url": "/plaintext",
       "json_url": "/json",
-      "update_url": "/update?queries=",
       "db_url": "/db",
       "query_url": "/db?queries=",
       "fortune_url": "/fortunes",


### PR DESCRIPTION
For some reason, the hhvm update queries test is hanging. It's the only one that isn't passing and is using the same route as the default test.