### PR TITLE
To remove locale errors/warnings

### DIFF
--- a/deployment/vagrant/Vagrantfile
+++ b/deployment/vagrant/Vagrantfile
@@ -5,6 +5,8 @@ require_relative 'core'
 
 Vagrant.configure("2") do |config|
 
+  ENV['LC_ALL']="en_US.UTF-8"
+
   config.vm.provision :file do |file|
       file.source = "custom_motd.sh"
       file.destination = "~/.custom_motd.sh"


### PR DESCRIPTION
Without the line, Vagrant takes hosts locale settings. And as VM does not build its missing locales. Then it gives out errors and warnings.
That line should unify Vagrant environment more.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
