### PR TITLE
Removed the two memory options for the java process.

### DIFF
--- a/frameworks/Java/vertx-web/setup.sh
+++ b/frameworks/Java/vertx-web/setup.sh
@@ -2,7 +2,7 @@
 
 sed -i 's|localhost|'"${DBHOST}"'|g' src/main/conf/config.json
 
-#fw_depends java maven
+fw_depends java maven
 
 mvn clean package
 

--- a/frameworks/Java/vertx-web/setup.sh
+++ b/frameworks/Java/vertx-web/setup.sh
@@ -2,8 +2,8 @@
 
 sed -i 's|localhost|'"${DBHOST}"'|g' src/main/conf/config.json
 
-fw_depends java maven
+#fw_depends java maven
 
 mvn clean package
 
-java -Xms2G -Xmx2G -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dvertx.disableWebsockets=true -Dvertx.flashPolicyHandler=false -Dvertx.threadChecks=false -Dvertx.disableContextTimings=true -Dvertx.disableTCCL=true -jar target/vertx-benchmark-1.0.0-SNAPSHOT-fat.jar --instances `grep --count ^processor /proc/cpuinfo` --conf src/main/conf/config.json &
+java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dvertx.disableWebsockets=true -Dvertx.flashPolicyHandler=false -Dvertx.threadChecks=false -Dvertx.disableContextTimings=true -Dvertx.disableTCCL=true -jar target/vertx-benchmark-1.0.0-SNAPSHOT-fat.jar --instances `grep --count ^processor /proc/cpuinfo` --conf src/main/conf/config.json &

--- a/frameworks/Java/vertx/setup.sh
+++ b/frameworks/Java/vertx/setup.sh
@@ -5,4 +5,4 @@ fw_depends java maven
 mvn clean package 
 
 cd target
-java -Xms2G -Xmx2G -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dvertx.disableWebsockets=true -Dvertx.flashPolicyHandler=false -Dvertx.threadChecks=false -Dvertx.disableContextTimings=true -Dvertx.disableTCCL=true -jar vertx.benchmark-0.0.1-SNAPSHOT-fat.jar &
+java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dvertx.disableWebsockets=true -Dvertx.flashPolicyHandler=false -Dvertx.threadChecks=false -Dvertx.disableContextTimings=true -Dvertx.disableTCCL=true -jar vertx.benchmark-0.0.1-SNAPSHOT-fat.jar &


### PR DESCRIPTION
 This commit removes the options for the process. Allowing the ergonomics system to make a selection suitable for the machine running the benchmark.
 This change includes changing vertx and the vertx-web platform. Making them similar to the Netty project jvm configuration.