### PR TITLE
Isolate cutelyst install to installs/cutelyst, let it use sudo again

### DIFF
--- a/frameworks/C++/cutelyst/config.sh
+++ b/frameworks/C++/cutelyst/config.sh
@@ -21,40 +21,41 @@ elif [ "${DRIVER}" == "QPSQL" ]; then
   fw_depends postgresql
 fi
 
+CROOT=${IROOT}/cutelyst
 
-mkdir ${IROOT}/cutelyst-benchmarks || true
-cd ${IROOT}/cutelyst-benchmarks
+mkdir -p ${CROOT}/benchmarks || true
+cd ${CROOT}/benchmarks
 
 # build
-export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM}:${IROOT}
-cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT
+export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM}:${CROOT}
+cmake $TROOT -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CROOT
 make -j $MAX_THREADS
 
 if [ -n "${UWSGI}" ]; then
-  cp -v ${TROOT}/config/config_socket.ini ${IROOT}/config.ini
+  cp -v ${TROOT}/config/config_socket.ini ${CROOT}/config.ini
   SEND_DATE=true
 else
-  cp -v ${TROOT}/config/config.ini ${IROOT}/config.ini
+  cp -v ${TROOT}/config/config.ini ${CROOT}/config.ini
   SEND_DATE=false
 fi
 
-sed -i "s|Driver=.*|Driver=${DRIVER}|g" ${IROOT}/config.ini
-sed -i "s|DatabaseHostName=.*|DatabaseHostName=${DBHOST}|g" ${IROOT}/config.ini
-sed -i "s|SendDate=.*|SendDate=${SEND_DATE}|g" ${IROOT}/config.ini
+sed -i "s|Driver=.*|Driver=${DRIVER}|g" ${CROOT}/config.ini
+sed -i "s|DatabaseHostName=.*|DatabaseHostName=${DBHOST}|g" ${CROOT}/config.ini
+sed -i "s|SendDate=.*|SendDate=${SEND_DATE}|g" ${CROOT}/config.ini
 
-export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${IROOT}/lib/x86_64-linux-gnu/
+export LD_LIBRARY_PATH=/opt/qt${QT_VERSION_MM}/lib:${CROOT}/lib/x86_64-linux-gnu/
 
 if [ -n "${UWSGI}" ]; then
-  uwsgi --ini ${IROOT}/config.ini --cutelyst-app ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so ${PROCESS_OR_THREAD} $MAX_THREADS &
+  uwsgi --ini ${CROOT}/config.ini --cutelyst-app ${CROOT}/benchmarks/src/libcutelyst_benchmarks.so ${PROCESS_OR_THREAD} $MAX_THREADS &
 else
-  ${IROOT}/bin/cutelyst-wsgi --ini ${IROOT}/config.ini -a ${IROOT}/cutelyst-benchmarks/src/libcutelyst_benchmarks.so ${PROCESS_OR_THREAD} $MAX_THREADS --socket-timeout 0 &
+  ${CROOT}/bin/cutelyst-wsgi --ini ${CROOT}/config.ini -a ${CROOT}/benchmarks/src/libcutelyst_benchmarks.so ${PROCESS_OR_THREAD} $MAX_THREADS --socket-timeout 0 &
 fi
 
 # configure Nginx
 if [ -n "${NGINX}" ]; then
   fw_depends nginx
-  cp -v ${TROOT}/nginx.conf ${IROOT}/nginx.conf
-  sed -i "s|include .*/conf/uwsgi_params;|include ${NGINX_HOME}/conf/uwsgi_params;|g" ${IROOT}/nginx.conf
-  nginx -c ${IROOT}/nginx.conf
+  cp -v ${TROOT}/nginx.conf ${CROOT}/nginx.conf
+  sed -i "s|include .*/conf/uwsgi_params;|include ${NGINX_HOME}/conf/uwsgi_params;|g" ${CROOT}/nginx.conf
+  nginx -c ${CROOT}/nginx.conf
 fi
 

--- a/toolset/setup/linux/frameworks/cutelyst.sh
+++ b/toolset/setup/linux/frameworks/cutelyst.sh
@@ -5,6 +5,7 @@ fw_installed cutelyst && return 0
 CUTELYST_VER=1.5.0
 QT_VERSION_MM=56
 QT_VERSION_FULL=562-trusty
+CROOT=${IROOT}/cutelyst
 
 sudo apt-add-repository --yes ppa:george-edison55/cmake-3.x
 sudo apt-add-repository --yes ppa:beineri/opt-qt$QT_VERSION_FULL
@@ -24,15 +25,18 @@ qt${QT_VERSION_MM}tools
 
 export CMAKE_PREFIX_PATH=/opt/qt${QT_VERSION_MM};
 
+mkdir -p ${CROOT} || true
+cd ${CROOT}
+
 fw_get -O https://github.com/cutelyst/cutelyst/archive/v$CUTELYST_VER.tar.gz
 fw_untar v$CUTELYST_VER.tar.gz
 
 cd cutelyst-$CUTELYST_VER
 mkdir build && cd build
 
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$IROOT -DUSE_JEMALLOC=on
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$CROOT -DUSE_JEMALLOC=on
 
-make -j $MAX_THREADS && make install
+make -j $MAX_THREADS && sudo make install
 
 echo "QT_VERSION_MM=${QT_VERSION_MM}" > $IROOT/cutelyst.installed
 


### PR DESCRIPTION
The use of sudo was breaking other frameworks because it created
root-owned directories in installs that the other frameworks could not
use.  However, removing sudo broke the cutelyst install.

This change lets cutelyst use sudo again but puts all of the installed
files in installs/cutelyst, meaning that it should no longer break other
frameworks (tested by running "toolset/run-tests.py --mode verify --test
cutelyst ffead-cpp").