### PR TITLE
Update light-4j's compiler and error prone versions

### DIFF
--- a/frameworks/Java/light-java/pom.xml
+++ b/frameworks/Java/light-java/pom.xml
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.7.0</version>
                 <configuration>
                     <compilerId>javac-with-errorprone</compilerId>
                     <showWarnings>true</showWarnings>
@@ -193,14 +193,14 @@
                     <dependency>
                         <groupId>org.codehaus.plexus</groupId>
                         <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                        <version>2.8</version>
+                        <version>2.8.2</version>
                     </dependency>
                     <!-- override plexus-compiler-javac-errorprone's dependency on
                          Error Prone with the latest version -->
                     <dependency>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_core</artifactId>
-                        <version>2.0.15</version>
+                        <version>2.1.3</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -227,7 +227,7 @@
         									maven-compiler-plugin
         								</artifactId>
         								<versionRange>
-        									[3.3,)
+        									[3.7.0,)
         								</versionRange>
         								<goals>
         									<goal>compile</goal>


### PR DESCRIPTION
This makes light-4j pass on Java 9.  Without this, it fails.  I didn't
try to narrow down which one of the three dependencies that I updated was
the source of the problem.