### PR TITLE
Fix connection errors between nginx and jester

### DIFF
--- a/frameworks/Nim/jester/config/nginx.conf
+++ b/frameworks/Nim/jester/config/nginx.conf
@@ -35,14 +35,14 @@ http {
   access_log off;
 
   upstream nimrod {
-    server localhost:9000;
-    server localhost:9001;
-    server localhost:9002;
-    server localhost:9003;
-    server localhost:9004;
-    server localhost:9005;
-    server localhost:9006;
-    server localhost:9007;
+    server 127.0.0.1:9000;
+    server 127.0.0.1:9001;
+    server 127.0.0.1:9002;
+    server 127.0.0.1:9003;
+    server 127.0.0.1:9004;
+    server 127.0.0.1:9005;
+    server 127.0.0.1:9006;
+    server 127.0.0.1:9007;
   }
 
   server {


### PR DESCRIPTION
Jester is currently getting near-zero RPS and there are many errors like
this in the log:

  [error] 31982#0: *72922 connect() failed (111: Connection refused)
  while connecting to upstream, client: 204.93.249.210, server: _,
  request: "GET /json HTTP/1.1", upstream: "http://[::1]:9001/json",
  host: "TFB-server"

Notice the [::1] upstream address.  It looks like jester is refusing
connections for the ipv6 version of localhost.  It accepts the ipv4
version 127.0.0.1 though.