### PR TITLE
Update to the latest Cython to fix wheezyweb-py3

### DIFF
--- a/frameworks/Python/falcon/requirements.txt
+++ b/frameworks/Python/falcon/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn==19.4.5
 meinheld==0.6.1
-Cython==0.23.4
+Cython==0.27.3
 falcon==0.3.0
 greenlet==0.4.9


### PR DESCRIPTION
This looks like a change for falcon, but it's actually intended to fix
wheezyweb.  Without this change, wheezyweb-py3 succeeds if tested on
its own from a clean environment, but it fails IF falcon-py3 has already
been tested in the same environment.  You can see this with:

```
toolset/run-tests.py --mode verify --test falcon-py3 wheezyweb-py3
```

You will see an error like this:

```
TypeError: can't pickle Cython.Compiler.FlowControl.NameAssignment objects
```

I believe it's the same issue described here, where the culprit was an
old version of Cython:  https://github.com/cython/cython/issues/1884

Adding the "Cython==0.27.3" to wheezyweb's requirements.txt does not fix
the problem.