### PR TITLE
Add support for the Luna C++ framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - "TESTDIR=C++/wt"
     - "TESTDIR=C++/ffead-cpp"
     - "TESTDIR=C++/poco"
+    - "TESTDIR=C++/luna"
     - "TESTDIR=Clojure/compojure"
     - "TESTDIR=Clojure/http-kit"
     - "TESTDIR=Clojure/luminus"

--- a/frameworks/C++/luna/CMakeLists.txt
+++ b/frameworks/C++/luna/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8)
+project(lunabench)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+
+find_package( Threads )
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+set(DEFAULT_SOURCE_FILES default.cpp common.h)
+add_executable(lunabench_default ${DEFAULT_SOURCE_FILES})
+target_link_libraries(lunabench_default ${CONAN_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+
+set(EPOLL_SOURCE_FILES epoll.cpp common.h)
+add_executable(lunabench_epoll ${EPOLL_SOURCE_FILES})
+target_link_libraries(lunabench_epoll ${CONAN_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+
+set(THREAD_SOURCE_FILES thread.cpp common.h)
+add_executable(lunabench_thread ${THREAD_SOURCE_FILES})
+target_link_libraries(lunabench_thread ${CONAN_LIBS} ${CMAKE_THREAD_LIBS_INIT})

--- a/frameworks/C++/luna/README.md
+++ b/frameworks/C++/luna/README.md
@@ -1,0 +1,40 @@
+#Luna Benchmarking Test
+
+[Luna](https://github.com/DEGoodmanWilson/luna) is a web framework for modern C++, designed for low latency and high throughput. These tests use version 2.10.1 of Luna.
+
+### Source Code
+
+* [Default threading mode, with thread pool](default.cpp)
+* [epoll threading mode (linux only)](epoll.cpp)
+* [Thread-per-connection mode](thread.cpp)
+
+### Test URLs
+
+[/plaintext](http://www.techempower.com/benchmarks/#section=plaintext)
+----------
+```
+HTTP/1.1 200 OK
+Connection: Keep-Alive
+Content-Length: 13
+Server: luna/2.10.1
+Content-Type: text/plain
+Server: luna
+Date: Thu, 13 Apr 2017 11:40:58 GMT
+
+Hello, world!
+```
+
+
+[/json](http://www.techempower.com/benchmarks/#section=json)
+----------
+```
+HTTP/1.1 200 OK
+Connection: Keep-Alive
+Content-Length: 27
+Server: luna/2.10.1
+Content-Type: application/json
+Server: luna
+Date: Thu, 13 Apr 2017 11:40:58 GMT
+
+{"message":"Hello, World!"}
+```

--- a/frameworks/C++/luna/benchmark_config.json
+++ b/frameworks/C++/luna/benchmark_config.json
@@ -1,0 +1,62 @@
+{
+  "framework": "luna",
+  "tests": [{
+    "default": {
+      "setup_file": "setup",
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Fullstack",
+      "database": "None",
+      "framework": "luna",
+      "language": "C++",
+      "orm": "Raw",
+      "platform": "None",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Luna",
+      "notes": "",
+      "versus": ""
+    },
+    "epoll": {
+      "setup_file": "setup_epoll",
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Fullstack",
+      "database": "None",
+      "framework": "luna",
+      "language": "C++",
+      "orm": "Raw",
+      "platform": "None",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Luna",
+      "notes": "",
+      "versus": ""
+    },
+    "thread-per-connection": {
+      "setup_file": "setup_thread",
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Fullstack",
+      "database": "None",
+      "framework": "luna",
+      "language": "C++",
+      "orm": "Raw",
+      "platform": "None",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Luna",
+      "notes": "",
+      "versus": ""
+    }
+  }]
+}

--- a/frameworks/C++/luna/common.h
+++ b/frameworks/C++/luna/common.h
@@ -1,0 +1,36 @@
+//
+// Created by Don Goodman-Wilson on 15/04/2017.
+//
+
+#pragma once
+
+#include <luna/luna.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+// Request handlers
+
+// /json
+auto json_handler = [](auto req) -> luna::response {
+    json j;
+    j["message"] = "Hello, World!";
+
+    return {
+            200,
+            luna::response_headers{{"Server", "luna"}},
+            "application/json",
+            j.dump(),
+    };
+};
+
+// /plaintext
+auto plaintext_handler = [](auto req) -> luna::response {
+    return {
+            200,
+            luna::response_headers{{"Server", "luna"}},
+            "text/plain",
+            "Hello, world!",
+    };
+};
+

--- a/frameworks/C++/luna/conanfile.txt
+++ b/frameworks/C++/luna/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+luna/2.10.1@DEGoodmanWilson/stable
+json/2.1.0@jjones646/stable
+
+[generators]
+cmake

--- a/frameworks/C++/luna/default.cpp
+++ b/frameworks/C++/luna/default.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <luna/luna.h>
+#include "common.h"
+
+// Main entrypoint
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " port nthreads" << std::endl;
+        return 1;
+    }
+
+    auto port = static_cast<uint16_t>(std::atoi(argv[1]));
+    auto threads = static_cast<uint16_t>(std::atoi(argv[2]));
+
+    luna::server server{
+            luna::server::port{port},
+            luna::server::thread_pool_size{threads},
+    };
+
+    server.handle_request(luna::request_method::GET,
+                          "/plaintext",
+                          plaintext_handler);
+
+    server.handle_request(luna::request_method::GET,
+                          "/json",
+                          json_handler);
+
+    server.await();
+}

--- a/frameworks/C++/luna/epoll.cpp
+++ b/frameworks/C++/luna/epoll.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <luna/luna.h>
+#include "common.h"
+
+// Main entrypoint
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " port nthreads" << std::endl;
+        return 1;
+    }
+
+    auto port = static_cast<uint16_t>(std::atoi(argv[1]));
+    auto threads = static_cast<uint16_t>(std::atoi(argv[2]));
+
+    luna::server server{
+            luna::server::port{port},
+            luna::server::use_epoll_if_available{true},
+            luna::server::thread_pool_size{threads},
+    };
+
+    server.handle_request(luna::request_method::GET,
+                          "/plaintext",
+                          plaintext_handler);
+
+    server.handle_request(luna::request_method::GET,
+                          "/json",
+                          json_handler);
+
+    server.await();
+}

--- a/frameworks/C++/luna/setup.sh
+++ b/frameworks/C++/luna/setup.sh
@@ -6,4 +6,6 @@ CC=gcc-4.9 CXX=g++-4.9 conan install --build=missing -s compiler="gcc" -s compil
 cmake . -DCMAKE_CXX_COMPILER=g++-4.9 -DCMAKE_CC_COMPILER=gcc-4.9
 cmake --build .
 
+MAX_THREADS=$((2 * $CPU_COUNT))
+
 $TROOT/bin/lunabench_default 8080 $MAX_THREADS

--- a/frameworks/C++/luna/setup.sh
+++ b/frameworks/C++/luna/setup.sh
@@ -6,4 +6,4 @@ CC=gcc-4.9 CXX=g++-4.9 conan install --build=missing -s compiler="gcc" -s compil
 cmake . -DCMAKE_CXX_COMPILER=g++-4.9 -DCMAKE_CC_COMPILER=gcc-4.9
 cmake --build .
 
-$TROOT/bin/lunabench 8080 $MAX_THREADS
+$TROOT/bin/lunabench_default 8080 $MAX_THREADS

--- a/frameworks/C++/luna/setup.sh
+++ b/frameworks/C++/luna/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+fw_depends luna
+
+CC=gcc-4.9 CXX=g++-4.9 conan install --build=missing -s compiler="gcc" -s compiler.version="4.9" .
+cmake . -DCMAKE_CXX_COMPILER=g++-4.9 -DCMAKE_CC_COMPILER=gcc-4.9
+cmake --build .
+
+$TROOT/bin/lunabench 8080 $MAX_THREADS

--- a/frameworks/C++/luna/setup_epoll.sh
+++ b/frameworks/C++/luna/setup_epoll.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+fw_depends luna
+
+CC=gcc-4.9 CXX=g++-4.9 conan install --build=missing -s compiler="gcc" -s compiler.version="4.9" .
+cmake . -DCMAKE_CXX_COMPILER=g++-4.9 -DCMAKE_CC_COMPILER=gcc-4.9
+cmake --build .
+
+$TROOT/bin/lunabench_epoll 8080 $MAX_THREADS

--- a/frameworks/C++/luna/setup_thread.sh
+++ b/frameworks/C++/luna/setup_thread.sh
@@ -6,6 +6,4 @@ CC=gcc-4.9 CXX=g++-4.9 conan install --build=missing -s compiler="gcc" -s compil
 cmake . -DCMAKE_CXX_COMPILER=g++-4.9 -DCMAKE_CC_COMPILER=gcc-4.9
 cmake --build .
 
-MAX_THREADS=$((2 * $CPU_COUNT))
-
-$TROOT/bin/lunabench_epoll 8080 $MAX_THREADS
+$TROOT/bin/lunabench_thread 8080

--- a/frameworks/C++/luna/thread.cpp
+++ b/frameworks/C++/luna/thread.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <luna/luna.h>
+#include "common.h"
+
+// Main entrypoint
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " port" << std::endl;
+        return 1;
+    }
+
+    auto port = static_cast<uint16_t>(std::atoi(argv[1]));
+
+    luna::server server{
+            luna::server::port{port},
+            luna::server::use_thread_per_connection{true},
+    };
+
+    server.handle_request(luna::request_method::GET,
+                          "/plaintext",
+                          plaintext_handler);
+
+    server.handle_request(luna::request_method::GET,
+                          "/json",
+                          json_handler);
+
+    server.await();
+}

--- a/frameworks/C++/luna/thread.cpp
+++ b/frameworks/C++/luna/thread.cpp
@@ -5,7 +5,7 @@
 // Main entrypoint
 
 int main(int argc, char **argv) {
-    if (argc != 3) {
+    if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " port" << std::endl;
         return 1;
     }

--- a/toolset/setup/linux/frameworks/luna.sh
+++ b/toolset/setup/linux/frameworks/luna.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+fw_depends gcc-4.9 conan
+
+fw_installed luna && return 0
+
+echo "" > $IROOT/luna.installed
+
+source $IROOT/luna.installed

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -27,6 +27,7 @@ sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options:
   libjson0-dev libmcrypt-dev libicu-dev gettext \
   libpq-dev mlton \
   cloc dstat                        `# Collect resource usage statistics` \
+  python-dev \
   python-pip
 
 sudo pip install colorama==0.3.1

--- a/toolset/setup/linux/systools/conan.sh
+++ b/toolset/setup/linux/systools/conan.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+fw_depends python-dev
+
+fw_installed conan && return 0
+
+pip install --user conan
+
+echo -e "export PATH=~/.local/bin:\$PATH" > $IROOT/conan.installed
+
+source $IROOT/conan.installed


### PR DESCRIPTION
Adding support for the Luna C++ framework. Luna depends on the Conan package manager, so this PR also adds support for Conan in the systools. I expect it is this addition that will want a little extra scrutiny. 