### PR TITLE
Update amber version

### DIFF
--- a/frameworks/Crystal/amber/shard.lock
+++ b/frameworks/Crystal/amber/shard.lock
@@ -2,7 +2,7 @@ version: 1.0
 shards:
   amber:
     github: amberframework/amber
-    version: 0.6.4
+    version: 0.6.5
 
   callback:
     github: mosop/callback
@@ -18,7 +18,7 @@ shards:
 
   granite_orm:
     github: amberframework/granite-orm
-    version: 0.8.2
+    version: 0.8.4
 
   kilt:
     github: jeromegn/kilt
@@ -54,7 +54,7 @@ shards:
 
   slang:
     github: jeromegn/slang
-    commit: 777e2fc3e63daf5cfe9bd4475257905903b78542
+    version: 1.7.1
 
   spinner:
     github: askn/spinner

--- a/frameworks/Crystal/amber/shard.yml
+++ b/frameworks/Crystal/amber/shard.yml
@@ -13,8 +13,8 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 0.6.4 
+    version: 0.6.5
 
   granite_orm:
     github: amberframework/granite-orm
-    version: 0.8.2
+    version: 0.8.4


### PR DESCRIPTION
This PR udates amber to latest version `v0.6.5`, see: https://github.com/amberframework/amber/releases/tag/v0.6.5


@elorest @eliasjpr @drujensen ^