### PR TITLE
http4s: Update http4s and dependency versions

### DIFF
--- a/frameworks/Scala/http4s/README.md
+++ b/frameworks/Scala/http4s/README.md
@@ -1,4 +1,4 @@
-#http4s Benchmarking Test
+# http4s Benchmarking Test
 
 ### JSON Encoding Test
 
@@ -7,9 +7,9 @@
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Java Oracle 1.8.0_25](http://www.oracle.com/technetwork/java/javase)
-* [http4s 0.6.2](http://http4s.org/)
-* [blaze 0.6.2](https://github.com/http4s/blaze/)
+* [Java Oracle 1.8.0_121](http://www.oracle.com/technetwork/java/javase)
+* [http4s 0.15.9a](http://http4s.org/)
+* [blaze 0.12.4](https://github.com/http4s/blaze/)
 
 ## Test URLs
 ### JSON Encoding Test
@@ -23,4 +23,4 @@ http://localhost:8080/plaintext
 ## How to run
 sbt 'oneJar'
 
-java -jar target/scala-2.11/http4s_2.11-1.0-SNAPSHOT-one-jar.jar
+java -jar target/scala-2.12/http4s_2.12-1.0-SNAPSHOT-one-jar.jar "$DBHOST"

--- a/frameworks/Scala/http4s/build.sbt
+++ b/frameworks/Scala/http4s/build.sbt
@@ -2,7 +2,7 @@ name := "http4s"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.2"
 
 enablePlugins(SbtTwirl)
 
@@ -10,9 +10,9 @@ TwirlKeys.templateImports += "http4s.techempower.benchmark._"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
-val http4sVersion = "0.11.3"
-val circeVersion = "0.3.0"
-val doobieVersion = "0.2.3"
+val http4sVersion = "0.15.9a"
+val circeVersion = "0.7.1"
+val doobieVersion = "0.4.1"
 
 libraryDependencies ++= Seq(
 	"org.http4s" %% "http4s-blaze-server" % http4sVersion,
@@ -23,10 +23,10 @@ libraryDependencies ++= Seq(
 	"io.circe" %% "circe-generic" % circeVersion,
 	"io.circe" %% "circe-parser" % circeVersion,
 	"org.tpolecat" %% "doobie-core" % doobieVersion,
-	"org.tpolecat" %% "doobie-contrib-hikari" % doobieVersion exclude("com.zaxxer", "HikariCP-java6"),
-	"com.zaxxer" %  "HikariCP" % "2.4.1",
-	"org.postgresql" % "postgresql" % "9.4.1208",
-	"ch.qos.logback" % "logback-classic" % "1.1.6"
+	"org.tpolecat" %% "doobie-hikari" % doobieVersion,
+	"com.zaxxer" %  "HikariCP" % "2.6.1",
+	"org.postgresql" % "postgresql" % "9.4.1212",
+	"ch.qos.logback" % "logback-classic" % "1.2.2"
 )
 
 mainClass in oneJar := Some("http4s.techempower.benchmark.WebServer")

--- a/frameworks/Scala/http4s/project/build.properties
+++ b/frameworks/Scala/http4s/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.15

--- a/frameworks/Scala/http4s/project/plugins.sbt
+++ b/frameworks/Scala/http4s/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.0")

--- a/frameworks/Scala/http4s/setup.sh
+++ b/frameworks/Scala/http4s/setup.sh
@@ -4,4 +4,4 @@ fw_depends postgresql java sbt
 
 sbt 'oneJar' -batch
 
-java -jar target/scala-2.11/http4s*one-jar.jar "${DBHOST}" &
+java -jar target/scala-2.12/http4s*one-jar.jar "${DBHOST}" &

--- a/frameworks/Scala/http4s/src/main/scala/WebServer.scala
+++ b/frameworks/Scala/http4s/src/main/scala/WebServer.scala
@@ -8,7 +8,7 @@ import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.twirl._
 import headers._
 
-import doobie.contrib.hikari.hikaritransactor._
+import doobie.hikari.hikaritransactor._
 import doobie.imports._
 
 import io.circe._
@@ -129,7 +129,7 @@ object WebServer extends TaskApp {
   // HTTP service definition
   def service(xa: Transactor[Task]) = HttpService {
     case GET -> Root / "json" =>
-      Ok(Json.obj("message" -> Json.string("Hello, World!")))
+      Ok(Json.obj("message" -> Json.fromString("Hello, World!")))
 
     case GET -> Root / "db" =>
       Ok(selectRandomWorld(xa))


### PR DESCRIPTION
Major version updates include:

 * http4s:   0.11.3 --> 0.15.9a
 * blaze:    0.10.1 --> 0.12.4
 * circe:    0.3.0 --> 0.7.1
 * Twirl:    1.1.1 --> 1.3.0
 * doobie:   0.2.3 -->  0.4.1
 * HikariCP: 2.4.1 --> 2.6.1