### PR TITLE
Python/pyramid persist updates

### DIFF
--- a/frameworks/Python/pyramid/frameworkbenchmarks/models.py
+++ b/frameworks/Python/pyramid/frameworkbenchmarks/models.py
@@ -11,13 +11,11 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
 
-DBHOSTNAME = os.environ.get('DBHOST', 'localhost')
-
 def get_conn():
     return psycopg2.connect(
         user = 'benchmarkdbuser',
         password = 'benchmarkdbpass',
-        host = DBHOSTNAME,
+        host = 'TFB-database',
         port = '5432',
         database = 'hello_world'
         )
@@ -49,7 +47,7 @@ class SQLAlchemyEncoder(json.JSONEncoder):
 
 
 class World(DatabaseBase):
-    __tablename__ = 'World'
+    __tablename__ = 'world'
 
     id = Column('id', Integer, primary_key=True)
     randomNumber = Column('randomnumber', Integer, nullable=False, server_default='0')
@@ -59,7 +57,7 @@ class World(DatabaseBase):
 
 
 class Fortune(DatabaseBase):
-    __tablename__ = 'Fortune'
+    __tablename__ = 'fortune'
 
     id = Column('id', Integer, primary_key=True)
     message = Column('message', String, nullable=False)

--- a/frameworks/Python/pyramid/gunicorn_conf.py
+++ b/frameworks/Python/pyramid/gunicorn_conf.py
@@ -12,7 +12,7 @@ if _is_travis:
 bind = "0.0.0.0:8080"
 keepalive = 120
 errorlog = '-'
-pidfile = 'gunicorn.pid'
+pidfile = '/tmp/gunicorn.pid'
 
 if _is_pypy:
     worker_class = "tornado"


### PR DESCRIPTION
Pyramid was not persisting updates to the databases (see #3210)

Also moved the `gunicorn.pid` file to `/tmp` because of a `text file busy` error when testing on vagrant and synced to a windows host. https://github.com/hashicorp/vagrant/issues/2282