### PR TITLE
Always use "resinctl console" instead of "resinctl start"

### DIFF
--- a/frameworks/Clojure/compojure/setup.sh
+++ b/frameworks/Clojure/compojure/setup.sh
@@ -7,4 +7,4 @@ lein clean
 lein ring uberwar
 rm -rf $RESIN_HOME/webapps/*
 cp target/hello-compojure-standalone.war $RESIN_HOME/webapps/compojure.war
-resinctl start
+resinctl console

--- a/frameworks/Groovy/grails/setup.sh
+++ b/frameworks/Groovy/grails/setup.sh
@@ -8,4 +8,4 @@ grails -Dgrails.work.dir=${IROOT}/.grails -non-interactive -plain-output compile
 grails -Dgrails.work.dir=${IROOT}/.grails prod -non-interactive -plain-output war
 rm -rf $RESIN_HOME/webapps/*
 cp target/hello-0.1.war $RESIN_HOME/webapps/grails.war
-resinctl start
+resinctl console

--- a/frameworks/Java/activeweb/setup.sh
+++ b/frameworks/Java/activeweb/setup.sh
@@ -7,4 +7,4 @@ mvn clean package -DskipTests
 
 rm -rf $RESIN_HOME/webapps/*
 cp target/activeweb.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/curacao/setup.sh
+++ b/frameworks/Java/curacao/setup.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven
 mvn clean compile war:war
 rm -rf $RESIN_HOME/webapps/*
 cp target/curacao.war $RESIN_HOME/webapps
-$RESIN_HOME/bin/resinctl start
+$RESIN_HOME/bin/resinctl console

--- a/frameworks/Java/gemini/start_postgresql.sh
+++ b/frameworks/Java/gemini/start_postgresql.sh
@@ -9,4 +9,4 @@ sed -i 's|db.Driver.UrlPrefix = .*|db.Driver.UrlPrefix = jdbc:postgresql://|g' D
 mkdir -p Docroot/WEB-INF/classes
 ant resolve
 ant compile
-resinctl -conf $TROOT/Docroot/WEB-INF/resin.xml start
+resinctl -conf $TROOT/Docroot/WEB-INF/resin.xml console

--- a/frameworks/Java/revenj-jvm/setup.sh
+++ b/frameworks/Java/revenj-jvm/setup.sh
@@ -10,4 +10,4 @@ cat $TROOT/web.xml | sed 's/localhost/'$DBHOST'/g' > $TROOT/src/main/webapp/WEB-
 mvn clean compile war:war
 rm -rf $RESIN_HOME/webapps/*
 cp target/revenj.war $RESIN_HOME/webapps/
-JAVA_EXE=$JAVA_HOME/bin/java resinctl start
+JAVA_EXE=$JAVA_HOME/bin/java resinctl console

--- a/frameworks/Java/servlet/setup.sh
+++ b/frameworks/Java/servlet/setup.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven
 mvn clean install
 rm -rf $RESIN_HOME/webapps/*
 cp target/servlet.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/servlet/setup_afterburner.sh
+++ b/frameworks/Java/servlet/setup_afterburner.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven
 mvn clean compile war:war -P afterburner
 rm -rf $RESIN_HOME/webapps/*
 cp target/servlet.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/servlet/setup_cjs.sh
+++ b/frameworks/Java/servlet/setup_cjs.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven
 mvn clean compile war:war -P cjs
 rm -rf $RESIN_HOME/webapps/*
 cp target/servlet.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/servlet/setup_mysql.sh
+++ b/frameworks/Java/servlet/setup_mysql.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven mysql
 mvn clean compile war:war -P mysql
 rm -rf $RESIN_HOME/webapps/*
 cp target/servlet.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/servlet/setup_postgresql.sh
+++ b/frameworks/Java/servlet/setup_postgresql.sh
@@ -5,4 +5,4 @@ fw_depends java resin maven postgresql
 mvn clean compile war:war -P postgresql
 rm -rf $RESIN_HOME/webapps/*
 cp target/servlet.war $RESIN_HOME/webapps/
-resinctl start
+resinctl console

--- a/frameworks/Java/spark/setup.sh
+++ b/frameworks/Java/spark/setup.sh
@@ -7,4 +7,4 @@ fw_depends mysql java resin maven
 mvn clean package -Ddb-host=${DBHOST}
 rm -rf $RESIN_HOME/webapps/*
 cp target/spark.war $RESIN_HOME/webapps/spark.war
-resinctl start
+resinctl console

--- a/frameworks/Java/tapestry/setup.sh
+++ b/frameworks/Java/tapestry/setup.sh
@@ -6,4 +6,4 @@ cd hello
 mvn clean compile war:war
 rm -rf $RESIN_HOME/webapps/*
 cp target/tapestry.war $RESIN_HOME/webapps/tapestry.war
-resinctl start
+resinctl console

--- a/frameworks/Java/wicket/setup.sh
+++ b/frameworks/Java/wicket/setup.sh
@@ -7,4 +7,4 @@ sed -i 's|localhost|'${DBHOST}'|g' src/main/java/hellowicket/WicketApplication.j
 mvn clean compile war:war
 rm -rf $RESIN_HOME/webapps/*
 cp target/hellowicket-*.war $RESIN_HOME/webapps/wicket.war
-resinctl start
+resinctl console

--- a/frameworks/Kotlin/hexagon/setup_resin_mongodb.sh
+++ b/frameworks/Kotlin/hexagon/setup_resin_mongodb.sh
@@ -9,5 +9,5 @@ export WEBENGINE='resin'
 
 rm -rf $RESIN_HOME/webapps/*
 cp build/libs/ROOT.war $RESIN_HOME/webapps
-resinctl start
+resinctl console
 

--- a/frameworks/Kotlin/hexagon/setup_resin_postgresql.sh
+++ b/frameworks/Kotlin/hexagon/setup_resin_postgresql.sh
@@ -9,5 +9,5 @@ export WEBENGINE='resin'
 
 rm -rf $RESIN_HOME/webapps/*
 cp build/libs/ROOT.war $RESIN_HOME/webapps
-resinctl start
+resinctl console
 


### PR DESCRIPTION
I did this for one permutation of Gemin in commit
b67c6e04dba5b99da572ca28bfaeee093f75e3ea, but the same reasoning applies
everywhere, I think.  "console" will result in the application's
standard output being captured in TFB's log files, whereas "start" will
result in no useful output at all.