### PR TITLE
H2O: Inhibit some compiler optimizations

### DIFF
--- a/frameworks/C/h2o/src/request_handler.c
+++ b/frameworks/C/h2o/src/request_handler.c
@@ -47,7 +47,9 @@ static int json_serializer(struct st_h2o_handler_t *self, h2o_req_t *req)
 	                                                      req->conn->ctx);
 	json_generator_t * const gen = get_json_generator(&ctx->json_generator,
 	                                                  &ctx->json_generator_num);
-	const struct {
+	// volatile is used to ensure that the object is instantiated every time
+	// the function is called.
+	const volatile struct {
 		const char *message;
 	} object = {HELLO_RESPONSE};
 


### PR DESCRIPTION
Semantically, the code used to do exactly what the JSON serialization test required (instantiating an object for every request), but the optimizer could remove the creation of the object completely, and propagate its field values (known at compile time) to the JSON generator arguments.

Normally I would be against disabling compiler optimizations, but a hypothetical assembly language implementation of the benchmarks would be at a disadvantage, since it wouldn't be able to use the same optimization without breaking the rules, so I decided to be conservative.