### PR TITLE
H2O: Remove the write polling work-around

### DIFF
--- a/frameworks/C/h2o/src/event_loop.h
+++ b/frameworks/C/h2o/src/event_loop.h
@@ -29,11 +29,9 @@
 typedef struct thread_context_t thread_context_t;
 
 typedef struct {
-	h2o_socket_t *epoll_socket;
 	h2o_socket_t *h2o_https_socket;
 	h2o_socket_t *h2o_socket;
 	size_t conn_num;
-	int epoll_fd;
 	h2o_accept_ctx_t h2o_accept_ctx;
 	h2o_context_t h2o_ctx;
 } event_loop_t;
@@ -44,10 +42,5 @@ void initialize_event_loop(bool is_main_thread,
                            global_data_t *global_data,
                            h2o_multithread_receiver_t *h2o_receiver,
                            event_loop_t *loop);
-int start_write_polling(int fd,
-                        void (**on_write_ready)(void *),
-                        bool rearm,
-                        event_loop_t *event_loop);
-void stop_write_polling(int fd, event_loop_t *event_loop);
 
 #endif // EVENT_LOOP_H_

--- a/frameworks/C/h2o/src/thread.c
+++ b/frameworks/C/h2o/src/thread.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <h2o/serverutil.h>
-#include <sys/epoll.h>
 #include <sys/syscall.h>
 
 #include "database.h"


### PR DESCRIPTION
libh2o's event loop now supports write polling without sending any data, so the current work-around is no longer necessary.