### PR TITLE
Update ninja's dependencies, minor cleanup

### DIFF
--- a/frameworks/Java/ninja-standalone/pom.xml
+++ b/frameworks/Java/ninja-standalone/pom.xml
@@ -8,11 +8,24 @@
     <description>Ninja test for the TechEmpower/FrameworkBenchmarks project</description>
 
     <properties>
-        <java-version>1.8</java-version>
-        <ninja.version>5.3.0</ninja.version>
-        <mysql.version>5.1.38</mysql.version>
-        <jetty.version>9.3.6.v20151106</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+        <maven-war-plugin.version>3.2.0</maven-war-plugin.version>
+
+        <h2.version>1.4.196</h2.version>
+        <hibernate.version>5.2.12.Final</hibernate.version>
+        <hibernate-validator.version>6.0.5.Final</hibernate-validator.version>
+        <jaxb-api.version>2.2.12</jaxb-api.version>
+        <jetty.version>9.3.6.v20151106</jetty.version>
+        <mysql.version>5.1.45</mysql.version>
+        <ninja.version>6.2.0</ninja.version>
+        <xml-apis.version>1.4.01</xml-apis.version>
     </properties>
 
     <dependencies>
@@ -42,21 +55,51 @@
         </dependency>
 
         <dependency>
-          <groupId>org.hibernate</groupId>
-          <artifactId>hibernate-hikaricp</artifactId>
-          <version>4.3.8.Final</version>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-hikaricp</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-c3p0</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
         </dependency>
                         
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.174</version>
+            <version>${h2.version}</version>
         </dependency>
 
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
+            <version>${xml-apis.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
         </dependency>
 
     </dependencies>
@@ -66,17 +109,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>${java-version}</source>
-                    <target>${java-version}</target>
-                </configuration>
+                <version>${maven-compiler-plugin.version}</version>
             </plugin>
 			
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-war-plugin.version}</version>
                 <configuration>
                     <warName>ninja</warName>
                 </configuration>
