### PR TITLE
[ci fw-only Erlang/chicagoboss] Accept non-localhost connections in chicagoboss

### DIFF
--- a/frameworks/Erlang/chicagoboss/boss.config
+++ b/frameworks/Erlang/chicagoboss/boss.config
@@ -327,7 +327,7 @@
     %% want to start simple_bridge with application:start(simple_bridge) or
     %% simple_bridge:start/0
 
-    {address, "127.0.0.1"},
+    {address, "0.0.0.0"},
     %% IP address to bind, either in tuple format or string
     %% use "0.0.0.0" to start on all interfaces available
 


### PR DESCRIPTION
Without this, the client machine running wrk cannot connect to the server and so chicagoboss gets zero RPS.

It still seems to have issues with the plaintext test, but this should at least fix the json test.