### PR TITLE
Don't restrict reitit HTTP requests to localhost

### DIFF
--- a/frameworks/Clojure/reitit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/reitit/hello/src/hello/handler.clj
@@ -30,4 +30,4 @@
       (println banner)
       (System/exit 0))
 
-    (web/run app {:host "localhost" :port port})))
+    (web/run app {:host "0.0.0.0" :port port})))


### PR DESCRIPTION
Without this, the reitit tests fail in the multi-machine benchmark setup,
since the wrk client runs on a different machine than the application
server.