### PR TITLE
Add dependencies to get rid of errors in Java 9 for utow-jersey-c3p0

### DIFF
--- a/frameworks/Java/undertow-jersey-c3p0/pom.xml
+++ b/frameworks/Java/undertow-jersey-c3p0/pom.xml
@@ -82,6 +82,18 @@
       <version>1.3.11.Final</version>
     </dependency>
 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/frameworks/Java/undertow-jersey-c3p0/src/main/resources/hibernate.cfg.xml
+++ b/frameworks/Java/undertow-jersey-c3p0/src/main/resources/hibernate.cfg.xml
@@ -2,7 +2,7 @@
 <hibernate-configuration>
   <session-factory>
     <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
-    <property name="hibernate.connection.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</property>
+    <property name="hibernate.connection.url">jdbc:mysql://localhost:3306/hello_world?useSSL=false&amp;jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</property>
     <property name="hibernate.connection.username">benchmarkdbuser</property>
     <property name="hibernate.connection.password">benchmarkdbpass</property>
     <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>


### PR DESCRIPTION
Without the javax.activation and javax.xml.bind dependencies, I was
seeing stack traces in the logs, though it still seemed to pass the
tests.  The stack traces were similar to those I've seen in other
frameworks when run on Java 9, so I added the same dependencies for
fixing them just in case.

Also add the "useSSL=false" to the MySQL connection string to remove a
bunch of warning messages.