### PR TITLE
Set useSSL=false in more MySQL connection strings

### DIFF
--- a/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
+++ b/frameworks/Clojure/http-kit/hello/src/hello/handler.clj
@@ -31,7 +31,7 @@
   (mysql {
     :classname "com.mysql.jdbc.Driver"
     :subprotocol "mysql"
-    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
+    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
     :user "benchmarkdbuser"
     :password "benchmarkdbpass"
     ;;OPTIONAL KEYS

--- a/frameworks/Clojure/pedestal/src/pedestal/service.clj
+++ b/frameworks/Clojure/pedestal/src/pedestal/service.clj
@@ -32,7 +32,7 @@
   (mysql {
     :classname "com.mysql.jdbc.Driver"
     :subprotocol "mysql"
-    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true"
+    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
     :user "benchmarkdbuser"
     :password "benchmarkdbpass"
     ;;OPTIONAL KEYS

--- a/frameworks/Java/activeweb/src/main/java/app/config/DbConfig.java
+++ b/frameworks/Java/activeweb/src/main/java/app/config/DbConfig.java
@@ -38,7 +38,8 @@ public class DbConfig extends AbstractDBConfig {
                 "&useReadAheadInput=false" +
                 "&maintainTimeStats=false" +
                 "&useServerPrepStmts" +
-                "&cacheRSMetadata=true";
+                "&cacheRSMetadata=true" +
+                "&useSSL=false";
 
         environment("development").jndi("java:comp/env/jdbc/hello_world");
 

--- a/frameworks/Java/activeweb/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/activeweb/src/main/webapp/WEB-INF/resin-web.xml
@@ -3,7 +3,7 @@
 <database jndi-name='jdbc/hello_world'>
   <driver>
     <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
     <useUnicode/>

--- a/frameworks/Java/gemini/Docroot/WEB-INF/GeminiHello.conf
+++ b/frameworks/Java/gemini/Docroot/WEB-INF/GeminiHello.conf
@@ -93,7 +93,7 @@ db.Driver.SupportsAbsolute = yes
 db.Driver.SupportsGetRow = yes
 db.Driver.Jdbc1 = no
 
-db.ConnectString = 127.0.0.1:5432/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true
+db.ConnectString = 127.0.0.1:5432/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false
 db.LoginName = benchmarkdbuser
 db.LoginPass = benchmarkdbpass
 

--- a/frameworks/Java/grizzly-jersey/src/main/resources/hibernate.cfg.xml
+++ b/frameworks/Java/grizzly-jersey/src/main/resources/hibernate.cfg.xml
@@ -9,7 +9,7 @@
     <property name="hibernate.hikari.maximumPoolSize">256</property>
     <property name="hibernate.hikari.idleTimeout">30000</property>
     <property name="hibernate.hikari.dataSourceClassName">com.mysql.jdbc.jdbc2.optional.MysqlDataSource</property>
-    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</property>
+    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</property>
     <property name="hibernate.hikari.dataSource.user">benchmarkdbuser</property>
     <property name="hibernate.hikari.dataSource.password">benchmarkdbpass</property>
   </session-factory>

--- a/frameworks/Java/light-java/src/main/resources/config/mysql.json
+++ b/frameworks/Java/light-java/src/main/resources/config/mysql.json
@@ -8,5 +8,6 @@
   "cachePrepStmts": true,
   "cacheCallableStmts": true,
   "prepStmtCacheSize": 4096,
-  "prepStmtCacheSqlLimit": 2048
+  "prepStmtCacheSqlLimit": 2048,
+  "useSSL": false
 }

--- a/frameworks/Java/ninja-standalone/src/main/java/conf/application.conf
+++ b/frameworks/Java/ninja-standalone/src/main/java/conf/application.conf
@@ -31,7 +31,7 @@ application.session.transferred_over_https_only=false
 ninja.migration.run=false
 
 %prod.ninja.jpa.persistence_unit_name = mysql
-%prod.db.connection.url=jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true
+%prod.db.connection.url=jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false
 %prod.db.connection.username=benchmarkdbuser
 %prod.db.connection.password=benchmarkdbpass
 

--- a/frameworks/Java/officefloor/raw/datasource.properties
+++ b/frameworks/Java/officefloor/raw/datasource.properties
@@ -1,5 +1,5 @@
 datanucleus.ConnectionDriverName = com.mysql.jdbc.Driver
-datanucleus.ConnectionURL = jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+datanucleus.ConnectionURL = jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
 datanucleus.ConnectionUserName = benchmarkdbuser
 datanucleus.ConnectionPassword = benchmarkdbpass
 datanucleus.connectionPoolingType = C3P0

--- a/frameworks/Java/play1/conf/application.conf
+++ b/frameworks/Java/play1/conf/application.conf
@@ -115,7 +115,7 @@ db.pool.minSize=10
 # generic "destroy" method :
 # db.destroyMethod=close
 db.driver= com.mysql.jdbc.Driver
-db.url=jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+db.url=jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
 #db.url=jdbc:mysql://localhost:3306/hello_world
 db.user=benchmarkdbuser
 db.pass=benchmarkdbpass

--- a/frameworks/Java/proteus/conf/application.conf
+++ b/frameworks/Java/proteus/conf/application.conf
@@ -46,7 +46,7 @@ mysql
 {
    hikaricp 
    {
-        jdbcUrl= "jdbc:mysql://TFB-database:3306/hello_world?useServerPrepStmts=true&cachePrepStmts=true",
+        jdbcUrl= "jdbc:mysql://TFB-database:3306/hello_world?useServerPrepStmts=true&cachePrepStmts=true&useSSL=false",
 
         #jdbcUrl= "jdbc:mysql://TFB-database:3306/hello_world?useServerPrepStmts=true&cachePrepStmts=true&useUnicode=true",
         maximumPoolSize=48

--- a/frameworks/Java/spring/src/main/resources/application.yml
+++ b/frameworks/Java/spring/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   datasource:
     initialize: false
     driverClassName: com.mysql.jdbc.Driver
-    url: jdbc:mysql://${database.host:localhost}:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+    url: jdbc:mysql://${database.host:localhost}:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
     username: benchmarkdbuser
     password: benchmarkdbpass
   jpa:

--- a/frameworks/Java/tapestry/hello/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/tapestry/hello/src/main/webapp/WEB-INF/resin-web.xml
@@ -3,7 +3,7 @@
 <database jndi-name='jdbc/hello_world'>
   <driver>
     <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</url>
+    <url>jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
     <useUnicode/>

--- a/frameworks/Java/undertow-jersey-hikaricp/src/main/resources/hibernate.cfg.xml
+++ b/frameworks/Java/undertow-jersey-hikaricp/src/main/resources/hibernate.cfg.xml
@@ -9,7 +9,7 @@
     <property name="hibernate.hikari.maximumPoolSize">256</property>
     <property name="hibernate.hikari.idleTimeout">30000</property>
     <property name="hibernate.hikari.dataSourceClassName">com.mysql.jdbc.jdbc2.optional.MysqlDataSource</property>
-    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true</property>
+    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</property>
     <property name="hibernate.hikari.dataSource.user">benchmarkdbuser</property>
     <property name="hibernate.hikari.dataSource.password">benchmarkdbpass</property>
   </session-factory>

--- a/frameworks/Java/wildfly-ee7/server-resources/datasources/mysql-ds.xml
+++ b/frameworks/Java/wildfly-ee7/server-resources/datasources/mysql-ds.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE xml>
 <datasources xmlns="http://www.jboss.org/ironjacamar/schema">
     <datasource jta="true" jndi-name="java:jboss/datasources/helloWorld" pool-name="MySqlDS" enabled="true" use-java-context="true" use-ccm="true">
-		<connection-url>jdbc:mysql://${database.host}:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;traceProtocol=false&amp;useServerPrepStmts=true&amp;enableQueryTimeouts=false&amp;useUnbufferedIO=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;cacheRSMetadata=true</connection-url>
+		<connection-url>jdbc:mysql://${database.host}:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;traceProtocol=false&amp;useServerPrepStmts=true&amp;enableQueryTimeouts=false&amp;useUnbufferedIO=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;cacheRSMetadata=true&amp;useSSL=false</connection-url>
 		<driver>mysql-connector-java-${version.mysql.connector}.jar_com.mysql.jdbc.Driver_5_1</driver>
 		<pool>
 		    <prefill>true</prefill>

--- a/frameworks/JavaScript/ringojs/app/models.js
+++ b/frameworks/JavaScript/ringojs/app/models.js
@@ -2,7 +2,7 @@ const { Store, Cache } = require('ringo-sqlstore');
 
 // create and configure store
 const connectionPool = module.singleton("connectionPool", function () {
-    const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true";
+    const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
     return Store.initConnectionPool({
         "url": "jdbc:mysql://TFB-database/hello_world" + mysqlConnectionProperties,
         "driver": "com.mysql.jdbc.Driver",

--- a/frameworks/JavaScript/ringojs/ringo-main.js
+++ b/frameworks/JavaScript/ringojs/ringo-main.js
@@ -95,7 +95,7 @@ exports.app = function(req) {
 
 
 const datasource = module.singleton('pooling-datasource', function() {
-  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true";
+  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
   return sql.connect("jdbc:mysql://TFB-database/hello_world" + mysqlConnectionProperties, 'benchmarkdbuser', 'benchmarkdbpass');
 });
 


### PR DESCRIPTION
I found these connection strings by searching for "cachePrepStmts" and
ignoring the ones that were actually using PostgreSQL.  So if there are
MySQL connection strings that don't set cachePrepStmts, I missed them.

I didn't test the performance impact in all of these frameworks, but for
the three I did test, there was a notable positive benefit from setting
useSSL=false compared to leaving it unspecified.  When it's unspecified,
we sometimes see warning messages like this in the logs:

  Establishing SSL connection without server's identity verification is
  not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+
  requirements SSL connection must be established by default if explicit
  option isn't set. For compliance with existing applications not using
  SSL the verifyServerCertificate property is set to 'false'. You need
  either to explicitly disable SSL by setting useSSL=false, or set
  useSSL=true and provide truststore for server certificate verification.

That seems to say that if we leave useSSL unspecified, then SSL will be
used.  Maybe that explains the performance difference.