### PR TITLE
Don't log "connection is closed" and "broken pipe" errors in grizzly-jersey

### DIFF
--- a/frameworks/Java/grizzly-jersey/src/main/java/hello/JerseyWebServer.java
+++ b/frameworks/Java/grizzly-jersey/src/main/java/hello/JerseyWebServer.java
@@ -6,11 +6,14 @@ import com.sun.jersey.api.core.ResourceConfig;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
+import org.glassfish.grizzly.Grizzly;
+import org.glassfish.grizzly.http.server.HttpHandler;
 import org.glassfish.grizzly.http.server.HttpServer;
 
 public class JerseyWebServer {
@@ -42,6 +45,13 @@ public class JerseyWebServer {
     rc.setPropertiesAndFeatures(properties());
     rc.getContainerResponseFilters().add(new ServerHeaderFilter());
     HttpServer server = GrizzlyServerFactory.createHttpServer(baseUri, rc);
+
+    // There will be *a lot* of broken connections during the plaintext test.
+    // That's not a good thing, but what would make matters even worse would be
+    // to log the full stack trace of an IOException for each broken connection.
+    // That's what Grizzly does by default, and it logs those messages at the
+    // WARNING level, so setting the threshold to SEVERE hides those messages.
+    Grizzly.logger(HttpHandler.class).setLevel(Level.SEVERE);
 
     try {
         server.start();


### PR DESCRIPTION
A huge number of these messages are written to the logs during the
plaintext test.  Broken connections aren't great, but they aren't
necessarily the framework's fault (wrk might be terminating the
connection), and it doesn't help anyone to write the same IOException
stack trace in the log over and over for ~120 MB worth of messages.

With this change, we don't bother writing those messages to the log
anymore.