### PR TITLE
Corrected unsafe character

### DIFF
--- a/toolset/setup/linux/prerequisites.sh
+++ b/toolset/setup/linux/prerequisites.sh
@@ -32,7 +32,7 @@ sudo apt-get -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options:
 
 sudo pip install colorama==0.3.1
 # Version 2.3 has a nice Counter() and other features
-# but it requires —-allow-external and -—allow-unverified
+# but it requires --allow-external and --allow-unverified
 sudo pip install progressbar==2.2
 sudo pip install requests
 


### PR DESCRIPTION
The double dash was apparently converted to a unicode long dash. Although this is in a comment, the mere existence of these characters triggers editors on Windows such as Notepad to insert extra characters at the beginning of file, which breaks the entire script

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
