### PR TITLE
Java/play-2 JSON test must create object instance

### DIFF
--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/app/controllers/Application.java
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/app/controllers/Application.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 public class Application extends Controller {
 
     private static final int TEST_DATABASE_ROWS = 10000;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final int partitionCount = Play.application().configuration().getInt("db.default.partitionCount");
     private static final int maxConnections =
@@ -41,10 +40,12 @@ public class Application extends Controller {
             new NamedThreadFactory("dbEc"));
     private static final ExecutionContext dbEc = ExecutionContexts.fromExecutorService(tpe);
 
+    public static class Message {
+        public final String message = "Hello, World!";
+    }
+
     public Result json() {
-        final ObjectNode result = OBJECT_MAPPER.createObjectNode();
-        result.put("message", "Hello World!");
-        return ok(result);
+        return ok(Json.toJson(new Message()));
     }
 
     // If the thread-pool used by the database grows too large then our server

--- a/frameworks/Java/play2-java/play2-java/app/controllers/Application.java
+++ b/frameworks/Java/play2-java/play2-java/app/controllers/Application.java
@@ -5,18 +5,18 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import play.mvc.Controller;
 import play.mvc.Result;
 import play.mvc.With;
+import play.libs.Json;
 import utils.Headers;
 
 @With(Headers.class)
 public class Application extends Controller {
 
-    //http://stackoverflow.com/questions/3907929/should-i-make-jacksons-objectmapper-as-static-final
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static class Message {
+        public final String message = "Hello, World!";
+    }
 
     public Result json() {
-        final ObjectNode result = OBJECT_MAPPER.createObjectNode();
-        result.put("message", "Hello, World!");
-        return ok(result);
+        return ok(Json.toJson(new Message()));
     }
 
     public Result plainText() {


### PR DESCRIPTION
The test implementations are now using the [embedded Jackson](https://www.playframework.com/documentation/2.4.x/api/java/play/libs/Json.html) in Play 2.4.
Fix for #2888.
