### PR TITLE
Fix the plaintext test and all database tests for http4k

### DIFF
--- a/frameworks/Kotlin/http4k/core/src/main/kotlin/Http4kBenchmarkServer.kt
+++ b/frameworks/Kotlin/http4k/core/src/main/kotlin/Http4kBenchmarkServer.kt
@@ -20,14 +20,16 @@ object Http4kBenchmarkServer {
         }
     }
 
+    private val database = Database("TFB-database")
+
     fun start(config: ServerConfig) = headers.then(
         routes(
             JsonRoute(),
-            PlainTextRoute()
-//            FortunesRoute(database),
-//            WorldRoutes.queryRoute(database),
-//            WorldRoutes.updateRoute(database),
-//            WorldRoutes.multipleRoute(database)
+            PlainTextRoute(),
+            FortunesRoute(database),
+            WorldRoutes.queryRoute(database),
+            WorldRoutes.updateRoute(database),
+            WorldRoutes.multipleRoute(database)
         )
     ).asServer(config).start().block()
 }

--- a/frameworks/Kotlin/http4k/core/src/main/kotlin/PlainTextRoute.kt
+++ b/frameworks/Kotlin/http4k/core/src/main/kotlin/PlainTextRoute.kt
@@ -1,4 +1,4 @@
-
+import org.http4k.asByteBuffer
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.TEXT_PLAIN
 import org.http4k.core.Method.GET
@@ -9,7 +9,7 @@ import org.http4k.lens.binary
 import org.http4k.routing.bind
 
 object PlainTextRoute {
-    private val preAllocatedHelloWorldText = "Hello, World!".byteInputStream()
+    private val preAllocatedHelloWorldText = "Hello, World!".asByteBuffer()
 
     private val plainTextBody = Body.binary(TEXT_PLAIN).toLens()
 


### PR DESCRIPTION
This fixes `http4k` but not `http4k-undertow`.  The undertow version is still failing because it's only accepting requests from localhost, and that needs to be fixed on http4k's side: https://github.com/http4k/http4k/blob/d2e2b84f4acc859ef55fc6d3d731f64431b486e8/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt#L44