### PR TITLE
Remove the .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-# disable line endings normalisation
-* -text
-
-# ensure Linux/Win specific files retain native line endings
-*.sh text eol=lf
-*.py text eol=lf
-*.ps1 text eol=crlf


### PR DESCRIPTION
I was wondering why, as of recently, I was having to manually convert
all my line endings each time I wanted to commit something to TFB.  It
looks like this (relatively new) .gitattributes file is to blame.  This
file came in with a commit to add a new framework back in November.  It
doesn't seem like it was addressing any real issues we were having.