### PR TITLE
Update nginx to v1.12.0

### DIFF
--- a/toolset/setup/linux/webservers/nginx.sh
+++ b/toolset/setup/linux/webservers/nginx.sh
@@ -2,11 +2,12 @@
 
 fw_installed nginx && return 0
 
+VERSION="1.12.0"
 NGINX_HOME=$IROOT/nginx
 
-fw_get -O http://nginx.org/download/nginx-1.9.9.tar.gz
-fw_untar nginx-1.9.9.tar.gz
-cd nginx-1.9.9
+fw_get -O http://nginx.org/download/nginx-${VERSION}.tar.gz
+fw_untar nginx-${VERSION}.tar.gz
+cd nginx-${VERSION}
 
 # There is no --quiet flag that I could find...
 echo "Configuring nginx..."


### PR DESCRIPTION
1.9.9 is too old
Should be no problems with php and other lenguajes.
Tested with openresty, that is fully integrated with nginx.
Work in progress

<!--
....................................

MAKE SURE YOU ARE OPENING A PULL
REQUEST AGAINST THE CORRECT BRANCH

....................................

master = currently open to all pull
requests for Round 14.

....................................
-->
