### PR TITLE
Add dependencies to get rid of errors in Java 9 for utow-jersey-hikaricp

### DIFF
--- a/frameworks/Java/undertow-jersey-hikaricp/pom.xml
+++ b/frameworks/Java/undertow-jersey-hikaricp/pom.xml
@@ -82,6 +82,18 @@
       <version>1.3.11.Final</version>
     </dependency>
 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
Without the javax.activation and javax.xml.bind dependencies, I was
seeing errors / stack traces when running on Java 9, though the tests
still seemed to pass somehow.  Adding these dependencies makes those
stack traces go away, which is probably for the best, so they don't
distract us from worse problems later.