### PR TITLE
Increment max_keepalive for Cowboy

### DIFF
--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :hello, Hello.Endpoint,
   url: [host: "0.0.0.0"],
-  http: [port: 8080],
+  http: [port: 8080, protocol_options: [max_keepalive: 5_000_000]],
   cache_static_lookup: false,
   server: true
 


### PR DESCRIPTION
The default of 100 is a reasonable default for regular browser/client usage
but implies in reconnections in case of benchmarks (which increases in
latency) when there is no connection recycling. 

By increasing the default we can make Cowboy closer to how other
webservers behave.
