### PR TITLE
Add javax.xml.bind dependencies for Java 9 compat in some Clojure tests

### DIFF
--- a/frameworks/Clojure/aleph/hello/project.clj
+++ b/frameworks/Clojure/aleph/hello/project.clj
@@ -4,6 +4,7 @@
                  [clj-tuple "0.2.2"]
                  [org.clojure/tools.cli "0.3.3"]
                  [aleph "0.4.1-beta2"]
+                 [javax.xml.bind/jaxb-api "2.2.12"]
                  [cheshire "5.5.0"]]
   :main hello.handler
   :aot :all)

--- a/frameworks/Clojure/http-kit/hello/project.clj
+++ b/frameworks/Clojure/http-kit/hello/project.clj
@@ -6,6 +6,7 @@
                  [ring/ring-json "0.4.0"]
                  [org.clojure/tools.cli "0.2.1"]
                  [http-kit "2.1.19"]
+                 [javax.xml.bind/jaxb-api "2.2.12"]
                  [korma "0.4.2"]
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  ; [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]

--- a/frameworks/Clojure/macchiato/hello/project.clj
+++ b/frameworks/Clojure/macchiato/hello/project.clj
@@ -7,6 +7,7 @@
                  [hiccups "0.3.0"]
                  [macchiato/core "0.1.6"]
                  [macchiato/env "0.0.5"]
+                 [javax.xml.bind/jaxb-api "2.2.12"]
                  [mount "0.1.11"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.518"]]


### PR DESCRIPTION
Without the javax.xml.bind dependency, these three frameworks fail at
runtime when run on Java 9.