### PR TITLE
Revert "Adjusting JVM parameters for Dropwizard, Jetty, Resin, Undert…

### DIFF
--- a/frameworks/Java/README.md
+++ b/frameworks/Java/README.md
@@ -19,11 +19,7 @@ should have an `install.sh` that contains at least
 
     fw_depends java
 
-This installs the Oracle Java 8 JDK. It also provides a shell variable `JAVA_OPTS_TFB` with tweaked default parameters for the JVM. Sample use:
-
-    #!/bin/bash
-
-    java -server $JAVA_OPTS_TFB
+This installs the Oracle Java 8 JDK.
 
 ## Get Help
 

--- a/frameworks/Java/dropwizard/setup_mongo.sh
+++ b/frameworks/Java/dropwizard/setup_mongo.sh
@@ -6,4 +6,4 @@ sed -i 's|host: 127.0.0.1|host: '"${DBHOST}"'|g' hello-world-mongo.yml
 
 mvn -P mongo clean package
 
-java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &
+java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mongo.yml &

--- a/frameworks/Java/dropwizard/setup_mysql.sh
+++ b/frameworks/Java/dropwizard/setup_mysql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:mysql://.*/hello_world|url: jdbc:mysql://'"${DBHOST}"':3306/
 
 mvn -P mysql clean package
 
-java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &
+java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-mysql.yml &

--- a/frameworks/Java/dropwizard/setup_postgresql.sh
+++ b/frameworks/Java/dropwizard/setup_postgresql.sh
@@ -6,4 +6,4 @@ sed -i 's|url: jdbc:postgresql://.*/hello_world|url: jdbc:postgresql://'"${DBHOS
 
 mvn -P postgres clean package
 
-java -server $JAVA_OPTS_TFB -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &
+java -jar target/hello-world-0.0.1-SNAPSHOT.jar server hello-world-postgres.yml &

--- a/frameworks/Java/jetty-servlet/setup.sh
+++ b/frameworks/Java/jetty-servlet/setup.sh
@@ -5,5 +5,4 @@ fw_depends java maven
 mvn clean compile assembly:single
 
 cd target
-
-java -server $JAVA_OPTS_TFB -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &
+java -jar jetty-servlet-example-0.2-jar-with-dependencies.jar &

--- a/frameworks/Java/jetty/setup.sh
+++ b/frameworks/Java/jetty/setup.sh
@@ -5,5 +5,4 @@ fw_depends java maven
 mvn clean compile assembly:single
 
 cd target
-
-java -server $JAVA_OPTS_TFB -jar jetty-example-0.1-jar-with-dependencies.jar
+java -jar jetty-example-0.1-jar-with-dependencies.jar

--- a/frameworks/Java/undertow/setup.sh
+++ b/frameworks/Java/undertow/setup.sh
@@ -6,5 +6,4 @@ fw_depends mongodb postgresql mysql java maven
 
 mvn clean compile assembly:single
 cd target
-
-java -server $JAVA_OPTS_TFB -jar undertow-example-0.1-jar-with-dependencies.jar &
+java -jar undertow-example-0.1-jar-with-dependencies.jar &

--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -12,6 +12,5 @@ sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y oracle-
 JAVA_HOME=/usr/lib/jvm/java-8-oracle
 echo "export JAVA_HOME=${JAVA_HOME}" > $IROOT/java.installed
 echo -e "export PATH=\$JAVA_HOME/bin:\$PATH" >> $IROOT/java.installed
-echo 'export JAVA_OPTS_TFB="-Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts"' >> $IROOT/java.installed
 
 source $IROOT/java.installed

--- a/toolset/setup/linux/webservers/resin/resin.properties
+++ b/toolset/setup/linux/webservers/resin/resin.properties
@@ -80,7 +80,8 @@ setuid_user   :
 setuid_group  : 
 
 # Arg passed directly to the JVM
-jvm_args  : -server -Xms1G -Xmx1G -Xss320k -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts
+jvm_args  : -Xmx2048m -Xms2048m -XX:MaxPermSize=256m
+jvm_mode    : -server
 
 # Local URLs for the watchdog to check to ensure the server is up,
 # space separated


### PR DESCRIPTION
…ow (#2652)"

This reverts commit 18e0797cd82438d4d37e0bc964dcc22dc48c0cb0.

Round 14 preview 4 results are not good:
Undertow Plaintext and JSON results are suffering. Jetty-servlet also. Dropwizard Plaintext is giving very strange behaviour at higher concurrences. The fluctuations of the Servlet (Resin) tests (Plaintext and JSON) are not gone as I hoped. Only the Jetty JSON have positive reaction.

Basically - total failure.