### PR TITLE
Bump Finch and Finagle benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,12 +1,12 @@
 name := "finagle"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
-version := "7.1.0"
+version := "17.11.0"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "7.1.0",
+  "com.twitter" %% "finagle-http" % "17.11.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4"
 )

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,12 +1,12 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.16.0-M3"
+version := "0.16.0-M5"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.16.0-M3",
-  "com.github.finagle" %% "finch-circe" % "0.16.0-M3"
+  "com.github.finagle" %% "finch-core" % "0.16.0-M5",
+  "com.github.finagle" %% "finch-circe" % "0.16.0-M5"
 )


### PR DESCRIPTION
- Finch is bumped to 0.16-M5
- Finagle is bumped to 17.11
- Scala version (for both benchmarks) is bumped to 2.11.12

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
