### PR TITLE
Disable gzip response encoding in Java/dropwizard

### DIFF
--- a/frameworks/Java/dropwizard/hello-world-mongo.yml
+++ b/frameworks/Java/dropwizard/hello-world-mongo.yml
@@ -5,6 +5,12 @@ server:
     type: http
     port: 9090
     useServerHeader: true
+    # There is no proxy in front of the server
+    useForwardedHeaders: false
+
+  # Test requirements forbid gzip compression of the replies
+  gzip:
+    enabled: false
 
   requestLog:
     appenders: []

--- a/frameworks/Java/dropwizard/hello-world-mysql.yml
+++ b/frameworks/Java/dropwizard/hello-world-mysql.yml
@@ -5,6 +5,12 @@ server:
     type: http
     port: 9090
     useServerHeader: true
+    # There is no proxy in front of the server
+    useForwardedHeaders: false
+
+  # Test requirements forbid gzip compression of the replies
+  gzip:
+    enabled: false
 
   requestLog:
     appenders: []

--- a/frameworks/Java/dropwizard/hello-world-postgres.yml
+++ b/frameworks/Java/dropwizard/hello-world-postgres.yml
@@ -5,6 +5,12 @@ server:
     type: http
     port: 9090
     useServerHeader: true
+    # There is no proxy in front of the server
+    useForwardedHeaders: false
+
+  # Test requirements forbid gzip compression of the replies
+  gzip:
+    enabled: false
 
   requestLog:
     appenders: []
@@ -23,7 +29,7 @@ database:
   password: benchmarkdbpass
 
   # the JDBC URL
-  url: jdbc:postgresql://127.0.0.1:5432/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+  url: jdbc:postgresql://127.0.0.1:5432/hello_world
 
   # any properties specific to your JDBC driver:
   properties:


### PR DESCRIPTION
This resolves #2646 for Dropwizard. Verified locally by inspecting the `verification.txt` files for gzip encoding.