### PR TITLE
Update facil.io & tuning memory allocation for the JSON route

### DIFF
--- a/frameworks/C/facil.io/bench_app.c
+++ b/frameworks/C/facil.io/bench_app.c
@@ -96,7 +96,7 @@ static void on_request_json(http_s *h) {
   http_set_header(h, HTTP_HEADER_CONTENT_TYPE, http_mimetype_find("json", 4));
   FIOBJ json;
   /* create a new Hash to be serialized for every request */
-  FIOBJ hash = fiobj_hash_new();
+  FIOBJ hash = fiobj_hash_new2(1);
   fiobj_hash_set(hash, JSON_KEY, fiobj_dup(JSON_VALUE));
   json = fiobj_obj2json(hash, 0);
   fiobj_free(hash);

--- a/frameworks/C/facil.io/setup.sh
+++ b/frameworks/C/facil.io/setup.sh
@@ -13,7 +13,8 @@ mkdir facil_app
 cd facil_app
 
 # Download and unpack
-curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.5
+
+curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.6
 tar --strip-components=1 -xzf facil.io.tar.gz
 if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
 rm facil.io.tar.gz
@@ -26,11 +27,16 @@ rm -r facil_app/src
 mkdir facil_app/src
 cp bench_app.c facil_app/src
 cd facil_app
-FACIL_CPU_CORES_LIMIT=7 make -j build
 
-# run test
+# we don't need more than 32K concurrent connections
+export CFLAGS="-DLIB_SOCK_MAX_CAPACITY=32768"
+
+# Build the app
+make -j build
+
+# Run the upp
 cd tmp
 ./demo -p 8080 -db "TFB-database" -w -1 -t 1 &
-# step out
+# step out of app folder
 cd ../..
  


### PR DESCRIPTION
This update continues the lessons learned from the last round of tests
and updates both the facil.io version and the JSON path.

This experience was very enlightening and evoked and updated set of
default values for the facil.io framework (reflected in the updated
version).

This version includes a fixed CPU core limiter as a library default
(the last update did not properly limit the CPU cores) as well as a
connection capacity limiter and other memory allocation improvements.

As part of the efforts to minimize memory allocation values, the
`fiobj_hash_new2` function was introduced. This allows very small (or
very large) hash tables to hint at the requested capacity (minimizing
allocations when possible).

I know this won't be reflected in the Round 15 final results, but I can't thank you all enough for your efforts and your time helping me adjust facil.io to such a different environment.

facil.io wasn't deployed on more than 2 cores and only ever tested only on 8 cores before now. Your input was helped me improve facil.io's cluster logic and realize the importance of lower default values.