### PR TITLE
Update facil.io version

### DIFF
--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -26,7 +26,7 @@ rm -r facil_app/src
 mkdir facil_app/src
 cp bench_app.c facil_app/src
 cd facil_app
-make -j build
+FACIL_CPU_CORES_LIMIT=7 make -j build
 
 # run test
 cd tmp

--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -13,7 +13,7 @@ mkdir facil_app
 cd facil_app
 
 # Download and unpack
-curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.4
+curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.5
 tar --strip-components=1 -xzf facil.io.tar.gz
 if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
 rm facil.io.tar.gz

--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -13,7 +13,7 @@ mkdir facil_app
 cd facil_app
 
 # Download and unpack
-curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/v.0.6.0.beta.2
+curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.4
 tar --strip-components=1 -xzf facil.io.tar.gz
 if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
 rm facil.io.tar.gz
@@ -30,6 +30,7 @@ make -j build
 
 # run test
 cd tmp
-./demo -b 0.0.0.0 -p 8080 -db "TFB-database" -w -1 -t 1 &
+./demo -p 8080 -db "TFB-database" -w -1 -t 1 &
 # step out
 cd ../..
+ 


### PR DESCRIPTION
I doubt if this is necessary, but Michael mentioned there were issue with the facil.io run (or, to be precise, that something happened on the app server during, or just before, the facil.io run).

The updated version mainly focused on the Websocket client features and minor refactoring, but the minor refactoring included changes to the logic in the beta.2 fix for cluster mode, so maybe this will help.

I should probably point out that I stress tested the beta.4 today with no adverse effects (no memory leaks, no crashes, all was good). However, I have no way to test an 80 core cluster with remote clients (I just don't have that kind of access), so I'm not sure if this fixes whatever went wrong (if it's even facil.io related).

**Sidenote**: I removed the `0.0.0.0` binding from the command line. The NULL address should support IPv6, while I fear the `0.0.0.0` might limit the address scheme to IPv4 (I doubt it, but I never tested the idea).