### PR TITLE
Upgrade to Resin 4.0.55, which is compatible with Java 9

### DIFF
--- a/toolset/setup/linux/webservers/resin/resin.sh
+++ b/toolset/setup/linux/webservers/resin/resin.sh
@@ -4,11 +4,9 @@ fw_depends java
 
 fw_installed resin && return 0
 
-RVER=4.0.53
+RVER=4.0.55
 RESIN=resin-$RVER
 RESIN_HOME=$IROOT/$RESIN
-
-sudo cp -r $JAVA_HOME/include $JAVA_HOME/jre/bin/
 
 fw_get -O http://www.caucho.com/download/resin-$RVER.tar.gz
 fw_untar resin-$RVER.tar.gz


### PR DESCRIPTION
Of the 11 frameworks that use Resin, this change makes 6 of them
compatible with Java 9.  The remaining 5 are incompatible with Java 9 for
other reasons, which we'll try to address.

I removed the line that modifies the contents of JAVA_HOME because:

 a) There is no jre directory in Java 9, so this line fails.
 b) It's not clear what this line is supposed to accomplish in the first
    place.  I've never had to do this for my own Java + Resin
    installations.