### PR TITLE
Vertx header optimizations

### DIFF
--- a/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
+++ b/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
@@ -30,6 +30,11 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 
 	private static final CharSequence TEXT_MESSAGE = new AsciiString("message");
 	private static final byte[] HELLO_WORLD = "Hello, world!".getBytes();
+
+	private static final String JSON_HELLO_WORLD = Json.encode(Collections.singletonMap(TEXT_MESSAGE, "Hello, world!"));
+	private static final Buffer JSON_HELLO_WORLD_BUFFER = Buffer.buffer(JSON_HELLO_WORLD);
+	private static final CharSequence JSON_HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(JSON_HELLO_WORLD.length()));
+	
 	private static final Buffer HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD);
 	private static final CharSequence HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(HELLO_WORLD.length));
 
@@ -78,13 +83,12 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 	private void handlePlainText(HttpServerRequest request) {
 		request.response()
 		.putHeader(CONTENT_TYPE , RESPONSE_TYPE_PLAIN).putHeader(SERVER, VERTX)
-		.putHeader(DATE, dateString).putHeader(CONTENT_TYPE, HELLO_WORLD_CONTENT_LENGTH).end(HELLO_WORLD_BUFFER);
+		.putHeader(DATE, dateString).putHeader(CONTENT_LENGTH, HELLO_WORLD_CONTENT_LENGTH).end(HELLO_WORLD_BUFFER);
 	}
 
 	private void handleJson(HttpServerRequest request) {
-		Buffer buff = Buffer.buffer(Json.encode(Collections.singletonMap(TEXT_MESSAGE, HELLO_WORLD)));
 		request.response().putHeader(CONTENT_TYPE, RESPONSE_TYPE_JSON).putHeader(SERVER,  VERTX)
-		.putHeader(DATE, dateString).end(buff);
+		.putHeader(DATE, dateString).putHeader(CONTENT_LENGTH, JSON_HELLO_WORLD_CONTENT_LENGTH).end(JSON_HELLO_WORLD_BUFFER);
 	}
 	
 	public static void main(String[] args) {

--- a/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
+++ b/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
@@ -14,8 +14,6 @@ import io.vertx.core.logging.LoggerFactory;
 
 import java.util.Collections;
 
-import com.sun.corba.se.impl.ior.ByteBuffer;
-
 import static io.vertx.core.http.HttpHeaders.*;
 
 public class WebServer extends AbstractVerticle implements Handler<HttpServerRequest> {
@@ -28,15 +26,11 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 	private static final CharSequence RESPONSE_TYPE_PLAIN = new AsciiString("text/plain");
 	private static final CharSequence RESPONSE_TYPE_JSON = new AsciiString("application/json");
 
-	private static final CharSequence TEXT_MESSAGE = new AsciiString("message");
-	private static final byte[] HELLO_WORLD = "Hello, world!".getBytes();
+	private static final String MESSAGE = "message";
+	private static final String HELLO_WORLD = "Hello, world!";
 
-	private static final String JSON_HELLO_WORLD = Json.encode(Collections.singletonMap(TEXT_MESSAGE, "Hello, world!"));
-	private static final Buffer JSON_HELLO_WORLD_BUFFER = Buffer.buffer(JSON_HELLO_WORLD);
-	private static final CharSequence JSON_HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(JSON_HELLO_WORLD.length()));
-	
 	private static final Buffer HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD);
-	private static final CharSequence HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(HELLO_WORLD.length));
+	private static final CharSequence HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(HELLO_WORLD.length()));
 
 	private static final CharSequence VERTX = new AsciiString("vertx".toCharArray());
 
