### PR TITLE
fasthttp: use 2xNumCPU connections to db

### DIFF
--- a/frameworks/Go/fasthttp/src/server-mysql/server.go
+++ b/frameworks/Go/fasthttp/src/server-mysql/server.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"flag"
 	"log"
+	"runtime"
 	"sort"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -13,10 +14,7 @@ import (
 	"templates"
 )
 
-const (
-	connectionString   = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world"
-	maxConnectionCount = 40
-)
+const connectionString = "benchmarkdbuser:benchmarkdbpass@tcp(localhost:3306)/hello_world"
 
 var (
 	worldSelectStmt   *sql.Stmt
@@ -37,6 +35,7 @@ func main() {
 		log.Fatalf("Cannot connect to db: %s", err)
 	}
 
+	maxConnectionCount := runtime.NumCPU() * 2
 	db.SetMaxIdleConns(maxConnectionCount)
 	db.SetMaxOpenConns(maxConnectionCount)
 

--- a/frameworks/Go/fasthttp/src/server-postgresql/server.go
+++ b/frameworks/Go/fasthttp/src/server-postgresql/server.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"runtime"
 	"sort"
 
 	"github.com/jackc/pgx"
@@ -12,8 +13,6 @@ import (
 	"common"
 	"templates"
 )
-
-const maxConnectionCount = 40
 
 var (
 	worldSelectStmt   *pgx.PreparedStatement
@@ -27,7 +26,7 @@ func main() {
 	flag.Parse()
 
 	var err error
-
+	maxConnectionCount := runtime.NumCPU() * 2
 	if db, err = initDatabase("localhost", "benchmarkdbuser", "benchmarkdbpass", "hello_world", 5432, maxConnectionCount); err != nil {
 		log.Fatalf("Error opening database: %s", err)
 	}


### PR DESCRIPTION
This should properly scale on host machines with different number of CPUs.

<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->
