### PR TITLE
Lua/octopus fix

### DIFF
--- a/frameworks/Lua/octopus/config.lua
+++ b/frameworks/Lua/octopus/config.lua
@@ -21,7 +21,7 @@ return {
 	
 	databaseConnection = {
 		rdbms       =   "mysql",
-		host        =   os.getenv("DBHOST"),
+		host        =   "TFB-database",
 		port        =   3306, 
 		database    =   "hello_world",
 		user        =   "benchmarkdbuser",

--- a/frameworks/Lua/octopus/config.lua
+++ b/frameworks/Lua/octopus/config.lua
@@ -21,7 +21,7 @@ return {
 	
 	databaseConnection = {
 		rdbms       =   "mysql",
-		host        =   "TFB-database",
+		host        =   "DBHOSTNAME",
 		port        =   3306, 
 		database    =   "hello_world",
 		user        =   "benchmarkdbuser",

--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -11,8 +11,7 @@ cd ..
 
 # The following line is a hacky way to get this framework working.
 # zlib fix needs to happen within the framework owner's repo
-
-sed -i 's|zlib_version=1\.2\.10|zlib_version=1.2.11|g' octopus/bin/unix/server.sh
+sed -i 's|zlib_url=http://zlib.net/zlib-$zlib_version.tar.gz|https://github.com/madler/zlib/archive/v$zlib_version.tar.gz|g' octopus/bin/unix/server.sh
 
 cp -avr app octopus/extensions
 cp -vf config.lua octopus/extensions

--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -11,7 +11,7 @@ cd ..
 
 # The following line is a hacky way to get this framework working.
 # zlib fix needs to happen within the framework owner's repo
-sed -i 's|zlib_url=http://zlib.net/zlib-$zlib_version.tar.gz|https://github.com/madler/zlib/archive/v$zlib_version.tar.gz|g' octopus/bin/unix/server.sh
+sed -i 's|zlib_url=http://zlib.net/zlib-$zlib_version.tar.gz|zlib_url=https://github.com/madler/zlib/archive/v$zlib_version.tar.gz|g' octopus/bin/unix/server.sh
 
 cp -avr app octopus/extensions
 cp -vf config.lua octopus/extensions

--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -13,7 +13,7 @@ cd ..
 # Ideally, TFB-database would be enough in config.lua to get this working and the
 # zlib fix needs to happen within the framework owner's repo
 DB_HOST=$(grep -Pio '.+(?= TFB-database)' /etc/hosts)
-sed -i s/TFB-database/${DB_HOST}/g config.lua
+sed -i 's/TFB-database/'${DB_HOST}'/g' config.lua
 sed -i 's|zlib_version=1\.2\.10|zlib_version=1.2.11|g' octopus/bin/unix/server.sh
 
 cp -avr app octopus/extensions

--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -9,6 +9,13 @@ cd octopus
 git checkout 0c4fc42198fed3a299c78d4b910188113d478bc5
 cd ..
 
+# The following 3 lines are a hacky way to get this framework working.
+# Ideally, TFB-database would be enough in config.lua to get this working and the
+# zlib fix needs to happen within the framework owner's repo
+DB_HOST=$(grep -Pio '.+(?= TFB-database)' /etc/hosts)
+sed -i s/TFB-database/${DB_HOST}/g config.lua
+sed -i 's|zlib_version=1\.2\.10|zlib_version=1.2.11|g' octopus/bin/unix/server.sh
+
 cp -avr app octopus/extensions
 cp -vf config.lua octopus/extensions
 

--- a/frameworks/Lua/octopus/setup.sh
+++ b/frameworks/Lua/octopus/setup.sh
@@ -9,15 +9,15 @@ cd octopus
 git checkout 0c4fc42198fed3a299c78d4b910188113d478bc5
 cd ..
 
-# The following 3 lines are a hacky way to get this framework working.
-# Ideally, TFB-database would be enough in config.lua to get this working and the
+# The following line is a hacky way to get this framework working.
 # zlib fix needs to happen within the framework owner's repo
-DB_HOST=$(grep -Pio '.+(?= TFB-database)' /etc/hosts)
-sed -i 's/TFB-database/'${DB_HOST}'/g' config.lua
+
 sed -i 's|zlib_version=1\.2\.10|zlib_version=1.2.11|g' octopus/bin/unix/server.sh
 
 cp -avr app octopus/extensions
 cp -vf config.lua octopus/extensions
+
+sed -i 's|DBHOSTNAME|'"${DBHOST}"'|g' octopus/extensions/config.lua
 
 cd octopus/bin/unix
 . ./server.sh install


### PR DESCRIPTION
This is a bit of a hacky solution to get octopus working again. The zlib change needs to be made with the framework owner's repo, as it's currently broken.

This will only work until zlib updates again, so if we see Octopus breaking in the future we should consider removing this benchmark until it's resolved by the owner.