### PR TITLE
[ci fw-only JavaScript/ringojs] Accept non-localhost connections in ringojs

### DIFF
--- a/frameworks/JavaScript/ringojs/setup-convenient.sh
+++ b/frameworks/JavaScript/ringojs/setup-convenient.sh
@@ -9,4 +9,4 @@ ringo-admin install orfon/reinhardt
 
 (cd $RINGOJS_HOME/packages/ringo-sqlstore/jars && curl -s -O https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar)
 
-ringo --production -J-server -J-Xmx1g -J-Xms1g ringo-convenient-main.js &
+ringo --production -J-server -J-Xmx1g -J-Xms1g ringo-convenient-main.js --host 0.0.0.0

--- a/frameworks/JavaScript/ringojs/setup.sh
+++ b/frameworks/JavaScript/ringojs/setup.sh
@@ -7,4 +7,4 @@ ringo-admin install oberhamsi/sql-ringojs-client
 ringo-admin install orfon/reinhardt
 (cd $RINGOJS_HOME/packages/sql-ringojs-client/jars && curl -s -o mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.39/mysql-connector-java-5.1.39.jar)
 
-ringo --production -J-server -J-Xmx1g -J-Xms1g ringo-main.js &
+ringo --production -J-server -J-Xmx1g -J-Xms1g ringo-main.js --host 0.0.0.0


### PR DESCRIPTION
Fixes #2613

Without this, the client machine running wrk cannot connect to the server and so ringojs gets zero RPS.

I also removed the `&` from the end of these lines, which is unnecessary and potentially problematic for our toolset if/when the server doesn't launch correctly (the toolset will sit idle for 1 hour and 45 minutes waiting for the server to appear).