### PR TITLE
Decrease maximum wrk thread count from 4*processors to 1*processors

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -34,7 +34,7 @@ class FrameworkTest:
   # Used for test types that require no pipelining or query string params.
   concurrency_template = """
 
-    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)*4
+    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)
     echo ""
     echo "---------------------------------------------------------"
     echo " Running Primer {name}"
@@ -78,7 +78,7 @@ class FrameworkTest:
   # Used for test types that require pipelining.
   pipeline_template = """
 
-    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)*4
+    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)
     echo ""
     echo "---------------------------------------------------------"
     echo " Running Primer {name}"
@@ -123,7 +123,7 @@ class FrameworkTest:
   # These tests run at a static concurrency level and vary the size of
   # the query sent with each request
   query_template = """
-    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)*4
+    let max_threads=$(cat /proc/cpuinfo | grep processor | wc -l)
     echo ""
     echo "---------------------------------------------------------"
     echo " Running Primer {name}"


### PR DESCRIPTION
We measured the effects of changing this on ServerCentral over the weekend, where our wrk client machine has 8 processors.  Using a maximum of 8 wrk threads instead of 32 improved the results of top-performing frameworks in JSON by roughly 20%.

With plaintext the results were less uniform, but 8 threads were still better than 32.  12 threads seemed slightly better, but 1\*processors is easier to explain than 1.5\*processors.

We saw no change to database test results.