### PR TITLE
Make wicket encode its fortunes response in UTF-8

### DIFF
--- a/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
+++ b/frameworks/Java/wicket/src/main/java/hellowicket/fortune/FortunePage.java
@@ -23,10 +23,10 @@ import org.apache.wicket.request.http.WebResponse;
  */
 public class FortunePage extends WebPage {
 	private static final long serialVersionUID = 1L;
-	private static final String TEXT_HTML = "text/html";
+	private static final String TEXT_HTML = "text/html;charset=utf-8";
 
 	public FortunePage() throws Exception {
-		List<Fortune> fortunes = new ArrayList<>(10000);
+		List<Fortune> fortunes = new ArrayList<>();
 
 		DataSource dataSource = WicketApplication.get().getDataSource();
 		try ( //


### PR DESCRIPTION
(This replaces a previous PR https://github.com/TechEmpower/FrameworkBenchmarks/pull/2662, incorporating the feedback.)

This should repair the wicket fortune test on ServerCentral, which is currently failing.

It appeared to be using the system default charset instead, which was not necessarily UTF-8.

I removed the `initialCapacity` argument for the `ArrayList` because there's no good reason to set it to 10,000.  Since the test requirements state that the list shouldn't be sized using foreknowledge of the row count, we might as well trust `ArrayList`'s defaults.