### PR TITLE
[WIP] Install resin with gcc-6 in separate directory and make Java/servlet with MySQL to use it

### DIFF
--- a/frameworks/Java/servlet/benchmark_config.json
+++ b/frameworks/Java/servlet/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "servlet",
   "tests": [{
     "default": {
-      "setup_file": "setup",
+      "setup_file": "setup-resin-gcc-6",
       "json_url": "/servlet/json",
       "plaintext_url": "/servlet/plaintext",
       "port": 8080,

--- a/frameworks/Java/servlet/setup-resin-gcc-6.sh
+++ b/frameworks/Java/servlet/setup-resin-gcc-6.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+fw_depends java resingcc6 maven
+
+mvn clean install
+rm -rf $RESIN_HOME/webapps/*
+cp target/servlet.war $RESIN_HOME/webapps/
+resinctl start

--- a/toolset/setup/linux/webservers/resin/resingcc6.sh
+++ b/toolset/setup/linux/webservers/resin/resingcc6.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+fw_depends java gcc-6
+
+fw_installed resingcc6 && return 0
+
+RVER=4.0.55
+RESIN=resingcc6-$RVER
+RESIN_HOME=$IROOT/$RESIN
+
+fw_get -O http://www.caucho.com/download/resin-$RVER.tar.gz
+fw_untar resin-$RVER.tar.gz
+# We need separate folder so not to clash with the normal resin folder
+mv resin-$RVER resingcc6-$RVER
+cd resingcc6-$RVER
+./configure --prefix=`pwd`
+make
+make install
+
+mv conf/resin.properties conf/resin.properties.orig
+cat $FWROOT/toolset/setup/linux/webservers/resin/resin.properties > conf/resin.properties
+
+mv conf/resin.xml conf/resin.xml.orig
+cat $FWROOT/toolset/setup/linux/webservers/resin/resin.xml > conf/resin.xml
+
+echo "export RESIN_HOME=${RESIN_HOME}" > $IROOT/resingcc6.installed
+echo -e "export PATH=\$RESIN_HOME/bin:\$PATH" >> $IROOT/resingcc6.installed
+
+source $IROOT/resingcc6.installed


### PR DESCRIPTION
I'm curious if the recompilation of the native parts of the Resin server with `gcc 6` will improve performance. I've played a little with the JSON test only. I see small improvements of the average response time compared to the default `gcc 4.8`. The throughput is almost the same.

Could TFB team provide a sample result for the JSON test of this PR and some recent numbers from the `master` branch:
```
vagrant@tfb-all:~$ tfb --mode benchmark --type json --test servlet
```
Of course if the time and resources allow it.

Considerations:
`Resin` is used from several frameworks and I don't want to hit their performance.