### PR TITLE
Adjust the maximum client concurrency assumed by undertow-mongodb

### DIFF
--- a/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
@@ -216,7 +216,7 @@ public final class HelloWebServer {
       return client.getDatabase(databaseName);
     }
 
-    private static final int MAX_DB_REQUEST_CONCURRENCY = 256;
+    private static final int MAX_DB_REQUEST_CONCURRENCY = 512;
     private static final int MAX_DB_QUERIES_PER_REQUEST = 20;
   }
 }


### PR DESCRIPTION
This should fix the large number of 5xx responses seen in
undertow-mongodb's results in round 15.  Its logs include a very large
number of stack traces like this:

```
  com.mongodb.MongoWaitQueueFullException: Too many threads are already waiting for a connection. Max number of threads (maxWaitQueueSize) of 256 has been exceeded.
    at com.mongodb.connection.DefaultConnectionPool.createWaitQueueFullException(DefaultConnectionPool.java:277)
    at com.mongodb.connection.DefaultConnectionPool.get(DefaultConnectionPool.java:96)
    at com.mongodb.connection.DefaultConnectionPool.get(DefaultConnectionPool.java:89)
    at com.mongodb.connection.DefaultServer.getConnection(DefaultServer.java:80)
    at com.mongodb.binding.ClusterBinding$ClusterBindingConnectionSource.getConnection(ClusterBinding.java:98)
    at com.mongodb.ClientSessionBinding$SessionBindingConnectionSource.getConnection(ClientSessionBinding.java:105)
    at com.mongodb.operation.OperationHelper.withConnectionSource(OperationHelper.java:468)
    at com.mongodb.operation.OperationHelper.withConnection(OperationHelper.java:414)
    at com.mongodb.operation.FindOperation.execute(FindOperation.java:711)
    at com.mongodb.operation.FindOperation.execute(FindOperation.java:83)
    at com.mongodb.Mongo$3.execute(Mongo.java:822)
    at com.mongodb.MongoIterableImpl.execute(MongoIterableImpl.java:130)
    at com.mongodb.MongoIterableImpl.iterator(MongoIterableImpl.java:77)
    at com.mongodb.MappingIterable.iterator(MappingIterable.java:40)
    at com.mongodb.MappingIterable.first(MappingIterable.java:45)
    at hello.DbMongoHandler.handleRequest(DbMongoHandler.java:29)
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:332)
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

It used to be the case that the client would make at most 256 concurrent
connections, but at least in the Server Central environment, now it may
make 512.  This number is defined in the environment's benchmark.cfg, in
the concurrency_levels property.