### PR TITLE
Toolset: Remove DB Connection messages

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -549,27 +549,7 @@ class Benchmarker:
             out.write(header("Starting %s" % test.name))
             out.flush()
             try:
-                if test.requires_database():
-                    p = subprocess.Popen(self.database_ssh_string, stdin=subprocess.PIPE, stdout=out, stderr=out, shell=True)
-                    p.communicate("""
-            sudo restart mysql
-            sudo restart mongod
-            sudo service postgresql restart
-            sudo service cassandra restart
-            /opt/elasticsearch/elasticsearch restart
-          """)
-                    time.sleep(10)
-
-                    st = verify_database_connections([
-                        ("mysql", self.database_host, 3306),
-                        ("mongodb", self.database_host, 27017),
-                        ("postgresql", self.database_host, 5432),
-                        ("cassandra", self.database_host, 9160),
-                        ("elasticsearch", self.database_host, 9200)
-                    ])
-                    print "database connection test results:\n" + "\n".join(st[1])
-
-                self.__cleanup_leftover_processes_before_test();
+                self.__cleanup_leftover_processes_before_test()
 
                 if self.__is_port_bound(test.port):
                     # We gave it our all


### PR DESCRIPTION
Now that databases are installed and restarted in framework setup files with `fw_depends` this section is not needed.