### PR TITLE
quick vagrant fix

### DIFF
--- a/deployment/vagrant-common/bootstrap.sh
+++ b/deployment/vagrant-common/bootstrap.sh
@@ -63,9 +63,6 @@ if [ ! -e "~/.firstboot" ]; then
     cat /etc/hosts
   fi
 
-  # Update the benchmark.cfg for vagrant
-  sed -i s/techempower/vagrant/g ~/FrameworkBenchmarks/benchmark.cfg
-
   # Workaround mitchellh/vagrant#289
   echo "grub-pc grub-pc/install_devices multiselect     /dev/sda" | sudo debconf-set-selections
 
@@ -95,6 +92,9 @@ if [ ! -e "~/.firstboot" ]; then
     echo "Cloning project from $GH_REPO $GH_BRANCH"
     git config --global core.autocrlf input
     git clone -b ${GH_BRANCH} https://github.com/${GH_REPO}.git $FWROOT
+    cd ~/FrameworkBenchmarks
+    # Update the benchmark.cfg for vagrant
+    sed -i s/techempower/vagrant/g ~/FrameworkBenchmarks/benchmark.cfg
     source ~/FrameworkBenchmarks/toolset/setup/linux/prerequisites.sh
   #fi
 

--- a/deployment/vagrant-common/bootstrap.sh
+++ b/deployment/vagrant-common/bootstrap.sh
@@ -89,6 +89,8 @@ if [ ! -e "~/.firstboot" ]; then
     #sudo mount -o bind /tmp/TFB_installs $FWROOT/installs
   #else
     # If there is no synced folder, clone the project
+    export FWROOT="/home/vagrant/FrameworkBenchmarks"
+    echo FWROOT="/home/vagrant/FrameworkBenchmarks" >> ~/.bashrc
     echo "Cloning project from $GH_REPO $GH_BRANCH"
     git config --global core.autocrlf input
     git clone -b ${GH_BRANCH} https://github.com/${GH_REPO}.git $FWROOT


### PR DESCRIPTION
Resolves #2511 and an issue reported in irc where the benchmark.cfg file was pointing to the wrong identity file. The `sed` command was being done before the repo was being cloned. That's not gonna do it.