### PR TITLE
Specify revel's app server host as 0.0.0.0

### DIFF
--- a/frameworks/Go/revel/src/benchmark/conf/app.conf
+++ b/frameworks/Go/revel/src/benchmark/conf/app.conf
@@ -1,5 +1,5 @@
 app.name=benchmark
-http.addr=
+http.addr=0.0.0.0
 http.port=8080
 
 db.driver = mysql


### PR DESCRIPTION
Without this change, as of recently, revel is acting as though requests
are restricted to localhost, which doesn't work in setups where the load
generating client (wrk) is on a different machine.

There haven't been any changes to the revel test code recently, so this
must be a change in the revel framework or one of the libraries we're
using.  I notice that revel's setup.sh grabs a few dependencies from
github and doesn't seem to specify a commit, tag, or version...