### PR TITLE
Repair lapis database tests by providing the correct db hostname

### DIFF
--- a/frameworks/Lua/lapis/config.moon
+++ b/frameworks/Lua/lapis/config.moon
@@ -12,4 +12,4 @@ config {"production", "development"}, ->
     database "hello_world"
     user "benchmarkdbuser"
     password "benchmarkdbpass"
-    host "DBHOSTNAME"
+    host os.getenv("DBHOST")

--- a/frameworks/Lua/lapis/nginx.conf
+++ b/frameworks/Lua/lapis/nginx.conf
@@ -3,6 +3,7 @@
     error_log stderr notice;
     #error_log /tmp/test.log error;
     env LAPIS_ENVIRONMENT;
+    env DBHOST;
     daemon off;
 
     events {

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -5,6 +5,7 @@ from benchmark.test_types import *
 import importlib
 import os
 import subprocess
+import socket
 import time
 import re
 from pprint import pprint
@@ -174,7 +175,7 @@ class FrameworkTest:
 
     os.environ['TROOT'] = self.directory
     os.environ['IROOT'] = self.install_root
-    os.environ['DBHOST'] = self.database_host
+    os.environ['DBHOST'] = socket.gethostbyname(self.database_host)
     os.environ['LOGDIR'] = logDir
     os.environ['MAX_THREADS'] = str(self.benchmarker.threads)
     os.environ['MAX_CONCURRENCY'] = str(max(self.benchmarker.concurrency_levels))
@@ -228,7 +229,7 @@ class FrameworkTest:
       %s/TFBReaper "bash -exc \\\"source %s && source %s.sh\\\"''' % (self.fwroot,
         self.directory,
         self.install_root,
-        self.database_host,
+        socket.gethostbyname(self.database_host),
         logDir,
         self.benchmarker.threads,
         max(self.benchmarker.concurrency_levels),


### PR DESCRIPTION
The lapis tests that required db access were all failing to connect to the database.  This was caused by two issues:

1. We were not passing along the "DBHOST" environment variable from nginx to lapis.  The fix was to explicitly share that variable in nginx.conf.

2. The "DBHOST" environment variable (at least in our current dedicated hardware environment) is set to "TFB-database", a name defined in our /etc/hosts file.  lapis doesn't know about names defined in /etc/hosts.  The fix was to change the "DBHOST" environment variable to be the resolved address of what it was previously, so for example "TFB-database" would become the IP address of that server in our dedicated hardware environment.  This *should* be compatible with every other use of the "DBHOST" environment variable...  It has always been the case that this variable could have been defined in the benchmark config as an IP address.

The change to config.moon is not strictly necessary and might not even be syntactically valid.  The tests seem to ignore the config.moon file and use the config.lua file instead.  I decided to make the change to the .moon file anyway because it's closer to correct than what was there before (at least it communicates the right intent).