### PR TITLE
Allow FROM dependencies to be loaded from the framework's directory

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -265,8 +265,10 @@ class FrameworkTest:
     docker_dir = os.path.join(setup_util.get_fwroot(), "toolset", "setup", "linux", "docker")
 
     for dependency in deps:
-      docker_file = os.path.join(docker_dir, dependency + ".dockerfile")
-      p = subprocess.Popen(["docker", "build", "-f", docker_file, "-t", dependency, docker_dir],
+      docker_file = os.path.join(self.directory, dependency + ".dockerfile")
+      if not os.path.exists(docker_file):
+        docker_file = os.path.join(docker_dir, dependency + ".dockerfile")
+      p = subprocess.Popen(["docker", "build", "-f", docker_file, "-t", dependency, os.path.dirname(docker_file)],
           stdout=subprocess.PIPE,
           stderr=subprocess.STDOUT)
       nbsr = setup_util.NonBlockingStreamReader(p.stdout)

--- a/toolset/benchmark/utils.py
+++ b/toolset/benchmark/utils.py
@@ -24,8 +24,10 @@ def gather_docker_dependencies(docker_file):
                     if tokens[1] != "ubuntu:16.04":
                         depTokens = tokens[1].strip().split(':')
                         deps.append(depTokens[0])
-                        dep_docker_file = os.path.join(setup_util.get_fwroot(), 
-                            "toolset", "setup", "linux", "docker", depTokens[0] + ".dockerfile")
+                        dep_docker_file = os.path.join(os.path.dirname(docker_file), depTokens[0] + ".dockerfile")
+                        if not os.path.exists(dep_docker_file):
+                            dep_docker_file = os.path.join(setup_util.get_fwroot(),
+                                "toolset", "setup", "linux", "docker", depTokens[0] + ".dockerfile")
                         deps.extend(gather_docker_dependencies(dep_docker_file))
 
     return deps


### PR DESCRIPTION
The intent is for it to look in the framework's directory for each
dependency first, then fall back to looking in the toolset directory.

This way, if a framework has multiple test permutations with shared build
steps, they can put the shared build steps in dockerfile inside their
own framework's directory.