### PR TITLE
upgrade packages for aiohttp

### DIFF
--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -1,10 +1,10 @@
-aiohttp==2.0.2
+aiohttp==2.1.0
 aiohttp-jinja2==0.13.0
 aiopg==0.13.0
-asyncpg==0.9.0
-cchardet==1.1.3
+asyncpg==0.11.0
+cchardet==2.1.0
 gunicorn==19.7.1
 psycopg2==2.7.1
-SQLAlchemy==1.1.6
+SQLAlchemy==1.1.10
 ujson==1.35
 uvloop==0.8.0


### PR DESCRIPTION
aiohttp tests all failed apparently due to an error [compiling Cython modules](http://tfb-logs.techempower.com/round-15/preview-1/aiohttp/out.txt).

It looks like wheezeweb-py3 [failed for the same reason](http://tfb-logs.techempower.com/round-15/preview-1/wheezyweb-py3/out.txt).

I suspect there's a problem with the setup generally but this can't hurt and could solve the problem.