### PR TITLE
Update go version to 1.8

### DIFF
--- a/toolset/setup/linux/languages/go.sh
+++ b/toolset/setup/linux/languages/go.sh
@@ -2,7 +2,7 @@
 
 fw_installed go && return 0
 
-VERSION=1.7
+VERSION=1.8
 GOROOT=$IROOT/go
 
 fw_get -O https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz


### PR DESCRIPTION
Go 1.8 is out. So let's use it in benchmarks.

<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->
