### PR TITLE
Fix web2py-optimized updates test implementation

### DIFF
--- a/frameworks/Python/web2py/app/standard/modules/controller.py
+++ b/frameworks/Python/web2py/app/standard/modules/controller.py
@@ -40,8 +40,6 @@ def updates():
         world['randomNumber'] = newNumber
         worlds.append(world)
         update_world(wid, newNumber)
-    if current.optimized:
-        db.flush_world_updates() # Batch updates.
     return jsonOut.dumps(worlds)
 
 def fortune():

--- a/frameworks/Python/web2py/app/standard/modules/database.py
+++ b/frameworks/Python/web2py/app/standard/modules/database.py
@@ -32,19 +32,14 @@ class Dal(object):
 class RawDal(Dal):
     def __init__(self):
         super(RawDal, self).__init__()
-        self.world_updates = []
 
     def get_world(self, wid):
         return self.db.executesql('SELECT * FROM World WHERE id = %s',
                                   placeholders=[wid], as_dict=True)[0]
 
     def update_world(self, wid, randomNumber):
-        self.world_updates.extend([randomNumber, wid])
-
-    def flush_world_updates(self):
-        query = ';'.join('UPDATE World SET randomNumber=%s WHERE id=%s'
-                         for _ in xrange(len(self.world_updates) / 2))
-        self.db.executesql(query, placeholders=self.world_updates)
+        self.db.executesql('UPDATE World SET randomNumber=%s WHERE id=%s',
+                           placeholders=[randomNumber, wid])
 
     def get_fortunes(self, new_message):
         fortunes = self.db.executesql('SELECT * FROM Fortune', as_dict=True)


### PR DESCRIPTION
It was failing verification before because it wasn't actually making all
the expected updates in the database.  I think what was happening was
it was building up a single long query containing multiple statements
like this:

  "UPDATE World SET randomNumber=4 WHERE id=5;UPDATE World SET randomNumber=1 WHERE id=2;..."

But the database driver was ignoring all but the first statement.  As far
as I know, most drivers prevent you from executing multiple statements in
one by default as a SQL injection countermeasure.

The revised implementation executes each UPDATE individually.  We've
learned from previous experiments in this project (with other
frameworks) that there isn't any way to execute a batch update against
the MySQL database that's faster than many individual updates.