@@ -87,8 +81,9 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 	}
 
 	private void handleJson(HttpServerRequest request) {
+	  Buffer buff = Buffer.buffer(Json.encode(Collections.singletonMap(MESSAGE, HELLO_WORLD)));
 		request.response().putHeader(CONTENT_TYPE, RESPONSE_TYPE_JSON).putHeader(SERVER,  VERTX)
-		.putHeader(DATE, dateString).putHeader(CONTENT_LENGTH, JSON_HELLO_WORLD_CONTENT_LENGTH).end(JSON_HELLO_WORLD_BUFFER);
+		.putHeader(DATE, dateString).end(buff);
 	}
 	
 	public static void main(String[] args) {

--- a/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
+++ b/frameworks/Java/vertx/src/main/java/vertx/WebServer.java
@@ -1,5 +1,6 @@
 package vertx;
 
+import io.netty.util.AsciiString;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
@@ -13,6 +14,10 @@ import io.vertx.core.logging.LoggerFactory;
 
 import java.util.Collections;
 
+import com.sun.corba.se.impl.ior.ByteBuffer;
+
+import static io.vertx.core.http.HttpHeaders.*;
+
 public class WebServer extends AbstractVerticle implements Handler<HttpServerRequest> {
 
 	static Logger logger = LoggerFactory.getLogger(WebServer.class.getName());
@@ -20,20 +25,17 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 	private static final String PATH_PLAINTEXT = "/plaintext";
 	private static final String PATH_JSON = "/json";
 
-	private static final String RESPONSE_TYPE_PLAIN = "text/plain";
-	private static final String RESPONSE_TYPE_JSON = "application/json";
+	private static final CharSequence RESPONSE_TYPE_PLAIN = new AsciiString("text/plain");
+	private static final CharSequence RESPONSE_TYPE_JSON = new AsciiString("application/json");
 
-	private static final String TEXT_MESSAGE = "message";
-	private static final String HELLO_WORLD = "Hello, world!";
+	private static final CharSequence TEXT_MESSAGE = new AsciiString("message");
+	private static final byte[] HELLO_WORLD = "Hello, world!".getBytes();
 	private static final Buffer HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD);
+	private static final CharSequence HELLO_WORLD_CONTENT_LENGTH = new AsciiString(String.valueOf(HELLO_WORLD.length));
 
-	private static final String HEADER_SERVER = "SERVER";
-	private static final String HEADER_DATE = "DATE";
-	private static final String HEADER_CONTENT = "content-type";
+	private static final CharSequence VERTX = new AsciiString("vertx".toCharArray());
 
-	private static final String SERVER = "vertx";
-
-	private String dateString;
+	private CharSequence dateString;
 
 	private HttpServer server;
 
@@ -46,7 +48,7 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 
 		server.requestHandler(WebServer.this).listen(port);
 
-		dateString = java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(java.time.ZonedDateTime.now());
+		dateString = new AsciiString(java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(java.time.ZonedDateTime.now()).getBytes());
 
 		vertx.setPeriodic(1000, handler -> {
 			dateString = java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(java.time.ZonedDateTime.now());
@@ -75,14 +77,14 @@ public class WebServer extends AbstractVerticle implements Handler<HttpServerReq
 
 	private void handlePlainText(HttpServerRequest request) {
 		request.response()
-		.putHeader(HEADER_CONTENT, RESPONSE_TYPE_PLAIN).putHeader(HEADER_SERVER,  SERVER)
-		.putHeader(HEADER_DATE, dateString).end(HELLO_WORLD_BUFFER);
+		.putHeader(CONTENT_TYPE , RESPONSE_TYPE_PLAIN).putHeader(SERVER, VERTX)
+		.putHeader(DATE, dateString).putHeader(CONTENT_TYPE, HELLO_WORLD_CONTENT_LENGTH).end(HELLO_WORLD_BUFFER);
 	}
 
 	private void handleJson(HttpServerRequest request) {
 		Buffer buff = Buffer.buffer(Json.encode(Collections.singletonMap(TEXT_MESSAGE, HELLO_WORLD)));
-		request.response().putHeader(HEADER_CONTENT, RESPONSE_TYPE_JSON).putHeader(HEADER_SERVER,  SERVER)
-		.putHeader(HEADER_DATE, dateString).end(buff);
+		request.response().putHeader(CONTENT_TYPE, RESPONSE_TYPE_JSON).putHeader(SERVER,  VERTX)
+		.putHeader(DATE, dateString).end(buff);
 	}
 	
 	public static void main(String[] args) {


### PR DESCRIPTION
 The changes in this PR affect the PLAINTEXT and JSON operations.

 Static header field are prepared using more efficient types. Incurring fewer allocations and instances.

 The changes tested on a dedicated machines provide the following improvements.

Plaintext.
Concurrency, Before, After

```
8       594124	   616546
16      1133246	1149831
32      1786700	1841151
64      2341128	2519504
128     3408049	3501957
256     3531211	3641489
1024    3622122	3772576
4096    3510294	3718517
16384   3327707	3660664
```

Json

Concurrency, Before, After
```
8    605786    639702
256  3320293   3734758
```

