### PR TITLE
Upgrade NodeJS to v8.0.0

### DIFF
--- a/toolset/setup/linux/webservers/nodejs.sh
+++ b/toolset/setup/linux/webservers/nodejs.sh
@@ -2,7 +2,7 @@
 
 fw_installed node && return 0
 
-VERSION="7.10.0"
+VERSION="8.0.0"
 
 fw_get -O http://nodejs.org/dist/v$VERSION/node-v$VERSION-linux-x64.tar.gz
 fw_untar node-v$VERSION-linux-x64.tar.gz


### PR DESCRIPTION
This should see a small bump in performance for all the JavaScript frameworks. There was a move to get most of the code over to es2015, which did result in some memory leak issues found in node v7.x.