### PR TITLE
Updated Wt to 4.0.2

### DIFF
--- a/frameworks/C++/wt/fortunes.xml
+++ b/frameworks/C++/wt/fortunes.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <messages>
     <message id="fortunes">
-        <html>
-            <head>
-                <title>Fortunes</title>
-            </head>
-            <body>
-                <table>
-                    <tr>
-                        <th>id</th>
-                        <th>message</th>
-                    </tr>
-                    ${while:next-fortune fortune-table-row}
-                </table>
-            </body>
-        </html>
-    </message>
+<html>
+    <head>
+        <title>Fortunes</title>
+    </head>
+    <body>
+        <table>
+            <tr>
+                <th>id</th>
+                <th>message</th>
+            </tr>
+            ${while:next-fortune fortune-table-row}
+        </table>
+    </body>
+</html></message>
 
     <message id="fortune-table-row">
         <tr>

--- a/frameworks/C++/wt/setup.sh
+++ b/frameworks/C++/wt/setup.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
-fw_depends mysql apache wt
+fw_depends wt
 
-sed -i 's|INSERT_DB_HOST_HERE|'"${DBHOST}"'|g' benchmark.cpp
+g++-6 \
+  -std=c++14 \
+  -O3 -march=native -DNDEBUG \
+  -I${BOOST_INC} \
+  -L${BOOST_LIB} \
+  -I${WT_INC} \
+  -L${WT_LIB} \
+  -o te-benchmark.wt \
+  benchmark.cpp \
+  -lwthttp -lwt \
+  -lwtdbo -lwtdbomysql \
+  -lboost_system \
+  -lboost_program_options \
+  -lboost_thread \
+  -lboost_filesystem \
+  -lpthread \
+  -lmysqlclient
 
-g++-4.8 -O3 -DNDEBUG -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbomysql -lboost_thread -lboost_system
-
-./benchmark.wt -c wt_config.xml -t ${CPU_COUNT} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression
+./te-benchmark.wt -c wt_config.xml -t ${CPU_COUNT} --docroot . --approot . --http-listen 0.0.0.0:8080 --accesslog=- --no-compression

--- a/frameworks/C++/wt/setup_postgres.sh
+++ b/frameworks/C++/wt/setup_postgres.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
-fw_depends postgresql apache wt
+fw_depends wt
 
-sed -i 's|INSERT_DB_HOST_HERE|'"${DBHOST}"'|g' benchmark.cpp
+g++-6 \
+  -std=c++14 \
+  -O3 -march=native -DNDEBUG \
+  -I${BOOST_INC} \
+  -L${BOOST_LIB} \
+  -I${WT_INC} \
+  -L${WT_LIB} \
+  -o te-benchmark-pg.wt \
+  -DBENCHMARK_USE_POSTGRES \
+  benchmark.cpp \
+  -lwthttp -lwt \
+  -lwtdbo -lwtdbopostgres \
+  -lboost_system \
+  -lboost_program_options \
+  -lboost_thread \
+  -lboost_filesystem \
+  -lpthread \
+  -lpq
 
-g++-4.8 -O3 -DNDEBUG -DBENCHMARK_USE_POSTGRES -std=c++0x -L${BOOST_LIB} -I${BOOST_INC} -L${WT_LIB} -I${WT_INC} -o benchmark_postgres.wt benchmark.cpp -lwt -lwthttp -lwtdbo -lwtdbopostgres -lboost_thread -lboost_system
-
-./benchmark_postgres.wt -c wt_config.xml -t ${CPU_COUNT} --docroot . --http-address 0.0.0.0 --http-port 8080 --accesslog=- --no-compression
+./te-benchmark-pg.wt -c wt_config.xml -t ${CPU_COUNT} --docroot . --approot . --http-listen 0.0.0.0:8080 --accesslog=- --no-compression

--- a/toolset/setup/linux/frameworks/wt.sh
+++ b/toolset/setup/linux/frameworks/wt.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+fw_depends postgresql mysql gcc-6
+
 fw_installed wt && return 0
 
-BOOST_ROOT=/usr/local
+WT_VERSION=4.0.2
+BOOST_ROOT=${IROOT}/boost
 BOOST_INC=${BOOST_ROOT}/include
 BOOST_LIB=${BOOST_ROOT}/lib
 WT_ROOT=${IROOT}/wt
@@ -11,40 +14,51 @@ WT_INC=${WT_ROOT}/include
 LD_LIBRARY_PATH="${BOOST_LIB}:${WT_LIB}:${LD_LIBRARY_PATH}"
 CPLUS_INCLUDE_PATH=/usr/include/postgresql:/usr/include/postgresql/9.3/server:$CPLUS_INCLUDE_PATH
 
