### PR TITLE
Implement parallelism for Crystal

### DIFF
--- a/frameworks/Crystal/crystal/server.cr
+++ b/frameworks/Crystal/crystal/server.cr
@@ -9,7 +9,7 @@ server = HTTP::Server.new("0.0.0.0", 8080) do |context|
   when "/json"
     response.status_code = 200
     response.headers["Content-Type"] = "application/json"
-    response.print({message: "Hello, World!"}.to_json)
+    {message: "Hello, World!"}.to_json(response)
   when "/plaintext"
     response.status_code = 200
     response.headers["Content-Type"] = "text/plain"
@@ -19,4 +19,4 @@ server = HTTP::Server.new("0.0.0.0", 8080) do |context|
   end
 end
 
-server.listen
+server.listen(reuse_port: true)

--- a/frameworks/Crystal/crystal/setup.sh
+++ b/frameworks/Crystal/crystal/setup.sh
@@ -4,4 +4,8 @@ fw_depends crystal
 
 crystal build --release server.cr -o server.out
 
-./server.out
+for i in {1..$(nproc --all)}; do
+  ./server.out &
+done
+
+wait

--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -109,4 +109,4 @@ get "/updates" do |env|
 end
 
 logging false
-Kemal.run
+Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -1,8 +1,6 @@
 require "kemal"
 require "pg"
 
-logging false
-
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
@@ -110,4 +108,5 @@ get "/updates" do |env|
   updated.to_json
 end
 
+logging false
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -1,6 +1,8 @@
 require "kemal"
 require "pg"
 
+logging false
+
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
@@ -108,5 +110,4 @@ get "/updates" do |env|
   updated.to_json
 end
 
-logging false
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -1,13 +1,10 @@
 require "kemal"
 require "pg"
-require "pool/connection"
 
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
-DB = ConnectionPool.new(capacity: 25, timeout: 0.01) do
-  PG.connect("postgres://benchmarkdbuser:benchmarkdbpass@#{ENV["DBHOST"]? || "127.0.0.1"}/hello_world")
-end
+APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@#{ENV["DBHOST"]? || "127.0.0.1"}/hello_world")
 
 class CONTENT
   UTF8  = "; charset=UTF-8"
@@ -20,25 +17,22 @@ ID_MAXIMUM = 10_000
 
 private def random_world
   id = rand(1..ID_MAXIMUM)
-  conn = DB.checkout
-  result = conn.exec({Int32, Int32}, "SELECT id, randomNumber FROM world WHERE id = $1", [id]).rows.first
-  DB.checkin(conn)
-  {id: result[0], randomNumber: result[1]}
+  random_number = APPDB.query_one("SELECT randomNumber FROM world WHERE id = $1", id, as: Int32)
+  {id: id, randomNumber: random_number}
 end
 
 private def set_world(world)
-  conn = DB.checkout
-  result = conn.exec("UPDATE world set randomNumber = $1 where id = $2", [world[:randomNumber], world[:id]])
-  DB.checkin(conn)
+  APPDB.exec("UPDATE world SET randomNumber = $1 WHERE id = $2", world[:randomNumber], world[:id])
   world
 end
 
 private def fortunes
-  data = [] of NamedTuple(id: Int32, message: String)
+  data = Array(NamedTuple(id: Int32, message: String)).new
 
-  DB.connection.exec({Int32, String}, "select id, message from Fortune").rows.each do |row|
-    data.push({id: row[0], message: row[1]})
+  APPDB.query_each("SELECT id, message FROM Fortune") do |rs|
+    data.push({id: rs.read(Int32), message: rs.read(String)})
   end
+
   data
 end
 

--- a/frameworks/Crystal/kemal/server-redis.cr
+++ b/frameworks/Crystal/kemal/server-redis.cr
@@ -109,4 +109,4 @@ get "/updates" do |env|
 end
 
 logging false
-Kemal.run
+Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-redis.cr
+++ b/frameworks/Crystal/kemal/server-redis.cr
@@ -1,6 +1,8 @@
 require "kemal"
 require "redis"
 
+logging false
+
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
@@ -108,5 +110,4 @@ get "/updates" do |env|
   updated.to_json
 end
 
-logging false
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-redis.cr
+++ b/frameworks/Crystal/kemal/server-redis.cr
@@ -1,8 +1,6 @@
 require "kemal"
 require "redis"
 
-logging false
-
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
@@ -110,4 +108,5 @@ get "/updates" do |env|
   updated.to_json
 end
 
+logging false
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/setup-postgres.sh
+++ b/frameworks/Crystal/kemal/setup-postgres.sh
@@ -6,4 +6,8 @@ shards install
 
 crystal build --release server-postgres.cr
 
-./server-postgres &
+for i in {1..$(nproc --all)}; do
+  ./server-postgres &
+done
+
+wait

