### PR TITLE
Update grizzly-jersey's dependencies

### DIFF
--- a/frameworks/Java/grizzly-jersey/pom.xml
+++ b/frameworks/Java/grizzly-jersey/pom.xml
@@ -14,15 +14,21 @@
   </prerequisites>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <activation.version>1.1.1</activation.version>
     <commons-cli.version>1.4</commons-cli.version>
     <grizzly.version>2.3.30</grizzly.version>
     <hibernate.version>4.3.11.Final</hibernate.version>
     <hibernate-jpa-api.version>1.0.0.Final</hibernate-jpa-api.version>
-    <jackson.version>2.8.7</jackson.version>
-    <jersey.version>1.19.3</jersey.version>
+    <jackson.version>2.9.2</jackson.version>
+    <jaxb.version>2.3.0</jaxb.version>
+    <jersey.version>1.19.4</jersey.version>
     <jsr311-api.version>1.1.1</jsr311-api.version>
-    <mustache.version>0.9.4</mustache.version>
-    <mysql-connector.version>5.1.41</mysql-connector.version>
+    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+    <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
+    <mustache.version>0.9.5</mustache.version>
+    <mysql-connector.version>5.1.45</mysql-connector.version>
   </properties>
 
   <dependencies>
@@ -91,6 +97,16 @@
       <artifactId>commons-cli</artifactId>
       <version>${commons-cli.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jaxb.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>${activation.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -100,10 +116,8 @@
         <inherited>true</inherited>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <optimize>true</optimize>
           <debug>false</debug>
         </configuration>
@@ -111,7 +125,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.1</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
Also added the jaxb and activation dependencies for compatibility with
Java 9.

There's a more recent version of Grizzly itself available, 2.4.2, but
when I tried it the toolset warned that all the responses were missing
the required Date header.