### PR TITLE
Several Toolset Verification Updates

### DIFF
--- a/frameworks/Erlang/mochiweb/src/web_handler.erl
+++ b/frameworks/Erlang/mochiweb/src/web_handler.erl
@@ -55,5 +55,6 @@ queries(Req) ->
     case {is_number(Queries), Queries > 500} of
         {true, true} -> 500;
         {false, _}   -> 1;
+        _ when Queries < 1 -> 1;
         _ -> Queries
     end.

--- a/frameworks/Java/restexpress/src/main/java/hello/controller/MongodbController.java
+++ b/frameworks/Java/restexpress/src/main/java/hello/controller/MongodbController.java
@@ -24,24 +24,26 @@ public class MongodbController
 
 	public Object read(Request request, Response response)
 	{
-		// Get the count of queries to run.
-		int count = 1;
-		String value = request.getHeader("queries");
+    // Get the count of queries to run.
+    int count = 1;
+    try
+    {
+      count = Integer.parseInt(request.getHeader("queries"));
 
-		if (value != null)
-		{
-			count = Integer.parseInt(value);
-		}
-
-		// Bounds check.
-		if (count > 500)
-		{
-			count = 500;
-		}
-		else if (count < 1)
-		{
-			count = 1;
-		}
+      // Bounds check.
+      if (count > 500)
+      {
+        count = 500;
+      }
+      if (count < 1)
+      {
+        count = 1;
+      }
+    }
+    catch(NumberFormatException nfexc)
+    {
+      // do nothing
+    }
 
 		// Fetch some rows from the database.
 		final World[] worlds = new World[count];

--- a/frameworks/JavaScript/express/app.js
+++ b/frameworks/JavaScript/express/app.js
@@ -114,7 +114,8 @@ if (cluster.isMaster) {
     res.header('Content-Type', 'text/plain').send('Hello, World!'));
 
   app.get('/mongoose', (req, res) => {
-    let queries = isNaN(req.query.queries) ? 1 : parseInt(req.query.queries, 10);
+    let queriesRaw = parseInt(req.query.queries, 10),
+      queries = isNaN(queriesRaw) ? 1 : queriesRaw;
     const queryFunctions = [];
 
     queries = Math.min(Math.max(queries, 1), 500);

--- a/frameworks/JavaScript/ringojs/app/views.js
+++ b/frameworks/JavaScript/ringojs/app/views.js
@@ -9,6 +9,17 @@ const fortuneTemplate = module.singleton('fortuneTemplate', function() {
 });
 
 const app = exports.app = Application();
+
+const formatQueries = function(queries) {
+  queries = parseInt(queries, 10) || 1;
+  if (isNaN(queries) || queries < 1) {
+    queries = 1;
+  } else if (queries > 500) {
+    queries = 500;
+  }
+  return queries;
+};
+
 app.configure("params", "route");
 
 app.get('/json', function() {
@@ -17,7 +28,7 @@ app.get('/json', function() {
 });
 
 app.get('/db/:queries?', function(request, queries) {
-   queries = parseInt(queries, 10) || 1;
+   queries = formatQueries(queries);
    let worlds = [];
    for (let i = 0; i < queries; i++) {
       let randId = ((Math.random() * 10000) | 0) + 1;
@@ -45,12 +56,7 @@ app.get('/plaintext', function() {
 });
 
 app.get('/updates/:queries?', function(request, queries) {
-   queries = parseInt(queries, 10) || 1;
-   if (isNaN(queries) || queries < 1) {
-      queries = 1;
-   } else if (queries > 500) {
-      queries = 500;
-   }
+   queries = formatQueries(queries);
    const worlds = [];
    for (let i = 0; i < queries; i++) {
       let randId = ((Math.random() * 10000) | 0) + 1;

--- a/frameworks/JavaScript/ringojs/ringo-main.js
+++ b/frameworks/JavaScript/ringojs/ringo-main.js
@@ -20,7 +20,7 @@ exports.app = function(req) {
      try {
        connection = datasource.getConnection();
        let randId, world;
-       if (queryCount === null) {
+       if (!queryCount || isNaN(queryCount) || queryCount < 1) {
          randId = ((Math.random() * 10000) | 0) + 1;
          world = sql.query(connection, 'select * from World where World.id = ' + randId)[0];
          return {

--- a/frameworks/PHP/fuel/fuel/app/classes/controller/bench.php
+++ b/frameworks/PHP/fuel/fuel/app/classes/controller/bench.php
@@ -12,6 +12,8 @@ class Controller_Bench extends Controller
     public function action_db()
     {
         $queries = Input::get('queries', 1);
+        $queries = is_numeric($queries) ? min(max($queries, 1), 500) : 1;
+
         $worlds = array();
 
         for($i = 0; $i < $queries; ++$i) {

--- a/frameworks/PHP/phreeze/libs/Controller/TestController.php
+++ b/frameworks/PHP/phreeze/libs/Controller/TestController.php
@@ -57,8 +57,9 @@ class TestController extends Controller
 	
 		// Read number of queries to run from URL parameter
 		$query_count = RequestUtil::Get('queries',1);
-		
-		// make sure the query count paramter is in range
+        $query_count = is_numeric($query_count) ? min(max($query_count, 1), 500) : 1;
+
+        // make sure the query count paramter is in range
 		if (!is_numeric($query_count)) {
 			$query_count = 1;
 		}
@@ -118,8 +119,9 @@ class TestController extends Controller
 		
 		// Read number of queries to run from URL parameter
 		$query_count = RequestUtil::Get('queries',1);
-		
-		$arr = array();
+        $query_count = is_numeric($query_count) ? min(max($query_count, 1), 500) : 1;
+
+        $arr = array();
 		
 		for ($i = 0; $i < $query_count; $i++) {
 		

--- a/frameworks/PHP/symfony2-stripped/src/Skamander/BenchmarkBundle/Controller/BenchController.php
+++ b/frameworks/PHP/symfony2-stripped/src/Skamander/BenchmarkBundle/Controller/BenchController.php
@@ -24,8 +24,7 @@ class BenchController extends Controller
     public function dbAction(Request $request)
     {
         $queries = $request->query->getInt('queries', 1);
-        $queries = max(1, $queries);
-        $queries = min(500, $queries);
+        $queries = is_numeric($queries) ? min(max($queries, 1), 500) : 1;
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = array();

--- a/frameworks/PHP/symfony2-stripped/src/Skamander/BenchmarkBundle/Controller/BenchController.php
+++ b/frameworks/PHP/symfony2-stripped/src/Skamander/BenchmarkBundle/Controller/BenchController.php
@@ -45,6 +45,7 @@ class BenchController extends Controller
     public function dbRawAction(Request $request)
     {
         $queries = $request->query->getInt('queries', 1);
+        $queries = is_numeric($queries) ? min(max($queries, 1), 500) : 1;
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = array();

--- a/frameworks/PHP/symfony2/src/Skamander/BenchmarkBundle/Controller/BenchController.php
+++ b/frameworks/PHP/symfony2/src/Skamander/BenchmarkBundle/Controller/BenchController.php
@@ -24,8 +24,7 @@ class BenchController extends Controller
     public function dbAction(Request $request)
     {
         $queries = $request->query->getInt('queries', 1);
-        $queries = max(1, $queries);
-        $queries = min(500, $queries);
+        $queries = is_numeric($queries) ? min(max($queries, 1), 500) : 1;
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = array();

--- a/frameworks/PHP/symfony2/src/Skamander/BenchmarkBundle/Controller/BenchController.php
+++ b/frameworks/PHP/symfony2/src/Skamander/BenchmarkBundle/Controller/BenchController.php
@@ -45,6 +45,7 @@ class BenchController extends Controller
     public function dbRawAction(Request $request)
     {
         $queries = $request->query->getInt('queries', 1);
+        $queries = is_numeric($queries) ? min(max($queries, 1), 500) : 1;
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = array();

--- a/frameworks/Perl/dancer/app.pl
+++ b/frameworks/Perl/dancer/app.pl
@@ -8,7 +8,7 @@ use JSON::XS;  # Ensure that the fast implementation of the serializer is instal
 
 set serializer => 'JSON';
 
-my $dsn = "dbi:mysql:database=hello_world;host=127.0.0.1;port=3306";
+my $dsn = "dbi:mysql:database=hello_world;host=TFB-database;port=3306";
 my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass', {} );
 my $sth = $dbh->prepare("SELECT * FROM World where id = ?");
 

--- a/frameworks/Perl/dancer/app.pl
+++ b/frameworks/Perl/dancer/app.pl
@@ -18,9 +18,9 @@ get '/json' => sub {
 
 get '/db' => sub {
     my $queries = params->{queries} || 1;
-    if ( $queries + 0 != $queries) {
-        $queries = 1;
-    }
+    $queries = 1 if ( $queries !~ /^\d+$/ || $queries < 1 );
+    $queries = 500 if $queries > 500;
+    
     my @response;
     for ( 1 .. $queries ) {
         my $id = int rand 10000 + 1;

--- a/frameworks/Perl/dancer/app.pl
+++ b/frameworks/Perl/dancer/app.pl
@@ -8,7 +8,7 @@ use JSON::XS;  # Ensure that the fast implementation of the serializer is instal
 
 set serializer => 'JSON';
 
-my $dsn = "dbi:mysql:database=hello_world;host=localhost;port=3306";
+my $dsn = "dbi:mysql:database=hello_world;host=127.0.0.1;port=3306";
 my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass', {} );
 my $sth = $dbh->prepare("SELECT * FROM World where id = ?");
 
@@ -18,6 +18,9 @@ get '/json' => sub {
 
 get '/db' => sub {
     my $queries = params->{queries} || 1;
+    if ( $queries + 0 != $queries) {
+        $queries = 1;
+    }
     my @response;
     for ( 1 .. $queries ) {
         my $id = int rand 10000 + 1;

--- a/frameworks/Perl/dancer/nginx.conf
+++ b/frameworks/Perl/dancer/nginx.conf
@@ -19,7 +19,7 @@ http {
   tcp_nodelay      on;
 
   upstream backendurl {
-    server unix:/home/tfb/FrameworkBenchmarks/dancer/frameworks-benchmark.sock;
+    server unix:/tmp/perl-dancer.sock;
   }
 
   server {

--- a/frameworks/Perl/dancer/setup.sh
+++ b/frameworks/Perl/dancer/setup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-sed -i 's|user .*;|user '"$(id -u -n)"';|g' nginx.conf
-sed -i 's|server unix.*frameworks-benchmark.sock;|server unix:'"${TROOT}"'/frameworks-benchmark.sock;|g' nginx.conf
-
 fw_depends perl nginx
 
 cpanm --notest --no-man-page \
@@ -16,4 +13,4 @@ cpanm --notest --no-man-page \
     
 nginx -c ${TROOT}/nginx.conf
 
-plackup -E production -s Starman --workers=${CPU_COUNT} -l ${TROOT}/frameworks-benchmark.sock -a ./app.pl &
+plackup -E production -s Starman --workers=${CPU_COUNT} -l /tmp/perl-dancer.sock -a ./app.pl &

--- a/frameworks/Perl/dancer/setup.sh
+++ b/frameworks/Perl/dancer/setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-sed -i 's|localhost|'"${DBHOST}"'|g' app.pl
 sed -i 's|user .*;|user '"$(id -u -n)"';|g' nginx.conf
 sed -i 's|server unix.*frameworks-benchmark.sock;|server unix:'"${TROOT}"'/frameworks-benchmark.sock;|g' nginx.conf
 

--- a/frameworks/Scala/fintrospect/src/main/scala/DatabaseRoutes.scala
+++ b/frameworks/Scala/fintrospect/src/main/scala/DatabaseRoutes.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.mysql.{Client, IntValue, Result, ResultSet}
 import com.twitter.util.Future.collect
 import io.fintrospect.formats.Jackson.JsonFormat.{array, number, obj}
 import io.fintrospect.formats.Jackson.ResponseBuilder._
-import io.fintrospect.parameters.{ParameterSpec, Query}
+import io.fintrospect.parameters.{ParameterSpec, Query, StringValidations}
 import io.fintrospect.{RouteSpec, ServerRoutes}
 
 import scala.language.reflectiveCalls
@@ -37,7 +37,7 @@ object DatabaseRoutes {
         .map(_.map(Ok(_)).getOrElse(NotFound("")).build())
     }
 
-    val numberOfQueries = Query.optional(ParameterSpec.string().map {
+    val numberOfQueries = Query.optional(ParameterSpec.string(StringValidations.EmptyIsValid).map {
       i => Try(i.toInt).getOrElse(1).max(1).min(500)
     }, "queries")
 

--- a/toolset/benchmark/test_types/query_type.py
+++ b/toolset/benchmark/test_types/query_type.py
@@ -34,10 +34,10 @@ class QueryTestType(FrameworkTestType):
         url = base_url + self.query_url
         cases = [
             ('2',   'fail'),
-            ('0',   'warn'),
-            ('foo', 'warn'),
+            ('0',   'fail'),
+            ('foo', 'fail'),
             ('501', 'warn'),
-            ('',    'warn')
+            ('',    'fail')
         ]
 
         problems = verify_query_cases(self, cases, url)

--- a/toolset/benchmark/test_types/update_type.py
+++ b/toolset/benchmark/test_types/update_type.py
@@ -27,10 +27,10 @@ class UpdateTestType(FrameworkTestType):
         url = base_url + self.update_url
         cases = [
             ('2',   'fail'),
-            ('0',   'warn'),
-            ('foo', 'warn'),
+            ('0',   'fail'),
+            ('foo', 'fail'),
             ('501', 'warn'),
-            ('',    'warn')
+            ('',    'fail')
         ]
         problems = verify_query_cases(self, cases, url)
 

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -258,10 +258,10 @@ def verify_query_cases(self, cases, url):
 
     cases = [
         ('2',   'fail'),
-        ('0',   'warn'),
-        ('foo', 'warn'),
+        ('0',   'fail'),
+        ('foo', 'fail'),
         ('501', 'warn'),
-        ('',    'warn')
+        ('',    'fail')
     ]
 
     The reason for using 'warn' is generally for a case that will be allowed in the

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -116,12 +116,15 @@ def verify_helloworld_object(json_object, url):
     if 'message' not in json_object:
         return [('fail', "Missing required key 'message'", url)]
     else:
-        if len(json_object) > 1:
+        json_len = len(json_object)
+        if json_len > 1:
             additional = (', ').join(
                 [k for k in json_object.keys() if k != 'message'])
             problems.append(
                 ('warn', "Too many JSON key/value pairs, consider removing: %s" % additional, url))
-
+        if json_len > 27:
+            problems.append(
+                'warn', "%s additional response byte(s) found. Consider removing unnecessary whitespace." % (json_len - 26))
         message = json_object['message']
 
         if message != 'hello, world!':


### PR DESCRIPTION
resolves #2634 

Now, during the verification step, there will be a check to see if the server is reachable from the client machine. The first step remains, which does header verification using python from the app server, and will throw errors as normal with useful information. If this step doesn't fail, then the client check will be made. Seeing that check fail will usually mean the server was set up correctly but only accepting connections from localhost.

### Queries

This PR revealed that only some frameworks are not sanitizing the query param in the queries and updates test. Since the [Test Requirements](http://frameworkbenchmarks.readthedocs.io/en/latest/Project-Information/Framework-Tests/#multiple-database-queries) make it clear that missing or non-integer parameters should be interpreted as `1`, no response in these cases will now be marked as failing.

_Those are now fixed_

### JSON

JSON now warns if response bytes are greater than 27 -> {"message":"hello, world!"}