### PR TITLE
Use mysql connector 5.x instead of 6.x in light-java-mysql

### DIFF
--- a/frameworks/Java/light-java/pom.xml
+++ b/frameworks/Java/light-java/pom.xml
@@ -37,7 +37,7 @@
         <version.httpasyncclient>4.1.2</version.httpasyncclient>
         <version.swagger>1.5.10</version.swagger>
         <version.hikaricp>2.5.1</version.hikaricp>
-        <version.mysql>6.0.4</version.mysql>
+        <version.mysql>5.1.41</version.mysql>
         <version.postgres>9.4.1211</version.postgres>
     </properties>
 
@@ -361,7 +361,7 @@
         		</plugin>
         	</plugins>
         </pluginManagement>
-        
+
     </build>
 
     <repositories>


### PR DESCRIPTION
This repairs the light-java-mysql test.

Our ServerCentral dedicated hardware environment is set up in such a way that breaks mysql connector 6.x with exceptions like this:

```
java.sql.SQLException: The server time zone value 'PDT' is
unrecognized or represents more than one time zone. You must
configure either the server or JDBC driver (via the serverTimezone
configuration property) to use a more specifc time zone value if you
want to utilize time zone support.
```

As far as I know, 6.x is presently an unstable development release whereas 5.x is the stable, production-ready release.  Other Java frameworks in the benchmarks use 5.x.  It doesn't seem worthwhile to try to fix this "problem" with our environment right now...  Maybe later when 6.x is stable or we aren't trying to get a new round of benchmarks out the door.
