### PR TITLE
Toolset --mode debug

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -582,8 +582,13 @@ class Benchmarker:
                 ##########################
                 # Verify URLs
                 ##########################
-                logging.info("Verifying framework URLs")
-                passed_verify = test.verify_urls(logDir)
+                if self.mode == "debug":
+                    logging.info("Entering debug mode. Server has started. CTRL-c to stop.")
+                    while True:
+                        time.sleep(1)
+                else:
+                    logging.info("Verifying framework URLs")
+                    passed_verify = test.verify_urls(logDir)
 
                 ##########################
                 # Nuke /tmp

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -145,7 +145,7 @@ def main(argv=None):
     parser.add_argument('--test-dir', nargs='+', dest='test_dir', help='name of framework directory containing all tests to run')
     parser.add_argument('--exclude', nargs='+', help='names of tests to exclude')
     parser.add_argument('--type', choices=['all', 'json', 'db', 'query', 'cached_query', 'fortune', 'update', 'plaintext'], default='all', help='which type of test to run')
-    parser.add_argument('-m', '--mode', choices=['benchmark', 'verify'], default='benchmark', help='verify mode will only start up the tests, curl the urls and shutdown')
+    parser.add_argument('-m', '--mode', choices=['benchmark', 'verify', 'debug'], default='benchmark', help='verify mode will only start up the tests, curl the urls and shutdown')
     parser.add_argument('--list-tests', action='store_true', default=False, help='lists all the known tests that can run')
 
     # Benchmark options

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -145,7 +145,7 @@ def main(argv=None):
     parser.add_argument('--test-dir', nargs='+', dest='test_dir', help='name of framework directory containing all tests to run')
     parser.add_argument('--exclude', nargs='+', help='names of tests to exclude')
     parser.add_argument('--type', choices=['all', 'json', 'db', 'query', 'cached_query', 'fortune', 'update', 'plaintext'], default='all', help='which type of test to run')
-    parser.add_argument('-m', '--mode', choices=['benchmark', 'verify', 'debug'], default='benchmark', help='verify mode will only start up the tests, curl the urls and shutdown')
+    parser.add_argument('-m', '--mode', choices=['benchmark', 'verify', 'debug'], default='benchmark', help='verify mode will only start up the tests, curl the urls and shutdown. debug mode will skip verification and leave the server running.')
     parser.add_argument('--list-tests', action='store_true', default=False, help='lists all the known tests that can run')
 
     # Benchmark options


### PR DESCRIPTION
Allows you to run a test in a "debug" mode, which spins up the server but does not do any url verification or benchmarking and waits for user input before spinning down:

`tfb --mode debug --test gemini`
