### PR TITLE
Fix broken wicket db tests by downgrading the mysql connector

### DIFF
--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>6.0.5</version>
+			<version>5.1.41</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/WicketApplication.java
@@ -80,7 +80,7 @@ public class WicketApplication extends WebApplication
 
 				// use faster DataSource impl
 				ds.setJdbcUrl("jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false");
-				ds.setDriverClassName("com.mysql.cj.jdbc.Driver");
+				ds.setDriverClassName("com.mysql.jdbc.Driver");
 				ds.setUsername("benchmarkdbuser");
 				ds.setPassword("benchmarkdbpass");
 				dataSource = ds;


### PR DESCRIPTION
Version 6.x of the connector is apparently more opinionated about time zones.  All of the db tests were failing with exceptions like this:

```
java.sql.SQLException: The server time zone value 'CDT' is
unrecognized or represents more than one time zone. You must
configure either the server or JDBC driver (via the serverTimezone
configuration property) to use a more specifc time zone value if you
want to utilize time zone support.
```

Maybe it's making a valid point that we should address, maybe not.  But right now mysql-connector-java 6.x is a "development release".  Let's use the stable release (5.x) instead, which is what every other framework that uses Java and mysql is doing already.