### PR TITLE
Fix saving the git commit id during continuous benchmarking

### DIFF
--- a/toolset/continuous/tasks/record-git-commit.sh
+++ b/toolset/continuous/tasks/record-git-commit.sh
@@ -3,8 +3,8 @@
 # save the current git commit to results/.commit
 #
 echo "Saving current git commit to results directory..."
-GIT_COMMIT=$(git rev-parse HEAD)
-mkdir -p results
-echo $GIT_COMMIT > results/.commit
+GIT_COMMIT=$(git -C $TFB_REPOPARENT/$TFB_REPONAME rev-parse HEAD)
+mkdir -p $TFB_REPOPARENT/$TFB_REPONAME/results
+echo $GIT_COMMIT > $TFB_REPOPARENT/$TFB_REPONAME/results/commit_id.txt
 echo "Using commit: " $GIT_COMMIT
 


### PR DESCRIPTION
The `record-git-commit.sh` script assumed it would be invoked from the root of the cloned TFB repo, but that was no longer true, so the script was failing.  Adding `$TFB_REPOPARENT/$TFB_REPONAME` to the paths fixes that issue.

Separately, the zipped results were no longer including the `.commit` file.  Renaming that file to `commit_id.txt` seems to fix that problem, though I don't understand why.