### PR TITLE
implement retries in wildfly since it has to be transactional

### DIFF
--- a/frameworks/Java/wildfly-ee7/src/main/java/com/techempower/ee7/tests/TestActions.java
+++ b/frameworks/Java/wildfly-ee7/src/main/java/com/techempower/ee7/tests/TestActions.java
@@ -1,0 +1,35 @@
+package com.techempower.ee7.tests;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
+import com.techempower.ee7.model.World;
+import com.techempower.ee7.util.Helpers;
+
+@RequestScoped
+public class TestActions {
+
+    @Inject
+    private EntityManager em;
+
+    @Transactional
+    public List<World> updateWorlds(int iterations) {
+        List<World> worlds = new ArrayList<>(iterations);
+
+        for (int i = 0; i < iterations; i++) {
+            int id = Helpers.randomWorldId();
+            worlds.add(em.find(World.class, id));
+        }
+
+        for (World w : worlds) {
+            w.getRandomNumber(); // Mandatory to read for the test
+            w.setRandomNumber(Helpers.randomWorldId());
+        }
+        return worlds;
+    }
+}

--- a/frameworks/Java/wildfly-ee7/src/main/java/com/techempower/ee7/tests/Updates.java
+++ b/frameworks/Java/wildfly-ee7/src/main/java/com/techempower/ee7/tests/Updates.java
@@ -1,19 +1,13 @@
 package com.techempower.ee7.tests;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
-import javax.transaction.Transactional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-
-import org.jboss.logging.Logger;
 
 import com.techempower.ee7.model.World;
 import com.techempower.ee7.util.Helpers;
@@ -21,39 +15,25 @@ import com.techempower.ee7.util.Helpers;
 @Path("/updates")
 public class Updates {
 
-    private static final Logger log = Logger.getLogger(Updates.class);
-
     private static final int MIN_QUERIES = 1;
     private static final int MAX_QUERIES = 500;
 
     @Inject
-    private EntityManager em;
+    private TestActions actions;
 
-    @Transactional
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public List<World> update(@QueryParam("queries") final String queries) {
         final int iterations = Helpers.boundedIntegerFromNullableString(queries, MIN_QUERIES, MAX_QUERIES);
-
-        List<World> worlds = new ArrayList<>(iterations);
-
-        for (int i = 0; i < iterations; i++) {
-            int id = Helpers.randomWorldId();
-            worlds.add(em.find(World.class, id));
+        int attempts = 0;
+        while (attempts < 10) {
+            try {
+                return actions.updateWorlds(iterations);
+            }
+            catch (Exception e) {
+                attempts++;
+            }
         }
-
-        for (World w : worlds) {
-            w.getRandomNumber(); // Mandatory to read for the test
-            w.setRandomNumber(Helpers.randomWorldId());
-        }
-
-        try {
-            em.flush();
-        }
-        catch (PersistenceException e) {
-            log.info("Failed to flush changes to database.");
-            throw e;
-        }
-        return worlds;
+        throw new RuntimeException(String.format("Unable to update after %s attempts", attempts));
     }
 }


### PR DESCRIPTION
Basically we can't turn transactions off so we should retry when we have db contention rather than reporting thousands of errors like we do each round. Wildfly had 4,484 errors in round 14 for the updates test.