--- a/frameworks/Crystal/kemal/setup-redis.sh
+++ b/frameworks/Crystal/kemal/setup-redis.sh
@@ -9,4 +9,8 @@ shards install
 
 crystal build --release server-redis.cr
 
-./server-redis &
+for i in {1..$(nproc --all)}; do
+  ./server-redis &
+done
+
+wait

--- a/frameworks/Crystal/kemal/shard.lock
+++ b/frameworks/Crystal/kemal/shard.lock
@@ -1,12 +1,12 @@
 version: 1.0
 shards:
-  html_builder:
-    github: crystal-lang/html_builder
-    version: 0.2.1
+  db:
+    github: crystal-lang/crystal-db
+    version: 0.4.2
 
   kemal:
     github: sdogruyol/kemal
-    version: 0.16.0
+    version: 0.18.3
 
   kilt:
     github: jeromegn/kilt
@@ -14,17 +14,13 @@ shards:
 
   pg:
     github: will/crystal-pg
-    version: 0.9.0
-
-  pool:
-    github: ysbaddaden/pool
-    version: 0.2.3
+    version: 0.13.3
 
   radix:
     github: luislavena/radix
-    version: 0.3.1
+    version: 0.3.8
 
   redis:
     github: stefanwille/crystal-redis
-    version: 1.6.6
+    version: 1.8.0
 

--- a/frameworks/Crystal/kemal/shard.lock
+++ b/frameworks/Crystal/kemal/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   kemal:
     github: sdogruyol/kemal
-    commit: 0b4856b7417592743a27fc3e30867fd141395bf6
+    version: 0.19.0
 
   kilt:
     github: jeromegn/kilt

--- a/frameworks/Crystal/kemal/shard.lock
+++ b/frameworks/Crystal/kemal/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   kemal:
     github: sdogruyol/kemal
-    version: 0.18.3
+    commit: 0b4856b7417592743a27fc3e30867fd141395bf6
 
   kilt:
     github: jeromegn/kilt

--- a/frameworks/Crystal/kemal/shard.yml
+++ b/frameworks/Crystal/kemal/shard.yml
@@ -4,15 +4,12 @@ version: "0.0.1"
 dependencies:
   pg:
     github: "will/crystal-pg"
-    version: "0.9.0"
-  pool:
-    github: "ysbaddaden/pool"
-    version: "0.2.3"
+    version: "0.13.3"
   kemal:
     github: "sdogruyol/kemal"
-    version: "0.16.0"
+    version: "0.18.3"
   redis:
     github: "stefanwille/crystal-redis"
-    version: "~> 1.6.6"
+    version: "1.8.0"
 
 license: "MIT"

--- a/frameworks/Crystal/kemal/shard.yml
+++ b/frameworks/Crystal/kemal/shard.yml
@@ -7,7 +7,7 @@ dependencies:
     version: "0.13.3"
   kemal:
     github: "sdogruyol/kemal"
-    branch: master
+    version: "0.19.0"
   redis:
     github: "stefanwille/crystal-redis"
     version: "1.8.0"

--- a/frameworks/Crystal/kemal/shard.yml
+++ b/frameworks/Crystal/kemal/shard.yml
@@ -7,7 +7,7 @@ dependencies:
     version: "0.13.3"
   kemal:
     github: "sdogruyol/kemal"
-    version: "0.18.3"
+    branch: master
   redis:
     github: "stefanwille/crystal-redis"
     version: "1.8.0"

--- a/toolset/setup/linux/languages/crystal.sh
+++ b/toolset/setup/linux/languages/crystal.sh
@@ -4,7 +4,7 @@ fw_installed crystal && return 0
 
 # install crystal
 
-VERSION="0.18.7"
+VERSION="0.22.0"
 
 SAVE_AS=crystal-$VERSION-1-linux-x86_64.tar.gz
 URL=https://github.com/crystal-lang/crystal/releases/download/$VERSION/crystal-$VERSION-1-linux-x86_64.tar.gz
@@ -15,7 +15,7 @@ fw_untar ${SAVE_AS}
 
 # install shards
 
-SVERSION="0.6.3"
+SVERSION="0.7.1"
 SAVE_AS=shards-${SVERSION}_linux_x86_64
 URL=https://github.com/crystal-lang/shards/releases/download/v${SVERSION}/shards-${SVERSION}_linux_x86_64.gz
 


### PR DESCRIPTION
This PR updates the Crystal version to 0.22.0, and implements parallelism by way of `SO_REUSEPORT`. We ensure to set `SO_REUSEPORT`, and spawn a process on each core. Incoming connections are then load balanced across all processes.

What might be a problem is that I see your environment has 40 cores, but wrk makes far fewer connections than that. Preferably 2 or 3 connections would be made per core, is there a way to make this change (only for crystal)?