### PR TITLE
Add libvirt provider for virtualbox

### DIFF
--- a/deployment/vagrant/Vagrantfile
+++ b/deployment/vagrant/Vagrantfile
@@ -10,7 +10,11 @@ Vagrant.configure("2") do |config|
       file.destination = "~/.custom_motd.sh"
   end
 
+  config.vm.network "private_network", ip: "172.16.0.16"
+  config.vm.network :forwarded_port, guest: 8080, host: 28080
+
   provision_bootstrap(config)
   provider_virtualbox(config)
+  provider_libvirt(config)
 
 end

--- a/deployment/vagrant/core.rb
+++ b/deployment/vagrant/core.rb
@@ -9,13 +9,29 @@ def provision_bootstrap(config)
   end
 end
 
-def provider_virtualbox(config, ip_address='172.16.0.16')
-  config.vm.network "private_network", ip: ip_address
-  
+def provider_libvirt(config)
+  config.vm.provider :libvirt do |virt, override|
+    override.vm.hostname = "TFB-all"
+    override.vm.box = "RX14/trusty64"
+
+    unless ENV.fetch('TFB_SHOW_VM', false)
+      virt.graphics_type = "none"
+    end
+
+    virt.memory = ENV.fetch('TFB_KVM_MEM', 3022)
+    virt.cpus = ENV.fetch('TFB_KVM_CPU', 2)
+
+    override.vm.synced_folder "../../toolset", "/home/vagrant/FrameworkBenchmarks/toolset", type: "nfs"
+    override.vm.synced_folder "../../frameworks", "/home/vagrant/FrameworkBenchmarks/frameworks", type: "nfs"
+    override.vm.synced_folder "../../results", "/home/vagrant/FrameworkBenchmarks/results", type: "nfs", create: true
+  end
+end
+
+def provider_virtualbox(config)
   config.vm.provider :virtualbox do |vb, override|
     override.vm.hostname = "TFB-all"
     override.vm.box = "ubuntu/trusty64"
-    
+
     if ENV.fetch('TFB_SHOW_VM', false)
       vb.gui = true
     end
@@ -42,7 +58,5 @@ def provider_virtualbox(config, ip_address='172.16.0.16')
     override.vm.synced_folder "../../toolset", "/home/vagrant/FrameworkBenchmarks/toolset"
     override.vm.synced_folder "../../frameworks", "/home/vagrant/FrameworkBenchmarks/frameworks"
     override.vm.synced_folder "../../results", "/home/vagrant/FrameworkBenchmarks/results", create: true
-
-    override.vm.network :forwarded_port, guest: 8080, host: 28080
   end
 end


### PR DESCRIPTION
The libvirt provider defaults to kvm, which is a much faster hypervisor than virtualbox, giving more realistic results.