### PR TITLE
Perl/dancer query fix

### DIFF
--- a/frameworks/Perl/dancer/app.pl
+++ b/frameworks/Perl/dancer/app.pl
@@ -9,7 +9,7 @@ use JSON::XS;  # Ensure that the fast implementation of the serializer is instal
 set serializer => 'JSON';
 
 my $dsn = "dbi:mysql:database=hello_world;host=TFB-database;port=3306";
-my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass', {} );
+my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass', { mysql_auto_reconnect=>1 } );
 my $sth = $dbh->prepare("SELECT * FROM World where id = ?");
 
 get '/json' => sub {


### PR DESCRIPTION
The MySQL connection is dropping between the db and query tests causing query tests to fail. Adding `mysql_auto_reconnect` option to the connection string fixes this.