### PR TITLE
[ci fw-only Go/revel] Repair revel tests, make future failures less punishing

### DIFF
--- a/frameworks/Go/revel/setup.sh
+++ b/frameworks/Go/revel/setup.sh
@@ -8,4 +8,4 @@ go get -u github.com/revel/cmd/revel
 go get -u github.com/coocood/qbs
 go get -u github.com/eaigner/jet
 
-bin/revel run benchmark prod &
+bin/revel run benchmark prod

--- a/frameworks/Go/revel/src/benchmark/app/controllers/app.go
+++ b/frameworks/Go/revel/src/benchmark/app/controllers/app.go
@@ -70,7 +70,7 @@ type App struct {
 }
 
 func (c App) Json() revel.Result {
-	return c.RenderJson(MessageStruct{"Hello, World!"})
+	return c.RenderJSON(MessageStruct{"Hello, World!"})
 }
 
 func (c App) Plaintext() revel.Result {
@@ -85,7 +85,7 @@ func (c App) Db(queries int) revel.Result {
 		if err != nil {
 			revel.ERROR.Fatalf("Error scanning world row: %v", err)
 		}
-		return c.RenderJson(w)
+		return c.RenderJSON(w)
 	}
 
 	ww := make([]World, queries)
@@ -96,7 +96,7 @@ func (c App) Db(queries int) revel.Result {
 			revel.ERROR.Fatalf("Error scanning world row: %v", err)
 		}
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) Update(queries int) revel.Result {
@@ -112,7 +112,7 @@ func (c App) Update(queries int) revel.Result {
 		if err != nil {
 			revel.ERROR.Fatalf("Error updating row: %v", err)
 		}
-		return c.RenderJson(&w)
+		return c.RenderJSON(&w)
 	}
 
 	ww := make([]World, queries)
@@ -125,7 +125,7 @@ func (c App) Update(queries int) revel.Result {
 		ww[i].RandomNumber = uint16(rand.Intn(WorldRowCount) + 1)
 		updateStatement.Exec(ww[i].RandomNumber, ww[i].Id)
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) Fortune() revel.Result {

--- a/frameworks/Go/revel/src/benchmark/app/controllers/jet.go
+++ b/frameworks/Go/revel/src/benchmark/app/controllers/jet.go
@@ -16,7 +16,7 @@ func (c App) JetDb(queries int) revel.Result {
 		if err != nil {
 			revel.ERROR.Fatalf("Db/WorldSelect error: %v", err)
 		}
-		return c.RenderJson(w)
+		return c.RenderJSON(w)
 	}
 
 	ww := make([]World, queries)
@@ -26,7 +26,7 @@ func (c App) JetDb(queries int) revel.Result {
 			revel.ERROR.Fatalf("Db/WorldSelect2 error: %v", err)
 		}
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) JetUpdate(queries int) revel.Result {
@@ -40,7 +40,7 @@ func (c App) JetUpdate(queries int) revel.Result {
 		if err = db.Jet.Query(WorldUpdate, w.RandomNumber, w.Id).Run(); err != nil {
 			revel.ERROR.Fatalf("Update/WorldUpdate error: %v", err)
 		}
-		return c.RenderJson(&w)
+		return c.RenderJSON(&w)
 	}
 
 	ww := make([]World, queries)
@@ -54,7 +54,7 @@ func (c App) JetUpdate(queries int) revel.Result {
 			revel.ERROR.Fatalf("Update/WorldUpdate2 error: %v", err)
 		}
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) JetFortune() revel.Result {
@@ -65,6 +65,6 @@ func (c App) JetFortune() revel.Result {
 	}
 	fortunes = append(fortunes, &Fortune{Message: "Additional fortune added at request time."})
 	sort.Sort(ByMessage{fortunes})
-	c.RenderArgs["fortunes"] = fortunes
+	c.ViewArgs["fortunes"] = fortunes
 	return c.RenderTemplate("App/Fortune.html")
 }

--- a/frameworks/Go/revel/src/benchmark/app/controllers/qbs.go
+++ b/frameworks/Go/revel/src/benchmark/app/controllers/qbs.go
@@ -19,7 +19,7 @@ func (c App) QbsDb(queries int) revel.Result {
 		if err != nil {
 			revel.ERROR.Fatalf("Error scanning world row: %v", err)
 		}
-		return c.RenderJson(w)
+		return c.RenderJSON(w)
 	}
 
 	ww := make([]World, queries)
@@ -29,7 +29,7 @@ func (c App) QbsDb(queries int) revel.Result {
 			revel.ERROR.Fatalf("Error scanning world row: %v", err)
 		}
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) QbsUpdate(queries int) revel.Result {
@@ -46,7 +46,7 @@ func (c App) QbsUpdate(queries int) revel.Result {
 		if _, err := qbs.Save(&w); err != nil {
 			revel.ERROR.Fatalf("Error updating world row: %v", err)
 		}
-		return c.RenderJson(&w)
+		return c.RenderJSON(&w)
 	}
 
 	ww := make([]World, queries)
@@ -60,7 +60,7 @@ func (c App) QbsUpdate(queries int) revel.Result {
 			revel.ERROR.Fatalf("Error scanning world row: %v", err)
 		}
 	}
-	return c.RenderJson(ww)
+	return c.RenderJSON(ww)
 }
 
 func (c App) QbsFortune() revel.Result {
@@ -72,6 +72,6 @@ func (c App) QbsFortune() revel.Result {
 	fortunes = append(fortunes,
 		&Fortune{Message: "Additional fortune added at request time."})
 	sort.Sort(ByMessage{fortunes})
-	c.RenderArgs["fortunes"] = fortunes
+	c.ViewArgs["fortunes"] = fortunes
 	return c.RenderTemplate("App/Fortune.html")
 }


### PR DESCRIPTION
A couple of function/property names have changed in the revel framework, causing our test code to not compile.  I updated our code to use the new names.

Also, the fact that `setup.sh` was doing compilation in the background meant the failures went unnoticed by our toolset (specifically by `framework_test.py`), causing a long period of inactivity in the test suite.  Removing the `&` fixes that problem, which will be useful in case the revel framework ever changes in a way that breaks our test code again.

There are more details in the commit messages.