### PR TITLE
upgrade to lts-10.0 (ghc 8.2.2)

### DIFF
--- a/frameworks/Haskell/wai/bench/stack.yaml
+++ b/frameworks/Haskell/wai/bench/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-6.3
+resolver: lts-10.0


### PR DESCRIPTION
I wanted to compare wai performance with the old libraries and compiler on lts-6.3 but i was unable to compile (this is strange because i followed the recommended procedure)

```
Setup wai: http2-1.6.0: configure
Setup wai: aeson-0.11.2.0: copy/register
Setup wai: 
Setup wai: --  While building custom Setup.hs for package http2-1.6.0 using:
Setup wai:       /home/vagrant/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_1.22.5.0_ghc-7.10.3 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.22.5.0 configure --with-ghc=/home/vagrant/.stack/programs/x86_64-linux/ghc-7.10.3/bin/ghc --with-ghc-pkg=/home/vagrant/.stack/programs/x86_64-linux/ghc-7.10.3/bin/ghc-pkg --user --package-db=clear --package-db=global --package-db=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/pkgdb --libdir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/lib --bindir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/bin --datadir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/share --libexecdir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/libexec --sysconfdir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/etc --docdir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/doc/http2-1.6.0 --htmldir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/doc/http2-1.6.0 --haddockdir=/home/vagrant/.stack/snapshots/x86_64-linux/lts-6.3/7.10.3/doc/http2-1.6.0 --dependency=array=array-0.5.1.0-960bf9ae8875cc30355e086f8853a049 --dependency=base=base-4.8.2.0-0d6d1084fbc041e1cded9228e80e264d --dependency=bytestring=bytestring-0.10.6.0-9a873bcf33d6ce2fd2698ce69e2c1c66 --dependency=bytestring-builder=bytestring-builder-0.10.6.0.0-8aa4073730c676dbe210ea8bffd8d092 --dependency=case-insensitive=case-insensitive-1.2.0.6-1e785ad7ea03fd7882502f10fd07e5a2 --dependency=containers=containers-0.5.6.2-59326c33e30ec8f6afd574cbac625bbb --dependency=psqueues=psqueues-0.2.2.1-7824de609dc312a467c2b75622b6db3f --dependency=stm=stm-2.4.4.1-7050c728ed5b2315e2c6b56d8bf9837f
Setup wai:     Process exited with code: ExitFailure 1
Setup wai:     Logs have been written to: /home/vagrant/FrameworkBenchmarks/frameworks/Haskell/wai/bench/.stack-work/logs/http2-1.6.0.log
Setup wai: 
Setup wai:     Configuring http2-1.6.0...
Setup wai:     Cabal-simple_mPHDZzAJ_1.22.5.0_ghc-7.10.3: At least the following dependencies
Setup wai:     are missing:
Setup wai:     aeson -any, aeson-pretty -any, hex -any, word8 -any
wai: setup.sh and framework processes have terminated
Setup wai: Setup has terminated
Setup wai: Status: Poll: 0, Port 8000 bound: False, Time Left: 1:32:53.196475
Setup wai: setup.sh process exited naturally with 0
```

Anyway .. i just upgraded the project to lts-10.0 and with the command `tfb --mode verify --test wai` i got PASS for plaintext and json (i guess the other benchmarks were not tested for wai). Whatever the performance impact of this change is (for better or worse) i think the lts version should be bumped regardless because people will be using the latest versions when they start a new project thus giving more realistic numbers.