### PR TITLE
disable static file handler

### DIFF
--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -108,5 +108,9 @@ get "/updates" do |env|
   updated.to_json
 end
 
-logging false
+Kemal.config do |cfg|
+  cfg.serve_static = false
+  cfg.logging = false
+end
+
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }

--- a/frameworks/Crystal/kemal/server-redis.cr
+++ b/frameworks/Crystal/kemal/server-redis.cr
@@ -108,5 +108,9 @@ get "/updates" do |env|
   updated.to_json
 end
 
-logging false
+Kemal.config do |cfg|
+  cfg.serve_static = false
+  cfg.logging = false
+end
+
 Kemal.run { |cfg| cfg.server.bind(reuse_port: true) }


### PR DESCRIPTION
This disables the static file handler for Kemal.  This provides a major performance enhancement and would be a standard configuration for RESTful servers.