### PR TITLE
Try to fix valum test timeout

### DIFF
--- a/frameworks/Vala/valum/app.vala
+++ b/frameworks/Vala/valum/app.vala
@@ -3,32 +3,29 @@ using Valum;
 using Valum.ContentNegotiation;
 using VSGI;
 
-int main (string[] args)
-{
-	var app = new Router ();
+var app = new Router ();
 
-	app.use ((req, res, next) => {
-		res.headers.replace ("Server", "VSGI/0.3");
-		return next ();
-	});
+app.use ((req, res, next) => {
+	res.headers.replace ("Server", "VSGI/0.3");
+	return next ();
+});
 
-	app.get ("/plaintext", accept ("text/plain", (req, res) => {
-		return res.expand ("Hello, World!".data);
-	}));
+app.get ("/plaintext", accept ("text/plain", (req, res) => {
+	return res.expand ("Hello, World!".data);
+}));
 
-	app.get ("/json", accept ("application/json", (req, res, next, stack) => {
-		var builder = new Json.Builder ();
+app.get ("/json", accept ("application/json", (req, res, next, stack) => {
+	var builder = new Json.Builder ();
 
-		builder.begin_object ();
-		builder.set_member_name ("message");
-		builder.add_string_value ("Hello, World!");
-		builder.end_object ();
+	builder.begin_object ();
+	builder.set_member_name ("message");
+	builder.add_string_value ("Hello, World!");
+	builder.end_object ();
 
-		var gen = new Json.Generator ();
-		gen.root = builder.get_root ();
+	var gen = new Json.Generator ();
+	gen.root = builder.get_root ();
 
-		return res.expand (gen.to_data (null).data);
-	}));
+	return res.expand (gen.to_data (null).data);
+}));
 
-	return Server.@new ("http", handler: app).run (args);
-}
+Server.@new ("http", handler: app).run ();


### PR DESCRIPTION
In the most recent run on ServerCentral, valum had this error message in
the "completed" map of results.json:

  __run_test timeout (=7200 seconds)

When I ran it locally, it would pause strangely.  For example, when
verifying the JSON output, I would see this in the console:

  Accessing URL http://TFB-server:3003/json:
  Response (trimmed to 40 bytes): "{"message":"Hello, World!"}"

...but then it would stop there and nothing else would be printed.  If
I ran "curl localhost:3003" in another ssh tab, it would un-pause the
test and proceed the next one, where it would stop again.

I have no explanation for what was going on there, but I assume the same
thing was responsible for the timeouts on ServerCentral.

I noticed that the valum implementation code wrapped everything in an
"int main" function whereas none of the examples on the valum GitHub
repository did that.  Removing that wrapping function caused the weird
pauses to go away, making valum pass all the tests locally.