### PR TITLE
Sync results/ folder for vagrant

### DIFF
--- a/deployment/vagrant/core.rb
+++ b/deployment/vagrant/core.rb
@@ -1,4 +1,3 @@
-
 def provision_bootstrap(config)
 
   # TODO this will break if the environment contains the ' delimiter, 
@@ -39,8 +38,10 @@ def provider_virtualbox(config, ip_address='172.16.0.16')
     #
     # See mitchellh/vagrant#4997
     # See http://superuser.com/a/640028/136050
+
     override.vm.synced_folder "../../toolset", "/home/vagrant/FrameworkBenchmarks/toolset"
     override.vm.synced_folder "../../frameworks", "/home/vagrant/FrameworkBenchmarks/frameworks"
+    override.vm.synced_folder "../../results", "/home/vagrant/FrameworkBenchmarks/results", create: true
 
     override.vm.network :forwarded_port, guest: 8080, host: 28080
   end

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -1019,7 +1019,7 @@ class Benchmarker:
         # setup results and latest_results directories
         self.result_directory = os.path.join(self.fwroot, "results")
         if (args['clean'] or args['clean_all']) and os.path.exists(os.path.join(self.fwroot, "results")):
-            shutil.rmtree(os.path.join(self.fwroot, "results"))
+            os.system("sudo rm -rf " + self.result_directory + "/*")
 
         # remove installs directories if --clean-all provided
         self.install_root = "%s/%s" % (self.fwroot, "installs")


### PR DESCRIPTION
Per the discussion in #2712, syncs the `/results` folder with the host for easier viewing of results. Only required a small change to `--clean` and `--clean-all` of the toolset to remove the contents of the directory instead of the directory itself.
