### PR TITLE
Try to fix workerman by upgrading libpcre3

### DIFF
--- a/frameworks/PHP/workerman/setup.sh
+++ b/frameworks/PHP/workerman/setup.sh
@@ -3,7 +3,7 @@
 fw_depends mysql
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get update
-sudo apt-get -y --force-yes install php-cli php-mysql
+sudo apt-get -y --force-yes install php-cli php-mysql libpcre3
 sudo add-apt-repository -y --remove ppa:ondrej/php
 php -r 'file_put_contents("composer.phar", file_get_contents("https://getcomposer.org/composer.phar"));'
 php composer.phar update


### PR DESCRIPTION
Without this change, we're seeing an error running workerman's setup file
like this, which causes the workerman tests to fail:

```
  Setup workerman: php: symbol lookup error: php: undefined symbol: pcre_jit_exec
  Setup workerman: Setup has terminated
  Setup workerman: Status: Poll: 0, Port 8080 bound: False, Time Left: 1:43:28.886132
  Setup workerman: setup.sh process exited naturally with 0
```

This GitHub issue and comment suggest that upgrading libpcre3 fixes the
problem:

  https://github.com/oerdnj/deb.sury.org/issues/683#issuecomment-325576448

And that does cause the workerman tests to pass locally.