### PR TITLE
Upgrade ktor version and add "Coroutine IO" (CIO) engine variant

### DIFF
--- a/frameworks/Kotlin/ktor/README.md
+++ b/frameworks/Kotlin/ktor/README.md
@@ -1,3 +1,8 @@
+# Ktor
+
+Ktor is a framework for building servers and clients in connected systems using Kotlin programming language.
+More information is available at [ktor.io](http://ktor.io). 
+
 # Setup
 
 * Java 8

--- a/frameworks/Kotlin/ktor/benchmark_config.json
+++ b/frameworks/Kotlin/ktor/benchmark_config.json
@@ -49,6 +49,30 @@
         "display_name": "ktor-jetty",
         "notes": "http://ktor.io/",
         "versus": "servlet"
+      },
+      "cio": {
+        "plaintext_url": "/plaintext",
+        "json_url": "/json",
+        "db_url": "/db",
+        "query_url": "/db?queries=",
+        "update_url": "/updates?queries=",
+        "fortune_url": "/fortunes",
+
+        "port": 9090,
+        "setup_file": "setup-cio",
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "MySQL",
+        "framework": "ktor",
+        "language": "Kotlin",
+        "orm": "Raw",
+        "platform": "ktor",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "ktor-cio",
+        "notes": "http://ktor.io/",
+        "versus": ""
       }
     }
   ]

--- a/frameworks/Kotlin/ktor/pom.xml
+++ b/frameworks/Kotlin/ktor/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gson.version>2.8.2</gson.version>
         <hikaricp.version>2.7.4</hikaricp.version>
-        <kotlin.version>1.2.0</kotlin.version>
-        <ktor.version>0.9.0</ktor.version>
+        <kotlin.version>1.2.21</kotlin.version>
+        <ktor.version>0.9.1-alpha-10</ktor.version>
         <logback.version>1.2.3</logback.version>
         <mysql-connector.version>5.1.44</mysql-connector.version>
     </properties>
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
@@ -39,12 +39,17 @@
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-html-builder</artifactId>
+            <artifactId>ktor-server-jetty</artifactId>
             <version>${ktor.version}</version>
         </dependency>
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-jetty</artifactId>
+            <artifactId>ktor-server-cio</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-html-builder</artifactId>
             <version>${ktor.version}</version>
         </dependency>
         <dependency>
@@ -71,7 +76,6 @@
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
 
         <plugins>
             <plugin>
@@ -86,8 +90,8 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <languageVersion>1.1</languageVersion>
-                            <apiVersion>1.1</apiVersion>
+                            <languageVersion>1.2</languageVersion>
+                            <apiVersion>1.2</apiVersion>
                             <args>
                                 <arg>-Xcoroutines=enable</arg>
                             </args>
@@ -119,6 +123,25 @@
                 <version>3.0.0</version>
 
                 <executions>
+                    <execution>
+                        <id>cio</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+
+                        <phase>package</phase>
+
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/cio-bundle.xml</descriptor>
+                            </descriptors>
+                            <archive>
+                                <manifest>
+                                    <mainClass>io.ktor.server.cio.DevelopmentEngine</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>netty</id>
                         <goals>

--- a/frameworks/Kotlin/ktor/setup-cio.sh
+++ b/frameworks/Kotlin/ktor/setup-cio.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+fw_depends mysql java maven
+
+./mvnw clean package
+nohup java -jar target/tech-empower-framework-benchmark-1.0-SNAPSHOT-cio-bundle.jar &
+

--- a/frameworks/Kotlin/ktor/src/main/assembly/cio-bundle.xml
+++ b/frameworks/Kotlin/ktor/src/main/assembly/cio-bundle.xml
@@ -1,7 +1,6 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-    <id>netty-bundle</id>
-
+    <id>cio-bundle</id>
     <formats>
         <format>jar</format>
     </formats>
@@ -13,9 +12,11 @@
             <unpack>true</unpack>
             <scope>runtime</scope>
 
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+
             <excludes>
+                <exclude>*:ktor-server-netty</exclude>
                 <exclude>*:ktor-server-jetty</exclude>
-                <exclude>*:ktor-server-cio</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/frameworks/Kotlin/ktor/src/main/assembly/jetty-bundle.xml
+++ b/frameworks/Kotlin/ktor/src/main/assembly/jetty-bundle.xml
@@ -16,6 +16,7 @@
 
             <excludes>
                 <exclude>*:ktor-server-netty</exclude>
+                <exclude>*:ktor-server-cio</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/frameworks/Kotlin/ktor/src/main/kotlin/org/jetbrains/ktor/benchmarks/Hello.kt
+++ b/frameworks/Kotlin/ktor/src/main/kotlin/org/jetbrains/ktor/benchmarks/Hello.kt
@@ -36,10 +36,9 @@ fun Application.main() {
 
     install(DefaultHeaders)
 
-    val okContent = TextContent("Hello, World!", ContentType.Text.Plain, HttpStatusCode.OK).also { it.contentLength() }
+    val okContent = TextContent("Hello, World!", ContentType.Text.Plain, HttpStatusCode.OK).also { it.contentLength }
 
     routing {
-
         get("/plaintext") {
             call.respond(okContent)
         }
@@ -50,7 +49,7 @@ fun Application.main() {
         }
 
         get("/db") {
-            val response = run(databaseDispatcher) {
+            val response = withContext(databaseDispatcher) {
                 pool.connection.use { connection ->
                     val random = ThreadLocalRandom.current()
                     val queries = call.queries()
@@ -80,7 +79,7 @@ fun Application.main() {
 
         get("/fortunes") {
             val result = mutableListOf<Fortune>()
-            run(databaseDispatcher) {
+            withContext(databaseDispatcher) {
                 pool.connection.use { connection ->
                     connection.prepareStatement("select id, message from fortune").use { statement ->
                         statement.executeQuery().use { rs ->
@@ -114,7 +113,7 @@ fun Application.main() {
         }
 
         get("/updates") {
-            val t = run(databaseDispatcher) {
+            val t = withContext(databaseDispatcher) {
                 pool.connection.use { connection ->
                     val queries = call.queries()
                     val random = ThreadLocalRandom.current()

--- a/frameworks/Kotlin/ktor/src/main/resources/application.conf
+++ b/frameworks/Kotlin/ktor/src/main/resources/application.conf
@@ -3,6 +3,7 @@ ktor {
         port = 9090
         autoreload = false
         watch = [ ]
+        shareWorkGroup = true
     }
 
     application {


### PR DESCRIPTION
Ktor framework received new engine based on Kotlin Coroutines I/O (CIO) in addition to Jetty and Netty. This PR adds new variant to the benchmark, and updates relevant versions (to -alpha- because we are pretty sure it should work fine, but didn't have a proper release yet due to documentation and other similar work pending). Hope there is still a chance to fit into Round 15 :)