### PR TITLE
H2O: Increase the maximum number of connections accepted simultaneously

### DIFF
--- a/frameworks/C/h2o/setup.sh
+++ b/frameworks/C/h2o/setup.sh
@@ -35,7 +35,7 @@ run_curl()
 
 run_h2o_app()
 {
-	"$1/h2o_app" -a1 -f "$2/template/fortunes.mustache" -m "$DB_CONN" "$3" "$4" \
+	"$1/h2o_app" -f "$2/template/fortunes.mustache" -m "$DB_CONN" "$3" "$4" \
 		-d "host=TFB-database dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass" &
 }
 


### PR DESCRIPTION
Previously, the maximum number of connections accepted simultaneously was 1 in order to improve load balancing. Now the SO_REUSEPORT socket option takes care of that, so the number can be increased to reduce the amount of system calls.