### PR TITLE
Crystal bash seq

### DIFF
--- a/frameworks/Crystal/crystal/setup.sh
+++ b/frameworks/Crystal/crystal/setup.sh
@@ -4,7 +4,7 @@ fw_depends crystal
 
 crystal build --release server.cr -o server.out
 
-for i in {1..$(nproc --all)}; do
+for i in $(seq 1 $(nproc --all)); do
   ./server.out &
 done
 

--- a/frameworks/Crystal/kemal/setup-postgres.sh
+++ b/frameworks/Crystal/kemal/setup-postgres.sh
@@ -6,7 +6,7 @@ shards install
 
 crystal build --release server-postgres.cr
 
-for i in {1..$(nproc --all)}; do
+for i in $(seq 1 $(nproc --all)); do
   ./server-postgres &
 done
 

--- a/frameworks/Crystal/kemal/setup-redis.sh
+++ b/frameworks/Crystal/kemal/setup-redis.sh
@@ -9,7 +9,7 @@ shards install
 
 crystal build --release server-redis.cr
 
-for i in {1..$(nproc --all)}; do
+for i in $(seq 1 $(nproc --all)); do
   ./server-redis &
 done
 


### PR DESCRIPTION
This PR fix `for` iteration because current bash script implementation just do one iteration. See #2758

See [stackoverflow](http://stackoverflow.com/questions/6191146/variables-in-bash-seq-replacement-1-10)

```sh
for i in {1..$(nproc --all)}; do
  echo "server"
done
# server
```

To archive more than one need to use `seq`

```sh
for i in $(seq 1 $(nproc --all)); do
  echo "server"
done
# server
# server
# server
# server
# server
# ...
```
