### PR TITLE
The produced artifact version was incorrect

### DIFF
--- a/frameworks/Java/vertx-web/setup.sh
+++ b/frameworks/Java/vertx-web/setup.sh
@@ -19,7 +19,7 @@ java \
   -Dvertx.disableContextTimings=true                \
   -Dvertx.disableTCCL=true                          \
   -jar                                              \
-  target/vertx-web-benchmark-3.5.0.Beta1-fat.jar    \
+  target/vertx-web-benchmark-3.5.0-fat.jar    \
   --instances                                       \
   `grep --count ^processor /proc/cpuinfo`           \
   --conf                                            \


### PR DESCRIPTION
The shell script that sets up the benchmark was referring to the previous beta version.