### PR TITLE
Update Finagle and Finch benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -2,11 +2,11 @@ name := "finagle"
 
 scalaVersion := "2.11.8"
 
-version := "1.0.2"
+version := "1.0.3"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "6.36.0",
+  "com.twitter" %% "finagle-http" % "6.41.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
 )

--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -1,5 +1,3 @@
-import java.util.Date
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.{Service, SimpleFilter, Http}
@@ -34,8 +32,8 @@ object Main extends App {
   val serverAndDate: SimpleFilter[Request, Response] = new SimpleFilter[Request, Response] {
 
     private[this] val addServerAndDate: Response => Response = { rep =>
-        rep.server = "Finagle"
-        rep.date = new Date()
+        rep.headerMap.set("Server", "Finagle")
+        rep.headerMap.set("Date", currentTime())
 
         rep
     }

--- a/frameworks/Scala/finagle/src/main/scala/currentTime.scala
+++ b/frameworks/Scala/finagle/src/main/scala/currentTime.scala
@@ -1,0 +1,18 @@
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneOffset}
+
+object currentTime {
+  private[this] val formatter: DateTimeFormatter = 
+    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
+
+  @volatile private[this] var last: (Long, String) = (0, "")
+
+  def apply(): String = {
+    val time = System.currentTimeMillis()
+    if (time - last._1 > 1000) {
+      last = time -> formatter.format(Instant.ofEpochMilli(time))
+    }
+
+    last._2
+  }
+}

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,18 +1,13 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.0.4"
+version := "0.0.5"
 
 scalaVersion := "2.11.8"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "6.36.0",
-  "com.github.finagle" %% "finch-core" % "0.11.0-M2",
-  "com.github.finagle" %% "finch-circe" % "0.11.0-M2",
-  "io.circe" %% "circe-core" % "0.5.0-M2",
-  "io.circe" %% "circe-generic" % "0.5.0-M2",
-  "io.circe" %% "circe-jawn" % "0.5.0-M2"
+  "com.github.finagle" %% "finch-core" % "0.12.0",
+  "com.github.finagle" %% "finch-circe" % "0.12.0",
+  "io.circe" %% "circe-generic" % "0.7.0"
 )
-
-resolvers += Resolver.sonatypeRepo("snapshots")

--- a/frameworks/Scala/finch/src/main/scala/Main.scala
+++ b/frameworks/Scala/finch/src/main/scala/Main.scala
@@ -1,6 +1,3 @@
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, ZoneOffset}
-
 import com.twitter.io.Buf
 import com.twitter.finagle.http.Response
 import com.twitter.finagle.Http
@@ -14,15 +11,12 @@ import io.finch.circe._
 
 object Main extends App {
 
-  val timeFormatter: DateTimeFormatter = 
-    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
-
   val helloWorld: Buf = Buf.Utf8("Hello, World!")
 
   val json: Endpoint[Json] = get("json") {
     Ok(Json.obj("message" -> Json.fromString("Hello, World!")))
       .withHeader("Server" -> "Finch")
-      .withHeader("Date" -> timeFormatter.format(Instant.now()))
+      .withHeader("Date" -> currentTime())
   }
 
   // Downgrade a text/plain endpoint to `Endpoint[Response]` as per
@@ -32,9 +26,9 @@ object Main extends App {
     rep.content = helloWorld
     rep.contentType = "text/plain"
     rep.headerMap.set("Server", "Finch")
-    rep.headerMap.set("Date", timeFormatter.format(Instant.now()))
+    rep.headerMap.set("Date", currentTime())
 
-    Ok(rep)
+    rep
   }
 
   Await.ready(Http.server

--- a/frameworks/Scala/finch/src/main/scala/currentTime.scala
+++ b/frameworks/Scala/finch/src/main/scala/currentTime.scala
@@ -1,0 +1,18 @@
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneOffset}
+
+object currentTime {
+  private[this] val formatter: DateTimeFormatter = 
+    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
+
+  @volatile private[this] var last: (Long, String) = (0, "")
+
+  def apply(): String = {
+    val time = System.currentTimeMillis()
+    if (time - last._1 > 1000) {
+      last = time -> formatter.format(Instant.ofEpochMilli(time))
+    }
+
+    last._2
+  }
+}


### PR DESCRIPTION
This PR updates Finagle and Finch benchmarks:

 - Finch is bumped to 0.12
 - Circe is bumped to 0.7
 - Finagle is bumped to 6.41

These are still using Scala 2.11 by a very simple reason - we haven't tested the effect of switching to 2.12 internally.

In addition to dependencies update, this extracts the date-time machinery into a standalone object `currentTime` that also maintains the previous value and only recalculates it when needed (ideally only once a second). I learned this trick from the [Netty benchmark](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Java/netty/src/main/java/hello/HelloServerHandler.java#L74-L81) where similar (but not the same) approach is taken to minimize the number of times the date object is allocated and formatted.