### PR TITLE
Adjusting JVM parameters for Dropwizard, Jetty, Resin, Undertow

### DIFF
--- a/frameworks/Java/README.md
+++ b/frameworks/Java/README.md
@@ -19,11 +19,11 @@ should have an `install.sh` that contains at least
 
     fw_depends java
 
-This installs the Oracle Java 8 JDK. It also provides a shell variable `JAVA_OPTS` with tweaked default parameters for the JVM. Sample use:
+This installs the Oracle Java 8 JDK. It also provides a shell variable `JAVA_OPTS_TFB` with tweaked default parameters for the JVM. Sample use:
 
     #!/bin/bash
 
-    java -server $JAVA_OPTS
+    java -server $JAVA_OPTS_TFB
 
 ## Get Help
 

--- a/frameworks/Java/README.md
+++ b/frameworks/Java/README.md
@@ -19,7 +19,11 @@ should have an `install.sh` that contains at least
 
     fw_depends java
 
-This installs the Oracle Java 8 JDK.
+This installs the Oracle Java 8 JDK. It also provides a shell variable `JAVA_OPTS` with tweaked default parameters for the JVM. Sample use:
+
+    #!/bin/bash
+
+    java -server $JAVA_OPTS
 
 ## Get Help
 

--- a/frameworks/Java/dropwizard/setup_mongo.sh
+++ b/frameworks/Java/dropwizard/setup_mongo.sh
@@ -6,4 +6,4 @@ sed -i 's|host: 127.0.0.1|host: '"${DBHOST}"'|g' hello-world-mongo.yml
 
 mvn -P mongo clean package
 
-java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &
+java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &

--- a/frameworks/Java/dropwizard/setup_mongo.sh
+++ b/frameworks/Java/dropwizard/setup_mongo.sh
@@ -6,4 +6,4 @@ sed -i 's|host: 127.0.0.1|host: '"${DBHOST}"'|g' hello-world-mongo.yml
 
 mvn -P mongo clean package
 
-java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &
+java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &

--- a/frameworks/Java/dropwizard/setup_mysql.sh
+++ b/frameworks/Java/dropwizard/setup_mysql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:mysql://.*/hello_world|url: jdbc:mysql://'"${DBHOST}"':3306/
 
 mvn -P mysql clean package
 
-java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &
+java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &

--- a/frameworks/Java/dropwizard/setup_mysql.sh
+++ b/frameworks/Java/dropwizard/setup_mysql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:mysql://.*/hello_world|url: jdbc:mysql://'"${DBHOST}"':3306/
 
 mvn -P mysql clean package
 
-java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &
+java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &

--- a/frameworks/Java/dropwizard/setup_postgresql.sh
+++ b/frameworks/Java/dropwizard/setup_postgresql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:postgresql://.*/hello_world|url: jdbc:postgresql://'"${DBHOS
 
 mvn -P postgres clean package
 
-java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &
+java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &

--- a/frameworks/Java/dropwizard/setup_postgresql.sh
+++ b/frameworks/Java/dropwizard/setup_postgresql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:postgresql://.*/hello_world|url: jdbc:postgresql://'"${DBHOS
 
 mvn -P postgres clean package
 
-java -server $JAVA_OPTS -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &
+java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &

--- a/frameworks/Java/jetty-servlet/setup.sh
+++ b/frameworks/Java/jetty-servlet/setup.sh
@@ -6,4 +6,4 @@ mvn clean compile assembly:single
 
 cd target
 
-java -server $JAVA_OPTS -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &
+java -server $JAVA_OPTS_TBF -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &

--- a/frameworks/Java/jetty-servlet/setup.sh
+++ b/frameworks/Java/jetty-servlet/setup.sh
@@ -6,4 +6,4 @@ mvn clean compile assembly:single
 
 cd target
 
-java -server $JAVA_OPTS_TBF -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &
+java -server $JAVA_OPTS_TFB -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &

--- a/frameworks/Java/jetty-servlet/setup.sh
+++ b/frameworks/Java/jetty-servlet/setup.sh
@@ -5,4 +5,5 @@ fw_depends java maven
 mvn clean compile assembly:single
 
 cd target
-java -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &
+
+java -server $JAVA_OPTS -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &

--- a/frameworks/Java/jetty/setup.sh
+++ b/frameworks/Java/jetty/setup.sh
@@ -6,4 +6,4 @@ mvn clean compile assembly:single
 
 cd target
 
-java -server $JAVA_OPTS -jar jetty-example-0.1-jar-with-dependencies.jar
+java -server $JAVA_OPTS_TFB -jar jetty-example-0.1-jar-with-dependencies.jar

--- a/frameworks/Java/jetty/setup.sh
+++ b/frameworks/Java/jetty/setup.sh
@@ -5,4 +5,5 @@ fw_depends java maven
 mvn clean compile assembly:single
 
 cd target
-java -jar jetty-example-0.1-jar-with-dependencies.jar
+
+java -server $JAVA_OPTS -jar jetty-example-0.1-jar-with-dependencies.jar

