### PR TITLE
PHP  twice as fast

### DIFF
--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -13,7 +13,7 @@ mkdir facil_app
 cd facil_app
 
 # Download and unpack
-curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/v.0.6.0.beta.2
+curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.5
 tar --strip-components=1 -xzf facil.io.tar.gz
 if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
 rm facil.io.tar.gz
@@ -26,10 +26,11 @@ rm -r facil_app/src
 mkdir facil_app/src
 cp bench_app.c facil_app/src
 cd facil_app
-make -j build
+FACIL_CPU_CORES_LIMIT=7 make -j build
 
 # run test
 cd tmp
-./demo -b 0.0.0.0 -p 8080 -db "TFB-database" -w -1 -t 1 &
+./demo -p 8080 -db "TFB-database" -w -1 -t 1 &
 # step out
 cd ../..
+ 

--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -53,6 +54,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /home/vagrant/FrameworkBenchmarks/installs/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -17,6 +17,7 @@ http {
 
 	upstream fastcgi_backend {
 		server 127.0.0.1:9001;
+		keepalive 50;
 	}
 
 	server {
@@ -33,6 +34,7 @@ http {
 		location ~ \.php$ {
 			try_files $uri =404;
 			fastcgi_pass   fastcgi_backend;
+			fastcgi_keep_conn on;
 			fastcgi_index  index.php;
 			fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
 			include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/codeigniter/deploy/nginx.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
   upstream fastcgi_backend {
     server 127.0.0.1:9001;
+    keepalive 50;
   }
 
   server {
@@ -77,6 +78,7 @@ http {
     location ~ \.php$ {
       try_files $uri =404;
       fastcgi_pass   fastcgi_backend;
+      fastcgi_keep_conn on;
       fastcgi_index  index.php;
       #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
       fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/hhvm/deploy/nginx.conf
+++ b/frameworks/PHP/hhvm/deploy/nginx.conf
@@ -14,7 +14,7 @@ http {
     keepalive_timeout  65;
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
-        keepalive 32;
+        keepalive 50;
     }
 
     server {
@@ -23,7 +23,7 @@ http {
         # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9001
         location ~ \.(hh|php)$ {
             root TEST_ROOT;
-            #fastcgi_keep_conn on;
+            fastcgi_keep_conn on;
             fastcgi_pass   fastcgi_backend;
             #fastcgi_pass   127.0.0.1:9001;
             fastcgi_index  index.php;

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -53,6 +54,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /home/vagrant/FrameworkBenchmarks/installs/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -15,6 +15,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -35,6 +36,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -15,6 +15,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
     server {
         listen       8080;
@@ -30,6 +31,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /usr/local/nginx/conf/fastcgi_params;

--- a/frameworks/PHP/phalcon-micro/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon-micro/deploy/nginx.conf
@@ -34,6 +34,7 @@ http {
     #gzip  on;
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
     server {
         listen       8080;
@@ -75,6 +76,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
     
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/php/deploy/nginx.conf
+++ b/frameworks/PHP/php/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -70,7 +71,9 @@ http {
         location ~ \.php$ {
             root TEST_ROOT;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
 #            fastcgi_pass 127.0.0.1:9001;
+#           fastcgi_pass unix:/tmp/php-fpm.sock;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -70,6 +71,7 @@ http {
         location ~ \.php$ {
             root /var/www/FrameworkBenchmarks/phreeze;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
 #            fastcgi_pass 127.0.0.1:9001;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;

--- a/frameworks/PHP/silex-orm/deploy/nginx.conf
+++ b/frameworks/PHP/silex-orm/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/slim/deploy/nginx.conf
+++ b/frameworks/PHP/slim/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -53,6 +54,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             fastcgi_param  APP_ENV "prod";

--- a/frameworks/PHP/yaf/deploy/nginx.conf
+++ b/frameworks/PHP/yaf/deploy/nginx.conf
@@ -14,6 +14,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -35,6 +36,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
             include        /usr/local/nginx/conf/fastcgi_params;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/yii2/deploy/nginx.conf
+++ b/frameworks/PHP/yii2/deploy/nginx.conf
@@ -30,6 +30,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -48,6 +49,7 @@ http {
         location ~ \.php$ {
             fastcgi_split_path_info  ^(.+\.php)(.*)$;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             set $fsn /index.php;
             if (-f $document_root$fastcgi_script_name){
                 set $fsn $fastcgi_script_name;

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/frameworks/PHP/zend1/deploy/nginx.conf
+++ b/frameworks/PHP/zend1/deploy/nginx.conf
@@ -35,6 +35,7 @@ http {
 
     upstream fastcgi_backend {
         server 127.0.0.1:9001;
+        keepalive 50;
     }
 
     server {
@@ -77,6 +78,7 @@ http {
         location ~ \.php$ {
             try_files $uri =404;
             fastcgi_pass   fastcgi_backend;
+            fastcgi_keep_conn on;
             fastcgi_index  index.php;
 #            fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -869,6 +869,12 @@ class Benchmarker:
         except (ValueError, IOError):
             pass
 
+    def __get_git_commit_id(self):
+        return subprocess.check_output('git rev-parse HEAD', shell=True).strip()
+
+    def __get_git_repository_url(self):
+        return subprocess.check_output('git config --get remote.origin.url', shell=True).strip()
+
     ############################################################
     # __finish
     ############################################################
@@ -985,6 +991,9 @@ class Benchmarker:
             self.results['uuid'] = str(uuid.uuid4())
             self.results['name'] = datetime.now().strftime(self.results_name)
             self.results['environmentDescription'] = self.results_environment
+            self.results['git'] = dict()
+            self.results['git']['commitId'] = self.__get_git_commit_id()
+            self.results['git']['repositoryUrl'] = self.__get_git_repository_url()
             self.results['startTime'] = int(round(time.time() * 1000))
             self.results['completionTime'] = None
             self.results['concurrencyLevels'] = self.concurrency_levels

--- a/toolset/setup/linux/databases/mysql/my.cnf
+++ b/toolset/setup/linux/databases/mysql/my.cnf
@@ -43,6 +43,12 @@ max_heap_table_size     = 128M
 tmp_table_size          = 128M
 
 #
+# monitoring off
+#
+
+performance-schema = false
+
+#
 # innodb settings
 #
 

--- a/toolset/setup/linux/languages/php/php-fpm.conf
+++ b/toolset/setup/linux/languages/php/php-fpm.conf
@@ -151,6 +151,7 @@ events.mechanism = epoll
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
 listen = 127.0.0.1:9001
+;listen = /tmp/php-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 128 (-1 on FreeBSD and OpenBSD)

--- a/toolset/setup/linux/languages/php/php.ini
+++ b/toolset/setup/linux/languages/php/php.ini
@@ -1871,6 +1871,17 @@ ldap.max_links = -1
 ;apc.enable_cli = 1
 ;apc.shm_size = 64M
 
+[mysqlnd]
+; Enable / Disable collection of general statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_statistics
+mysqlnd.collect_statistics = Off
+
+; Enable / Disable collection of memory usage statistics by mysqlnd which can be
+; used to tune and monitor MySQL operations.
+; http://php.net/mysqlnd.collect_memory_statistics
+mysqlnd.collect_memory_statistics = Off
+
 [opcache]
 opcache.validate_timestamps = 0 ; The same that apc.stat = 0
 opcache.max_accelerated_files = 20000


### PR DESCRIPTION
About the issue #2717 
The problem was: Remove keepalive from PHP frameworks using fastcgi #1959
The performance is similar with: 
upstream with keepalive, 
fastcgi_pass 127.0.0.1:9001; (tcp directly)
fastcgi_pass unix:/tmp/php-fpm.sock; (sockets)

But using upstream without keepalive,  the performance is reduced by half. With keepalive there’s no TCP open or close overhead, and the TCP stacks quickly adapt to the optimal window size and retry parameters.

Of course that we will saturate the slowest frameworks, but the problem isn't the nginx config.
Because some frameworks aren't fast enough, we should not reduce all to the lowest denominator.

Please try with tcp or socket directly too, and php is twice as fast in the vagrant box.

We can discuss the better solution for the slowest frameworks with problems.

Also I will send more commits for the nginx and php-fpm configs. The configs are from the i7 benchmarks, and nobody touch it. 

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
