### PR TITLE
Switch to go 1.9

### DIFF
--- a/toolset/setup/linux/languages/go.sh
+++ b/toolset/setup/linux/languages/go.sh
@@ -2,7 +2,7 @@
 
 fw_installed go && return 0
 
-VERSION=1.8
+VERSION=1.9
 GOROOT=$IROOT/go
 
 fw_get -O https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz


### PR DESCRIPTION
Go 1.9 is out ( https://blog.golang.org/go1.9 ), so let's switch to it.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
