### PR TITLE
Upgrade Finch to 0.16-M1

### DIFF
--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,12 +1,12 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.15.0"
+version := "0.16.0-M1"
 
 scalaVersion := "2.11.11"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.15.0",
-  "com.github.finagle" %% "finch-circe" % "0.15.0"
+  "com.github.finagle" %% "finch-core" % "0.16.0-M1",
+  "com.github.finagle" %% "finch-circe" % "0.16.0-M1"
 )

--- a/frameworks/Scala/finch/src/main/scala/Main.scala
+++ b/frameworks/Scala/finch/src/main/scala/Main.scala
@@ -1,5 +1,7 @@
 import com.twitter.io.Buf
 import com.twitter.finagle.Http
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.Service
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.tracing.NullTracer
 import com.twitter.util.Await
@@ -14,23 +16,23 @@ object Main extends App {
 
   val json: Endpoint[Json] = get("json") {
     Ok(Json.obj("message" -> Json.fromString("Hello, World!")))
-      .withHeader("Server" -> "Finch")
   }
 
-  // We need to downgrade to Buf and override Content-Type header manually
-  // to serve non-JSON payload out of the JSON service. This workaround
-  // shouldn't be needed in Finch 1.0.
   val plaintext: Endpoint[Buf] = get("plaintext") {
     Ok(helloWorld)
-      .withHeader("Server" -> "Finch")
-      .withHeader("Content-Type" -> "text/plain")
   }
+
+  val service: Service[Request, Response] =
+    Bootstrap.configure(includeDateHeader = true, includeServerHeader = true)
+      .serve[Application.Json](json)
+      .serve[Text.Plain](plaintext)
+      .toService
 
   Await.ready(Http.server
     .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
     .withStatsReceiver(NullStatsReceiver)
     .withTracer(NullTracer)
-    .serve(":9000", (json :+: plaintext).toServiceAs[Application.Json])
+    .serve(":9000", service)
   )
 }


### PR DESCRIPTION
This PR upgrades Finch to 0.16-M1 that makes it possible serving multiple content-type out of a single `Service`.