### PR TITLE
Haskell/snap - lock down dependencies

### DIFF
--- a/frameworks/Haskell/snap/bench/snap-bench.cabal
+++ b/frameworks/Haskell/snap/bench/snap-bench.cabal
@@ -15,20 +15,20 @@ Executable snap-bench
   main-is: Main.hs
 
   Build-depends:
-    aeson,
+    aeson == 0.11.2.0,
     base,
-    bytestring,
-    MonadCatchIO-transformers,
-    mtl,
-    snap-core,
-    snap-server,
-    configurator,
-    resource-pool,
-    mysql-simple,
-    text,
-    transformers,
-    random,
-    unordered-containers
+    bytestring == 0.10.6.0,
+    MonadCatchIO-transformers == 0.3.1.3,
+    mtl == 2.2.1,
+    snap-core == 0.9.8.0,
+    snap-server == 0.9.5.1,
+    configurator == 0.3.0.0,
+    resource-pool == 0.2.3.2,
+    mysql-simple == 0.2.2.5,
+    text == 1.2.2.1,
+    transformers == 0.4.*,
+    random == 1.1,
+    unordered-containers == 0.2.7.1
 
   ghc-options: -threaded -Wall -fwarn-tabs -funbox-strict-fields -O2
                -fno-warn-unused-do-bind -rtsopts


### PR DESCRIPTION
After looking in to the recent Haskell framework failures, I found that packages can be locked down to specific versions in the `.cabal` file. I'll be locking haskell frameworks down to their most recent working versions.