### PR TITLE
Fix the db host name for play2-scala-reactive

### DIFF
--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/conf/application.conf
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/conf/application.conf
@@ -45,6 +45,6 @@ play.i18n.langs = [ "en" ]
 
 play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoModule"
 
-mongodb.servers = ["localhost:27017"]
+mongodb.servers = ["TFB-database:27017"]
 mongodb.db = "hello_world"
 

--- a/frameworks/Scala/play2-scala/setup_scala_reactivemongo.sh
+++ b/frameworks/Scala/play2-scala/setup_scala_reactivemongo.sh
@@ -3,7 +3,6 @@
 fw_depends mongodb java sbt
 
 cd play2-scala-reactivemongo
-sed -i 's|jdbc:mysql://.*:3306|jdbc:mysql://'"${DBHOST}"':3306|g' ${TROOT}/play2-scala-reactivemongo/conf/application.conf
 
 rm -rf ${TROOT}/play2-scala-reactivemongo/target/universal/stage/RUNNING_PID
 


### PR DESCRIPTION
This repairs the four db-related tests for play2-scala-reactive, which are currently failing.