--- a/frameworks/Java/undertow/setup.sh
+++ b/frameworks/Java/undertow/setup.sh
@@ -7,4 +7,4 @@ fw_depends mongodb postgresql mysql java maven
 mvn clean compile assembly:single
 cd target
 
-java -server $JAVA_OPTS_TBF -jar undertow-example-0.1-jar-with-dependencies.jar &
+java -server $JAVA_OPTS_TFB -jar undertow-example-0.1-jar-with-dependencies.jar &

--- a/frameworks/Java/undertow/setup.sh
+++ b/frameworks/Java/undertow/setup.sh
@@ -6,4 +6,5 @@ fw_depends mongodb postgresql mysql java maven
 
 mvn clean compile assembly:single
 cd target
-java -jar undertow-example-0.1-jar-with-dependencies.jar &
+
+java -server $JAVA_OPTS -jar undertow-example-0.1-jar-with-dependencies.jar &

--- a/frameworks/Java/undertow/setup.sh
+++ b/frameworks/Java/undertow/setup.sh
@@ -7,4 +7,4 @@ fw_depends mongodb postgresql mysql java maven
 mvn clean compile assembly:single
 cd target
 
-java -server $JAVA_OPTS -jar undertow-example-0.1-jar-with-dependencies.jar &
+java -server $JAVA_OPTS_TBF -jar undertow-example-0.1-jar-with-dependencies.jar &

--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -12,6 +12,6 @@ sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y oracle-
 JAVA_HOME=/usr/lib/jvm/java-8-oracle
 echo "export JAVA_HOME=${JAVA_HOME}" > $IROOT/java.installed
 echo -e "export PATH=\$JAVA_HOME/bin:\$PATH" >> $IROOT/java.installed
-echo 'export JAVA_OPTS="-Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts"' >> $IROOT/java.installed
+echo 'export JAVA_OPTS_TFB="-Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts"' >> $IROOT/java.installed
 
 source $IROOT/java.installed

--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -12,5 +12,6 @@ sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y oracle-
 JAVA_HOME=/usr/lib/jvm/java-8-oracle
 echo "export JAVA_HOME=${JAVA_HOME}" > $IROOT/java.installed
 echo -e "export PATH=\$JAVA_HOME/bin:\$PATH" >> $IROOT/java.installed
+echo 'export JAVA_OPTS="-Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts"' >> $IROOT/java.installed
 
 source $IROOT/java.installed

--- a/toolset/setup/linux/webservers/resin/resin.properties
+++ b/toolset/setup/linux/webservers/resin/resin.properties
@@ -80,8 +80,7 @@ setuid_user   :
 setuid_group  : 
 
 # Arg passed directly to the JVM
-jvm_args  : -Xmx2048m -Xms2048m -XX:MaxPermSize=256m
-jvm_mode    : -server
+jvm_args  : -server -Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts
 
 # Local URLs for the watchdog to check to ensure the server is up,
 # space separated


### PR DESCRIPTION
Since these projects don't have explicit settings for the JVM they are picking the defaults for the current version of the JVM and the OS. The `-server` mode will be enabled on 64-bit OS with more than 2GB RAM and `UseParallelGC` is the default garbage collector. Significant change is to enable NUMA architecture support which helps the GC threads to be local on the CPU for which RAM area they are responsible cleaning. `-XX:+UseNUMA` support works only with `+UseParallelGC`. Why this is needed? Both the physical server at ServerCentral and the Azure D3v2 machines are using NUMA architecture. If the machine is not using NUMA there shouldn't be any penalties when this option is provided, it just will be ignored. `-Xms1G -Xmx1G` restricts the JVM to 1GB of heap memory. `-Xss320k` will set the thread's stack size to 320 KB, the default is 2 MB for 64-bit OSes, 320 KB for 32-bit OSes. `XX:+AggressiveOpts` enables additional bytecode optimizations which are experimental and not enabled by default for the current JVM release version. The current version of the JVM (java version "1.8.0_121") changes only two options:

> intx AutoBoxCacheMax                         = 20000
> intx BiasedLockingStartupDelay                 = 500

How to verify what is enabled/disabled see [this StackOverflow answer](http://stackoverflow.com/questions/2959878/what-flags-are-enabled-by-xxaggressiveopts-on-sun-jre-1-6u20#21361242).

Additional notes:

- Credit for the decreasing thread stack sizes goes to [amichair](https://github.com/zloster/FrameworkBenchmarks/commit/d78dfdb6041c472cbcbbb2d6a4798661b0317207#diff-1d283148ad090e8126999400a7b3a81eR11). I suspect that by decreasing the thread stack the CPU caches are utilized slightly better and you get a small increase in performance.
- The decrease of the heap memory could affect the results if a default heap is relatively big and the framework is not producing enough garbage to trigger the major GC events. I can't find the memory size of the ServerCentral machines to calculate the default heap-stack size. All of the frameworks hit 100K+ rps in the JSON and plaintext test (except Dropwizard which is around 90K+ rps) so I don't expect to hit such a problem.
- [The resin configuration reference](http://www.caucho.com/resin-4.0/admin/config-resin-properties.xtp) doesn't mention anything about ` -jvm_mode` property key. That's why I've deleted it and moved the configuration to the `-jvm_args` key.