### PR TITLE
Update treefrog to version 1.19.0

### DIFF
--- a/frameworks/C++/treefrog/views/fortune/index.erb
+++ b/frameworks/C++/treefrog/views/fortune/index.erb
@@ -13,7 +13,7 @@
 <% tfetch(QList<Fortune>, fortuneList); %>
 <% for (auto &i : fortuneList) { %>
 <tr>
-<td><%= i.id() %></td>
+<td><%= (ulong)i.id() %></td>
 <td><%= i.message() %></td>
 </tr>
 <% } %>

--- a/frameworks/C++/treefrog/views/fortune/show.erb
+++ b/frameworks/C++/treefrog/views/fortune/show.erb
@@ -11,7 +11,7 @@
 <p style="color: green"><%=$ notice %></p>
 
 <h1>Showing Fortune</h1>
-<dt>ID</dt><dd><%= fortune.id() %></dd><br />
+<dt>ID</dt><dd><%= (ulong)fortune.id() %></dd><br />
 <dt>Message</dt><dd><%= fortune.message() %></dd><br />
 
 <%== linkTo("Edit", urla("edit", fortune.id())) %> |

--- a/frameworks/C++/treefrog/views/world/index.erb
+++ b/frameworks/C++/treefrog/views/world/index.erb
@@ -20,7 +20,7 @@
 <% for (QListIterator<World> it(worldList); it.hasNext(); ) {
      const World &i = it.next(); %>
   <tr>
-    <td><%= i.id() %></td>
+    <td><%= (ulong)i.id() %></td>
     <td><%= i.randomNumber() %></td>
     <td>
       <%== linkTo("Show", urla("show", i.id())) %>

--- a/frameworks/C++/treefrog/views/world/show.erb
+++ b/frameworks/C++/treefrog/views/world/show.erb
@@ -11,7 +11,7 @@
 <p style="color: green"><%=$ notice %></p>
 
 <h1>Showing World</h1>
-<dt>ID</dt><dd><%= world.id() %></dd><br />
+<dt>ID</dt><dd><%= (ulong)world.id() %></dd><br />
 <dt>RandomNumber</dt><dd><%= world.randomNumber() %></dd><br />
 
 <%== linkTo("Edit", urla("edit", world.id())) %> |

--- a/toolset/setup/linux/frameworks/treefrog.sh
+++ b/toolset/setup/linux/frameworks/treefrog.sh
@@ -2,11 +2,11 @@
 
 fw_installed treefrog && return 0
 
-TFVER=1.18.0
+TFVER=1.19.0
 
 sudo apt-get update -qq
-sudo apt-get install -y qt5-qmake qt5-default qtbase5-dev qtbase5-dev-tools libqt5sql5 libqt5sql5-mysql libqt5sql5-psql libqt5qml5 libqt5xml5 qtdeclarative5-dev libqt5quick5 libqt5quickparticles5 g++ libjemalloc-dev gcc
-
+sudo apt-get install -y g++ gcc libjemalloc-dev
+sudo apt-get install -y qt5-qmake qt5-default qtbase5-dev qtbase5-dev-tools libqt5sql5 libqt5sql5-mysql libqt5sql5-psql libqt5qml5 libqt5xml5 qtdeclarative5-dev libqt5quick5 libqt5quickparticles5 libqt5gui5 libqt5printsupport5 libqt5widgets5 libqt5opengl5-dev libqt5quicktest5
 fw_get -O https://github.com/treefrogframework/treefrog-framework/archive/v${TFVER}.tar.gz
 fw_untar v${TFVER}.tar.gz
 cd treefrog-framework-${TFVER}


### PR DESCRIPTION
Update treefrog to version 1.19.0.
Fix compilation errors in v 1.19.

Sorry to send many times..