### PR TITLE
[ci fw-only Clojure/pedestal] Accept non-localhost connections in pedestal

### DIFF
--- a/frameworks/Clojure/pedestal/src/pedestal/pdg.clj
+++ b/frameworks/Clojure/pedestal/src/pedestal/pdg.clj
@@ -266,7 +266,7 @@
   [service-map server-opts]
   (let [handler (::handler service-map)
         {:keys [host port join?]
-         :or {host "127.0.0.1"
+         :or {host "0.0.0.0"
               port 8080
               join? false}} server-opts
         addr (InetSocketAddress. ^String host ^int port)


### PR DESCRIPTION
Without this, the client machine running wrk cannot connect to the server and so pedestal gets zero RPS.