### PR TITLE
Increase the amount of time we wait for stopped tests to die

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -670,7 +670,7 @@ class Benchmarker:
             slept = 0
             returnCode = None
             # Check once a second to see if TFBReaper has exited
-            while(slept < 30 and returnCode is None):
+            while(slept < 300 and returnCode is None):
                 time.sleep(1)
                 slept += 1
                 returnCode = self.__process.poll()


### PR DESCRIPTION
At the current number, many PHP frameworks don't get shut down completely
before the toolset gives up and prints an error message.  These error
messages are very alarming because they make it look like a port like
port 8080 isn't being released.

The new, higher number was enough to not see that error message in a
test on ServerCentral with cakephp.  Hopefully that means it's high
enough for the rest of the PHP frameworks.