### PR TITLE
Specify amd64 in the HHVM installation

### DIFF
--- a/toolset/setup/linux/languages/hhvm.sh
+++ b/toolset/setup/linux/languages/hhvm.sh
@@ -4,7 +4,7 @@ fw_installed hhvm && return 0
 
 # TODO: Someday move away from apt-get
 fw_get http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
-echo deb http://dl.hhvm.com/ubuntu `lsb_release -sc` main | sudo tee /etc/apt/sources.list.d/hhvm.list
+echo deb [arch=amd64] http://dl.hhvm.com/ubuntu `lsb_release -sc` main | sudo tee /etc/apt/sources.list.d/hhvm.list
 sudo apt-get update
 sudo apt-get install -y hhvm
 


### PR DESCRIPTION
Without this, it seemed to be trying to grab an i386 release that didn't
exist, so the HHVM installation would fail.