### PR TITLE
HHVM disabled gzip encoding

### DIFF
--- a/frameworks/PHP/codeigniter/deploy/config.hdf
+++ b/frameworks/PHP/codeigniter/deploy/config.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /home/vagrant/FrameworkBenchmarks/frameworks/PHP/codeigniter
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Disable logging completely

--- a/frameworks/PHP/hhvm/deploy/config-debug.hdf
+++ b/frameworks/PHP/hhvm/deploy/config-debug.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /tmp/FrameworkBenchmarks/hhvm
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Enable debug logging

--- a/frameworks/PHP/hhvm/deploy/config.hdf
+++ b/frameworks/PHP/hhvm/deploy/config.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /tmp/FrameworkBenchmarks/hhvm
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Disable logging completely

--- a/frameworks/PHP/laravel/deploy/config.hdf
+++ b/frameworks/PHP/laravel/deploy/config.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /home/vagrant/FrameworkBenchmarks/frameworks/PHP/php-laravel
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Disable logging completely

--- a/frameworks/PHP/slim/deploy/config.hdf
+++ b/frameworks/PHP/slim/deploy/config.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /home/vagrant/FrameworkBenchmarks/frameworks/PHP/php-slim
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Disable logging completely

--- a/frameworks/PHP/symfony2/deploy/config.hdf
+++ b/frameworks/PHP/symfony2/deploy/config.hdf
@@ -9,6 +9,8 @@ Server {
   Type = fastcgi
   SourceRoot = /home/vagrant/FrameworkBenchmarks/frameworks/PHP/symfony2
   DefaultDocument = index.php
+  GzipCompressionLevel = 0
+  EnableKeepAlive = true
 }
 
 # Disable logging completely


### PR DESCRIPTION
and enabled Keep Alive
.hdf is deprecated
Partiallly solves for php (hhvm) #2646
<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->
