### PR TITLE
Fix amber dependencies

### DIFF
--- a/frameworks/Crystal/amber/benchmark_config.json
+++ b/frameworks/Crystal/amber/benchmark_config.json
@@ -21,7 +21,7 @@
       "webserver": "None",
       "os": "Linux",
       "database_os": "Linux",
-      "display_name": "Amber (MVC, Postgres)",
+      "display_name": "Amber (MVC, PSQL)",
       "notes": "",
       "versus": "kemal"
     }

--- a/frameworks/Crystal/amber/config/application.cr
+++ b/frameworks/Crystal/amber/config/application.cr
@@ -1,4 +1,10 @@
+require "amber"
+
+require "../src/models/*"
+require "../src/controllers/*"
+
 Amber::Server.configure do |app|
-  app.name = "Amber web application."
+  app.name = "TFB test app"
+  app.color = false
   app.port = 8080
 end

--- a/frameworks/Crystal/amber/shard.lock
+++ b/frameworks/Crystal/amber/shard.lock
@@ -2,15 +2,15 @@ version: 1.0
 shards:
   amber:
     github: amberframework/amber
-    version: 0.3.0
+    version: 0.3.6
 
   callback:
     github: mosop/callback
-    version: 0.5.1
+    version: 0.6.3
 
   cli:
     github: mosop/cli
-    version: 0.5.2
+    version: 0.6.10
 
   db:
     github: crystal-lang/crystal-db
@@ -18,15 +18,11 @@ shards:
 
   granite_orm:
     github: amberframework/granite-orm
-    version: 0.7.6
-
-  icr:
-    github: TechMagister/crystal-icr
-    commit: b28bb938cc9e9e439424217c074a9168d253ba4b
+    version: 0.7.8
 
   kilt:
     github: jeromegn/kilt
-    version: 0.3.3
+    version: 0.4.0
 
   micrate:
     github: juanedi/micrate
@@ -38,7 +34,7 @@ shards:
 
   optarg:
     github: mosop/optarg
-    version: 0.4.4
+    version: 0.5.8
 
   pg:
     github: will/crystal-pg
@@ -46,15 +42,15 @@ shards:
 
   radix:
     github: luislavena/radix
-    commit: 905bd9e14b9996c793ac95e1e77d2809f7f79568
+    version: 0.3.8
 
   redis:
     github: stefanwille/crystal-redis
-    version: 1.8.0
+    version: 1.9.0
 
   sentry:
-    github: TechMagister/sentry
-    commit: a78129ec1e66aa24c91b93199ea187e4793c8d58
+    github: samueleaton/sentry
+    version: 0.1.1
 
   shell-table:
     github: jwaldrip/shell-table.cr
@@ -62,7 +58,7 @@ shards:
 
   slang:
     github: jeromegn/slang
-    commit: b817c89c7e5ae39562710c0d6c7f42cee685e14f
+    version: 1.7.0
 
   spinner:
     github: askn/spinner

--- a/frameworks/Crystal/amber/shard.yml
+++ b/frameworks/Crystal/amber/shard.yml
@@ -8,10 +8,9 @@ license: MIT
 
 dependencies:
   amber:
-    github: amberframework/amber 
+    github: amberframework/amber
+    version: "0.3.6" 
 
   granite_orm:
     github: amberframework/granite-orm
-
-  pg:
-    github: will/crystal-pg
+    version: "0.7.8"

--- a/frameworks/Crystal/amber/src/amber.cr
+++ b/frameworks/Crystal/amber/src/amber.cr
@@ -1,8 +1,3 @@
-require "amber"
-
-require "./models/**"
-require "./controllers/**"
-
 require "../config/*"
 
-Amber::Server.instance.run
+Amber::Server.start


### PR DESCRIPTION
Hi @nbrady-techempower I found amber is failing on round 15 preview 3 because dependency mismatch, this PR fixes amber's dependencies.

![failing](https://i.imgur.com/tf1KqQF.png)

Also we have had multiple discussions about Amber and Kemal performance vs `crystal-raw` and some of us concluded crystal's frameworks are slow not because radix algorithm but because they're using proc in some critical places inside the core slowing down high RPS tests like plaintext and json.

We added `Amber::Pipe::Last` to replace current proc in amber framework core, so we hope to see improvement on plaintext and json tests 😅 

I'm not surprised about slow result in crystal database tests, we're still very young and we need a lot of performance improves in database drivers, so we can accept those results for now 😉 

BTW, Thank @nbrady-techempower and @msmith-techempower for all your nice support!

You, friends, helped us a lot 👍 
