### PR TITLE
[ci fw-only Java/servlet] Add Jackson+Afterburner JSON servlet

### DIFF
--- a/frameworks/Java/servlet/README.md
+++ b/frameworks/Java/servlet/README.md
@@ -6,6 +6,7 @@ This is the Java Servlet portion of a [benchmarking test suite](../) comparing a
 
 * [Plaintext test source](src/main/java/hello/PlaintextServlet.java)
 * [JSON test source](src/main/java/hello/JsonServlet.java)
+* [JSON test source with Jackson Afterburner module](src/main/java/hello/JsonAfterburnerServlet.java)
 
 ### `MySQL` implementation
 
@@ -36,9 +37,13 @@ Please confirm the versions data with the latest install scripts of TFB project.
 
 ## Test URLs
 
-### Default maven profile
+### Default Maven profile
 
  * Plaintext - `http://localhost:8080/servlet/plaintext`
+ * JSON - `http://localhost:8080/servlet/json`
+
+### `afterburner` Maven profile
+
  * JSON - `http://localhost:8080/servlet/json`
 
 ### `mysql` and `postgresql` Maven profiles

--- a/frameworks/Java/servlet/benchmark_config.json
+++ b/frameworks/Java/servlet/benchmark_config.json
@@ -21,6 +21,25 @@
       "notes": "",
       "versus": "servlet"
     },
+    "afterburner": {
+      "setup_file": "setup_afterburner",
+      "json_url": "/servlet/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "None",
+      "language": "Java",
+      "flavor": "None",
+      "orm": "Raw",
+      "platform": "Servlet",
+      "webserver": "Resin",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "servlet",
+      "notes": "Jackson with Afterburner module",
+      "versus": "servlet"
+    },
     "raw": {
       "setup_file": "setup_mysql",
       "db_url": "/servlet/db",

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -12,6 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>1.8</java-version>
 		<cache2k-version>1.0.2.Final</cache2k-version>
+		<jackson-version>2.9.3</jackson-version>
 		<!-- This is the default web.xml for plaintext and json only -->
 		<maven.war.xml>src/main/webapp/WEB-INF/web.xml</maven.war.xml>
 	</properties>
@@ -20,9 +21,15 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.3</version>
+			<version>${jackson-version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-afterburner</artifactId>
+			<version>${jackson-version}</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.taglibs</groupId>
 			<artifactId>taglibs-standard-impl</artifactId>
@@ -60,6 +67,31 @@
 	</dependencies>
 
 	<profiles>
+		<profile>
+			<id>afterburner</id>
+			<properties>
+				<maven.war.xml>src/main/resources/WEB-INF/afterburner/web.xml</maven.war.xml>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-war-plugin</artifactId>
+						<configuration>
+							<webResources>
+								<resource>
+									<directory>src/main/resources/WEB-INF/afterburner</directory>
+									<excludes>
+										<exclude>src/main/resources/WEB-INF/</exclude>
+									</excludes>
+									<targetPath>WEB-INF</targetPath>
+								</resource>
+							</webResources>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>mysql</id>
 			<properties>

--- a/frameworks/Java/servlet/setup_afterburner.sh
+++ b/frameworks/Java/servlet/setup_afterburner.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+fw_depends java resin maven
+
+mvn clean compile war:war -P afterburner
+rm -rf $RESIN_HOME/webapps/*
+cp target/servlet.war $RESIN_HOME/webapps/
+resinctl start

--- a/frameworks/Java/servlet/src/main/java/hello/Common.java
+++ b/frameworks/Java/servlet/src/main/java/hello/Common.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 /**
  * Some common functionality and constants used by the Servlet tests.
@@ -21,8 +22,15 @@ public class Common {
 
 	// Jackson encoder, reused for each response.
 	protected static final ObjectMapper MAPPER = new ObjectMapper();
-	
+	// Jackson encoder with AfterBurner module
+	protected static final ObjectMapper AF_MAPPER = new ObjectMapper().registerModule(new AfterburnerModule());
+
 	private static final String DB_QUERY = "SELECT * FROM world";
+
+	// Response message class.
+	public static class HelloMessage {
+		public final String message = "Hello, World!";
+	}
 	
 	public static int normalise(String param) {
 		int count = 1;

--- a/frameworks/Java/servlet/src/main/java/hello/JsonAfterburnerServlet.java
+++ b/frameworks/Java/servlet/src/main/java/hello/JsonAfterburnerServlet.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
  * JSON Encoding Test
  */
 @SuppressWarnings("serial")
-public class JsonServlet extends HttpServlet {
+public class JsonAfterburnerServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException,
 			IOException {
@@ -19,6 +19,6 @@ public class JsonServlet extends HttpServlet {
 		res.setHeader(Common.HEADER_CONTENT_TYPE, Common.CONTENT_TYPE_JSON);
 
 		// Write JSON encoded message to the response.
-		Common.MAPPER.writeValue(res.getOutputStream(), new Common.HelloMessage());
+		Common.AF_MAPPER.writeValue(res.getOutputStream(), new Common.HelloMessage());
 	}
 }

--- a/frameworks/Java/servlet/src/main/resources/WEB-INF/afterburner/web.xml
+++ b/frameworks/Java/servlet/src/main/resources/WEB-INF/afterburner/web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+	version="2.4">
+	<servlet>
+		<servlet-name>json</servlet-name>
+		<servlet-class>hello.JsonAfterburnerServlet</servlet-class>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>json</servlet-name>
+		<url-pattern>/json</url-pattern>
+	</servlet-mapping>
+</web-app>


### PR DESCRIPTION
This change provides another `json` servlet which is using [Jackson with Afterburner module](https://github.com/FasterXML/jackson-modules-base/blob/master/afterburner/README.md#what-is-optimized) enabled.