### PR TITLE
Upgrade Finch/Finagle/Finatra benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -2,11 +2,11 @@ name := "finagle"
 
 scalaVersion := "2.11.11"
 
-version := "6.44.0"
+version := "6.45.0"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "6.44.0",
+  "com.twitter" %% "finagle-http" % "6.45.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3"
 )

--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -29,20 +29,22 @@ object Main extends App {
       Future.value(rep)
     })
 
-  val serverAndDate: SimpleFilter[Request, Response] = new SimpleFilter[Request, Response] {
+  val serverAndDate: SimpleFilter[Request, Response] =
+    new SimpleFilter[Request, Response] with (Response => Response) {
 
-    private[this] val addServerAndDate: Response => Response = { rep =>
-        rep.headerMap.set("Server", "Finagle")
-        rep.headerMap.set("Date", currentTime())
+    def apply(rep: Response): Response = {
+      rep.headerMap.set("Server", "Finagle")
+      rep.headerMap.set("Date", currentTime())
 
-        rep
+      rep
     }
 
     def apply(req: Request, s: Service[Request, Response]): Future[Response] =
-      s(req).map(addServerAndDate)
+      s(req).map(this)
   }
 
   Await.ready(Http.server
+    .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
     .withStatsReceiver(NullStatsReceiver)
     .withTracer(NullTracer)

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,8 +1,8 @@
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"
-version := "2.8.0"
+version := "2.11.0"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases")
@@ -16,6 +16,6 @@ assemblyMergeStrategy in assembly := {
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "2.8.0",
+  "com.twitter" %% "finatra-http" % "2.11.0",
   "org.slf4j" % "slf4j-nop" % "1.7.21"
 )

--- a/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
+++ b/frameworks/Scala/finatra/src/main/scala/benchmark/Server.scala
@@ -16,6 +16,7 @@ class Server extends HttpServer {
 
   override protected def configureHttpServer(server: Http.Server): Http.Server = {
     server
+      .configured(Http.Netty3Impl)
       .withCompressionLevel(0)
       .withStatsReceiver(NullStatsReceiver)
       .withTracer(NullTracer)

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,12 +1,12 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.14.1"
+version := "0.15.0"
 
 scalaVersion := "2.11.11"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.14.1",
-  "com.github.finagle" %% "finch-circe" % "0.14.1"
+  "com.github.finagle" %% "finch-core" % "0.15.0",
+  "com.github.finagle" %% "finch-circe" % "0.15.0"
 )

--- a/frameworks/Scala/finch/src/main/scala/Main.scala
+++ b/frameworks/Scala/finch/src/main/scala/Main.scala
@@ -27,6 +27,7 @@ object Main extends App {
   }
 
   Await.ready(Http.server
+    .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
     .withStatsReceiver(NullStatsReceiver)
     .withTracer(NullTracer)


### PR DESCRIPTION
## Finch changes:
- Upgrade Finch to 0.15
- Pin HTTP server to Netty 3 (as of it's known to perform better)

## Finagle changes:
- Upgrade Finagle to 6.45
- Pin HTTP server to Netty 3 (as of it's known to perform better)
- Embed `(Response => Response)` function into a filter to reduce allocations

## Finatra changes:
- Updated Finatra to 2.11
- Updated Scala version to 2.11.11
- Pin HTTP server to Netty 3 (as of it's known to perform better)