### PR TITLE
Use OpenJDK instead of the Oracle JDK

### DIFF
--- a/frameworks/Java/restexpress/benchmark_config.json
+++ b/frameworks/Java/restexpress/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "restexpress",
   "tests": [{
     "default": {
-      "setup_file": "setup_mongodb",
+      "setup_file": "setup",
       "json_url": "/restexpress/json",
       "plaintext_url": "/restexpress/plaintext",
       "db_url": "/restexpress/mongodb",
@@ -24,7 +24,7 @@
       "versus": "netty"
     },
     "mysql-raw": {
-      "setup_file": "setup_mysql",
+      "setup_file": "setup",
       "db_url": "/restexpress/mysql",
       "query_url": "/restexpress/mysql?queries=",
       "port": 8080,

--- a/frameworks/Java/restexpress/setup.sh
+++ b/frameworks/Java/restexpress/setup.sh
@@ -3,7 +3,7 @@
 sed -i 's|mongodb://.*/hello_world|mongodb://'"${DBHOST}"'/hello_world|g' config/dev/environment.properties
 sed -i 's|mysql://.*:3306|mysql://'"${DBHOST}"':3306|g' config/dev/environment.properties
 
-fw_depends java maven
+fw_depends java maven mysql mongodb
 
 mvn clean package
 mvn assembly:single

--- a/frameworks/Java/restexpress/setup_mongodb.sh
+++ b/frameworks/Java/restexpress/setup_mongodb.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mongodb
-
-source ./setup.sh

--- a/frameworks/Java/restexpress/setup_mysql.sh
+++ b/frameworks/Java/restexpress/setup_mysql.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-fw_depends mysql
-
-source ./setup.sh

--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -3,13 +3,12 @@
 fw_installed java && return 0
 
 # TODO: Someday get away from apt-get
-sudo add-apt-repository -y ppa:webupd8team/java
+sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get update
-echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y oracle-java8-installer
+sudo apt-get install openjdk-8-jdk
 
 # Setup environment variables
-JAVA_HOME=/usr/lib/jvm/java-8-oracle
+JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 echo "export JAVA_HOME=${JAVA_HOME}" > $IROOT/java.installed
 echo -e "export PATH=\$JAVA_HOME/bin:\$PATH" >> $IROOT/java.installed
 

--- a/toolset/setup/linux/languages/java.sh
+++ b/toolset/setup/linux/languages/java.sh
@@ -7,6 +7,9 @@ sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get update
 sudo apt-get install openjdk-8-jdk
 
+# https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1396760
+sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
 # Setup environment variables
 JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 echo "export JAVA_HOME=${JAVA_HOME}" > $IROOT/java.installed


### PR DESCRIPTION
Please let Travis run the entire test suite on this one.

---

The oracle-java8-installer package is currently failing with a 404 error.
We found workarounds to fix the installer but they seem more complicated
than using OpenJDK instead.

We don't think that anything in TFB actually depends on something that's
in the Oracle JDK and not in OpenJDK such that test implementations would
start to fail.  If there are test implementations like that, we should
probably fix them so that they aren't like that.

We're asserting that there will be no difference in performance.

Looking ahead to the future, Oracle provides OpenJDK 9 in .tar.gz form
(at http://jdk.java.net/9/), which we would prefer to use instead of apt.
We're going to upgrade Java versions eventually, so we'd probably switch
to OpenJDK then for the .tar.gz convenience even if we didn't switch now.