### PR TITLE
Make ulimit on App server configurable / $ULIMIT env var

### DIFF
--- a/benchmark.cfg.example
+++ b/benchmark.cfg.example
@@ -25,6 +25,7 @@ type=all
 verbose=True
 clean=False
 clean_all=False
+ulimit=200000
 #results_name=My Benchmarking Run %%Y-%%m-%%d %%H:%%M:%%S
 #results_environment=My Server Environment
 #results_upload_uri=https://example.com/uploads

--- a/deployment/vagrant/bootstrap.sh
+++ b/deployment/vagrant/bootstrap.sh
@@ -64,6 +64,7 @@ type=all
 verbose=True
 clean=False
 clean_all=False
+ulimit=200000
 EOF
 
   source ./toolset/setup/linux/prerequisites.sh

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -350,7 +350,6 @@ class Benchmarker:
                 return True
             subprocess.call(['sudo', 'sysctl', '-w', 'net.ipv4.tcp_max_syn_backlog=65535'], stdout=self.quiet_out, stderr=subprocess.STDOUT)
             subprocess.call(['sudo', 'sysctl', '-w', 'net.core.somaxconn=65535'], stdout=self.quiet_out, stderr=subprocess.STDOUT)
-            subprocess.call(['sudo', '-s', 'ulimit', '-n', '65535'], stdout=self.quiet_out, stderr=subprocess.STDOUT)
             subprocess.call(['sudo', 'sysctl', 'net.ipv4.tcp_tw_reuse=1'], stdout=self.quiet_out, stderr=subprocess.STDOUT)
             subprocess.call(['sudo', 'sysctl', 'net.ipv4.tcp_tw_recycle=1'], stdout=self.quiet_out, stderr=subprocess.STDOUT)
             subprocess.call(['sudo', 'sysctl', '-w', 'kernel.shmmax=134217728'], stdout=self.quiet_out, stderr=subprocess.STDOUT)

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -118,6 +118,10 @@ def main(argv=None):
         defaults['database_host'] = defaults['client_host']
     if defaults['server_host'] is None:
         defaults['server_host'] = defaults['client_host']
+    if defaults['ulimit'] is None:
+        defaults['ulimit'] = 200000
+
+    os.environ['ULIMIT'] = defaults['ulimit']
 
     ##########################################################
     # Set up argument parser

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -121,7 +121,7 @@ def main(argv=None):
     if defaults['ulimit'] is None:
         defaults['ulimit'] = 200000
 
-    os.environ['ULIMIT'] = defaults['ulimit']
+    os.environ['ULIMIT'] = str(defaults['ulimit'])
 
     ##########################################################
     # Set up argument parser

--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -36,7 +36,18 @@ sudo pip install colorama==0.3.1
 sudo pip install progressbar==2.2
 sudo pip install requests
 
-sudo sh -c "echo '*               -    nofile          65535' >> /etc/security/limits.conf"
+# Get the ulimit from the benchmark config
+if [ -f benchmark.cfg ]; then
+  FILE=benchmark.cfg
+else
+  FILE=benchmark.cfg.example
+fi
+
+ULIMIT=$(grep '^ulimit=' $FILE | grep -Po '[0-9]+')
+
+if [ ! $ULIMIT ]; then ULIMIT=200000; fi;
+
+sudo sh -c "echo '*               -    nofile          ${ULIMIT}' >> /etc/security/limits.conf"
 sudo sh -c "echo '*            hard    rtprio             99' >> /etc/security/limits.conf"
 sudo sh -c "echo '*            soft    rtprio             99' >> /etc/security/limits.conf"
 


### PR DESCRIPTION
Makes the ulimit max on the server configurable via the `benchmark.cfg` and sets the default to 200000

Also provides $ULIMIT environment variable for test to reference.

resolves #2790 
resolves #2576 