### PR TITLE
kemal - Use env.response as IO to avoid intermediate string

### DIFF
--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -54,7 +54,7 @@ end
 # Test 1: JSON Serialization
 get "/json" do |env|
   env.response.content_type = CONTENT::JSON
-  {message: "Hello, World!"}.to_json
+  {message: "Hello, World!"}.to_json(env.response)
 end
 
 # Test 6: Plaintext
@@ -70,7 +70,7 @@ end
 # Postgres Test 2: Single database query
 get "/db" do |env|
   env.response.content_type = CONTENT::JSON
-  random_world.to_json
+  random_world.to_json(env.response)
 end
 
 # Postgres Test 3: Multiple database query
@@ -80,7 +80,7 @@ get "/queries" do |env|
   end
 
   env.response.content_type = CONTENT::JSON
-  results.to_json
+  results.to_json(env.response)
 end
 
 # Postgres Test 4: Fortunes
@@ -105,7 +105,7 @@ get "/updates" do |env|
   end
 
   env.response.content_type = CONTENT::JSON
-  updated.to_json
+  updated.to_json(env.response)
 end
 
 logging false

--- a/frameworks/Crystal/kemal/server-redis.cr
+++ b/frameworks/Crystal/kemal/server-redis.cr
@@ -54,7 +54,7 @@ end
 # Test 1: JSON Serialization
 get "/json" do |env|
   env.response.content_type = CONTENT::JSON
-  {message: "Hello, World!"}.to_json
+  {message: "Hello, World!"}.to_json(env.response)
 end
 
 # Test 6: Plaintext
@@ -70,7 +70,7 @@ end
 # Redis Test 2: Single database query
 get "/db" do |env|
   env.response.content_type = CONTENT::JSON
-  random_world.to_json
+  random_world.to_json(env.response)
 end
 
 # Redis Test 3: Multiple database query
@@ -80,7 +80,7 @@ get "/queries" do |env|
   end
 
   env.response.content_type = CONTENT::JSON
-  results.to_json
+  results.to_json(env.response)
 end
 
 # Redis Test 4: Fortunes
@@ -105,7 +105,7 @@ get "/updates" do |env|
   end
 
   env.response.content_type = CONTENT::JSON
-  updated.to_json
+  updated.to_json(env.response)
 end
 
 logging false


### PR DESCRIPTION
This updates Kemal to use `env.response` as existing `IO` instead of creating intermediates for every `to_json` call.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
