### PR TITLE
Fix PHP session file overload

### DIFF
--- a/toolset/setup/linux/languages/php/php.ini
+++ b/toolset/setup/linux/languages/php/php.ini
@@ -1400,7 +1400,7 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://php.net/session.save-path
-;session.save_path = "/tmp"
+session.save_path = "3;/tmp"
 
 ; Whether to use cookies.
 ; http://php.net/session.use-cookies


### PR DESCRIPTION
**Problem**
Some php frameworks were writing thousands of session files to `/tmp` and locking up the device.

**Solution**
This fix to the `php.ini` file spreads out session files into sub-directories. After testing in our production environment, the toolset is now able to continue and clear out the `/tmp` folder.