### PR TITLE
Remove sources list after each test

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -629,6 +629,12 @@ class Benchmarker:
                     except OSError:
                         print "Failed to remove contents of /tmp directory."
 
+    
+                ##########################################################
+                # Remove apt sources to avoid pkg errors and collisions
+                ##########################################################
+                os.system("sudo rm -rf /etc/apt/sources.list.d/*")
+
                 ##########################################################
                 # Save results thus far into the latest results directory
                 ##########################################################


### PR DESCRIPTION
Some framework, language, or util setup files can add repositories that end up breaking other framework tests, either by resulting in missing or broken repositories causing the test to error out, or by adding packages that collide with ones that framework intended on using. This ensures each framework test starts with the basic apt repositories and then must add the ones necessary for their particular framework test to work properly.

Currently, this is in lieu of using the `--remove` option after `apt-add-repository`. 

*Edit:* Actually, this won't "remove" packages, just remove the repositories that might cause additional packages to be installed from the wrong repo. This is `// hax` and a better way to contain this will have to be devised. 