### PR TITLE
Fix Rails 4.1.4 failures in Travis

### DIFF
--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -1,18 +1,20 @@
+---
+_: &common
+  adapter: <%= RUBY_PLATFORM == 'java' ? 'jdbcmysql' : 'mysql2' %>
+  database: hello_world
+  username: benchmarkdbuser
+  password: benchmarkdbpass
+  host: <%= ENV['DB_HOST'] %>
+  timeout: 5000
 
 development:
-  adapter: <%= RUBY_PLATFORM == 'java' ? 'jdbcmysql' : 'mysql2' %>
-  database: hello_world
-  username: benchmarkdbuser
-  password: benchmarkdbpass
-  host: <%= ENV['DB_HOST'] %>
+  <<: *common
   pool: 5
-  timeout: 5000
+
+test:
+  <<: *common
+  pool: 64
 
 production:
-  adapter: <%= RUBY_PLATFORM == 'java' ? 'jdbcmysql' : 'mysql2' %>
-  database: hello_world
-  username: benchmarkdbuser
-  password: benchmarkdbpass
-  host: <%= ENV['DB_HOST'] %>
+  <<: *common
   pool: 256
-  timeout: 5000

--- a/frameworks/Ruby/rails/config/environments/test.rb
+++ b/frameworks/Ruby/rails/config/environments/test.rb
@@ -1,0 +1,39 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # The test environment is used exclusively to run your application's
+  # test suite. You never need to work with it otherwise. Remember that
+  # your test database is "scratch space" for the test suite and is wiped
+  # and recreated between test runs. Don't rely on the data there!
+  config.cache_classes = true
+
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
+  # Configure static asset server for tests with Cache-Control for performance.
+  config.serve_static_assets  = true
+  config.static_cache_control = 'public, max-age=3600'
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
+  # Print deprecation notices to the stderr.
+  config.active_support.deprecation = :stderr
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+end


### PR DESCRIPTION
Rails sees a test environment where none exists, and fails the sanity
check of said environment. Puma, Unicorn, and Thin all set RACK_ENV to
production, so it should be safe to create a dummy test environment to
placate the sanity check. We won't use it.