### PR TITLE
Use dynamic server_host in header template

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from datetime import timedelta
 
 class FrameworkTest:
-  headers_template = "-H 'Host: TFB-server' -H 'Accept: {accept}' -H 'Connection: keep-alive'"
+  headers_template = "-H 'Host: {server_host}' -H 'Accept: {accept}' -H 'Connection: keep-alive'"
 
   # Used for test types that require no pipelining or query string params.
   concurrency_template = """
@@ -644,7 +644,7 @@ class FrameworkTest:
   # and DB)
   ############################################################
   def __generate_concurrency_script(self, url, port, accept_header, wrk_command="wrk"):
-    headers = self.headers_template.format(accept=accept_header)
+    headers = self.headers_template.format(server_host=self.benchmarker.server_host, accept=accept_header)
     return self.concurrency_template.format(max_concurrency=max(self.benchmarker.concurrency_levels),
       name=self.name, duration=self.benchmarker.duration,
       levels=" ".join("{}".format(item) for item in self.benchmarker.concurrency_levels),
@@ -656,7 +656,7 @@ class FrameworkTest:
   # be run on the client to benchmark a single pipeline test.
   ############################################################
   def __generate_pipeline_script(self, url, port, accept_header, wrk_command="wrk"):
-    headers = self.headers_template.format(accept=accept_header)
+    headers = self.headers_template.format(server_host=self.benchmarker.server_host, accept=accept_header)
     return self.pipeline_template.format(max_concurrency=16384,
       name=self.name, duration=self.benchmarker.duration,
       levels=" ".join("{}".format(item) for item in [256,1024,4096,16384]),
@@ -670,7 +670,7 @@ class FrameworkTest:
   # specifically works for the variable query tests (Query)
   ############################################################
   def __generate_query_script(self, url, port, accept_header, query_levels):
-    headers = self.headers_template.format(accept=accept_header)
+    headers = self.headers_template.format(server_host=self.benchmarker.server_host, accept=accept_header)
     return self.query_template.format(max_concurrency=max(self.benchmarker.concurrency_levels),
       name=self.name, duration=self.benchmarker.duration,
       levels=" ".join("{}".format(item) for item in query_levels),


### PR DESCRIPTION
No reason as far as I can see to have the hard coded TFB-server here when we can use the same server host that is used to build the url.

When running this with Pivotal Cloud Foundry, I hit an issue where traffic from the client to the server was being rejected due to the 'Host: TFB-server' entry in the header. This proposed change fixed the problem.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
