### PR TITLE
Use /etc/hosts aliases instead of $DBHOST and other

### DIFF
--- a/benchmark.cfg.example
+++ b/benchmark.cfg.example
@@ -1,9 +1,9 @@
 [Defaults]
 # Available Keys: 
-client_host=127.0.0.1
+client_host=TFB-client
 client_identity_file=None
 client_user=techempower
-database_host=127.0.0.1
+database_host=TFB-database
 database_identity_file=None
 database_os=linux
 database_user=techempower
@@ -20,7 +20,7 @@ query_levels=[1, 5,10,15,20]
 threads=8
 mode=benchmark
 os=linux
-server_host=127.0.0.1
+server_host=TFB-server
 sleep=60
 test=None
 type=all

--- a/frameworks/C++/cpoll_cppsp/setup.sh
+++ b/frameworks/C++/cpoll_cppsp/setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-sed -i 's|#define BENCHMARK_DB_HOST ".*"|#define BENCHMARK_DB_HOST "'"$DBHOST"'"|g' www/connectioninfo.H
-
 fw_depends postgresql-server-dev-9.3 cppsp
 
 make clean

--- a/frameworks/C++/cpoll_cppsp/www/connectioninfo.H
+++ b/frameworks/C++/cpoll_cppsp/www/connectioninfo.H
@@ -1,4 +1,4 @@
-#define BENCHMARK_DB_HOST "localhost"
+#define BENCHMARK_DB_HOST "TFB-database"
 #define MYSQL_MAX_CONNECTIONS 3000
 
 #include <stdexcept>

--- a/frameworks/C/h2o/setup.sh
+++ b/frameworks/C/h2o/setup.sh
@@ -5,7 +5,7 @@ fw_depends postgresql h2o mustache-c yajl
 H2O_APP_HOME="${IROOT}/h2o_app"
 BUILD_DIR="${H2O_APP_HOME}_build"
 H2O_APP_PROFILE_PORT="54321"
-H2O_APP_PROFILE_URL="http://TFB-database:$H2O_APP_PROFILE_PORT"
+H2O_APP_PROFILE_URL="http://127.0.0.1:$H2O_APP_PROFILE_PORT"
 
 # A hacky way to detect whether we are running in the physical hardware or the cloud environment.
 if [[ $(nproc) -gt 16 ]]; then
@@ -36,7 +36,7 @@ run_curl()
 run_h2o_app()
 {
 	"$1/h2o_app" -a1 -f "$2/template/fortunes.mustache" -m "$DB_CONN" "$3" "$4" \
-		-d "host=$DBHOST dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass" &
+		-d "host=TFB-database dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass" &
 }
 
 generate_profile_data()

--- a/frameworks/C/h2o/setup.sh
+++ b/frameworks/C/h2o/setup.sh
@@ -5,7 +5,7 @@ fw_depends postgresql h2o mustache-c yajl
 H2O_APP_HOME="${IROOT}/h2o_app"
 BUILD_DIR="${H2O_APP_HOME}_build"
 H2O_APP_PROFILE_PORT="54321"
-H2O_APP_PROFILE_URL="http://127.0.0.1:$H2O_APP_PROFILE_PORT"
+H2O_APP_PROFILE_URL="http://TFB-database:$H2O_APP_PROFILE_PORT"
 
 # A hacky way to detect whether we are running in the physical hardware or the cloud environment.
 if [[ $(nproc) -gt 16 ]]; then

--- a/frameworks/Clojure/compojure/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/hello/src/hello/handler.clj
@@ -29,7 +29,7 @@
   (mysql {
           :classname "com.mysql.jdbc.Driver"
           :subprotocol "mysql"
-          :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
+          :subname "//TFB-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
           :user "benchmarkdbuser"
           :password "benchmarkdbpass"
           ;;OPTIONAL KEYS

--- a/frameworks/Clojure/compojure/setup.sh
+++ b/frameworks/Clojure/compojure/setup.sh
@@ -2,8 +2,6 @@
 
 fw_depends mysql java resin leiningen
 
-sed -i 's|127.0.0.1|'"${DBHOST}"'|g' hello/src/hello/handler.clj
-
 cd hello
 lein clean
 lein ring uberwar

--- a/frameworks/JavaScript/ringojs/ringo-main.js
+++ b/frameworks/JavaScript/ringojs/ringo-main.js
@@ -3,8 +3,8 @@ var mustache = require('ringo/mustache');
 
 // DO NOT TOUCH THE FOLLOWING LINE.
 // THIS VARIABLE IS REGEX REPLACED BY setup.py
-var dbHost = 'localhost';
-var mongodbUri = 'mongodb://localhost/hello_world';
+var dbHost = 'TFB-database';
+var mongodbUri = 'mongodb://TFB-database/hello_world';
 
 var sortFortunes = function(a, b) {
  return (a.message < b.message) ? -1 : (a.message > b.message) ? 1 : 0;

--- a/frameworks/JavaScript/ringojs/setup.sh
+++ b/frameworks/JavaScript/ringojs/setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-sed -i 's|dbHost = \x27.*\x27;|dbHost = \x27'"${DBHOST}"'\x27|g' ringo-main.js
-
 fw_depends mysql java ringojs
 
 rm -rf $RINGOJS_HOME/packages/*
@@ -9,3 +7,4 @@ ringo-admin install oberhamsi/sql-ringojs-client
 (cd $RINGOJS_HOME/packages/sql-ringojs-client/jars && curl -s -o mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar)
 
 ringo --production -J-server -J-Xmx1g -J-Xms1g ringo-main.js &
+

--- a/toolset/travis/travis_setup.sh
+++ b/toolset/travis/travis_setup.sh
@@ -36,3 +36,8 @@ echo "database_user=travis"                            >> benchmark.cfg
 echo "runner_user=travis"                              >> benchmark.cfg
 
 echo "travis ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
+
+echo 127.0.0.1 TFB-database | sudo tee --append /etc/hosts
+echo 127.0.0.1 TFB-client   | sudo tee --append /etc/hosts
+echo 127.0.0.1 TFB-server   | sudo tee --append /etc/hosts
+


### PR DESCRIPTION
I noticed that `TFB-client` `TFB-database` and `TFB-server` were already being set up in the `/etc/hosts` file during vagrant bootstrapping. I've updated the travis setup to do the same. Before something like this gets merged in, a note in the [Installation Guide](http://frameworkbenchmarks.readthedocs.io/en/latest/Development/Installation-Guide/) for those not using vagrant is needed.

Ideally, we would no longer need to use $DBHOST and other environment variables for IP addresses. We would also no longer need to use `sed` in setup files to replace IPs. I've edited a few frameworks here as a proof of concept, but also, the suite uses `benchmark.cfg.example` if a `benchmark.cfg` doesn't exist. So for the sake of this travis run, `$DBHOST=TFB-database`. 
