### PR TITLE
Make wicket encode its fortunes response in UTF-8

### DIFF
--- a/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
@@ -14,7 +14,6 @@ import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
-import org.apache.wicket.request.http.WebResponse;
 
 /**
  * A page that loads all fortune cookies. This mimics the Servlet example
@@ -23,10 +22,9 @@ import org.apache.wicket.request.http.WebResponse;
  */
 public class FortunePage extends WebPage {
 	private static final long serialVersionUID = 1L;
-	private static final String TEXT_HTML = "text/html";
 
 	public FortunePage() throws Exception {
-		List<Fortune> fortunes = new ArrayList<>(10000);
+		List<Fortune> fortunes = new ArrayList<>();
 
 		DataSource dataSource = WicketApplication.get().getDataSource();
 		try ( //
@@ -55,14 +53,5 @@ public class FortunePage extends WebPage {
 			}
 		};
 		add(listView);
-	}
-
-	@Override
-	protected void configureResponse(final WebResponse response) {
-		response.setContentType(TEXT_HTML);
-	}
-
-	@Override
-	protected void renderXmlDecl() {
 	}
 }


### PR DESCRIPTION
This should repair the wicket fortune test on ServerCentral, which is currently failing.

It appeared to be using the system default charset instead, which was not necessarily UTF-8.

Changing the `TEXT_HTML` constant to `"text/html;charset=utf-8"` also would have fixed it, but this solution involves fewer lines of code and seems (to me) like more idiomatic wicket application code.

I removed the `renderXmlDecl()` override for a similar reason (fewer lines, seems more idiomatic) although it had nothing to do with the UTF-8 issue.

I removed the `initialCapacity` argument for the `ArrayList` because there's no good reason to set it to 10,000.  Since the test requirements state that the list shouldn't be sized using foreknowledge of the row count, we might as well trust `ArrayList`'s defaults.