-# The commented code works. While we would love to get boost from source
-# so we know exactly what we are getting, it just takes too long. Also, 
-# Ubuntu1204 can only run boost 1.48 and Ubuntu1404 can only run 1.54, 
-# even if you compile from source. Apt supplies different boost version 
-# numbers anyways (which is something it often does not do and one of the 
-# main reasons for compilation from a specific source version), so we can 
-# just use apt. See https://github.com/TechEmpower/FrameworkBenchmarks/issues/1013
-#
-#fw_get -o boost_1_48_0.tar.gz http://downloads.sourceforge.net/project/boost/boost/1.48.0/boost_1_48_0.tar.gz
-#fw_untar boost_1_48_0.tar.gz
-#cd boost_1_48_0
-#./bootstrap.sh --prefix=$IROOT/boost
-#./b2 install
-#cd ..
+# Install CMake 3.x
+sudo apt-add-repository --yes ppa:george-edison55/cmake-3.x
+sudo apt-get update -qq
 
-# Instead of compiling from source, just use apt to install onto 
-# host machine
-if [ "$TFB_DISTRIB_CODENAME" == "trusty" ]; then
-    sudo apt-get -y install libboost1.54-all-dev
-elif [ "$TFB_DISTRIB_CODENAME" == "precise" ]; then
-    sudo apt-get -y install libboost1.48-all-dev
-fi
+sudo apt-get install -qqy \
+  cmake
 
-fw_get -O https://github.com/emweb/wt/archive/3.3.8.tar.gz
-mv 3.3.8.tar.gz wt-3.3.8.tar.gz
-fw_untar wt-3.3.8.tar.gz
+# Build boost_thread, boost_system, boost_filesystem and boost_program_options
+fw_get -o boost_1_65_1.tar.gz https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz
+fw_untar boost_1_65_1.tar.gz
+cd boost_1_65_1
+./bootstrap.sh
+./b2 \
+  -d0 \
+  toolset=gcc-6 \
+  variant=release \
+  link=static \
+  cxxflags="-std=c++14 -march=native" \
+  cflags="-march=native" \
+  --prefix=${BOOST_ROOT} \
+  --with-system \
+  --with-thread \
+  --with-program_options \
+  --with-filesystem \
+  install
+cd ..
 
-cd wt-3.3.8
+fw_get -O https://github.com/emweb/wt/archive/$WT_VERSION.tar.gz
+mv $WT_VERSION.tar.gz wt-$WT_VERSION.tar.gz
+fw_untar wt-$WT_VERSION.tar.gz
+
+cd wt-$WT_VERSION
 mkdir -p build
 cd build
-cmake .. -DWT_CPP_11_MODE=-std=c++0x -DCMAKE_BUILD_TYPE=Release \
+cmake .. -DCMAKE_CXX_STANDARD=14 -DCMAKE_BUILD_TYPE=Release \
+  -DBOOST_PREFIX=${BOOST_ROOT} \
   -DCMAKE_INSTALL_PREFIX=${IROOT}/wt -DCONFIGDIR=${IROOT}/wt/etc \
-  -DCMAKE_CXX_COMPILER=$(which g++-4.8) -DDESTDIR=${IROOT}/wt \
-  -DWEBUSER=$(id -u -n) -DWEBGROUP=$(id -g -n)
+  -DCMAKE_C_COMPILER=$(which gcc-6) \
+  -DCMAKE_CXX_COMPILER=$(which g++-6) -DDESTDIR=${IROOT}/wt \
+  -DWEBUSER=$(id -u -n) -DWEBGROUP=$(id -g -n) \
+  -DENABLE_SSL=OFF -DHTTP_WITH_ZLIB=OFF \
+  -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -DNDEBUG" \
+  -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -DNDEBUG" \
+  -DBUILD_TESTS=OFF -DENABLE_LIBWTTEST=OFF \
+  -DSHARED_LIBS=OFF
 make
 make install
 


### PR DESCRIPTION
This updates the Wt framework test to the latest version (4.0.2), released today.

Wt now includes the framework benchmarks as one of its examples, so this will build the implementation that's part of the Wt 4.0.2 source tree. If this is unacceptable, let me know. I can put the example C++ code back in, and do it the old way, compiling the example manually and separate from Wt.

Also, I made it so Wt builds with the latest GCC version available on the test systems, which appears to be version 6, and I made it so that boost, instead of being installed, is built with only the libraries that Wt needs, so it should still be fast enough for Travis, so it doesn't kill the build.

I hope this also fixes the strange performance issues we're seeing Wt having on the test hardware (on our own hardware, Wt does a lot better).