### PR TITLE
Check DB services even if already installed

### DIFF
--- a/toolset/setup/linux/databases/mongodb/mongodb.sh
+++ b/toolset/setup/linux/databases/mongodb/mongodb.sh
@@ -41,6 +41,7 @@ fi
 EOF
 
 echo -e "ssh \$DBHOST 'bash' <<EOF" > $IROOT/mongodb.installed
+echo -e "sudo service mongod start || echo 'mongod service already started'" >> $IROOT/mongodb.installed
 echo -e "mongo < create.js" >> $IROOT/mongodb.installed
 echo -e "EOF" >> $IROOT/mongodb.installed
 

--- a/toolset/setup/linux/databases/mysql/mysql.sh
+++ b/toolset/setup/linux/databases/mysql/mysql.sh
@@ -39,6 +39,7 @@ EOF
 sudo apt-get install -y mysql-client
 
 echo -e "ssh \$DBHOST 'bash' <<EOF" > $IROOT/mysql.installed
+echo -e "sudo start mysql || echo 'mysql service already started'" >> $IROOT/mysql.installed
 echo -e "mysql -uroot -psecret < create.sql" >> $IROOT/mysql.installed
 echo -e "EOF" >> $IROOT/mysql.installed
 

--- a/toolset/setup/linux/databases/postgresql/postgresql.sh
+++ b/toolset/setup/linux/databases/postgresql/postgresql.sh
@@ -41,11 +41,10 @@ sudo mv 60-postgresql-shm.conf /etc/sysctl.d/60-postgresql-shm.conf
 
 sudo chown postgres:postgres /etc/sysctl.d/60-postgresql-shm.conf
 sudo chown postgres:postgres create-postgres*
-
-service postgresql status &> /dev/null || sudo service postgresql start
 EOF
 
 echo -e "ssh \$DBHOST <<EOF" > $IROOT/postgresql.installed
+echo "service postgresql status &> /dev/null || sudo service postgresql start" >> $IROOT/postgresql.installed
 echo "sudo -u postgres psql -q template1 < create-postgres-database.sql" >> $IROOT/postgresql.installed
 echo "sudo -u postgres psql -q hello_world < create-postgres.sql" >> $IROOT/postgresql.installed
 echo "EOF" >> $IROOT/postgresql.installed


### PR DESCRIPTION
resolves #2645

If the db server is restarted or the service is stopped for some other reason, make sure each database service is running. Previously we only checked that the service was running right after installation.