### PR TITLE
bottle: Drop CPython 2

### DIFF
--- a/frameworks/Python/bottle/benchmark_config.json
+++ b/frameworks/Python/bottle/benchmark_config.json
@@ -15,38 +15,14 @@
       "database": "MySQL",
       "framework": "bottle",
       "language": "Python",
-      "flavor": "Python2",
+      "flavor": "CPython",
       "orm": "Full",
       "platform": "Meinheld",
       "webserver": "None",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "Bottle",
-      "notes": "CPython 2",
-      "versus": "wsgi"
-    },
-    "py3": {
-      "setup_file": "setup_py3",
-      "json_url": "/json",
-      "db_url": "/db",
-      "query_url": "/queries?queries=",
-      "fortune_url": "/fortune",
-      "update_url": "/updates?queries=",
-      "plaintext_url": "/plaintext",
-      "port": 8080,
-      "approach": "Realistic",
-      "classification": "Micro",
-      "database": "MySQL",
-      "framework": "bottle",
-      "language": "Python",
-      "flavor": "Python3",
-      "orm": "Full",
-      "platform": "Meinheld",
-      "webserver": "None",
-      "os": "Linux",
-      "database_os": "Linux",
-      "display_name": "Bottle",
-      "notes": "CPython 3",
+      "notes": "",
       "versus": "wsgi"
     },
     "pypy2": {
@@ -73,7 +49,7 @@
       "notes": "PyPy2",
       "versus": "wsgi"
     },
-    "mysql-raw": {
+    "raw": {
       "setup_file": "setup",
       "db_url": "/raw-db",
       "query_url": "/raw-queries?queries=",
@@ -85,14 +61,14 @@
       "database": "MySQL",
       "framework": "bottle",
       "language": "Python",
-      "flavor": "Python2",
+      "flavor": "CPython",
       "orm": "Raw",
       "platform": "Meinheld",
       "webserver": "None",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "Bottle-raw",
-      "notes": "CPython 2",
+      "notes": "",
       "versus": "wsgi"
     },
     "nginx-uwsgi": {
@@ -109,14 +85,14 @@
       "database": "MySQL",
       "framework": "bottle",
       "language": "Python",
-      "flavor": "Python2",
+      "flavor": "CPython",
       "orm": "Full",
       "platform": "uWSGI",
       "webserver": "nginx",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "Bottle-uWSGI",
-      "notes": "CPython 2",
+      "notes": "",
       "versus": "wsgi"
     }
   }]

--- a/frameworks/Python/bottle/requirements-pypy.txt
+++ b/frameworks/Python/bottle/requirements-pypy.txt
@@ -4,4 +4,3 @@ gunicorn==19.7.1
 PyMySQL==0.8.0
 SQLAlchemy==1.2.2
 tornado==4.5.3
-ujson==1.35

--- a/frameworks/Python/bottle/setup.sh
+++ b/frameworks/Python/bottle/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-fw_depends mysql python2
+fw_depends mysql python3
 
-pip install --install-option="--prefix=${PY2_ROOT}" -r $TROOT/requirements.txt
+pip3 install --install-option="--prefix=${PY3_ROOT}" -r $TROOT/requirements.txt
 
 gunicorn app:app -c gunicorn_conf.py &

--- a/frameworks/Python/bottle/setup_nginxuwsgi.sh
+++ b/frameworks/Python/bottle/setup_nginxuwsgi.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-fw_depends mysql python2 nginx
+fw_depends mysql python3 nginx
 
 sed -i 's|include .*/conf/uwsgi_params;|include '"${NGINX_HOME}"'/conf/uwsgi_params;|g' nginx.conf
 
-pip install --install-option="--prefix=${PY2_ROOT}" -r $TROOT/requirements.txt
+pip3 install --install-option="--prefix=${PY3_ROOT}" -r $TROOT/requirements.txt
 
 nginx -c $TROOT/nginx.conf
-uwsgi --ini $TROOT/uwsgi.ini --processes $CPU_COUNT --wsgi app:app &
+uwsgi --ini $TROOT/uwsgi.ini --processes $((CPU_COUNT*3)) --wsgi app:app &

--- a/frameworks/Python/bottle/setup_py3.sh
+++ b/frameworks/Python/bottle/setup_py3.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-fw_depends mysql python3
-
-pip3 install --install-option="--prefix=${PY3_ROOT}" -r $TROOT/requirements.txt
-
-gunicorn app:app -c gunicorn_conf.py &


### PR DESCRIPTION
New project should use Python 3 by default.
It's good time to remove Python 2 from TFB.

But PyPy 3.5 is still slower than PyPy 2.7.  I keep PyPy 2.7 for now.

There are some minor tweaks:

* uWSGI should use more processes, same to gunicorn.
* ujson should not be used on Tornado