### PR TITLE
upgrade servant to lts-10.0

### DIFF
--- a/frameworks/Haskell/servant/servant-bench.cabal
+++ b/frameworks/Haskell/servant/servant-bench.cabal
@@ -19,21 +19,20 @@ library
   exposed-modules:     ServantBench
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.9
-                     , servant == 0.7.*
-                     , servant-server == 0.7.*
-                     , servant-lucid == 0.7.*
+  build-depends:       base
+                     , aeson
+                     , bytestring
+                     , contravariant
+                     , hasql
+                     , hasql-pool
+                     , http-media
                      , lucid
-                     , aeson == 0.11.*
-                     , hasql == 0.19.*
-                     , hasql-pool == 0.4.*
-                     , bytestring == 0.10.6.*
-                     , mwc-random == 0.13.*
-                     , warp == 3.2.*
-                     , transformers
-                     , text == 1.2.*
-                     , contravariant == 1.4.*
-                     , http-media == 0.6.*
+                     , mwc-random
+                     , servant
+                     , servant-lucid
+                     , servant-server
+                     , text
+                     , warp
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/frameworks/Haskell/servant/stack.yaml
+++ b/frameworks/Haskell/servant/stack.yaml
@@ -1,9 +1,8 @@
-resolver: lts-6.5
+resolver: lts-10.0
 packages:
 - '.'
 
 extra-deps:
-- hasql-pool-0.4.1
 
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
don't have bechmarks of lts-6.3 because of https://github.com/TechEmpower/FrameworkBenchmarks/pull/3149#issuecomment-352936343