### PR TITLE
Update dstat options so timestamp to be the first column

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -676,7 +676,7 @@ class FrameworkTest:
   ############################################################
   def __begin_logging(self, test_type):
     output_file = "{file_name}".format(file_name=self.benchmarker.get_stats_file(self.name, test_type))
-    dstat_string = "dstat -afilmprsT --aio --fs --ipc --lock --raw --socket --tcp \
+    dstat_string = "dstat -Tafilmprs --aio --fs --ipc --lock --raw --socket --tcp \
                                       --raw --socket --tcp --udp --unix --vm --disk-util \
                                       --rpc --rpcd --output {output_file}".format(output_file=output_file)
     cmd = shlex.split(dstat_string)


### PR DESCRIPTION
Instead of the data about 4 cores imagine the data about 80 cores * 6 columns per core; I didn't bother to check which is the actual number of the timestamp column):

```
zloster@box:~/sources/FrameworkBenchmarks/toolset$ dstat -afT
Terminal width too small, trimming output.
-------cpu0-usage--------------cpu1-usage--------------cpu2-usage--------------cpu3-usage------ --dsk/sda-----dsk/sdb-- ---paging-->
usr sys idl wai hiq siq:usr sys idl wai hiq siq:usr sys idl wai hiq siq:usr sys idl wai hiq siq| read  writ: read  writ|  in   out >
  1   5  93   1   0   0:  1   4  94   1   0   0:  4   6  89   1   0   2:  4   6  89   1   0   0| 376k  383k: 181B    0 |  34B   90B>
  3   2  91   4   0   0:  0   0 100   0   0   0:  0   2  98   0   0   0:  2   1  97   0   0   0| 212k  744k:   0     0 |   0     0 >
  0   1  66  33   0   0:  0   0  92   8   0   0:  5   1  93   0   0   1:  2   1  96   0   0   1| 164k 3484k:   0     0 |   0     0 >
  0   0 100   0   0   0:  0   0 100   0   0   0: 12   2  85   0   0   1:  2   1  96   1   0   0| 144k 8192B:   0     0 |   0     0 >^C
```

We will get this in the stats file:
```
zloster@box:~/sources/FrameworkBenchmarks/toolset$ dstat -Taf
Terminal width too small, trimming output.
--epoch--- -------cpu0-usage--------------cpu1-usage--------------cpu2-usage--------------cpu3-usage------ --dsk/sda-----dsk/sdb-->
  epoch   |usr sys idl wai hiq siq:usr sys idl wai hiq siq:usr sys idl wai hiq siq:usr sys idl wai hiq siq| read  writ: read  writ>
1491155592|  1   5  93   1   0   0:  1   4  94   1   0   0:  4   6  89   1   0   2:  4   6  89   1   0   0| 376k  383k: 181B    0 >
1491155593|  0   0 100   0   0   0:  0   0  95   5   0   0:  3   1  95   0   0   1:  4   0  96   0   0   0|  56k  132k:   0     0 >
1491155594|  0   0 100   0   0   0:  0   0 100   0   0   0:  5   2  93   0   0   0:  1   2  97   0   0   0|  40k    0 :   0     0 >
1491155595|  0   0 100   0   0   0:  1   7  92   0   0   0:  4   2  92   0   0   2:  5   1  94   0   0   0| 220k    0 :   0     0 >^C
```
IMO this relates with  #2358. There will not be separate statistics per test type, but is should be easier to check for which testcase is the data (we know the durations from the wrk client log).