### PR TITLE
Extract common logic for Ruby Sequel benchmarks

### DIFF
--- a/frameworks/Ruby/rack-sequel/boot.rb
+++ b/frameworks/Ruby/rack-sequel/boot.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'bundler'
+require 'time'
+
+MAX_PK = 10_000
+QUERIES_MIN = 1
+QUERIES_MAX = 500
+SEQUEL_NO_ASSOCIATIONS = true
+
+Bundler.require(:default) # Load core modules
+
+def connect(dbtype)
+  Bundler.require(dbtype) # Load database-specific modules
+
+  adapters = {
+    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
+    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
+  }
+
+  opts = {}
+
+  # Determine threading/thread pool size and timeout
+  if defined?(JRUBY_VERSION)
+    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
+    opts[:pool_timeout] = 10
+  elsif defined?(Puma)
+    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
+    opts[:pool_timeout] = 10
+  else
+    Sequel.single_threaded = true
+  end
+
+  Sequel.connect \
+    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
+      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
+      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
+      :database=>'hello_world',
+      :user=>'benchmarkdbuser',
+      :password=>'benchmarkdbpass'
+    }, opts
+end
+
+DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
+  db.extension(:freeze_datasets)
+  db.freeze
+end
+
+# Define ORM models
+class World < Sequel::Model(:World)
+  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
+end
+
+class Fortune < Sequel::Model(:Fortune)
+  # Allow setting id to zero (0) per benchmark requirements
+  unrestrict_primary_key
+end
+
+SERVER_STRING =
+  if defined?(PhusionPassenger)
+    [
+      PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
+      PhusionPassenger::VERSION_STRING
+    ].join('/').freeze
+  elsif defined?(Puma)
+    Puma::Const::PUMA_SERVER_STRING
+  elsif defined?(Unicorn)
+    Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
+  end

--- a/frameworks/Ruby/rack-sequel/config.ru
+++ b/frameworks/Ruby/rack-sequel/config.ru
@@ -1,3 +1,4 @@
+require_relative 'boot'
 require_relative 'hello_world'
 use Rack::ContentLength
 use Rack::Chunked

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -1,76 +1,9 @@
 # frozen_string_literal: true
-require 'bundler'
-require 'time'
-
-MAX_PK = 10_000
-QUERIES_MIN = 1
-QUERIES_MAX = 500
-SEQUEL_NO_ASSOCIATIONS = true
-
-Bundler.require(:default) # Load core modules
-
-def connect(dbtype)
-  Bundler.require(dbtype) # Load database-specific modules
-
-  adapters = {
-    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
-    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
-  }
-
-  opts = {}
-
-  # Determine threading/thread pool size and timeout
-  if defined?(JRUBY_VERSION)
-    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
-    opts[:pool_timeout] = 10
-  elsif defined?(Puma)
-    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
-    opts[:pool_timeout] = 10
-  else
-    Sequel.single_threaded = true
-  end
-
-  Sequel.connect \
-    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
-      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
-      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
-      :database=>'hello_world',
-      :user=>'benchmarkdbuser',
-      :password=>'benchmarkdbpass'
-    }, opts
-end
-
-DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
-  db.extension(:freeze_datasets)
-  db.freeze
-end
-
-# Define ORM models
-class World < Sequel::Model(:World)
-  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
-end
-
-class Fortune < Sequel::Model(:Fortune)
-  # Allow setting id to zero (0) per benchmark requirements
-  unrestrict_primary_key
-end
 
 # Our Rack application to be executed by rackup
 class HelloWorld
   DEFAULT_HEADERS = {}.tap do |h|
-    server_string =
-      if defined?(PhusionPassenger)
-        [
-          PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
-          PhusionPassenger::VERSION_STRING
-        ].join('/').freeze
-      elsif defined?(Puma)
-        Puma::Const::PUMA_SERVER_STRING
-      elsif defined?(Unicorn)
-        Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
-      end
-
-    h['Server'] = server_string if server_string
+    h['Server'] = SERVER_STRING if SERVER_STRING
   end.freeze
 
   def bounded_queries(env)

--- a/frameworks/Ruby/rack-sequel/source_code
+++ b/frameworks/Ruby/rack-sequel/source_code
@@ -1,1 +1,3 @@
+./rack-sequel/config.ru
+./rack-sequel/boot.rb
 ./rack-sequel/hello_world.rb

