### PR TITLE
Update SBT from 0.13.9 to 1.0.4

### DIFF
--- a/frameworks/Scala/blaze/project/build.properties
+++ b/frameworks/Scala/blaze/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/frameworks/Scala/colossus/project/build.properties
+++ b/frameworks/Scala/colossus/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/toolset/setup/linux/systools/sbt.sh
+++ b/toolset/setup/linux/systools/sbt.sh
@@ -2,9 +2,9 @@
 
 fw_installed sbt && return 0
   
-VERSION="0.13.9"
+VERSION="1.0.4"
 
-fw_get -o sbt-$VERSION.zip http://dl.bintray.com/sbt/native-packages/sbt/$VERSION/sbt-$VERSION.zip
+fw_get -o sbt-$VERSION.zip https://github.com/sbt/sbt/releases/download/v$VERSION/sbt-$VERSION.zip
 fw_unzip sbt-$VERSION.zip
 
 echo -e "export PATH=${IROOT}/sbt/bin:\$PATH" > $IROOT/sbt.installed


### PR DESCRIPTION
This makes several Scala frameworks compatible with Java 9.

Add the build.properties specifying an old SBT version to blaze and
colossus because without that file, and with the SBT 1.0.4 upgrade, a
build.properties is auto-generated with `sbt.version=1.0.4`, and this
causes problems for the sbt-onejar plugin.  Having a build.properties
file puts blaze and colossus in line with all the other Scala frameworks,
which had that file already.