### PR TITLE
Haskell/yesod use lowercase collection for postgres update

### DIFF
--- a/frameworks/Haskell/yesod/yesod-postgres/src/Main.hs
+++ b/frameworks/Haskell/yesod/yesod-postgres/src/Main.hs
@@ -40,7 +40,7 @@ import           Yesod
 import Data.Maybe (fromJust)
 
 mkPersist sqlSettings { mpsGeneric = True } [persistLowerCase|
-World sql=World
+World sql=world
     randomNumber Int sql=randomnumber
 |]
 


### PR DESCRIPTION
yesod-postgres was the only haskell test not passing the update verification in #3210 