### PR TITLE
Ensure no running DB services before Test Start

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -369,7 +369,11 @@ class Benchmarker:
     def __cleanup_leftover_processes_before_test(self):
         p = subprocess.Popen(self.database_ssh_string, stdin=subprocess.PIPE, shell=True, stdout=self.quiet_out, stderr=subprocess.STDOUT)
         p.communicate("""
-      sudo /etc/init.d/apache2 stop
+      sudo service mysql stop
+      sudo service mongod stop
+      sudo kill -9 $(pgrep postgres)
+      sudo kill -9 $(pgrep mysql)
+      sudo kill -9 $(pgrep mongo)
     """)
 
     ############################################################


### PR DESCRIPTION
With updated MySQL conf holding on to 80% of the RAM on the DB server, it highlights the need to make sure all DB services are shutdown before a new test starts so that thew new test only uses the services it needs.