### PR TITLE
Fix padrino build by updating its json dependency

### DIFF
--- a/frameworks/Ruby/padrino/Gemfile
+++ b/frameworks/Ruby/padrino/Gemfile
@@ -7,7 +7,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'mysql2', '0.3.16'
+  gem 'mysql2', '0.3.20'
   gem "unicorn", '4.8.3'
   gem "thin", '1.6.2'
 end

--- a/frameworks/Ruby/padrino/Gemfile
+++ b/frameworks/Ruby/padrino/Gemfile
@@ -13,7 +13,7 @@ platforms :ruby do
 end
 
 gem 'puma', "~> 3.9.1"
-gem 'json', '1.8.1'
+gem 'json', '1.8.3'
 
 gem 'slim', '2.0.3'
 gem 'dm-mysql-adapter', '1.2.0'


### PR DESCRIPTION
This blog post describes the error we were seeing and the fix:
http://fuzzyblog.io/blog/ruby/2016/10/11/what-to-do-when-bundle-install-fails-with-json-1-8-1.html