### PR TITLE
Update treefrog to version 1.18.0

### DIFF
--- a/frameworks/C++/treefrog/config/application.ini
+++ b/frameworks/C++/treefrog/config/application.ini
@@ -121,7 +121,7 @@ Session.CsrfProtectionKey=_csrfId
 ##
 
 # Number of application server processes to be started.
-MPM.thread.MaxAppServers=10
+MPM.thread.MaxAppServers=
 
 # Maximum number of action threads allowed to start simultaneously
 # per server process.
@@ -132,7 +132,7 @@ MPM.thread.MaxThreadsPerAppServer=100
 ##
 
 # Number of application server processes to be started.
-MPM.hybrid.MaxAppServers=10
+MPM.hybrid.MaxAppServers=
 
 # Maximum number of worker threads allowed to start simultaneously
 # per server process.

--- a/toolset/setup/linux/frameworks/treefrog.sh
+++ b/toolset/setup/linux/frameworks/treefrog.sh
@@ -2,12 +2,10 @@
 
 fw_installed treefrog && return 0
 
-TFVER=1.16.0
+TFVER=1.18.0
 
-sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa
 sudo apt-get update -qq
-sudo apt-get install -y --no-install-recommends qt5-qmake qt5-default qtbase5-dev qtbase5-dev-tools libqt5sql5 libqt5sql5-mysql libqt5sql5-psql libqt5qml5 libqt5xml5 qtdeclarative5-dev libqt5quick5 libqt5quickparticles5 libqt5quicktest5 g++ libjemalloc-dev gcc
-sudo add-apt-repository --remove --yes ppa:ubuntu-sdk-team/ppa
+sudo apt-get install -y --no-install-recommends qt5-qmake qt5-default qtbase5-dev qtbase5-dev-tools libqt5sql5 libqt5sql5-mysql libqt5sql5-psql libqt5qml5 libqt5xml5 qtdeclarative5-dev g++ libjemalloc-dev gcc
 
 fw_get -O https://github.com/treefrogframework/treefrog-framework/archive/v${TFVER}.tar.gz
 fw_untar v${TFVER}.tar.gz


### PR DESCRIPTION
Update treefrog to version 1.18.0.
Changed not to install ubuntu-sdk-team/ppa packages.

However, the following error could not be reproduced. Maybe fixed.
http://tfb-logs.techempower.com/round-14/preview-4/treefrog/out.txt