### PR TITLE
Update Finatra framework to most recently released version (2.8.0)

### DIFF
--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,12 +1,11 @@
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"
-version := "0.0.1"
+version := "2.8.0"
 
 scalaVersion := "2.11.8"
 
 resolvers ++= Seq(
-  Resolver.sonatypeRepo("releases"),
-  "Twitter Maven" at "https://maven.twttr.com"
+  Resolver.sonatypeRepo("releases")
 )
 
 assemblyJarName in assembly := "finatra-benchmark.jar"
@@ -17,6 +16,6 @@ assemblyMergeStrategy in assembly := {
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "2.7.0",
+  "com.twitter" %% "finatra-http" % "2.8.0",
   "org.slf4j" % "slf4j-nop" % "1.7.21"
 )


### PR DESCRIPTION
<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->

Problem

We'd like to update the Finatra framework test to the most recently released version of Finatra: [v`2.8.0`](https://github.com/twitter/finatra/releases/tag/finatra-2.8.0). We'd also like to track the benchmark project's version against the Finatra version it is testing. And finally, the "maven.twttr.com" repository is no longer needed (yay).

Solution

Update the FrameworkBenchmarks/Scala/finatra/build.sbt file accordingly.
