### PR TITLE
Create the requried directories for saving php session files

### DIFF
--- a/toolset/setup/linux/languages/php/php.ini
+++ b/toolset/setup/linux/languages/php/php.ini
@@ -1400,7 +1400,7 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://php.net/session.save-path
-session.save_path = "3;/tmp"
+session.save_path = "3;/tmp/php_sessions"
 
 ; Whether to use cookies.
 ; http://php.net/session.use-cookies

--- a/toolset/setup/linux/languages/php/php5.sh
+++ b/toolset/setup/linux/languages/php/php5.sh
@@ -5,6 +5,8 @@ RETCODE=$(fw_exists ${IROOT}/php5.installed)
   echo "Moving PHP config files into place"; 
   sudo cp $FWROOT/toolset/setup/linux/languages/php/php.ini /usr/local/lib/php.ini
   sudo cp $FWROOT/toolset/setup/linux/languages/php/php-fpm.conf /usr/local/lib/php-fpm.conf
+  rm -rf /tmp/php_sessions
+  /bin/bash $IROOT/php5/ext/session/mod_files.sh /tmp/php_sessions 3 5
   source $IROOT/php5.installed
   return 0; }
 
@@ -14,6 +16,7 @@ PHP_HOME=$IROOT/php-$VERSION
 # Precaution, unlikely to happen.
 rm -rf $IROOT/php PHP_HOME cphalcon
 
+rm -rf $IROOT/php5
 fw_get -o php-${VERSION}.tar.gz http://php.net/distributions/php-${VERSION}.tar.gz
 fw_untar php-${VERSION}.tar.gz
 mv php-${VERSION} php5
@@ -41,6 +44,8 @@ sed -i 's|;extension=mongo.so|extension=mongo.so|g' $FWROOT/toolset/setup/linux/
 
 cp $FWROOT/toolset/setup/linux/languages/php/php.ini $PHP_HOME/lib/php.ini
 cp $FWROOT/toolset/setup/linux/languages/php/php-fpm.conf $PHP_HOME/lib/php-fpm.conf
+rm -rf /tmp/php_sessions
+/bin/bash $IROOT/php5/ext/session/mod_files.sh /tmp/php_sessions 3 5
 
 # =======================
 #
@@ -57,9 +62,6 @@ printf "\n" | $PHP_HOME/bin/pecl -q install -f redis-2.2.5
 
 # mongo.so
 printf "\n" | $PHP_HOME/bin/pecl -q install -f mongo
-
-# Clean up a bit
-rm -rf $IROOT/php
 
 echo "export PHP_HOME=${PHP_HOME}" > $IROOT/php5.installed
 echo -e "export PATH=\$PHP_HOME/bin:\$PHP_HOME/sbin:\$PATH" >> $IROOT/php5.installed

--- a/toolset/setup/linux/languages/php/php7.sh
+++ b/toolset/setup/linux/languages/php/php7.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
-fw_installed php7 && return 0
+RETCODE=$(fw_exists ${IROOT}/php7.installed)
+[ ! "$RETCODE" == 0 ] || { \
+  echo "Moving PHP config files into place";
+  sudo cp $FWROOT/toolset/setup/linux/languages/php/php.ini /usr/local/lib/php.ini
+  sudo cp $FWROOT/toolset/setup/linux/languages/php/php-fpm.conf /usr/local/lib/php-fpm.conf
+  rm -rf /tmp/php_sessions
+  /bin/bash $IROOT/php7/ext/session/mod_files.sh /tmp/php_sessions 3 5
+  source $IROOT/php7.installed
+  return 0; }
 
 VERSION="7.1.4"
 PHP_HOME=$IROOT/php-$VERSION
 
+rm -rf $IROOT/php7
 fw_get -o php-${VERSION}.tar.gz http://php.net/distributions/php-${VERSION}.tar.gz
 fw_untar php-${VERSION}.tar.gz
 mv php-${VERSION} php7
@@ -32,6 +41,8 @@ sed -i 's|;extension=mongodb.so|extension=mongodb.so|g' $FWROOT/toolset/setup/li
 
 cp $FWROOT/toolset/setup/linux/languages/php/php.ini $PHP_HOME/lib/php.ini
 cp $FWROOT/toolset/setup/linux/languages/php/php-fpm.conf $PHP_HOME/lib/php-fpm.conf
+rm -rf /tmp/php_sessions
+/bin/bash $IROOT/php7/ext/session/mod_files.sh /tmp/php_sessions 3 5
 
 # =======================
 #
@@ -54,9 +65,6 @@ $PHP_HOME/bin/pecl config-set php_ini $PHP_HOME/lib/php.ini
 
 # mongodb.so - mongo.so deprecated in php7 use mongodb.so
 printf "\n" | $PHP_HOME/bin/pecl -q install -f mongodb
-
-# Clean up a bit
-rm -rf $IROOT/php7
 
 echo "export PHP_HOME=${PHP_HOME}" > $IROOT/php7.installed
 echo -e "export PATH=\$PHP_HOME/bin:\$PHP_HOME/sbin:\$PATH" >> $IROOT/php7.installed


### PR DESCRIPTION
By setting `session.save_path` to "3;/tmp" in php.ini, we were
effectively breaking session files for all PHP frameworks, because we
were never creating the required subdirectories inside /tmp to hold
those session files.  For whatever reason, PHP doesn't create those
directories on demand, but it does provide a script to create them.
We're now invoking that script.

Since /tmp is cleaned out each time a framework is tested, we must
recreate these directories whenever a framework claims to depend on PHP,
regardless of whether PHP was installed already.

This should allow PHP to create session files once again, which should
prevent frameworks such as phreeze from printing a huge amount of error
messages to the logs.  Theoretically, no PHP framework should need to use
sessions in order to satisfy our test requirements, so they could be more
efficient by avoiding sessions, but that's a problem for people
optimizing those frameworks to solve.  The toolset should provide
non-broken session files to frameworks that want them.

I also added the "when already instealled, copy php.ini and php-fpm.conf"
step from our PHP5 install script to the PHP7 install script.  I don't
actually know why the PHP5 install script does this, but it seems fishy
to do this for one PHP version and not the other.