--- a/frameworks/Ruby/roda-sequel/boot.rb
+++ b/frameworks/Ruby/roda-sequel/boot.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'bundler'
+require 'time'
+
+MAX_PK = 10_000
+QUERIES_MIN = 1
+QUERIES_MAX = 500
+SEQUEL_NO_ASSOCIATIONS = true
+
+Bundler.require(:default) # Load core modules
+
+def connect(dbtype)
+  Bundler.require(dbtype) # Load database-specific modules
+
+  adapters = {
+    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
+    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
+  }
+
+  opts = {}
+
+  # Determine threading/thread pool size and timeout
+  if defined?(JRUBY_VERSION)
+    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
+    opts[:pool_timeout] = 10
+  elsif defined?(Puma)
+    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
+    opts[:pool_timeout] = 10
+  else
+    Sequel.single_threaded = true
+  end
+
+  Sequel.connect \
+    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
+      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
+      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
+      :database=>'hello_world',
+      :user=>'benchmarkdbuser',
+      :password=>'benchmarkdbpass'
+    }, opts
+end
+
+DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
+  db.extension(:freeze_datasets)
+  db.freeze
+end
+
+# Define ORM models
+class World < Sequel::Model(:World)
+  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
+end
+
+class Fortune < Sequel::Model(:Fortune)
+  # Allow setting id to zero (0) per benchmark requirements
+  unrestrict_primary_key
+end
+
+SERVER_STRING =
+  if defined?(PhusionPassenger)
+    [
+      PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
+      PhusionPassenger::VERSION_STRING
+    ].join('/').freeze
+  elsif defined?(Puma)
+    Puma::Const::PUMA_SERVER_STRING
+  elsif defined?(Unicorn)
+    Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
+  end

--- a/frameworks/Ruby/roda-sequel/config.ru
+++ b/frameworks/Ruby/roda-sequel/config.ru
@@ -1,2 +1,3 @@
+require_relative 'boot'
 require_relative 'hello_world'
 run HelloWorld.freeze.app

--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -1,80 +1,12 @@
 # frozen_string_literal: true
-require 'bundler'
-require 'time'
-
-MAX_PK = 10_000
-QUERIES_MIN = 1
-QUERIES_MAX = 500
-SEQUEL_NO_ASSOCIATIONS = true
-
-Bundler.require(:default) # Load core modules
-
-def connect(dbtype)
-  Bundler.require(dbtype) # Load database-specific modules
-
-  adapters = {
-    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
-    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
-  }
-
-  opts = {}
-
-  # Determine threading/thread pool size and timeout
-  if defined?(JRUBY_VERSION)
-    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
-    opts[:pool_timeout] = 10
-  elsif defined?(Puma)
-    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
-    opts[:pool_timeout] = 10
-  else
-    Sequel.single_threaded = true
-  end
-
-  Sequel.connect \
-    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
-      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
-      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
-      :database=>'hello_world',
-      :user=>'benchmarkdbuser',
-      :password=>'benchmarkdbpass'
-    }, opts
-end
-
-DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
-  db.extension(:freeze_datasets)
-  db.freeze
-end
-
-# Define ORM models
-class World < Sequel::Model(:World)
-  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
-end
-
-class Fortune < Sequel::Model(:Fortune)
-  # Allow setting id to zero (0) per benchmark requirements
-  unrestrict_primary_key
-end
 
 # Our Rack application to be executed by rackup
 class HelloWorld < Roda
   plugin :default_headers, 'Content-Type'=>'text/html; charset=utf-8'
+  plugin :default_headers, 'Server'=>SERVER_STRING if SERVER_STRING
   plugin :json
   plugin :render, :escape=>:erubi, :layout_opts=>{ :cache_key=>'default_layout' }
   plugin :static_routing
-
-  server_string =
-    if defined?(PhusionPassenger)
-      [
-        PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
-        PhusionPassenger::VERSION_STRING
-      ].join('/').freeze
-    elsif defined?(Puma)
-      Puma::Const::PUMA_SERVER_STRING
-    elsif defined?(Unicorn)
-      Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
-    end
-
-  plugin :default_headers, 'Server'=>server_string if server_string
 
   def bounded_queries
     queries = request['queries'].to_i

--- a/frameworks/Ruby/roda-sequel/source_code
+++ b/frameworks/Ruby/roda-sequel/source_code
@@ -1,1 +1,3 @@
+./roda-sequel/config.ru
+./roda-sequel/boot.rb
 ./roda-sequel/hello_world.rb

--- a/frameworks/Ruby/sinatra-sequel/boot.rb
+++ b/frameworks/Ruby/sinatra-sequel/boot.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'bundler'
+require 'time'
+
+MAX_PK = 10_000
+QUERIES_MIN = 1
+QUERIES_MAX = 500
+SEQUEL_NO_ASSOCIATIONS = true
+
+Bundler.require(:default) # Load core modules
+
+def connect(dbtype)
+  Bundler.require(dbtype) # Load database-specific modules
+
+  adapters = {
+    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
+    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
+  }
+
+  opts = {}
+
+  # Determine threading/thread pool size and timeout
+  if defined?(JRUBY_VERSION)
+    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
+    opts[:pool_timeout] = 10
+  elsif defined?(Puma)
+    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
+    opts[:pool_timeout] = 10
+  else
+    Sequel.single_threaded = true
+  end
+
+  Sequel.connect \
+    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
+      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
+      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
+      :database=>'hello_world',
+      :user=>'benchmarkdbuser',
+      :password=>'benchmarkdbpass'
+    }, opts
+end
+
+DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
+  db.extension(:freeze_datasets)
+  db.freeze
+end
+
+# Define ORM models
+class World < Sequel::Model(:World)
+  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
+end
+
+class Fortune < Sequel::Model(:Fortune)
+  # Allow setting id to zero (0) per benchmark requirements
+  unrestrict_primary_key
+end
+
+SERVER_STRING =
+  if defined?(PhusionPassenger)
+    [
+      PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
+      PhusionPassenger::VERSION_STRING
+    ].join('/').freeze
+  elsif defined?(Puma)
+    Puma::Const::PUMA_SERVER_STRING
+  elsif defined?(Unicorn)
+    Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
+  end

