### PR TITLE
Disable in-memory caching of worlds and fortunes for minijax

### DIFF
--- a/frameworks/Java/minijax/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/minijax/src/main/resources/META-INF/persistence.xml
@@ -1,5 +1,6 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd" version="2.0">
     <persistence-unit name="minijax" transaction-type="RESOURCE_LOCAL">
+        <shared-cache-mode>NONE</shared-cache-mode>
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>com.techempower.minijax.Fortune</class>
         <class>com.techempower.minijax.World</class>


### PR DESCRIPTION
We noticed minijax's multi-query results/sec were 4x higher than any
other framework's.  Testing locally, we saw that the multi-query and
fortunes pages both did not reflect updates made directly in the database
while the application server was running.  In other words, if we changed
the randomNumber of a world or the message of a fortune in the database
directly, the application would keep showing the old randomNumber or
message.

Adding the shared-cache-mode=NONE setting to persistence.xml appears to
fix this issue.