### PR TITLE
[ci fw-only C++/wt] Upgrade to wt 3.3.6, fixing the wt tests

### DIFF
--- a/frameworks/C++/wt/setup.sh
+++ b/frameworks/C++/wt/setup.sh
@@ -4,6 +4,6 @@ fw_depends mysql apache wt
 
 sed -i 's|INSERT_DB_HOST_HERE|'"${DBHOST}"'|g' benchmark.cpp
 
-g++-4.8 -O3 -DNDEBUG -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbomysql -lboost_thread
+g++-4.8 -O3 -DNDEBUG -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbomysql -lboost_thread -lboost_system
 
-./benchmark.wt -c wt_config.xml -t ${MAX_THREADS} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression &
+./benchmark.wt -c wt_config.xml -t ${MAX_THREADS} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression

--- a/frameworks/C++/wt/setup_postgres.sh
+++ b/frameworks/C++/wt/setup_postgres.sh
@@ -4,6 +4,6 @@ fw_depends postgresql apache wt
 
 sed -i 's|INSERT_DB_HOST_HERE|'"${DBHOST}"'|g' benchmark.cpp
 
-g++-4.8 -O3 -DNDEBUG -DBENCHMARK_USE_POSTGRES -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark_postgres.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbopostgres -lboost_thread
+g++-4.8 -O3 -DNDEBUG -DBENCHMARK_USE_POSTGRES -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark_postgres.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbopostgres -lboost_thread -lboost_system
 
-./benchmark_postgres.wt -c wt_config.xml -t ${MAX_THREADS} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression &
+./benchmark_postgres.wt -c wt_config.xml -t ${MAX_THREADS} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression

--- a/toolset/setup/linux/frameworks/wt.sh
+++ b/toolset/setup/linux/frameworks/wt.sh
@@ -34,10 +34,11 @@ elif [ "$TFB_DISTRIB_CODENAME" == "precise" ]; then
     sudo apt-get -y install libboost1.48-all-dev
 fi
 
-fw_get -O http://downloads.sourceforge.net/witty/wt-3.3.3.tar.gz
-fw_untar wt-3.3.3.tar.gz
+fw_get -O https://github.com/emweb/wt/archive/3.3.6.tar.gz
+mv 3.3.6.tar.gz wt-3.3.6.tar.gz
+fw_untar wt-3.3.6.tar.gz
 
-cd wt-3.3.3
+cd wt-3.3.6
 mkdir -p build
 cd build
 cmake .. -DWT_CPP_11_MODE=-std=c++0x -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
The sourceforge.net link for wt 3.3.3 is broken, causing the wt tests to fail.

Adding the `-lboost_system` flag in the setup files seemed to be necessary.  Without it, the wt framework would install, but the tests would fail.  I found out about that flag by googling for the error message; I don't actually know what the flag does.

I removed the trailing `&` from the final line of the setup files as I've been doing with other frameworks, since it has become unnecessary (and even harmful sometimes) due to other changes in our toolset.
