### PR TITLE
Script to generate long travis run

### DIFF
--- a/toolset/travis/travis_long.sh
+++ b/toolset/travis/travis_long.sh
@@ -22,9 +22,10 @@ $MATRIX
 
 before_script:
   - source ./toolset/travis/travis_clean.sh
+  - source ./toolset/travis/travis_setup.sh
 
 script:
-  - tfb --mode verify --test "\$TEST"
+  - ./toolset/run-tests.py --mode verify --test "\$TEST"
   
 cache:
   directories:

--- a/toolset/travis/travis_long.sh
+++ b/toolset/travis/travis_long.sh
@@ -25,7 +25,7 @@ before_script:
   - source ./toolset/travis/travis_setup.sh
 
 script:
-  - ./toolset/run-tests.py --mode verify --test "\$TEST"
+  - tfb --mode verify --test "\$TEST"
   
 cache:
   directories:

--- a/toolset/travis/travis_long.sh
+++ b/toolset/travis/travis_long.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Use to generate a new .travis.yml that runs individual
+# tests within a framework directory in a new vm
+
+# Backup original travis file
+mv $FWROOT/.travis.yml $FWROOT/.travis.bak
+
+# generate new matrix
+MATRIX=`$FWROOT/toolset/run-tests.py --list-tests | sed '/FWROOT */d' | sed '/Time */d' | sed '/Results */d' | sed -E 's/(.+)/    - "TEST=\1"/g'`
+
+tee $FWROOT/.travis.yml <<EOF
+sudo: required
+dist: trusty
+language: generic
+python:
+  - "2.7"
+  
+env:
+  matrix:
+$MATRIX
+
+before_script:
+  - source ./toolset/travis/travis_clean.sh
+
+script:
+  - tfb --mode verify --test "\$TEST"
+  
+cache:
+  directories:
+    - $HOME/.m2/repository
+    - $HOME/.cache/pip
+EOF
+


### PR DESCRIPTION
Running this generates a `.travis.yml` like in #2485 for all tests
Good for identifying individual problems with tests between rounds