### PR TITLE
Upgrade limonade's activerecord dependency to 1.2.0

### DIFF
--- a/frameworks/PHP/limonade/composer.json
+++ b/frameworks/PHP/limonade/composer.json
@@ -1,7 +1,7 @@
 {
    "require": {
    	"sofadesign/limonade" : "dev-master",
-   	"php-activerecord/php-activerecord" : "1.1.2"
+   	"php-activerecord/php-activerecord" : "1.2.0"
    }
 }
 


### PR DESCRIPTION
With version 1.1.2, we get warnings like this in the logs:

"Server limonade: 2017/11/09 18:32:55 [error] 67957#0: *1625383 FastCGI
sent in stderr: "PHP message: PHP Warning:  Declaration of
ActiveRecord\DateTime::setTime($hour, $minute, $second = NULL) should
be compatible with DateTime::setTime($hour, $minute, $second = NULL,
$microseconds = NULL) in ..."

This warning seems to be issued on every request.  The resulting log file
is ~1 GB in size, which is ~1/5 of the total size of the results files
across all frameworks.