### PR TITLE
JS/hapi fix updates test

### DIFF
--- a/frameworks/JavaScript/hapi/handlers/mongoose.js
+++ b/frameworks/JavaScript/hapi/handlers/mongoose.js
@@ -1,11 +1,8 @@
 // Connects to MongoDB using the mongoose driver
 // Handles related routes
 
-const Promise = require('bluebird');
 const h = require('../helper');
-// Can treat mongoose library as one that supports Promises
-// these methods will then have "-Async" appended to them.
-const Mongoose = Promise.promisifyAll(require('mongoose'));
+const Mongoose = require('mongoose');
 const connection = Mongoose.connect(
   'mongodb://TFB-database/hello_world',
   { useMongoClient: true }
@@ -27,80 +24,54 @@ const FortuneSchema = new Mongoose.Schema({
 const Worlds = connection.model('World', WorldSchema);
 const Fortunes = connection.model('Fortune', FortuneSchema);
 
-const randomWorldPromise = () =>
-  Worlds.findOneAsync({ id: h.randomTfbNumber() })
-    .then((world) => world)
-    .catch((err) => process.exit(1));
+const randomWorld = async () =>
+  await Worlds.findOne({ id: h.randomTfbNumber() });
 
-
-const promiseAllFortunes = () =>
-  Fortunes.findAsync({})
-    .then((fortunes) => fortunes)
-    .catch((err) => process.exit(1));
-
-const updateWorld = (world) =>
-  Worlds
-    .updateAsync(
+const updateWorld = async (world) =>
+  await Worlds.update(
       { id: world.randomNumber },
       { randomNumber: world.randomNumber }
-    )
-    .then((result) => world)
-    .catch((err) => process.exit(1));
+    );
 
 module.exports = {
 
-  SingleQuery: (req, reply) => {
-    randomWorldPromise()
-      .then((world) => {
-        reply(world)
-          .header('Server', 'hapi');
-      });
+  SingleQuery: async (req, reply) => {
+    reply(await randomWorld()).header('Server', 'hapi');
   },
 
-  MultipleQueries: (req, reply) => {
+  MultipleQueries: async (req, reply) => {
     const queries = h.getQueries(req);
-    const worldPromises = h.fillArray(randomWorldPromise(), queries);
+    const results = h.fillArray(await randomWorld(), queries);
 
-    Promise
-      .all(worldPromises)
-      .then((worlds) => {
-        reply(worlds)
-          .header('Server', 'hapi');
-      });
+    reply(results).header('Server', 'hapi');
   },
 
-  Fortunes: (req, reply) => {
-    promiseAllFortunes()
-      .then((fortunes) => {
-        fortunes.push(h.additionalFortune());
-        fortunes.sort((a, b) => a.message.localeCompare(b.message));
-      
-        reply.view('fortunes', {
-          fortunes: fortunes
-        })
-          .header('Content-Type', 'text/html')
-          .header('Server', 'hapi');
-      });
+  Fortunes: async (req, reply) => {
+    const fortunes = await Fortunes.find({});
+    fortunes.push(h.additionalFortune());
+    fortunes.sort((a, b) => a.message.localeCompare(b.message));
+
+    reply.view('fortunes', {
+      fortunes: fortunes
+    })
+      .header('Content-Type', 'text/html')
+      .header('Server', 'hapi');
   },
 
-  Updates: (req, reply) => {
+  Updates: async (req, reply) => {
     const queries = h.getQueries(req);
-    const worldPromises = [];
+    const results = [];
 
     for (let i = 0; i < queries; i++) {
-      worldPromises.push(randomWorldPromise());
+      const world = await randomWorld();
+      world.randomNumber = h.randomTfbNumber();
+      await updateWorld(world);
+      results.push(world);
     }
 
-    Promise
-      .all(worldPromises)
-      .map((world) => {
-        world.randomNumber = h.randomTfbNumber();
-        return updateWorld(world);
-      })
-      .then((worlds) => {
-        reply(worlds)
-          .header('Server', 'hapi');
-      });
+    reply(results)
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   }
 
 };

--- a/frameworks/JavaScript/hapi/handlers/sequelize-postgres.js
+++ b/frameworks/JavaScript/hapi/handlers/sequelize-postgres.js
@@ -1,17 +1,16 @@
 // Connects to Postgres using the sequelize driver
 // Handles related routes
 
-const Promise = require('bluebird');
 const h = require('../helper');
-const Sequelize = require('sequelize');
 
+const Sequelize = require('sequelize');
 const sequelize = new Sequelize('hello_world', 'benchmarkdbuser', 'benchmarkdbpass', {
   host: 'TFB-database',
   dialect: 'postgres',
   logging: false
 });
 
-const Worlds = sequelize.define('world', {
+const Worlds = sequelize.define('World', {
   id: {
     type: 'Sequelize.INTEGER',
     primaryKey: true
@@ -33,26 +32,28 @@ const Fortunes = sequelize.define('Fortune', {
   freezeTableName: true
 });
 
-const randomWorldPromise = () =>
-  Worlds.findOne({ where: { id: h.randomTfbNumber() } })
-    .then((results) => results)
-    .catch((err) => process.exit(1));
+const randomWorld = async () =>
+  await Worlds.findOne({ where: { id: h.randomTfbNumber() } });
 
 module.exports = {
 
-  SingleQuery: (req, reply) =>
-    randomWorldPromise().then((world) => reply(world).header('Server', 'hapi')),
+  SingleQuery: (req, reply) => {
+    reply(randomWorld())
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
+  },
 
-  MultipleQueries: (req, reply) => {
-    const queries = h.getQueries(req),
-      worldPromises = [];
+  MultipleQueries: async (req, reply) => {
+    const queries = h.getQueries(req);
+    const results = [];
 
     for (let i = 0; i < queries; i++) {
-      worldPromises.push(randomWorldPromise());
+      results.push(await randomWorld());
     }
 
-    Promise.all(worldPromises)
-      .then((worlds) => reply(worlds).header('Server', 'hapi'));
+    reply(results)
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   },
 
   Fortunes: (req, reply) => {
@@ -60,36 +61,26 @@ module.exports = {
       fortunes.push(h.additionalFortune());
       fortunes.sort((a, b) => a.message.localeCompare(b.message));
 
-      reply.view('fortunes', { fortunes: fortunes })
+      reply.view('fortunes', { fortunes })
         .header('Content-Type', 'text/html')
         .header('Server', 'hapi');
     }).catch((err) => process.exit(1));
   },
 
-  Updates: (req, reply) => {
-    const queries = h.getQueries(req),
-      worldPromises = [];
+  Updates: async (req, reply) => {
+    const queries = h.getQueries(req);
+    const results = [];
 
     for (let i = 0; i < queries; i++) {
-      worldPromises.push(randomWorldPromise());
+      const world = await randomWorld();
+      await world.set('randomnumber', h.randomTfbNumber());
+      await world.save();
+      results.push(world);
     }
 
-    const worldUpdate = (world) => {
-      world.randomNumber = h.randomTfbNumber();
-
-      return Worlds.update(
-        {randomNumber: world.randomNumber},
-        {where: {id: world.id}}
-      )
-        .then((results) => world)
-        .catch((err) => process.exit(1));
-    };
-
-    Promise
-      .all(worldPromises)
-      .map((world) => worldUpdate(world))
-      .then((updated) => reply(updated).header('Server', 'hapi'))
-      .catch((err) => process.exit(1));
+    reply(results)
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   }
 
 };

--- a/frameworks/JavaScript/hapi/handlers/sequelize.js
+++ b/frameworks/JavaScript/hapi/handlers/sequelize.js
@@ -1,7 +1,6 @@
 // Connects to MySQL using the sequelize driver
 // Handles related routes
 
-const Promise = require('bluebird');
 const h = require('../helper');
 
 const Sequelize = require('sequelize');
@@ -33,31 +32,28 @@ const Fortunes = sequelize.define('Fortune', {
   freezeTableName: true
 });
 
-const randomWorldPromise = () =>
-  Worlds.findOne({ where: { id: h.randomTfbNumber() } })
-    .then((results) => results)
-    .catch((err) => process.exit(1));
-
+const randomWorld = async () =>
+  await Worlds.findOne({ where: { id: h.randomTfbNumber() } });
 
 module.exports = {
 
   SingleQuery: (req, reply) => {
-    randomWorldPromise().then((world) => {
-      reply(world)
-        .header('Server', 'hapi');
-    })
+    reply(randomWorld())
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   },
 
-  MultipleQueries: (req, reply) => {
+  MultipleQueries: async (req, reply) => {
     const queries = h.getQueries(req);
-    const worldPromises = [];
+    const results = [];
 
     for (let i = 0; i < queries; i++) {
-      worldPromises.push(randomWorldPromise());
+      results.push(await randomWorld());
     }
 
-    Promise.all(worldPromises).then((worlds) =>
-      reply(worlds).header('Server', 'hapi'));
+    reply(results)
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   },
 
   Fortunes: (req, reply) => {
@@ -71,29 +67,23 @@ module.exports = {
     }).catch((err) => process.exit(1));
   },
 
-  Updates: (req, reply) => {
+  Updates: async (req, reply) => {
     const queries = h.getQueries(req);
-    const worldPromises = [];
+    const results = [];
 
     for (let i = 0; i < queries; i++) {
-      worldPromises.push(randomWorldPromise());
+      const world = await randomWorld();
+      world.randomNumber = h.randomTfbNumber();
+      await Worlds.update(
+        { randomNumber: world.randomNumber },
+        { where: { id: world.id } }
+      );
+      results.push(world);
     }
 
-    const worldUpdate = (world) => {
-      world.randomNumber = h.randomTfbNumber();
-
-      return Worlds.update(
-          { randomNumber: world.randomNumber },
-          { where: { id: world.id } }
-        )
-        .then((results) => world)
-        .catch((err) => process.exit(1));
-    };
-
-    Promise
-      .all(worldPromises)
-      .map((world) => worldUpdate(world))
-      .then((updated) => reply(updated).header('Server', 'hapi'))
-      .catch((e) => process.exit(1));
+    reply(results)
+      .header('Content-Type', 'application/json')
+      .header('Server', 'hapi');
   }
+
 };

--- a/frameworks/JavaScript/hapi/helper.js
+++ b/frameworks/JavaScript/hapi/helper.js
@@ -1,8 +1,3 @@
-const Handlebars = require('handlebars');
-
-const GREETING = "Hello, World";
-const HELLO_OBJ = { message: GREETING };
-
 module.exports = {
   randomTfbNumber: () => Math.floor(Math.random() * 10000) + 1,
 

--- a/frameworks/JavaScript/hapi/package.json
+++ b/frameworks/JavaScript/hapi/package.json
@@ -7,7 +7,7 @@
     "bluebird": "3.4.7",
     "handlebars": "4.0.6",
     "hapi": "16.1.0",
-    "vision":"4.1.0",
+    "vision": "4.1.0",
     "mongoose": "4.12.4",
     "mysql": "2.13.0",
     "pg": "6.1.2",

--- a/frameworks/JavaScript/hapi/setup.sh
+++ b/frameworks/JavaScript/hapi/setup.sh
@@ -2,5 +2,5 @@
 
 fw_depends mongodb postgresql mysql nodejs
 
-npm install
+npm install --no-bin-links
 node app &


### PR DESCRIPTION
In the middle of fixing the query update test here, I realized that #3210 wasn't actually checking both casing variations of the world table as "Select * from World" and "Select * from world" were the same table. That's been fixed there. Hapi was likely committing the updates. In any event, I've cleaned up some things here and removed the bluebird promise library in favor of node's native async/await.