### PR TITLE
Use NilStack for Finagle and Finch benchmarks

### DIFF
--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -1,8 +1,7 @@
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.twitter.finagle.{Service, SimpleFilter, Http}
-import com.twitter.finagle.stats.NullStatsReceiver
-import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.http.{Request, Response, HttpMuxer}
 import com.twitter.util.{Await, Future}
 import com.twitter.io.Buf
@@ -46,8 +45,7 @@ object Main extends App {
   Await.ready(Http.server
     .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
-    .withStatsReceiver(NullStatsReceiver)
-    .withTracer(NullTracer)
+    .withStack(nilStack)
     .serve(":8080", serverAndDate.andThen(muxer))
   )
 }

--- a/frameworks/Scala/finch/src/main/scala/Main.scala
+++ b/frameworks/Scala/finch/src/main/scala/Main.scala
@@ -2,8 +2,7 @@ import com.twitter.io.Buf
 import com.twitter.finagle.Http
 import com.twitter.finagle.http.{Request, Response}
 import com.twitter.finagle.Service
-import com.twitter.finagle.stats.NullStatsReceiver
-import com.twitter.finagle.tracing.NullTracer
+import com.twitter.finagle.stack.nilStack
 import com.twitter.util.Await
 
 import io.circe.Json
@@ -31,8 +30,7 @@ object Main extends App {
   Await.ready(Http.server
     .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
-    .withStatsReceiver(NullStatsReceiver)
-    .withTracer(NullTracer)
+    .withStack(nilStack)
     .serve(":9000", service)
   )
 }


### PR DESCRIPTION
Turns out we can disable all (unnecessary for the purpose of this test) Finagle features (e.g., tracing, admission control, timeouts, stats, etc) with just `nilStack`. This change does it for both Finch and Finagle benchmarks.