### PR TITLE
 Update dependencies, switch to most efficient JSON serializer and tune JVM options

### DIFF
--- a/frameworks/Scala/colossus/build.sbt
+++ b/frameworks/Scala/colossus/build.sbt
@@ -1,14 +1,14 @@
 name := """colossus-example"""
 
-version := "0.3.0"
+version := "0.4.0"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.4"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 mainClass in oneJar := Some("example.Main")
 
 libraryDependencies ++= Seq(
-  "com.tumblr" %% "colossus" % "0.7.1-RC1",
-  "org.json4s" %% "json4s-jackson" % "3.3.0"  
+  "com.tumblr" %% "colossus" % "0.11.0-M4",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "macros" % "0.3.4"
 )

--- a/frameworks/Scala/colossus/setup.sh
+++ b/frameworks/Scala/colossus/setup.sh
@@ -4,4 +4,4 @@ fw_depends java sbt
 
 sbt 'oneJar' -batch
 
-java -jar target/scala-2.11/colossus*one-jar.jar
+java -server -Xms1g -Xmx1g -XX:NewSize=512m -XX:+UseG1GC -XX:MaxGCPauseMillis=30 -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.11/colossus*one-jar.jar

--- a/frameworks/Scala/colossus/setup.sh
+++ b/frameworks/Scala/colossus/setup.sh
@@ -4,4 +4,4 @@ fw_depends java sbt
 
 sbt 'oneJar' -batch
 
-java -server -Xms1g -Xmx1g -XX:NewSize=512m -XX:+UseG1GC -XX:MaxGCPauseMillis=30 -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.11/colossus*one-jar.jar
+java -server -Xms1g -Xmx1g -XX:NewSize=512m -XX:MaxNewSize=512m -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.12/colossus*one-jar.jar

--- a/frameworks/Scala/colossus/src/main/scala/example/Main.scala
+++ b/frameworks/Scala/colossus/src/main/scala/example/Main.scala
@@ -13,7 +13,7 @@ import com.github.plokhotnyuk.jsoniter_scala.macros._
 
 import scala.concurrent.duration.Duration
 
-case class Message(message: String = "Hello, World!")
+case class Message(message: String)
 
 object Main extends App {
   def toHttpBodyEncoder[T](codec: JsonCodec[T]): HttpBodyEncoder[T] = new HttpBodyEncoder[T] {
@@ -41,7 +41,7 @@ object Main extends App {
     override def onConnect: RequestHandlerFactory = serverContext => new RequestHandler(serverContext, serviceConfig) {
       override def handle: PartialHandler[Http] = {
         case req if req.head.url == "/plaintext" => req.ok("Hello, World!")
-        case req if req.head.url == "/json" => req.ok(Message())
+        case req if req.head.url == "/json" => req.ok(Message("Hello, World!"))
       }
     }
   })

--- a/frameworks/Scala/colossus/src/main/scala/example/Main.scala
+++ b/frameworks/Scala/colossus/src/main/scala/example/Main.scala
@@ -1,58 +1,48 @@
 package example
 
-import colossus._
-import colossus.core.{Initializer, Server, ServerRef, ServerSettings}
-import colossus.service._
-import Callback.Implicits._
+import akka.actor.ActorSystem
+import colossus.core._
 import colossus.protocols.http._
+import colossus.service._
+import colossus.service.Callback.Implicits._
+import colossus.service.GenRequestHandler.PartialHandler
+import colossus.util.DataSize
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
 
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
-import org.json4s.JsonDSL._
+import scala.concurrent.duration.Duration
 
-object BenchmarkService {
-
-  implicit object JsonBody extends HttpBodyEncoder[JValue] {
-    val jsonHeader            = HttpHeader("Content-Type", "application/json")
-    def encode(json: JValue)  = new HttpBody(compact(render(json)).getBytes("UTF-8"), Some(jsonHeader))
-  }
-
-  def json: JValue      = ("message" -> "Hello, World!")
-  val plaintext         = HttpBody("Hello, World!")
-  val serverHeader      = HttpHeader("Server", "Colossus")
-
-  def start(port: Int)(implicit io: IOSystem) {
-
-    val serverConfig = ServerSettings(
-      port = port,
-      maxConnections = 16384,
-      tcpBacklogSize = Some(1024)
-    )
-    val serviceConfig = ServiceConfig(
-      requestMetrics = false
-    )
-
-    Server.start("benchmark", serverConfig) { new Initializer(_) {
-
-      val dateHeader = new DateHeader
-      val headers = HttpHeaders(serverHeader, dateHeader)
-
-      def onConnect = ctx => new Service[Http](serviceConfig, ctx){ 
-        def handle = { 
-          case req if (req.head.url == "/plaintext")  => req.ok(plaintext, headers)
-          case req if (req.head.url == "/json")       => req.ok(json, headers)
-        }
-      }
-    }}
-  }
-
-}
-
+case class Message(message: String = "Hello, World!")
 
 object Main extends App {
+  def toHttpBodyEncoder[T](codec: JsonCodec[T]): HttpBodyEncoder[T] = new HttpBodyEncoder[T] {
+    override def encode(data: T): HttpBody = new HttpBody(JsonWriter.write(codec, data))
 
-  implicit val io_system = IOSystem()
+    override def contentType: String = "application/json"
+  }
 
-  BenchmarkService.start(9007)
+  val serverConfig = ServerSettings(
+    port = 9007,
+    maxConnections = 16384,
+    tcpBacklogSize = Some(1024))
+  val serviceConfig = ServiceConfig(
+    logErrors = false,
+    requestMetrics = false,
+    requestTimeout = Duration("1s"),
+    requestBufferSize = 65536,
+    maxRequestSize = DataSize(1024 * 1024))
 
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  implicit val ioSystem: IOSystem = IOSystem()
+  implicit val messageEncoder: HttpBodyEncoder[Message] = toHttpBodyEncoder(make[Message](CodecMakerConfig()))
+
+  HttpServer.start("Colossus", serverConfig)(initContext => new Initializer(initContext) {
+    override def onConnect: RequestHandlerFactory = serverContext => new RequestHandler(serverContext, serviceConfig) {
+      override def handle: PartialHandler[Http] = {
+        case req if req.head.url == "/plaintext" => req.ok("Hello, World!")
+        case req if req.head.url == "/json" => req.ok(Message())
+      }
+    }
+  })
 }


### PR DESCRIPTION
Latest version of Colossus sets Server, Date, Content-Type & Content-Length headers by default.

Plain text request/response:
```
andriy@notebook:~/Projects/com/github/plokhotnyuk/FrameworkBenchmarks/frameworks/Scala/colossus$ curl -v http://localhost:9007/plaintext
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 9007 (#0)
> GET /plaintext HTTP/1.1
> Host: localhost:9007
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< content-type: text/plain
< Date: Sun, 14 Jan 2018 16:58:55 GMT
< Server: Colossus
< Content-Length: 13
< 
* Connection #0 to host localhost left intact
Hello, World!
```

JSON request/response:
```
andriy@notebook:~/Projects/com/github/plokhotnyuk/FrameworkBenchmarks/frameworks/Scala/colossus$ curl -v http://localhost:9007/json
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 9007 (#0)
> GET /json HTTP/1.1
> Host: localhost:9007
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< content-type: application/json
< Date: Sun, 14 Jan 2018 17:06:40 GMT
< Server: Colossus
< Content-Length: 27
< 
* Connection #0 to host localhost left intact
{"message":"Hello, World!"}
```