### PR TITLE
Updates the Rust compiler to 1.19

### DIFF
--- a/frameworks/Rust/nickel/Cargo.toml
+++ b/frameworks/Rust/nickel/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.0.1"
 
 [dependencies]
 rustc-serialize = "0.3.19"
-nickel = "0.8.1"
+nickel = "0.10.0"
 nickel_macros = "0.1.0"

--- a/toolset/setup/linux/languages/rust.sh
+++ b/toolset/setup/linux/languages/rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUST_VERSION="1.16.0"
+RUST_VERSION="1.19.0"
 
 fw_installed rust && return 0
 


### PR DESCRIPTION

Updates the Rust compiler to the latest stable version.
It uses LLVM 4.0 and that seems to have some performance implications, it would be useful to see  the results.
@alexcrichton 