### PR TITLE
upgrading aiohttp and correcting README

### DIFF
--- a/frameworks/Python/aiohttp/README.md
+++ b/frameworks/Python/aiohttp/README.md
@@ -19,7 +19,19 @@ separately [asyncpg](https://magicstack.github.io/asyncpg/current/) for database
 
 ### Database
 
-PostgreSQL
+PostgreSQL.
+
+Two variants:
+* ORM using [aiopg + sqlalchemy](http://aiopg.readthedocs.io/en/stable/sa.html)
+* RAW using [asyncpg](https://magicstack.github.io/asyncpg/current/)
+
+**To enabled "RAW" mode set the following environment variable:**
+ 
+```
+export CONNECTION=RAW
+```
+
+This will switch which database engine the app uses to execute queries with tests 2, 3, 4 & 5.
 
 ### Server
 
@@ -33,44 +45,20 @@ gunicorn+uvloop on CPython
 
 ### Test 2: Single Row Query
 
-With ORM:
-
     http://localhost:8080/db
-
-Without ORM (raw):
-
-    http://localhost:8080/raw/db
 
 ### Test 3: Multi Row Query 
 
-With ORM:
-
-    http://localhost:8080/queries?queries=20
-
-Without ORM (raw):
-
-    http://localhost:8080/raw/queries?queries=20
+    http://localhost:8080/queries/20
 
 ### Test 4: Fortunes (Template rendering)
 
-With ORM:
-
     http://localhost:8080/fortunes
-
-Without ORM (raw):
-
-    http://localhost:8080/raw/fortunes
 
 ### Test 5: Update Query
 
-With ORM:
+    http://localhost:8080/updates/20
 
-    http://localhost:8080/updates?queries=20
-
-Without ORM (raw):
-
-    http://localhost:8080/raw/updates?queries=20
-
-### Test6: Plaintext
+### Test 6: Plaintext
 
     http://localhost:8080/plaintext

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==1.2.0
+aiohttp==1.3.1
 aiohttp-jinja2==0.13.0
 aiopg==0.13.0
 asyncpg==0.8.4


### PR DESCRIPTION
Upgrading aiohttp to stop it spewing loads of `CancelledError` tracebacks (https://github.com/KeepSafe/aiohttp/issues/1565).

Also correct the readme to reflect the changes in #2555 (forgot to do it there).

