### PR TITLE
Include stack traces and debug logging in officefloor build

### DIFF
--- a/frameworks/Java/officefloor/setup.sh
+++ b/frameworks/Java/officefloor/setup.sh
@@ -19,4 +19,4 @@ echo "OfficeFloor test application built"
 
 # Run application
 echo "Starting OfficeFloor application"
-mvn -DincludeGWT=false -DenvDir=production net.officefloor.maven:woof-maven-plugin:run
+mvn -e -X -DincludeGWT=false -DenvDir=production net.officefloor.maven:woof-maven-plugin:run


### PR DESCRIPTION
This line has been failing in the Server Central environment, and this
change should make officefloor tell us more about what's going wrong the
next time it fails.  The framework passes all tests in a local setup, so
I bet it's close to passing in Server Central too.