### PR TITLE
Use the correct hostname for the database in Compojure w/ HikariCP

### DIFF
--- a/frameworks/Clojure/compojure/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/hello/src/hello/handler.clj
@@ -50,7 +50,7 @@
                                   :username           "benchmarkdbuser"
                                   :password           "benchmarkdbpass"
                                   :database-name      "hello_world"
-                                  :server-name        "127.0.0.1"
+                                  :server-name        "TFB-database"
                                   :port-number        3306
                                   :register-mbeans    false})
 


### PR DESCRIPTION
Previously, "127.0.0.1" was replaced with the correct hostname by a setup script, but that script was removed in https://github.com/TechEmpower/FrameworkBenchmarks/commit/acbfff44d8ed50419bc8bb74171aa2e117d5f4bc.