### PR TITLE
Update ejs dependency for sailsjs

### DIFF
--- a/frameworks/JavaScript/sailsjs/package.json
+++ b/frameworks/JavaScript/sailsjs/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "async": "1.5.2",
     "bluebird": "3.4.1",
-    "ejs": "2.4.2",
+    "ejs": "2.5.7",
     "handlebars": "4.0.5",
     "hiredis": "0.5.0",
     "mysql": "2.11.0",


### PR DESCRIPTION
I don't know if this breaks the sailsjs test, and I'm relying on travis to tell us.  sailsjs fails with or without this change in the local TFB setup that I do most of my testing with.