### PR TITLE
Updates Rust Iron packages to latest version in the current minor and postgresql

### DIFF
--- a/frameworks/Rust/iron/Cargo.toml
+++ b/frameworks/Rust/iron/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "iron"
-version = "0.0.2"
+version = "0.0.3"
 build = "build.rs"
 
 [build-dependencies]
 serde_codegen = "0.8"
 
 [dependencies]
-serde = "0.8.19"
-serde_json = "0.8.3"
-iron = "0.4.0"
-router = "0.4.0"
-persistent = "0.2.1"
-hyper = "0.9.13"
+serde = "0.8"
+serde_json = "0.8"
+iron = "0.4"
+router = "0.4"
+persistent = "0.2"
+hyper = "0.9"
 rand = "0.3"
-postgres = "0.13.3"
-r2d2 = "0.7.1"
-r2d2_postgres = "0.11.0"
-mustache = "0.8.0"
+r2d2 = "0.7"
+postgres = "0.15.1"
+r2d2_postgres = "0.13"
+mustache = "0.8"
 rustc-serialize = "0.3"


### PR DESCRIPTION

Lifting the restriction of the last number should bring slightly newer dependencies. Also updated Postgresql. 

Updating further would be ideal but makes the compilation break and I do not know enough about these packages to fix it.