### PR TITLE
H2O: Reuse JSON generators across HTTP requests

### DIFF
--- a/frameworks/C/h2o/setup.sh
+++ b/frameworks/C/h2o/setup.sh
@@ -71,7 +71,7 @@ rm -rf "$BUILD_DIR"
 echo "Maximum database connections per thread: $DB_CONN"
 
 if "$CLOUD_ENVIRONMENT"; then
-	run_h2o_app "0-$((NUM_PROC - 1))" "${H2O_APP_HOME}/bin" "${H2O_APP_HOME}/share/h2o_app"
+	run_h2o_app 0 "${H2O_APP_HOME}/bin" "${H2O_APP_HOME}/share/h2o_app"
 else
 	for ((i = 0; i < PHYSICAL_ENVIRONMENT_THREADS; i++)); do
 		run_h2o_app "$i" "${H2O_APP_HOME}/bin" "${H2O_APP_HOME}/share/h2o_app" -t1

--- a/frameworks/C/h2o/src/main.c
+++ b/frameworks/C/h2o/src/main.c
@@ -43,7 +43,7 @@
 #define USAGE_MESSAGE \
 	"Usage:\n%s [-a <max connections accepted simultaneously>] [-b <bind address>] " \
 	"[-c <certificate file>] [-d <database connection string>] [-f fortunes template file path] " \
-	"[-k <private key file>] [-l <log path>] " \
+	"[-j <max reused JSON generators>] [-k <private key file>] [-l <log path>] " \
 	"[-m <max database connections per thread>] [-p <port>] " \
 	"[-q <max enqueued database queries per thread>] [-r <root directory>] " \
 	"[-s <HTTPS port>] [-t <thread number>]\n"
@@ -165,10 +165,12 @@ error:
 static int parse_options(int argc, char *argv[], config_t *config)
 {
 	memset(config, 0, sizeof(*config));
+	// Need to set the default value here because 0 is a valid input value.
+	config->max_json_generator = 32;
 	opterr = 0;
 
 	while (1) {
-		const int opt = getopt(argc, argv, "?a:b:c:d:f:k:l:m:p:q:r:s:t:");
+		const int opt = getopt(argc, argv, "?a:b:c:d:f:j:k:l:m:p:q:r:s:t:");
 
 		if (opt == -1)
 			break;
@@ -203,6 +205,9 @@ static int parse_options(int argc, char *argv[], config_t *config)
 				break;
 			case 'f':
 				config->template_path = optarg;
+				break;
+			case 'j':
+				PARSE_NUMBER(config->max_json_generator);
 				break;
 			case 'k':
 				config->key = optarg;

--- a/frameworks/C/h2o/src/request_handler.h
+++ b/frameworks/C/h2o/src/request_handler.h
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <yajl/yajl_gen.h>
 
+#include "utility.h"
+
 #define REQ_ERROR "request error\n"
 
 typedef enum {
@@ -47,7 +49,7 @@ const char *get_query_param(const char *query,
                             size_t param_len);
 void register_request_handlers(h2o_hostconf_t *hostconf, h2o_access_log_filehandle_t *log_handle);
 void send_error(http_status_code_t status_code, const char *body, h2o_req_t *req);
-int send_json_response(yajl_gen gen, bool free_gen, h2o_req_t *req);
+int send_json_response(json_generator_t *gen, bool free_gen, h2o_req_t *req);
 void send_service_unavailable_error(const char *body, h2o_req_t *req);
 void set_default_response_param(content_type_t content_type,
                                 size_t content_length,

--- a/frameworks/C/h2o/src/thread.c
+++ b/frameworks/C/h2o/src/thread.c
@@ -32,6 +32,7 @@
 #include "error.h"
 #include "event_loop.h"
 #include "thread.h"
+#include "utility.h"
 
 static void *run_thread(void *arg);
 
@@ -50,6 +51,16 @@ void free_thread_context(thread_context_t *ctx)
 {
 	free_database_state(ctx->event_loop.h2o_ctx.loop, &ctx->db_state);
 	free_event_loop(&ctx->event_loop, &ctx->global_thread_data->h2o_receiver);
+
+	if (ctx->json_generator)
+		do {
+			json_generator_t * const gen = H2O_STRUCT_FROM_MEMBER(json_generator_t,
+			                                                      l,
+			                                                      ctx->json_generator);
+
+			ctx->json_generator = gen->l.next;
+			free_json_generator(gen, NULL, NULL, 0);
+		} while (ctx->json_generator);
 }
 
 global_thread_data_t *initialize_global_thread_data(const config_t *config,

--- a/frameworks/C/h2o/src/thread.h
+++ b/frameworks/C/h2o/src/thread.h
@@ -47,6 +47,8 @@ struct thread_context_t {
 	// global_thread_data contains config and global_data as well,
 	// but keep copies here to avoid some pointer chasing.
 	global_thread_data_t *global_thread_data;
+	list_t *json_generator;
+	size_t json_generator_num;
 	unsigned random_seed;
 	pid_t tid;
 	db_state_t db_state;

--- a/frameworks/C/h2o/src/utility.h
+++ b/frameworks/C/h2o/src/utility.h
@@ -28,6 +28,8 @@
 #include <yajl/yajl_gen.h>
 #include <mustache.h>
 
+#include "list.h"
+
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*(a)))
 // mainly used to silence compiler warnings about unused function parameters
 #define IGNORE_FUNCTION_PARAMETER(p) ((void) (p))
@@ -50,6 +52,7 @@ typedef struct {
 	const char *template_path;
 	size_t max_accept;
 	size_t max_db_conn_num;
+	size_t max_json_generator;
 	size_t max_query_num;
 	size_t thread_num;
 	uint16_t https_port;
@@ -68,11 +71,13 @@ typedef struct {
 	h2o_globalconf_t h2o_config;
 } global_data_t;
 
-// Call yajl_gen_free() on the result, even though the JSON generator
-// uses a memory pool; in this way the code remains correct if the
-// underlying memory allocator is changed (e.g. for debugging purposes).
-yajl_gen get_json_generator(h2o_mem_pool_t *pool);
+typedef struct {
+	list_t l;
+	yajl_gen gen;
+} json_generator_t;
 
+void free_json_generator(json_generator_t *gen, list_t **pool, size_t *gen_num, size_t max_gen);
+json_generator_t *get_json_generator(list_t **pool, size_t *gen_num);
 uint32_t get_random_number(uint32_t max_rand, unsigned int *seed);
 
 #endif // UTILITY_H_


### PR DESCRIPTION
Previously, whenever a memory allocation for the sake of a JSON generator was performed, the application used the memory pool associated with the HTTP request, so the generator was freed after the response was sent (since the memory pool was subsequently destroyed), and a new one was created for the next request. In this way the memory management overhead for the JSON generator was reduced.

However, it has been discovered that some of the memory allocation sizes associated with the JSON generator are above the limit imposed by libh2o, so the latter resorts to calling malloc() directly, which defeats the purpose of using a memory pool in the first place.

The solution is to separate the memory management for the JSON generators from the memory pools managed by libh2o, and to reuse generators across HTTP requests. After a response is sent, the state of each generator is fully reset (as if the generator has just been constructed), so that when it is reused, the new JSON response is created from scratch. Reinitializing the generator is much cheaper than freeing it and allocating a new one.

Since this approach increases the memory usage of the application, the maximum number of JSON generators that can be reused is configurable. Any generator above that limit will be deallocated immediately as soon as it is no longer used.