### PR TITLE
Avoid deadlocks in ninja-standalone updates test by avoiding transactions

### DIFF
--- a/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloDbController.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloDbController.java
@@ -10,7 +10,6 @@ import ninja.Results;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.google.inject.persist.Transactional;
 import ninja.jpa.UnitOfWork;
 import ninja.params.Param;
 
@@ -45,7 +44,7 @@ public class HelloDbController {
         return Results.json().render(worlds);
     }
 
-    @Transactional
+    @UnitOfWork
     public Result update(@Param("queries") Integer queries) {
         if (queries == null || queries < 1) {
             queries = 1;


### PR DESCRIPTION
It is not a requirement of the updates test to use transactions, and
doing so causes ninja-standadlone to run into lots of SQL deadlocks and
to print lots of enormous stack traces to its logs.