### PR TITLE
Prevent revel from writing to the log on every request

### DIFF
--- a/frameworks/Go/revel/src/benchmark/conf/app.conf
+++ b/frameworks/Go/revel/src/benchmark/conf/app.conf
@@ -22,7 +22,7 @@ log.error.output = stderr
 mode.dev=false
 watch=false
 
-log.trace.output = stderr
-log.info.output  = stderr
+log.trace.output = off
+log.info.output  = off
 log.warn.output  = stderr
 log.error.output = stderr


### PR DESCRIPTION
This should decrease the size of the log files of revel-raw, revel-jet,
and revel-qbs after a full run by about 600 MB each.