### PR TITLE
Avoid using sudo in the cppcms-cppdb installation

### DIFF
--- a/toolset/setup/linux/frameworks/cppcms-cppdb.sh
+++ b/toolset/setup/linux/frameworks/cppcms-cppdb.sh
@@ -23,7 +23,7 @@ cmake -DCMAKE_INSTALL_PREFIX=${CPPDBROOT} ..
 
 make
 #make test
-sudo make install
+make install
 #make clean
 
 


### PR DESCRIPTION
Using sudo here is unnecessary (apparently, given that all the cppcms
tests pass without it locally) and it creates root-owned files in the
installs directory, which is something we generally try to avoid.