### PR TITLE
update rust, use target-cpu=native

### DIFF
--- a/frameworks/Rust/hyper/setup.sh
+++ b/frameworks/Rust/hyper/setup.sh
@@ -3,5 +3,5 @@
 fw_depends postgresql rust
 
 cargo clean
-cargo build --release
+RUSTFLAGS="-C target-cpu=native" cargo build --release
 ./target/release/hello &

--- a/frameworks/Rust/tokio-minihttp/setup.sh
+++ b/frameworks/Rust/tokio-minihttp/setup.sh
@@ -3,5 +3,5 @@
 fw_depends postgresql rust
 
 cargo clean
-cargo build --release
+RUSTFLAGS="-C target-cpu=native" cargo build --release
 ./target/release/tokio-minihttp &

--- a/toolset/setup/linux/languages/rust.sh
+++ b/toolset/setup/linux/languages/rust.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUST_VERSION="1.21.0"
+RUST_VERSION="1.22.1"
 
 fw_installed rust && return 0
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
Hint Rust compiler to target the CPU it is building on, update Rust to 1.22.1.