### PR TITLE
Use Travis ubuntu environment from 2017Q2 group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 
 sudo: required
 dist: trusty
-group: deprecated-2017Q3
+group: deprecated-2017Q2
 language: generic
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q3
 language: generic
 python:
   - "2.7"


### PR DESCRIPTION
Resolves #2944 

This uses the travis ubuntu group from earlier in 2017 before some environment changes broke our MySQL configuration.