--- a/frameworks/Ruby/sinatra-sequel/config.ru
+++ b/frameworks/Ruby/sinatra-sequel/config.ru
@@ -1,2 +1,3 @@
+require_relative 'boot'
 require_relative 'hello_world'
 run HelloWorld.new

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -1,59 +1,4 @@
 # frozen_string_literal: true
-require 'bundler'
-require 'time'
-
-MAX_PK = 10_000
-QUERIES_MIN = 1
-QUERIES_MAX = 500
-SEQUEL_NO_ASSOCIATIONS = true
-
-Bundler.require(:default) # Load core modules
-
-def connect(dbtype)
-  Bundler.require(dbtype) # Load database-specific modules
-
-  adapters = {
-    :mysql=>{ :jruby=>'jdbc:mysql', :mri=>'mysql2' },
-    :postgresql=>{ :jruby=>'jdbc:postgresql', :mri=>'postgres' }
-  }
-
-  opts = {}
-
-  # Determine threading/thread pool size and timeout
-  if defined?(JRUBY_VERSION)
-    opts[:max_connections] = Integer(ENV.fetch('MAX_CONCURRENCY'))
-    opts[:pool_timeout] = 10
-  elsif defined?(Puma)
-    opts[:max_connections] = Puma.cli_config.options.fetch(:max_threads)
-    opts[:pool_timeout] = 10
-  else
-    Sequel.single_threaded = true
-  end
-
-  Sequel.connect \
-    '%<adapter>s://%<host>s/%<database>s?user=%<user>s&password=%<password>s' % {
-      :adapter=>adapters.fetch(dbtype).fetch(defined?(JRUBY_VERSION) ? :jruby : :mri),
-      :host=>ENV.fetch('DBHOST', '127.0.0.1'),
-      :database=>'hello_world',
-      :user=>'benchmarkdbuser',
-      :password=>'benchmarkdbpass'
-    }, opts
-end
-
-DB = connect(ENV.fetch('DBTYPE').to_sym).tap do |db|
-  db.extension(:freeze_datasets)
-  db.freeze
-end
-
-# Define ORM models
-class World < Sequel::Model(:World)
-  def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
-end
-
-class Fortune < Sequel::Model(:Fortune)
-  # Allow setting id to zero (0) per benchmark requirements
-  unrestrict_primary_key
-end
 
 # Configure Slim templating engine
 Slim::Engine.set_options \
@@ -72,18 +17,6 @@ class HelloWorld < Sinatra::Base
 
     # Only add the charset parameter to specific content types per the requirements
     set :add_charset, [mime_type(:html)]
-
-    set :server_string,
-      if defined?(PhusionPassenger)
-        [
-          PhusionPassenger::SharedConstants::SERVER_TOKEN_NAME,
-          PhusionPassenger::VERSION_STRING
-        ].join('/').freeze
-      elsif defined?(Puma)
-        Puma::Const::PUMA_SERVER_STRING
-      elsif defined?(Unicorn)
-        Unicorn::HttpParser::DEFAULTS['SERVER_SOFTWARE']
-      end
   end
 
   helpers do
@@ -115,8 +48,8 @@ class HelloWorld < Sinatra::Base
   end
 
   after do
-    response['Server'] = settings.server_string
-  end if server_string
+    response['Server'] = SERVER_STRING
+  end if SERVER_STRING
 
   # Test type 1: JSON serialization
   get '/json' do

--- a/frameworks/Ruby/sinatra-sequel/source_code
+++ b/frameworks/Ruby/sinatra-sequel/source_code
@@ -1,1 +1,3 @@
+./sinatra-sequel/config.ru
+./sinatra-sequel/boot.rb
 ./sinatra-sequel/hello_world.rb


### PR DESCRIPTION
This should make it easier to keep all the benchmarks in the suite
up-to-date and in-sync! And easier to compare and contrast the
frameworks.

(This literally just takes the stuff that's common to all three and moves it into a boot.rb file in the same directory. No dragons here.)

[ci fw-only Ruby/sinatra-sequel Ruby/rack-sequel Ruby/roda-sequel]