### PR TITLE
Downgrade hhvm from 3.24 to 3.21 to fix segfaults

### DIFF
--- a/toolset/setup/linux/languages/hhvm.sh
+++ b/toolset/setup/linux/languages/hhvm.sh
@@ -3,8 +3,19 @@
 fw_installed hhvm && return 0
 
 # TODO: Someday move away from apt-get
+
+# Uninstall hhvm if it was previously installed.
+if [ $(dpkg-query -W -f='${Status}' hhvm 2>/dev/null | grep -c "ok installed") -eq 1 ];
+then
+  sudo apt-get remove -y hhvm
+fi
+
 fw_get http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
-echo deb [arch=amd64] http://dl.hhvm.com/ubuntu `lsb_release -sc` main | sudo tee /etc/apt/sources.list.d/hhvm.list
+
+# hhvm 3.24 causes most of our hhvm-using test implementations to segmentation
+# fault when connecting to the mysql database (the crash happens right as they
+# try to specify utf8 as the charset).  hhvm 3.21 doesn't have this problem.
+echo deb [arch=amd64] http://dl.hhvm.com/ubuntu `lsb_release -sc`-lts-3.21 main | sudo tee /etc/apt/sources.list.d/hhvm.list
 sudo apt-get update
 sudo apt-get install -y hhvm
 


### PR DESCRIPTION
This should fix the hhvm variants of codeigniter, yii2, and laravel.

In commit 903997f3be7dbe3c2fba93accbcb0023063c1167 I worked around this
segfault for the no-framework hhvm tests by removing a "SET NAMES"
command we were issuing to MySQL and by specifying utf8 as the charset a
different way.  For these other frameworks though, the same strategy
isn't viable because the call to set the charset is happening deep in the
frameworks themselves, not in our test implementation code.