### PR TITLE
NodeJS: Load all dbs in the setup

### DIFF
--- a/frameworks/JavaScript/nodejs/benchmark_config.json
+++ b/frameworks/JavaScript/nodejs/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "nodejs",
   "tests": [{
     "default": {
-      "setup_file": "setup-mysql",
+      "setup_file": "setup",
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "db_url": "/mysql/db",
@@ -26,7 +26,7 @@
       "versus": "nodejs"
     },
     "mongodb": {
-      "setup_file": "setup-mongodb",
+      "setup_file": "setup",
       "db_url": "/mongoose/db",
       "query_url": "/mongoose/queries?queries=",
       "update_url": "/mongoose/updates?queries=",
@@ -47,7 +47,7 @@
       "versus": "nodejs"
     },
     "mongodb-raw": {
-      "setup_file": "setup-mongodb",
+      "setup_file": "setup",
       "db_url": "/mongodb/db",
       "query_url": "/mongodb/queries?queries=",
       "update_url": "/mongodb/updates?queries=",
@@ -69,7 +69,7 @@
       "versus": "nodejs"
     },
     "mysql": {
-      "setup_file": "setup-mysql",
+      "setup_file": "setup",
       "db_url": "/sequelize/db",
       "query_url": "/sequelize/queries?queries=",
       "update_url": "/sequelize/updates?queries=",
@@ -91,7 +91,7 @@
       "versus": "nodejs"
     },
     "postgres": {
-      "setup_file": "setup-postgresql",
+      "setup_file": "setup",
       "db_url": "/sequelize-pg/db",
       "query_url": "/sequelize-pg/queries?queries=",
       "update_url": "/sequelize-pg/updates?queries=",

--- a/frameworks/JavaScript/nodejs/setup-mongodb.sh
+++ b/frameworks/JavaScript/nodejs/setup-mongodb.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mongodb
-
-source ./setup.sh

--- a/frameworks/JavaScript/nodejs/setup-mysql.sh
+++ b/frameworks/JavaScript/nodejs/setup-mysql.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mysql
-
-source ./setup.sh

--- a/frameworks/JavaScript/nodejs/setup-postgresql.sh
+++ b/frameworks/JavaScript/nodejs/setup-postgresql.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends postgresql
-
-source ./setup.sh

--- a/frameworks/JavaScript/nodejs/setup.sh
+++ b/frameworks/JavaScript/nodejs/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends mongodb nodejs
+fw_depends mongodb mysql postgresql nodejs
 
 sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/mongodb-raw.js
 sed -i 's|127.0.0.1|'"${DBHOST}"'|g' handlers/mongoose.js


### PR DESCRIPTION
NodeJS's db dependencies seem to be intertwined, such that all `package.json` file is loading all the modules for each test and checking connections for databases not being used by that test. Rather than rewrite this particular framework, I've loaded all the databases in the setup file.'

resolves #2482 