### PR TITLE
	Use all available CPUs for Jester implementation

### DIFF
--- a/frameworks/Nim/jester/setup.sh
+++ b/frameworks/Nim/jester/setup.sh
@@ -5,9 +5,6 @@ fw_depends mysql nim jester nginx
 nim c -d:release hello.nim
 nginx -c $TROOT/config/nginx.conf
 
-current=9000
-end=9008
-while [ $current -lt $end ]; do
-  ./hello $current &
-  let current=current+1
+for i in $(seq 1 $(nproc --all)); do
+  ./hello &
 done


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
