### PR TITLE
Fix the multi query database test for blade

### DIFF
--- a/frameworks/Java/blade/benchmark_config.json
+++ b/frameworks/Java/blade/benchmark_config.json
@@ -5,7 +5,7 @@
       "setup_file": "setup",
       "json_url": "/json",
       "db_url": "/db",
-      "query_url": "/db?queries=",
+      "query_url": "/queries?queries=",
       "plaintext_url": "/plaintext",
       "port": 9000,
       "approach": "Realistic",

--- a/frameworks/Java/blade/src/main/java/hello/Application.java
+++ b/frameworks/Java/blade/src/main/java/hello/Application.java
@@ -26,8 +26,16 @@ public class Application {
     private static final ByteBuf      PLAINTEXT_CONTENT_BUFFER = Unpooled.unreleasableBuffer(Unpooled.directBuffer().writeBytes(STATIC_PLAINTEXT));
     private static final CharSequence PLAINTEXT_CLHEADER_VALUE = AsciiString.cached(String.valueOf(STATIC_PLAINTEXT.length));
 
-    private static int getQueries(Optional<Integer> queryCount) {
-        int count = queryCount.orElse(1);
+    private static int getQueries(Optional<String> queryCount) {
+        if (!queryCount.isPresent()) {
+            return 1;
+        }
+        int count;
+        try {
+            count = Integer.parseInt(queryCount.get());
+        } catch (NumberFormatException ignored) {
+            return 1;
+        }
         count = count < 1 ? 1 : count;
         count = count > 500 ? 500 : count;
         return count;
@@ -45,7 +53,7 @@ public class Application {
                     response.json(new World().find(random.nextInt(DB_ROWS) + 1));
                 })
                 .get("/queries", (request, response) -> {
-                    int           queries = getQueries(request.queryInt("queries"));
+                    int           queries = getQueries(request.query("queries"));
                     final World[] worlds  = new World[queries];
                     final Random  random  = ThreadLocalRandom.current();
                     for (int i = 0; i < queries; i++) {


### PR DESCRIPTION
It was giving the toolset the wrong URL for the multi query test, so
that the toolset was hitting its single query endpoint instead and
always querying for and responding with one world instead of a variable
number.  That issue is now fixed and the correct endpoint is used.

Surprisingly, our verification step doesn't catch this kind of issue,
and it was satisfied by single-world output.

When I fixed that issue in benchmark_config.json and ran the test again,
it became apparent that the multi query endpoint wasn't handling invalid
parameters correctly.  For example, ?queries=foo would lead to an
uncaught NumberFormatException instead of defaulting to a query count of
1 as specified in the test requirements:

  "If the parameter is missing, is not an integer, or is an integer less
   than 1, the value should be interpreted as 1"

That issue is now fixed as well.