### PR TITLE
Clean up system prior to installing dotnet-sdk-2.0.0

### DIFF
--- a/toolset/setup/linux/languages/dotnetcore.sh
+++ b/toolset/setup/linux/languages/dotnetcore.sh
@@ -2,6 +2,9 @@
 
 fw_installed dotnetcore && return 0
 
+sudo apt-get purge -y --auto-remove dotnet-dev-2.0.0-* || true
+sudo apt-get purge -y --auto-remove dotnet-sdk-2.0.0-preview* || true
+
 # https://www.microsoft.com/net/core#linuxubuntu
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg


### PR DESCRIPTION
- TechEmpower/FrameworkBenchmarks#2962
- ignore `apt-get purge` command failures

/cc @nbrady-techempower @mikeharder 