### PR TITLE
Capitalize "Rust" for consistency with other language IDs

### DIFF
--- a/frameworks/Rust/iron/benchmark_config.json
+++ b/frameworks/Rust/iron/benchmark_config.json
@@ -14,7 +14,7 @@
       "classification": "Micro",
       "database": "Postgres",
       "framework": "iron",
-      "language": "rust",
+      "language": "Rust",
       "orm": "raw",
       "platform": "Rust",
       "webserver": "hyper",

--- a/frameworks/Rust/nickel/benchmark_config.json
+++ b/frameworks/Rust/nickel/benchmark_config.json
@@ -10,7 +10,7 @@
       "classification": "Micro",
       "database": "None",
       "framework": "nickel",
-      "language": "rust",
+      "language": "Rust",
       "orm": "raw",
       "platform": "Rust",
       "webserver": "hyper",

--- a/frameworks/Rust/rouille/benchmark_config.json
+++ b/frameworks/Rust/rouille/benchmark_config.json
@@ -10,7 +10,7 @@
       "classification": "Micro",
       "database": "None",
       "framework": "rouille",
-      "language": "rust",
+      "language": "Rust",
       "orm": "raw",
       "platform": "Rust",
       "webserver": "rouille",

--- a/frameworks/Rust/tokio-minihttp/benchmark_config.json
+++ b/frameworks/Rust/tokio-minihttp/benchmark_config.json
@@ -12,7 +12,7 @@
       "classification": "Micro",
       "database": "Postgres",
       "framework": "tokio-minihttp",
-      "language": "rust",
+      "language": "Rust",
       "orm": "raw",
       "platform": "Rust",
       "webserver": "tokio-minihttp",


### PR DESCRIPTION
I've noticed that on the preliminary results page for round 14 that frameworks written in Rust are abbreviated as "rus" under the Language column and "Rus" under the Platform column, which mildly annoys me. :) I didn't find the string "rus" anywhere (or other abbreviations like "ngx") so I'm assuming that you have an algorithm somewhere that generates abbreviations based on benchmark_configs, where the string "rust" was present as the "Language" field for every benchmark but hyper.