### PR TITLE
Lua/octopus update

### DIFF
--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -5,12 +5,9 @@ fw_depends mysql
 rm -rf octopus
 git clone https://github.com/cyberz-eu/octopus.git
 cd octopus
-# November 1st, 2016
-git checkout d123ba46d352fafebd74cb8ebeddc4810ba2c68b
+# January 4th, 2017
+git checkout 0c4fc42198fed3a299c78d4b910188113d478bc5
 cd ..
-
-# Patch for fixing zlib version
-sed -i 's|zlib_version=1\.2\.8|zlib_version=1.2.10|g' octopus/bin/unix/server.sh
 
 cp -avr app octopus/extensions
 cp -vf config.lua octopus/extensions


### PR DESCRIPTION
Maintainer updated repo. No longer need `zlib` patch.