### PR TITLE
Java/officefloor update

### DIFF
--- a/frameworks/Java/officefloor/pom.xml
+++ b/frameworks/Java/officefloor/pom.xml
@@ -8,7 +8,7 @@
 	<name>TechEmpowerPerformance</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<officefloor-version>2.16.0</officefloor-version>
+		<officefloor-version>2.18.0</officefloor-version>
 		<compiler-version>3.1</compiler-version>
 		<datanucleus-version>4.0.0-release</datanucleus-version>
 		<mysql-version>5.1.38</mysql-version>

--- a/frameworks/Java/officefloor/raw/datasource.properties
+++ b/frameworks/Java/officefloor/raw/datasource.properties
@@ -1,5 +1,5 @@
 datanucleus.ConnectionDriverName = com.mysql.jdbc.Driver
-datanucleus.ConnectionURL = jdbc:mysql://DATABASE_HOST:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+datanucleus.ConnectionURL = jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
 datanucleus.ConnectionUserName = benchmarkdbuser
 datanucleus.ConnectionPassword = benchmarkdbpass
 datanucleus.connectionPoolingType = C3P0

--- a/frameworks/Java/officefloor/setup.sh
+++ b/frameworks/Java/officefloor/setup.sh
@@ -10,7 +10,6 @@ fw_depends mysql java maven
 echo "Creating configuration for OfficeFloor environment ..."
 mkdir -p ./production
 cp ./raw/datasource.properties ./production 
-sed -i 's|DATABASE_HOST|'"${DBHOST}"'|g' ./production/datasource.properties
 echo "Configuration created"
 
 # Compile application


### PR DESCRIPTION
2.16.0 didn't seem to be building properly, while 2.18.0 has passed travis. Not sure if this was the only issue [here](http://tfb-logs.techempower.com/round-14/preview-2/officefloor/out.txt) but it passes local testing.