### PR TITLE
[ci fw-only Java/servlet] Fix cache_query implementation to return the requested number of results

### DIFF
--- a/frameworks/Java/servlet/src/main/java/hello/Cache2kPostgresServlet.java
+++ b/frameworks/Java/servlet/src/main/java/hello/Cache2kPostgresServlet.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -60,8 +59,8 @@ public class Cache2kPostgresServlet extends HttpServlet {
 			IOException {
 		final int count = Common.normalise(req.getParameter("queries"));
 		final int start = ThreadLocalRandom.current().nextInt(DB_ROWS);
-		Set<Integer> keys = IntStream.range(start, start + count)
-				.mapToObj(i -> randomNumbers.get(i)).collect(Collectors.toSet());
+		List<Integer> keys = IntStream.range(start, start + count)
+				.mapToObj(i -> randomNumbers.get(i)).collect(Collectors.toList());
 
 		// Set content type to JSON
 		res.setHeader(Common.HEADER_CONTENT_TYPE, Common.CONTENT_TYPE_JSON);

--- a/frameworks/Java/servlet/src/main/java/hello/Cache2kPostgresServlet.java
+++ b/frameworks/Java/servlet/src/main/java/hello/Cache2kPostgresServlet.java
@@ -1,14 +1,24 @@
 package hello;
 
-import java.io.*;
-import java.sql.*;
-import java.util.*;
-import java.util.concurrent.*;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import javax.annotation.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
-import javax.sql.*;
+import javax.annotation.Resource;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
 
 import org.cache2k.Cache;
 import org.cache2k.Cache2kBuilder;
@@ -20,7 +30,8 @@ import org.cache2k.Cache2kBuilder;
 public class Cache2kPostgresServlet extends HttpServlet {
 	// Database details.
 	private static final int DB_ROWS = 10000;
-	
+	private CircularList<Integer> randomNumbers;
+
 	// Database connection pool.
 	@Resource(name = "jdbc/hello_world")
 	private DataSource dataSource;
@@ -29,6 +40,7 @@ public class Cache2kPostgresServlet extends HttpServlet {
 	@Override
 	public void init(ServletConfig config) throws ServletException {
 		super.init(config);
+		randomNumbers = new CircularList<>(shuffledNumbers(DB_ROWS));
 
 		Map<Integer, CachedWorld> worlds;
 		try {
@@ -36,13 +48,10 @@ public class Cache2kPostgresServlet extends HttpServlet {
 		} catch (SQLException e) {
 			throw new ServletException(e);
 		}
-		
+
 		// Build the cache
-		cache = new Cache2kBuilder<Integer, CachedWorld>() {}
-		    .name("cachedWorld")
-		    .eternal(true)
-		    .entryCapacity(DB_ROWS)
-		    .build();
+		cache = new Cache2kBuilder<Integer, CachedWorld>() {
+		}.name("cachedWorld").eternal(true).entryCapacity(DB_ROWS).build();
 		cache.putAll(worlds);
 	}
 
@@ -50,18 +59,32 @@ public class Cache2kPostgresServlet extends HttpServlet {
 	protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException,
 			IOException {
 		final int count = Common.normalise(req.getParameter("queries"));
-		final Random random = ThreadLocalRandom.current();
+		final int start = ThreadLocalRandom.current().nextInt(DB_ROWS);
+		Set<Integer> keys = IntStream.range(start, start + count)
+				.mapToObj(i -> randomNumbers.get(i)).collect(Collectors.toSet());
 
-		//TODO prevent duplicate numbers to be added
-		List<Integer> keys = new ArrayList<Integer>(count);
-		for (int i = 0; i < count; i++) {
-			keys.add(new Integer(random.nextInt(DB_ROWS) + 1));
-		}
-		
 		// Set content type to JSON
 		res.setHeader(Common.HEADER_CONTENT_TYPE, Common.CONTENT_TYPE_JSON);
 
 		// Write JSON encoded message to the response.
 		Common.MAPPER.writeValue(res.getOutputStream(), cache.getAll(keys).values());
+	}
+
+	private List<Integer> shuffledNumbers(int size) {
+		List<Integer> buffer = IntStream.rangeClosed(1, size).boxed().collect(Collectors.toList());
+		Collections.shuffle(buffer, ThreadLocalRandom.current());
+		return buffer;
+	}
+
+	// Credits here: https://stackoverflow.com/questions/18659792/circular-arraylist-extending-arraylist#18659966
+	private class CircularList<E> extends ArrayList<E> {
+		public CircularList(Collection<? extends E> arg0) {
+			super(arg0);
+		}
+
+		@Override
+		public E get(int index) {
+			return super.get(index % size());
+		}
 	}
 }


### PR DESCRIPTION
I'm really trying to use the `mass retrieve` operation of the cache implementation. I need a non-repeated keys for this.
The explanation:
1. Generate all the numbers from 1 to 10000 when starting;
1. Shuffle them;
1. Store the result in a custom `ArrayList` which allows the reads of indexes past the end to read data from the begging;
1. When a request comes choose a random start element and read the requested number of keys - wrapping around at the end.