### PR TITLE
Python/api-hour fix

### DIFF
--- a/frameworks/Python/api_hour/aiohttp.web/hello/services/mysql.py
+++ b/frameworks/Python/api_hour/aiohttp.web/hello/services/mysql.py
@@ -36,8 +36,9 @@ def update_random_records(container, limit):
             yield from cur.execute('SELECT id AS "Id", randomnumber AS "RandomNumber" FROM world WHERE id=%(idx)s LIMIT 1',
                                    {'idx': randint(1, 10000)})
             world = yield from cur.fetchone()
+            world['RandomNumber'] = randint(1, 10000)
             yield from cur.execute('UPDATE world SET randomnumber=%(random_number)s WHERE id=%(idx)s',
-                                   {'random_number': randint(1, 10000), 'idx': world['Id']})
+                                   {'random_number': world['RandomNumber'], 'idx': world['Id']})
             results.append(world)
     return results
 

--- a/frameworks/Python/api_hour/aiohttp.web/hello/services/world.py
+++ b/frameworks/Python/api_hour/aiohttp.web/hello/services/world.py
@@ -34,8 +34,9 @@ def update_random_records(container, limit):
             yield from cur.execute('SELECT id AS "Id", randomnumber AS "RandomNumber" FROM world WHERE id=%(idx)s LIMIT 1',
                                    {'idx': randint(1, 10000)})
             world = yield from cur.fetchone()
+            world['RandomNumber'] = randint(1, 10000)
             yield from cur.execute('UPDATE world SET randomnumber=%(random_number)s WHERE id=%(idx)s',
-                                   {'random_number': randint(1, 10000), 'idx': world['Id']})
+                                   {'random_number': world['RandomNumber'], 'idx': world['Id']})
             results.append(world)
     return results
 


### PR DESCRIPTION
For two of the updates tests, api_hour is returning the original object. Per [Update Rule #12](http://frameworkbenchmarks.readthedocs.io/en/latest/Project-Information/Framework-Tests/#database-updates) the object needs to be updated, then sent back.