### PR TITLE
the default cache size too low for php frameworks

### DIFF
--- a/toolset/setup/linux/languages/php/php.ini
+++ b/toolset/setup/linux/languages/php/php.ini
@@ -339,13 +339,13 @@ disable_classes =
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
 ; http://php.net/realpath-cache-size
-;realpath_cache_size = 16k
+realpath_cache_size = 4096K
 
 ; Duration of time, in seconds for which to cache realpath information for a given
 ; file or directory. For systems with rarely changing files, consider increasing this
 ; value.
 ; http://php.net/realpath-cache-ttl
-;realpath_cache_ttl = 120
+realpath_cache_ttl = 600
 
 ; Enables or disables the circular reference collector.
 ; http://php.net/zend.enable-gc
@@ -1873,6 +1873,7 @@ ldap.max_links = -1
 
 [opcache]
 opcache.validate_timestamps = 0 ; The same that apc.stat = 0
+opcache.max_accelerated_files = 20000
 ;opcache.enable_file_override = 1 ; Faster for some frameworks
 ;opcache.save_comments = 0 ; Breaks any fw using annotations comments
 ;opcache.fast_shutdown = 1 ; Have problems with some big frameworks


### PR DESCRIPTION
the default php.ini config is not suitable for php fameworks (symfony/laravel) that open many PHP files, especially on Windows systems.


