### PR TITLE
Don't restrict facil.io requests to the app server

### DIFF
--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -23,6 +23,6 @@ make -j build
 
 # run test
 cd tmp
-./demo -b TFB-server -p 8080 -db "TFB-database" -w -1 -t 1 &
+./demo -b 0.0.0.0 -p 8080 -db "TFB-database" -w -1 -t 1 &
 # step out
 cd ../..


### PR DESCRIPTION
It was not accepting requests from a client running on a different server
so it was failing the tests in a 3 machine benchmarking setup.