### PR TITLE
Fix silicon json test output, fix to fix new installations

### DIFF
--- a/frameworks/C++/silicon/techempower.hh
+++ b/frameworks/C++/silicon/techempower.hh
@@ -45,7 +45,7 @@ auto techempower_api = http_api(
                                        _body = string_ref("Hello, World!")); },
 
   GET / _json = [] () { return response(_content_type = string_ref("application/json"),
-                                  _body = D(_message = string_ref("Hello, World!"))); },
+                                  _body = D(_message = "Hello, World!")); },
                         
   GET / _db = [] (rn_orm& orm) {
     random_number r;

--- a/toolset/setup/linux/frameworks/silicon.sh
+++ b/toolset/setup/linux/frameworks/silicon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-fw_depends libboost-dev clang-3.9 gcc-4.9
+fw_depends libboost-dev clang-3.9 gcc-6
 
 fw_installed silicon && return 0
 


### PR DESCRIPTION
The output from silicon's json endpoint was missing quotes around a
value, so it was failing the tests:

  {"message":Hello, World!}

I changed the code to look more like the hello world example on the
silicon website, and that made it pass tests locally.
http://siliconframework.org/docs/hello_world.html

Before I could do that, I had to tweak the silicon installer to depend
on a later version of gcc, or else the silicon installer would fail and
so would all of the test types.