### PR TITLE
Specify UTF-8 encoding in the revenj-jvm fortunes jsp

### DIFF
--- a/frameworks/Java/revenj-jvm/src/main/webapp/WEB-INF/jsp/fortunes.jsp
+++ b/frameworks/Java/revenj-jvm/src/main/webapp/WEB-INF/jsp/fortunes.jsp
@@ -1,4 +1,4 @@
-<%@ page import="dsl.FrameworkBench.*,java.util.*,org.apache.commons.lang3.*" session="false" %>
+<%@ page import="dsl.FrameworkBench.*,java.util.*,org.apache.commons.lang3.*" session="false" pageEncoding="UTF-8" %>
 <% List<Fortune> fortunes = (List)request.getAttribute("fortunes"); %>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Without this, it appears to use the system default charset, which leads to the test failing when the default is not UTF-8.

This should repair the revenj-jvm fortune test on ServerCentral.