### PR TITLE
Python/Django: Upgrade Django 1.11 to 2.0

### DIFF
--- a/frameworks/Python/django/requirements_py3.txt
+++ b/frameworks/Python/django/requirements_py3.txt
@@ -1,4 +1,4 @@
-Django==1.11.9
+Django==2.0.1
 greenlet==0.4.12
 gunicorn==19.7.1
 meinheld==0.6.1

--- a/frameworks/Python/django/setup_py3.sh
+++ b/frameworks/Python/django/setup_py3.sh
@@ -2,6 +2,6 @@
 
 fw_depends mysql python3
 
-pip3 install --install-option="--prefix=${PY3_ROOT}" -r $TROOT/requirements.txt
+pip3 install --install-option="--prefix=${PY3_ROOT}" -r $TROOT/requirements_py3.txt
 
 gunicorn --pid=gunicorn.pid hello.wsgi:application -c gunicorn_conf.py --env DJANGO_DB=mysql &


### PR DESCRIPTION
* Django 2.0 is py3 only, so split requirements.txt for py2/py3
* Upgrade 1.11.7 to 1.11.9 for good measure
