### PR TITLE
Round 14 JVM tuning for ruby-sequel/sinatra benchmarks

### DIFF
--- a/frameworks/Ruby/rack-sequel/config/java_tune.sh
+++ b/frameworks/Ruby/rack-sequel/config/java_tune.sh
@@ -2,23 +2,17 @@
 stack_size=1
 cache_size=240
 meta_size=192
-
-# Factor in Ruby's per-thread overhead...
-avail_mem=$(awk '/^MemAvailable/ { print int(0.7 * $2 / 1024) - ( \
-  $ENVIRON["MAX_CONCURRENCY"] * $ENVIRON["THREAD_FACTOR"] \
-); exit }' /proc/meminfo)
-
-# ...as well as Java's per-thread stack size.
-heap_size=$(( avail_mem - meta_size - cache_size - (
-  stack_size * MAX_CONCURRENCY * THREAD_FACTOR
-) ))
+avail_mem=$(awk '/^MemAvailable/ { print int(0.6 * $2 / 1024); exit }' /proc/meminfo)
+heap_size=$(( avail_mem - meta_size - cache_size - (stack_size * MAX_CONCURRENCY * THREAD_FACTOR) ))
 
 JRUBY_OPTS="-J-server -J-XX:+AggressiveOpts -J-Djava.net.preferIPv4Stack=true"
-JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
-#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:MaxGCPauseMillis=100"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
+JRUBY_OPTS="$JRUBY_OPTS -J-XX:+CMSClassUnloadingEnabled -J-XX:+UseConcMarkSweepGC"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:+UseStringDeduplication"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xms${heap_size}m -J-Xmx${heap_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xss${stack_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:MaxMetaspaceSize=${meta_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:ReservedCodeCacheSize=${cache_size}m"
+#JRUBY_OPTS="$JRUBY_OPTS -Xcompile.invokedynamic=true"
 
 export JRUBY_OPTS

--- a/frameworks/Ruby/roda-sequel/config/java_tune.sh
+++ b/frameworks/Ruby/roda-sequel/config/java_tune.sh
@@ -2,23 +2,17 @@
 stack_size=1
 cache_size=240
 meta_size=192
-
-# Factor in Ruby's per-thread overhead...
-avail_mem=$(awk '/^MemAvailable/ { print int(0.7 * $2 / 1024) - ( \
-  $ENVIRON["MAX_CONCURRENCY"] * $ENVIRON["THREAD_FACTOR"] \
-); exit }' /proc/meminfo)
-
-# ...as well as Java's per-thread stack size.
-heap_size=$(( avail_mem - meta_size - cache_size - (
-  stack_size * MAX_CONCURRENCY * THREAD_FACTOR
-) ))
+avail_mem=$(awk '/^MemAvailable/ { print int(0.6 * $2 / 1024); exit }' /proc/meminfo)
+heap_size=$(( avail_mem - meta_size - cache_size - (stack_size * MAX_CONCURRENCY * THREAD_FACTOR) ))
 
 JRUBY_OPTS="-J-server -J-XX:+AggressiveOpts -J-Djava.net.preferIPv4Stack=true"
-JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
-#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:MaxGCPauseMillis=100"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
+JRUBY_OPTS="$JRUBY_OPTS -J-XX:+CMSClassUnloadingEnabled -J-XX:+UseConcMarkSweepGC"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:+UseStringDeduplication"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xms${heap_size}m -J-Xmx${heap_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xss${stack_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:MaxMetaspaceSize=${meta_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:ReservedCodeCacheSize=${cache_size}m"
+#JRUBY_OPTS="$JRUBY_OPTS -Xcompile.invokedynamic=true"
 
 export JRUBY_OPTS

--- a/frameworks/Ruby/sinatra-sequel/config/java_tune.sh
+++ b/frameworks/Ruby/sinatra-sequel/config/java_tune.sh
@@ -2,23 +2,17 @@
 stack_size=1
 cache_size=240
 meta_size=192
-
-# Factor in Ruby's per-thread overhead...
-avail_mem=$(awk '/^MemAvailable/ { print int(0.7 * $2 / 1024) - ( \
-  $ENVIRON["MAX_CONCURRENCY"] * $ENVIRON["THREAD_FACTOR"] \
-); exit }' /proc/meminfo)
-
-# ...as well as Java's per-thread stack size.
-heap_size=$(( avail_mem - meta_size - cache_size - (
-  stack_size * MAX_CONCURRENCY * THREAD_FACTOR
-) ))
+avail_mem=$(awk '/^MemAvailable/ { print int(0.6 * $2 / 1024); exit }' /proc/meminfo)
+heap_size=$(( avail_mem - meta_size - cache_size - (stack_size * MAX_CONCURRENCY * THREAD_FACTOR) ))
 
 JRUBY_OPTS="-J-server -J-XX:+AggressiveOpts -J-Djava.net.preferIPv4Stack=true"
-JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
-#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:MaxGCPauseMillis=100"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
+JRUBY_OPTS="$JRUBY_OPTS -J-XX:+CMSClassUnloadingEnabled -J-XX:+UseConcMarkSweepGC"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:+UseStringDeduplication"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xms${heap_size}m -J-Xmx${heap_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xss${stack_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:MaxMetaspaceSize=${meta_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:ReservedCodeCacheSize=${cache_size}m"
+#JRUBY_OPTS="$JRUBY_OPTS -Xcompile.invokedynamic=true"
 
 export JRUBY_OPTS

--- a/frameworks/Ruby/sinatra/config/java_tune.sh
+++ b/frameworks/Ruby/sinatra/config/java_tune.sh
@@ -2,23 +2,17 @@
 stack_size=1
 cache_size=240
 meta_size=192
-
-# Factor in Ruby's per-thread overhead...
-avail_mem=$(awk '/^MemAvailable/ { print int(0.7 * $2 / 1024) - ( \
-  $ENVIRON["MAX_CONCURRENCY"] * $ENVIRON["THREAD_FACTOR"] \
-); exit }' /proc/meminfo)
-
-# ...as well as Java's per-thread stack size.
-heap_size=$(( avail_mem - meta_size - cache_size - (
-  stack_size * MAX_CONCURRENCY * THREAD_FACTOR
-) ))
+avail_mem=$(awk '/^MemAvailable/ { print int(0.6 * $2 / 1024); exit }' /proc/meminfo)
+heap_size=$(( avail_mem - meta_size - cache_size - (stack_size * MAX_CONCURRENCY * THREAD_FACTOR) ))
 
 JRUBY_OPTS="-J-server -J-XX:+AggressiveOpts -J-Djava.net.preferIPv4Stack=true"
-JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
-#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:MaxGCPauseMillis=100"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseSerialGC"
+JRUBY_OPTS="$JRUBY_OPTS -J-XX:+CMSClassUnloadingEnabled -J-XX:+UseConcMarkSweepGC"
+#JRUBY_OPTS="$JRUBY_OPTS -J-XX:+UseG1GC -J-XX:+UseStringDeduplication"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xms${heap_size}m -J-Xmx${heap_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-Xss${stack_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:MaxMetaspaceSize=${meta_size}m"
 JRUBY_OPTS="$JRUBY_OPTS -J-XX:ReservedCodeCacheSize=${cache_size}m"
+#JRUBY_OPTS="$JRUBY_OPTS -Xcompile.invokedynamic=true"
 
 export JRUBY_OPTS


### PR DESCRIPTION
Switch the garbage collector and simplify MemAvailable calculations. No
more tweaking, I promise!

[ci fw-only Ruby/sinatra Ruby/sinatra-sequel Ruby/rack-sequel Ruby/roda-sequel]