### PR TITLE
[ci fw-only Java/dropwizard] Revert Jetty configuration change

### DIFF
--- a/frameworks/Java/dropwizard/hello-world-mysql.yml
+++ b/frameworks/Java/dropwizard/hello-world-mysql.yml
@@ -1,6 +1,5 @@
 server:
   type: simple
-  maxQueuedRequests: 8192 
   applicationContextPath: /
   connector:
     type: http


### PR DESCRIPTION
Very damaging change as it seems: JSON test results are even below single query results in Round 15.
The data is here: https://www.techempower.com/benchmarks/#section=data-r15&hw=ph&test=json&f=zik0zj-ziimf3-zik0zj-zik0zj-zik0zj-zik0zj-zik0zj-cn3