### PR TITLE
Prevent hanami-unicorn from logging each request

### DIFF
--- a/frameworks/Ruby/hanami/run_mri_unicorn.sh
+++ b/frameworks/Ruby/hanami/run_mri_unicorn.sh
@@ -8,4 +8,4 @@ rvm ruby-$MRI_VERSION do bundle install --jobs=4 --gemfile=$TROOT/Gemfile --path
 
 nginx -c $TROOT/config/nginx.conf
 
-DB_HOST=${DBHOST} rvm ruby-$MRI_VERSION do bundle exec unicorn_rails -E production -c $TROOT/config/unicorn.rb &
+RACK_ENV=none DB_HOST=${DBHOST} rvm ruby-$MRI_VERSION do bundle exec unicorn_rails -E production -c $TROOT/config/unicorn.rb &


### PR DESCRIPTION
Prior to this change, hanami-unicorn would print something like this
to the log on each incoming request:

  Server hanami-unicorn: 204.93.249.210 - - [13/Nov/2017:01:03:18 -0600]
  "GET  HTTP/1.0" 200 31 0.0038

This looks a lot like an nginx access log, but it isn't (notice the
"0.0038" at the end where nginx would usually write the user agent).

I think this is actually coming form unicorn's request log, and that's
being enabled by some Rack middleware component that's being pulled in
automatically somewhere.  Setting the RACK_ENV environment variable to
"none" apparently disables this middleware, and it does get rid of these
particular log messages, so that's the change I've made here.

For more background, see this unicorn documentation:

  https://bogomips.org/unicorn/unicorn_1.html#rack-environment

I'm looking at this part specifically:

  Accepted values of RACK_ENV and the middleware they automatically
  load (outside of RACKUP_FILE) are exactly as those in rackup(1):

    * development - loads Rack::CommonLogger, Rack::ShowExceptions,
      and Rack::Lint middleware
    * deployment - loads Rack::CommonLogger middleware
    * none - loads no middleware at all, relying entirely on RACKUP_FILE