### PR TITLE
Vagrant benchmark.cfg

### DIFF
--- a/deployment/vagrant-common/bootstrap.sh
+++ b/deployment/vagrant-common/bootstrap.sh
@@ -97,6 +97,7 @@ if [ ! -e "~/.firstboot" ]; then
     cd ~/FrameworkBenchmarks
     # Update the benchmark.cfg for vagrant
     sed -i s/techempower/vagrant/g ~/FrameworkBenchmarks/benchmark.cfg
+    git update-index --assume-unchanged benchmark.cfg
     source ~/FrameworkBenchmarks/toolset/setup/linux/prerequisites.sh
   #fi
 


### PR DESCRIPTION
I think the decision was to add back the benchmark.cfg.example.

In the meantime this ensures that the bencmark.cfg won't be tracked for vagrant users.