### PR TITLE
Clear out /tmp after tests, not during, and make it non-optional

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -591,14 +591,6 @@ class Benchmarker:
                     passed_verify = test.verify_urls(logDir)
 
                 ##########################
-                # Nuke /tmp
-                ##########################
-                try:
-                    subprocess.check_call('sudo rm -rf /tmp/*', shell=True, stderr=out, stdout=out)
-                except Exception:
-                    out.write(header("Error: Could not empty /tmp"))
-
-                ##########################
                 # Benchmark this test
                 ##########################
                 if self.mode == "benchmark":
@@ -618,16 +610,10 @@ class Benchmarker:
                 ##########################################################
                 # Remove contents of  /tmp folder
                 ##########################################################
-                if self.clear_tmp:
-                    try:
-                        filelist = [ f for f in os.listdir("/tmp") ]
-                        for f in filelist:
-                            try:
-                                os.remove("/tmp/" + f)
-                            except OSError as err:
-                                print "Failed to remove " + str(f) + " from /tmp directory: " + str(err)
-                    except OSError:
-                        print "Failed to remove contents of /tmp directory."
+                try:
+                    subprocess.check_call('sudo rm -rf /tmp/*', shell=True, stderr=out, stdout=out)
+                except Exception:
+                    out.write(header("Error: Could not empty /tmp"))
 
     
                 ##########################################################

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -159,7 +159,6 @@ def main(argv=None):
     parser.add_argument('--parse', help='Parses the results of the given timestamp and merges that with the latest results')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Causes the configuration to print before any other commands are executed.')
     parser.add_argument('--quiet', action='store_true', default=False, help='Only print a limited set of messages to stdout, keep the bulk of messages in log files only')
-    parser.add_argument('--clear-tmp', action='store_true', default=False, help='Clears files written to /tmp after each framework\'s tests complete.')
     parser.set_defaults(**defaults) # Must do this after add, or each option's default will override the configuration file default
     args = parser.parse_args(remaining_argv)
 


### PR DESCRIPTION
The "Nuke /tmp" section of the script was problematic for a few
frameworks, since it would clear out /tmp *after* the framework's
server had started but before the tests were run.  If the framework
put files it needed into /tmp upon startup, they'd be deleted right
afterwards.

This causes problems for dancer, for example, who wants to create a
/tmp/perl-dancer.sock file on startup, and when that file gets deleted,
it starts printing a warning message to the log on every request.

The fix is to move the "Nuke /tmp" section so that it runs after the
server is shut down.  Since we're always cleaning up /tmp in that spot
now, there's no reason to support the --clear-tmp argument anymore.