### PR TITLE
Upload the results.json once more after the completion time is set

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -149,6 +149,7 @@ class Benchmarker:
 
 
         self.__set_completion_time()
+        self.__upload_results()
         self.__finish()
         return result
 


### PR DESCRIPTION
This makes it easier for the consumer of the uploaded results to tell when the run is complete.
