### PR TITLE
=akka-http remove unnecessary copying of entity

### DIFF
--- a/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/handlers/PlaintextHandler.scala
+++ b/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/handlers/PlaintextHandler.scala
@@ -14,5 +14,5 @@ class PlaintextHandler(components: {
     }
   }
 
-  def response = HttpResponse(StatusCodes.OK, entity = HttpEntity("Hello, World!").withContentType(`text/plain`.withCharset(`UTF-8`)))
+  def response = HttpResponse(StatusCodes.OK, entity = HttpEntity("Hello, World!"))
 }


### PR DESCRIPTION
Just a small improvement which I noticed while skimming the code.

The HttpEntity call made on this line already makes the content type be `text/plain` (UTF-8), the additional call made here created an entire copy of the entity object for each request and did not really have to do that since it is the right content type already. See here: https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala#L253
