### PR TITLE
Updated facil.io version (fixes for Cluster mode)

### DIFF
--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -3,18 +3,25 @@
 # enter root folder
 cd $TROOT
 
-if ! [ -d facil_app ] ; then
-	mkdir facil_app
-	cd facil_app
-	curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/v.0.6.0.beta
-	tar --strip-components=1 -xzf facil.io.tar.gz
-	if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
-	rm facil.io.tar.gz
-	./scripts/new/cleanup
-	cd ..
+# remove existing installation, if any
+if [ -d facil_app ] ; then
+	rm -R facil_app
 fi
 
-# recompile test
+# create new installation folder
+mkdir facil_app
+cd facil_app
+
+# Download and unpack
+curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/v.0.6.0.beta.2
+tar --strip-components=1 -xzf facil.io.tar.gz
+if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
+rm facil.io.tar.gz
+./scripts/new/cleanup
+cd ..
+
+
+# compile test
 rm -r facil_app/src
 mkdir facil_app/src
 cp bench_app.c facil_app/src


### PR DESCRIPTION
Reviewing the benchmarking testing logs exposed the fact that facil.io detected 80 CPU cores on the host machine (?!)… which invoked 80 forks in facil.io's cluster mode.

This large number of forks was never attempted before and it exposed a number of issues which were fixed in the beta.2 release.

This release also includes other minor updates and fixes which are probably irrelevant (such as updates to the pub/sub layer and a fix for the Redis engine etc’).