### PR TITLE
remove harmony async flags for koa

### DIFF
--- a/frameworks/JavaScript/koa/package.json
+++ b/frameworks/JavaScript/koa/package.json
@@ -11,9 +11,9 @@
     "koa-bodyparser": "4.2.0",
     "koa-hbs": "1.0.0-alpha.1",
     "koa-router": "7.1.1",
-    "mongoose": "4.9.8",
+    "mongoose": "4.9.10",
     "mysql": "2.13.0",
-    "pg": "6.1.5",
+    "pg": "6.2.2",
     "pg-hstore": "2.3.2",
     "sequelize": "3.30.4"
   }

--- a/frameworks/JavaScript/koa/setup.sh
+++ b/frameworks/JavaScript/koa/setup.sh
@@ -3,4 +3,4 @@
 fw_depends mongodb postgresql mysql nodejs
 
 npm install
-node --harmony-async-await app &
+node app &


### PR DESCRIPTION
because of https://github.com/TechEmpower/FrameworkBenchmarks/commit/c0bf5607f46d684e34c0d60e41f58bb52565637b koa no longer needs the harmony async flags.