### PR TITLE
Speed up the app packaging process

### DIFF
--- a/frameworks/Scala/akka-http/build.sbt
+++ b/frameworks/Scala/akka-http/build.sbt
@@ -1,3 +1,5 @@
+enablePlugins(JavaAppPackaging)
+
 val akkaV = "2.5.1"
 val akkaHttpV = "10.0.6"
 
@@ -21,6 +23,4 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 )
 
-assemblyJarName in assembly := "akka-http-benchmark.jar"
-
-mainClass in assembly := Some("com.typesafe.akka.http.benchmark.Main")
+mainClass in Compile := Some("com.typesafe.akka.http.benchmark.Main")

--- a/frameworks/Scala/akka-http/project/plugins.sbt
+++ b/frameworks/Scala/akka-http/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC11")

--- a/frameworks/Scala/akka-http/project/project/plugins.sbt
+++ b/frameworks/Scala/akka-http/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC11")

--- a/frameworks/Scala/akka-http/setup.sh
+++ b/frameworks/Scala/akka-http/setup.sh
@@ -2,6 +2,7 @@
 
 fw_depends mysql java sbt
 
-sbt 'assembly' -batch
+sbt -batch 'universal:stage'
 
-java -server -Dakka.http.benchmark.mysql.dbhost=$DBHOST -jar target/scala-2.12/akka-http-benchmark.jar &
+./target/universal/stage/bin/akka-http-benchmark \
+  -Dakka.http.benchmark.mysql.dbhost=$DBHOST &


### PR DESCRIPTION
Packaging of any non-trivial scala app with sbt-assembly plugin takes ages. 
To get faster feedback on changes this commit uses sbt-native-packager plugin
to prepare bundle to benchmark.