### PR TITLE
crystal add --no-debug to release build for llvm-3.8

### DIFF
--- a/frameworks/Crystal/amber/setup.sh
+++ b/frameworks/Crystal/amber/setup.sh
@@ -4,7 +4,7 @@ fw_depends postgresql crystal
 
 shards install
 
-crystal build --release src/amber.cr
+crystal build --release --no-debug src/amber.cr
 
 for i in $(seq 1 $(nproc --all)); do
   ./amber &

--- a/frameworks/Crystal/crystal/setup.sh
+++ b/frameworks/Crystal/crystal/setup.sh
@@ -4,7 +4,7 @@ fw_depends postgresql crystal
 
 shards install
 
-crystal build --release server.cr -o server.out
+crystal build --release --no-debug server.cr -o server.out
 
 for i in $(seq 1 $(nproc --all)); do
   ./server.out &

--- a/frameworks/Crystal/kemal/setup-postgres.sh
+++ b/frameworks/Crystal/kemal/setup-postgres.sh
@@ -4,7 +4,7 @@ fw_depends postgresql crystal
 
 shards install
 
-crystal build --release server-postgres.cr
+crystal build --release --no-debug server-postgres.cr
 
 for i in $(seq 1 $(nproc --all)); do
   ./server-postgres &

--- a/frameworks/Crystal/kemal/setup-redis.sh
+++ b/frameworks/Crystal/kemal/setup-redis.sh
@@ -7,7 +7,7 @@ fw_depends crystal
 
 shards install
 
-crystal build --release server-redis.cr
+crystal build --release --no-debug server-redis.cr
 
 for i in $(seq 1 $(nproc --all)); do
   ./server-redis &


### PR DESCRIPTION
@sdogruyol @RX14 This add the `--no-debug` flag to crystal-raw, kemal, and amber for crystal 0.23.1 and llvm-3.8.