### PR TITLE
Fix the database host name for vertx-web

### DIFF
--- a/frameworks/Java/vertx-web/setup.sh
+++ b/frameworks/Java/vertx-web/setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-sed -i 's|localhost|'"${DBHOST}"'|g' src/main/conf/config.json
-
 fw_depends java maven
 
 mvn clean package

--- a/frameworks/Java/vertx-web/src/main/conf/config.json
+++ b/frameworks/Java/vertx-web/src/main/conf/config.json
@@ -1,8 +1,8 @@
 {
-  "connection_string": "mongodb://127.0.0.1:27017",
+  "connection_string": "mongodb://TFB-database:27017",
   "db_name": "hello_world",
 
-  "host": "127.0.0.1",
+  "host": "TFB-database",
   "username": "benchmarkdbuser",
   "password": "benchmarkdbpass",
   "database": "hello_world",


### PR DESCRIPTION
The setup script was trying to replace "localhost" with the IP of the
actual database server, but it wasn't doing anything because the config
file had "127.0.0.1", not "localhost".  But there's no need to do any
replacing; the "TFB-database" name exists for exactly this purpose.

In local testing, this change fixes all the database-related tests for
vertx-web.