### PR TITLE
Add explicit javax.xml.bind dependency to rapidoid for Java 9 compat

### DIFF
--- a/frameworks/Java/rapidoid/pom.xml
+++ b/frameworks/Java/rapidoid/pom.xml
@@ -33,6 +33,11 @@
 			<artifactId>HikariCP</artifactId>
 			<version>2.6.1</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.2.12</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Without this, the rapidoid test fails with a runtime exception on Java 9.