### PR TITLE
Remove flags to be like other Crystal setups

### DIFF
--- a/frameworks/Crystal/amber/setup.sh
+++ b/frameworks/Crystal/amber/setup.sh
@@ -2,7 +2,7 @@
 
 fw_depends postgresql crystal
 
-shards install --production
+shards install
 
 crystal build --release src/amber.cr
 

--- a/frameworks/Crystal/amber/setup.sh
+++ b/frameworks/Crystal/amber/setup.sh
@@ -4,7 +4,7 @@ fw_depends postgresql crystal
 
 shards install --production
 
-crystal build --release --no-debug src/amber.cr
+crystal build --release src/amber.cr
 
 for i in $(seq 1 $(nproc --all)); do
   ./amber &


### PR DESCRIPTION
Other crystal projects aren't using `--no-debug` or `--production` flags.

This PR removes `--no-debug` and `--production` flags to have the same install and build command as other crystal projects in this repository.

See: [Crystal](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Crystal/crystal/setup.sh#L7), [Kemal](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Crystal/kemal/setup-postgres.sh#L7) and [Kemalyst](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Crystal/kemalyst/setup.sh#L7)