@@ -91,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-banned-dependencies</id>
@@ -140,7 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
+                <version>${maven-deploy-plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -148,7 +187,7 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloJsonController.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloJsonController.java
@@ -9,15 +9,15 @@ import com.google.inject.Singleton;
 public class HelloJsonController {
 
     public Result index() {
-	return Results.json().render(new Message("Hello, World!"));
+        return Results.json().render(new Message("Hello, World!"));
     }
 
-    public final static class Message {
+    public static final class Message {
 
-	public final String message;
+        public final String message;
 
-	public Message(String message) {
-	    this.message = message;
-	}
+        public Message(String message) {
+            this.message = message;
+        }
     }
 }

--- a/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloPlaintextController.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/controllers/HelloPlaintextController.java
@@ -7,7 +7,9 @@ import com.google.inject.Singleton;
 
 @Singleton
 public class HelloPlaintextController {
+
     public Result index() {
-	return Results.text().renderRaw("Hello, World!");
+        return Results.text().render("Hello, World!");
     }
+
 }

--- a/frameworks/Java/ninja-standalone/src/main/java/controllers/SetupController.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/controllers/SetupController.java
@@ -1,11 +1,5 @@
 package controllers;
 
-import dao.WorldDao;
-import model.World;
-
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
-
 import ninja.Result;
 import ninja.Results;
 
@@ -20,16 +14,14 @@ public class SetupController {
     SetupDao setupDao;
 
     public Result setupData() {
-        
+
         setupDao.deleteAllData();
-        
+
         setupDao.generateWorldsForTest();
         setupDao.generateFortunesForTest();
-        
+
         return Results.text().render("setup done");
-        
+
     }
-    
-   
 
 }

--- a/frameworks/Java/ninja-standalone/src/main/java/dao/SetupDao.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/dao/SetupDao.java
@@ -8,8 +8,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.persist.Transactional;
-import java.util.List;
-import javax.persistence.Query;
 import model.World;
 
 /**

--- a/frameworks/Java/ninja-standalone/src/main/java/dao/WorldDao.java
+++ b/frameworks/Java/ninja-standalone/src/main/java/dao/WorldDao.java
@@ -12,15 +12,15 @@ import com.google.inject.Singleton;
 public class WorldDao {
 
     @Inject
-    Provider<EntityManager> entitiyManagerProvider;
+    Provider<EntityManager> entityManagerProvider;
 
     public World get(int id) {
-        EntityManager entityManager = entitiyManagerProvider.get();
+        EntityManager entityManager = entityManagerProvider.get();
         return entityManager.find(World.class, id);
     }
 
     public void put(World world) {
-        EntityManager entityManager = entitiyManagerProvider.get();
+        EntityManager entityManager = entityManagerProvider.get();
         entityManager.persist(world);
     }
 }

--- a/frameworks/Java/ninja-standalone/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/ninja-standalone/src/main/resources/META-INF/persistence.xml
@@ -1,57 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
-	version="2.0">
-    
-        
-        <!-- Database for tests and local dev mode... -->
-        <persistence-unit name="h2" transaction-type="RESOURCE_LOCAL">
-            <provider>org.hibernate.ejb.HibernatePersistence</provider>
-            <properties>
-                <property name="javax.persistence.provider" value="org.hibernate.ejb.HibernatePersistence" />
-                <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
-                <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
-                <!-- you may want to enable the ddl if you do not use migrations. -->
-                <property name="hibernate.hbm2ddl.auto" value="create" />
-                <property name="hibernate.show_sql" value="false" />
-                <property name="hibernate.format_sql" value="false" />
-                <property name="hibernate.jdbc.batch_size" value="100" />
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
 
-                <!-- Connection Pooling settings -->
-                <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-                <property name="hibernate.cache.use_query_cache" value="false" />
-                <property name="hibernate.minimumIdle" value="256" />
-                <property name="hibernate.maximumPoolSize" value="256" />
-                <property name="hibernate.idleTimeout" value="30000" />
-                <property name="hibernate.dataSourceClassName" value="org.h2.jdbcx.JdbcDataSource" />
-            </properties>
-        </persistence-unit>
+  <persistence-unit name="h2" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+    <properties>
+      <property name="javax.persistence.provider" value="org.hibernate.jpa.HibernatePersistenceProvider" />
+      <property name="hibernate.connection.driver_class" value="org.h2.Driver" />
+      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+      <property name="hibernate.hbm2ddl.auto" value="create" />
+      <property name="hibernate.show_sql" value="false" />
+      <property name="hibernate.format_sql" value="false" />
+      <property name="hibernate.jdbc.batch_size" value="100" />
+      <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
+      <property name="hibernate.cache.use_query_cache" value="false" />
+      <property name="hibernate.minimumIdle" value="256" />
+      <property name="hibernate.maximumPoolSize" value="256" />
+      <property name="hibernate.idleTimeout" value="30000" />
+      <property name="hibernate.dataSourceClassName" value="org.h2.jdbcx.JdbcDataSource" />
+    </properties>
+  </persistence-unit>
 
-	<!-- Direct mysql -->
-	<persistence-unit name="mysql" transaction-type="RESOURCE_LOCAL">
-		<provider>org.hibernate.ejb.HibernatePersistence</provider>
-
-		<properties>
-			<property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
-			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
-
-			<property name="hibernate.show_sql" value="false" />
-			<property name="hibernate.format_sql" value="false" />
-                        <property name="hibernate.jdbc.batch_size" value="100" />
-			<!-- Connection Pooling settings -->
-                        <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-                        <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
-                        <property name="hibernate.cache.use_query_cache" value="false" />
-                        <property name="hibernate.hikari.minimumIdle" value="256" />
-                        <property name="hibernate.hikari.maximumPoolSize" value="256" />
-                        <property name="hibernate.hikari.idleTimeout" value="30000" />
-                        <property name="hibernate.hikari.dataSourceClassName" value="com.mysql.jdbc.jdbc2.optional.MysqlDataSource" />
-                        <property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true" />
-                        <property name="hibernate.hikari.dataSource.user" value="benchmarkdbuser" />
-                        <property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" />
-		</properties>
-	</persistence-unit>
+  <persistence-unit name="mysql" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+    <properties>
+      <property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
+      <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
+      <property name="hibernate.show_sql" value="false" />
+      <property name="hibernate.format_sql" value="false" />
+      <property name="hibernate.jdbc.batch_size" value="100" />
+      <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
+      <property name="hibernate.cache.use_query_cache" value="false" />
+      <property name="hibernate.hikari.minimumIdle" value="256" />
+      <property name="hibernate.hikari.maximumPoolSize" value="256" />
+      <property name="hibernate.hikari.idleTimeout" value="30000" />
+      <property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://localhost:3306/hello_world?useSSL=false&amp;jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true" />
+      <property name="hibernate.hikari.dataSource.user" value="benchmarkdbuser" />
+      <property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" />
+    </properties>
+  </persistence-unit>
 
 </persistence>

--- a/frameworks/Java/ninja-standalone/src/test/java/controllers/HelloPlaintextControllerTest.java
+++ b/frameworks/Java/ninja-standalone/src/test/java/controllers/HelloPlaintextControllerTest.java
@@ -21,7 +21,7 @@ public class HelloPlaintextControllerTest extends NinjaDocTester {
         assertThat(response.payload, CoreMatchers.is("Hello, World!"));
         assertThat(
             response.headers.get("Content-Type"), 
-            is("text/plain; charset=UTF-8"));
+            is("text/plain;charset=utf-8"));
         
    
     }


### PR DESCRIPTION
This makes ninja-standalone run on both Java 8 and Java 9.  Before, it
seemed like the old version of Hibernate was causing problems on Java 9.
The part that initialized the HikariCP pool was throwing an exception,
something related to the pool max and min sizes being set out of order
and failing a bounds check.