### PR TITLE
Remove verbose GC logging to file for Java/wildfly-ee7

### DIFF
--- a/frameworks/Java/wildfly-ee7/setup.sh
+++ b/frameworks/Java/wildfly-ee7/setup.sh
@@ -2,7 +2,7 @@
 
 fw_depends mysql java maven
 
-export JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Xms2g -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=50 -verbosegc -Xloggc:/tmp/wildfly_gc.log"
+export JAVA_OPTS="-Djava.net.preferIPv4Stack=true -Xms2g -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=50"
 
 mvn clean initialize package -Pbenchmark -Ddatabase.host=${DBHOST}
 target/wildfly-10.1.0.Final/bin/standalone.sh -b 0.0.0.0 &


### PR DESCRIPTION
This logging doesn't follow the project recommendation about the logs and IMO is affecting the benchmark results of Wildfly. But this gave me an idea about a new test type: which framework can fill a SSD disk faster. Or which framework logs are the biggest for given test run :)