### PR TITLE
Mutliple docker containers for a single test

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -412,7 +412,7 @@ class Benchmarker:
     # Sets up a container for the given database and port, and
     # starts said docker container.
     ############################################################
-    def __setup_database_container(self, database, port):
+    def __setup_database_container(self, database):
         def __is_hex(s):
             try:
                 int(s, 16)
@@ -448,7 +448,7 @@ class Benchmarker:
                 return None
 
         p = subprocess.Popen(self.database_ssh_string, stdin=subprocess.PIPE, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        (out,err) = p.communicate("docker run -d --rm -p %s:%s --network=host %s" % (port,port,database))
+        (out,err) = p.communicate("docker run -d --rm --network=host %s" % database)
         return out.splitlines()[len(out.splitlines()) - 1]
     ############################################################
     # End __setup_database_container
@@ -609,13 +609,7 @@ class Benchmarker:
                 # Start database container
                 ##########################
                 if test.database != "None":
-                    # TODO: this is horrible... how should we really do it?
-                    ports = {
-                        "mysql": 3306,
-                        "postgres": 5432,
-                        "mongodb": 27017
-                    }
-                    database_container_id = self.__setup_database_container(test.database.lower(), ports[test.database.lower()])
+                    database_container_id = self.__setup_database_container(test.database.lower())
                     if not database_container_id:
                         out.write("ERROR: Problem building/running database container")
                         out.flush()

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -196,21 +196,15 @@ class FrameworkTest:
     # Build the Docker images
     ##########################
 
-    # Grab a list of all the docker files we need with
-    # the following priority:
-    # 1) An array of files in docker_files
-    # 2) A single file in docker_files
-    # 3) If none of the above, default to <test name>.dockerfile
+    # Build the test docker file based on the test name
+    # then build any additional docker files specified in the benchmark_config
 
-    test_docker_files = []
-    if self.docker_file is not None:
-      if type(self.docker_file) is list:
-        print "HERE WE ARE"
-        test_docker_files = self.docker_file
+    test_docker_files = ["%s.dockerfile" % self.name]
+    if self.docker_files is not None:
+      if type(self.docker_files) is list:
+        test_docker_files.extend(self.docker_files)
       else:
-        test_docker_files.append(self.docker_file)
-    if len(test_docker_files) == 0:
-      test_docker_files = ["%s.dockerfile" % self.name]
+        raise Exception("docker_files in benchmark_config.json must be an array")
 
     for test_docker_file in test_docker_files:
         test_docker_file_name = test_docker_file.replace(".dockerfile", "")
@@ -876,7 +870,7 @@ class FrameworkTest:
     self.display_name = ""
     self.notes = ""
     self.versus = ""
-    self.docker_file = None
+    self.docker_files = None
 
     # setup logging
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -195,139 +195,164 @@ class FrameworkTest:
     ##########################
     # Build the Docker images
     ##########################
-    test_docker_file = os.path.join(self.directory, "%s.dockerfile" % self.name)
-    deps = list(reversed(gather_docker_dependencies( test_docker_file )))
 
-    docker_dir = os.path.join(setup_util.get_fwroot(), "toolset", "setup", "linux", "docker")
+    # Grab a list of all the docker files we need with
+    # the following priority:
+    # 1) An array of files in docker_files
+    # 2) A single file in docker_files
+    # 3) If none of the above, default to <test name>.dockerfile
 
-    for dependency in deps:
-      docker_file = os.path.join(self.directory, dependency + ".dockerfile")
-      if not docker_file or not os.path.exists(docker_file):
-        docker_file = find_docker_file(docker_dir, dependency + ".dockerfile")
-      if not docker_file:
-        tee_output(prefix, "Docker build failed; %s could not be found; terminating\n" % (dependency + ".dockerfile"))
-        return 1
-      p = subprocess.Popen([
-        "docker", 
-        "build", 
-        "--build-arg",
-        "CPU_COUNT=%s" % str(multiprocessing.cpu_count()),
-        "--build-arg",
-        "MAX_CONCURRENCY=%s" % max(self.benchmarker.concurrency_levels),
-        "-f", 
-        docker_file, 
-        "-t", 
-        "tfb/%s" % dependency, 
-        os.path.dirname(docker_file)],
-          stdout=subprocess.PIPE,
-          stderr=subprocess.STDOUT)
-      nbsr = setup_util.NonBlockingStreamReader(p.stdout)
-      while (p.poll() is None):
-        for i in xrange(10):
-          try:
-            line = nbsr.readline(0.05)
-            if line:
-              tee_output(prefix, line)
-          except setup_util.EndOfStream:
-            break
-      if p.returncode != 0:
-        tee_output(prefix, "Docker build failed; terminating\n")
-        return 1
-    p = subprocess.Popen([
-      "docker", 
-      "build", 
-      "--build-arg",
-      "CPU_COUNT=%s" % str(multiprocessing.cpu_count()),
-      "--build-arg",
-      "MAX_CONCURRENCY=%s" % max(self.benchmarker.concurrency_levels),
-      "-f", 
-      test_docker_file, 
-      "-t", 
-      "tfb/test/%s" % self.name, 
-      self.directory],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
-    nbsr = setup_util.NonBlockingStreamReader(p.stdout)
-    while (p.poll() is None):
-      for i in xrange(10):
-        try:
-          line = nbsr.readline(0.05)
-          if line:
-            tee_output(prefix, line)
-        except setup_util.EndOfStream:
-          break
-    if p.returncode != 0:
-      tee_output(prefix, "Docker build failed; terminating\n")
-      return 1
-        
+    test_docker_files = []
+    if self.docker_file is not None:
+      if type(self.docker_file) is list:
+        print "HERE WE ARE"
+        test_docker_files = self.docker_file
+      else:
+        test_docker_files.append(self.docker_file)
+    if len(test_docker_files) == 0:
+      test_docker_files = ["%s.dockerfile" % self.name]
+
+    for test_docker_file in test_docker_files:
+        test_docker_file_name = test_docker_file.replace(".dockerfile", "")
+        test_docker_file_path = os.path.join(self.directory, "%s.dockerfile" % self.name)
+
+        deps = list(reversed(gather_docker_dependencies( test_docker_file_path )))
+
+        docker_dir = os.path.join(setup_util.get_fwroot(), "toolset", "setup", "linux", "docker")
+
+        for dependency in deps:
+          docker_file = os.path.join(self.directory, dependency + ".dockerfile")
+          if not docker_file or not os.path.exists(docker_file):
+            docker_file = find_docker_file(docker_dir, dependency + ".dockerfile")
+          if not docker_file:
+            tee_output(prefix, "Docker build failed; %s could not be found; terminating\n" % (dependency + ".dockerfile"))
+            return 1
+          p = subprocess.Popen([
+            "docker",
+            "build",
+            "--build-arg",
+            "CPU_COUNT=%s" % str(multiprocessing.cpu_count()),
+            "--build-arg",
+            "MAX_CONCURRENCY=%s" % max(self.benchmarker.concurrency_levels),
+            "-f",
+            docker_file,
+            "-t",
+            "tfb/%s" % dependency,
+            os.path.dirname(docker_file)],
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT)
+          nbsr = setup_util.NonBlockingStreamReader(p.stdout)
+          while (p.poll() is None):
+            for i in xrange(10):
+              try:
+                line = nbsr.readline(0.05)
+                if line:
+                  tee_output(prefix, line)
+              except setup_util.EndOfStream:
+                break
+          if p.returncode != 0:
+            tee_output(prefix, "Docker build failed; terminating\n")
+            return 1
+
+        p = subprocess.Popen([
+          "docker",
+          "build",
+          "--build-arg",
+          "CPU_COUNT=%s" % str(multiprocessing.cpu_count()),
+          "--build-arg",
+          "MAX_CONCURRENCY=%s" % max(self.benchmarker.concurrency_levels),
+          "-f",
+          test_docker_file_path,
+          "-t",
+          "tfb/test/%s" % test_docker_file_name,
+          self.directory],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT)
+        nbsr = setup_util.NonBlockingStreamReader(p.stdout)
+        while (p.poll() is None):
+          for i in xrange(10):
+            try:
+              line = nbsr.readline(0.05)
+              if line:
+                tee_output(prefix, line)
+            except setup_util.EndOfStream:
+              break
+        if p.returncode != 0:
+          tee_output(prefix, "Docker build failed; terminating\n")
+          return 1
+
 
     ##########################
     # Run the Docker container
     ##########################
-    p = subprocess.Popen(["docker", "run", "--rm", "-p", "%s:%s" % (self.port, self.port), "--network=host", "tfb/test/%s" % self.name],
-          stdout=subprocess.PIPE,
-          stderr=subprocess.STDOUT)
-    nbsr = setup_util.NonBlockingStreamReader(p.stdout,
-      "%s: framework processes have terminated" % self.name)
 
-    # Set a limit on total execution time of setup.sh
-    timeout = datetime.now() + timedelta(minutes = 105)
-    time_remaining = timeout - datetime.now()
+    for test_docker_file in test_docker_files:
+        test_docker_file_name = test_docker_file.replace(".dockerfile", "")
+        test_docker_file_path = os.path.join(self.directory, "%s.dockerfile" % self.name)
+        p = subprocess.Popen(["docker", "run", "--rm", "-p", "%s:%s" % (self.port, self.port), "--network=host", "tfb/test/%s" % test_docker_file_name],
+              stdout=subprocess.PIPE,
+              stderr=subprocess.STDOUT)
+        nbsr = setup_util.NonBlockingStreamReader(p.stdout,
+          "%s: framework processes have terminated" % self.name)
 
-    # Need to print to stdout once every 10 minutes or Travis-CI will abort
-    travis_timeout = datetime.now() + timedelta(minutes = 5)
+        # Set a limit on total execution time of setup.sh
+        timeout = datetime.now() + timedelta(minutes = 105)
+        time_remaining = timeout - datetime.now()
 
-    # Flush output until docker run work is finished. This is
-    # either a) when docker run exits b) when the port is bound
-    # c) when we run out of time. 
-    prefix = "Server %s: " % self.name
-    while (p.poll() is None
-      and not self.benchmarker.is_port_bound(self.port)
-      and not time_remaining.total_seconds() < 0):
-
-      # The conditions above are slow to check, so
-      # we will delay output substantially if we only
-      # print one line per condition check.
-      # Adding a tight loop here mitigates the effect,
-      # ensuring that most of the output directly from
-      # docker is sent to tee_output before the outer
-      # loop exits and prints things like "docker exited"
-      for i in xrange(10):
-        try:
-          line = nbsr.readline(0.05)
-          if line:
-            tee_output(prefix, line)
-
-            # Reset Travis-CI timer
-            travis_timeout = datetime.now() + timedelta(minutes = 5)
-        except setup_util.EndOfStream:
-          tee_output(prefix, "Docker has terminated\n")
-          break
-      time_remaining = timeout - datetime.now()
-
-      if (travis_timeout - datetime.now()).total_seconds() < 0:
-        sys.stdout.write(prefix + 'Printing so Travis-CI does not time out\n')
-        sys.stdout.write(prefix + "Status: Poll: %s, Port %s bound: %s, Time Left: %s\n" % (
-          p.poll(), self.port, self.benchmarker.is_port_bound(self.port), time_remaining))
-        sys.stdout.flush()
+        # Need to print to stdout once every 10 minutes or Travis-CI will abort
         travis_timeout = datetime.now() + timedelta(minutes = 5)
 
-    # Did we time out?
-    if time_remaining.total_seconds() < 0:
-      tee_output(prefix, "Docker run has timed out!! Aborting...\n" % self.setup_file)
-      p.kill()
-      return 1
+        # Flush output until docker run work is finished. This is
+        # either a) when docker run exits b) when the port is bound
+        # c) when we run out of time.
+        prefix = "Server %s: " % self.name
+        while (p.poll() is None
+          and not self.benchmarker.is_port_bound(self.port)
+          and not time_remaining.total_seconds() < 0):
 
-    # What's our return code?
-    # If docker run has terminated, use that code
-    # Otherwise, detect if the port was bound
-    tee_output(prefix, "Status: Poll: %s, Port %s bound: %s, Time Left: %s\n" % (
-      p.poll(), self.port, self.benchmarker.is_port_bound(self.port), time_remaining))
-    retcode = (p.poll() if p.poll() is not None else 0 if self.benchmarker.is_port_bound(self.port) else 1)
-    if p.poll() is not None:
-      tee_output(prefix, "Docker run process exited naturally with %s\n" % p.poll())
-    elif self.benchmarker.is_port_bound(self.port):
-      tee_output(prefix, "Bound port detected on %s\n" % self.port)
+          # The conditions above are slow to check, so
+          # we will delay output substantially if we only
+          # print one line per condition check.
+          # Adding a tight loop here mitigates the effect,
+          # ensuring that most of the output directly from
+          # docker is sent to tee_output before the outer
+          # loop exits and prints things like "docker exited"
+          for i in xrange(10):
+            try:
+              line = nbsr.readline(0.05)
+              if line:
+                tee_output(prefix, line)
+
+                # Reset Travis-CI timer
+                travis_timeout = datetime.now() + timedelta(minutes = 5)
+            except setup_util.EndOfStream:
+              tee_output(prefix, "Docker has terminated\n")
+              break
+          time_remaining = timeout - datetime.now()
+
+          if (travis_timeout - datetime.now()).total_seconds() < 0:
+            sys.stdout.write(prefix + 'Printing so Travis-CI does not time out\n')
+            sys.stdout.write(prefix + "Status: Poll: %s, Port %s bound: %s, Time Left: %s\n" % (
+              p.poll(), self.port, self.benchmarker.is_port_bound(self.port), time_remaining))
+            sys.stdout.flush()
+            travis_timeout = datetime.now() + timedelta(minutes = 5)
+
+        # Did we time out?
+        if time_remaining.total_seconds() < 0:
+          tee_output(prefix, "Docker run has timed out!! Aborting...\n" % self.setup_file)
+          p.kill()
+          return 1
+
+        # What's our return code?
+        # If docker run has terminated, use that code
+        # Otherwise, detect if the port was bound
+        tee_output(prefix, "Status: Poll: %s, Port %s bound: %s, Time Left: %s\n" % (
+          p.poll(), self.port, self.benchmarker.is_port_bound(self.port), time_remaining))
+        retcode = (p.poll() if p.poll() is not None else 0 if self.benchmarker.is_port_bound(self.port) else 1)
+        if p.poll() is not None:
+          tee_output(prefix, "Docker run process exited naturally with %s\n" % p.poll())
+        elif self.benchmarker.is_port_bound(self.port):
+          tee_output(prefix, "Bound port detected on %s\n" % self.port)
 
     # Before we return control to the benchmarker, spin up a
     # thread to keep an eye on the pipes in case the running
@@ -851,6 +876,7 @@ class FrameworkTest:
     self.display_name = ""
     self.notes = ""
     self.versus = ""
+    self.docker_file = None
 
     # setup logging
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -283,7 +283,7 @@ class FrameworkTest:
     for test_docker_file in test_docker_files:
         test_docker_file_name = test_docker_file.replace(".dockerfile", "")
         test_docker_file_path = os.path.join(self.directory, "%s.dockerfile" % self.name)
-        p = subprocess.Popen(["docker", "run", "--rm", "-p", "%s:%s" % (self.port, self.port), "--network=host", "tfb/test/%s" % test_docker_file_name],
+        p = subprocess.Popen(["docker", "run", "--rm", "--network=host", "tfb/test/%s" % test_docker_file_name],
               stdout=subprocess.PIPE,
               stderr=subprocess.STDOUT)
         nbsr = setup_util.NonBlockingStreamReader(p.stdout,


### PR DESCRIPTION
The goal here is to allow a `benchmark_config.json` to have an additional parameter called `docker_files` where a user can specify an array of __additional__ dockerfiles from the framework test root that must run in conjunction with the `<test name>.dockerfile`

#### WIP

@msmith-techempower this is currently working _except_ that in the array case all dockerfiles are being run and bound with `self.port` [here](https://github.com/TechEmpower/FrameworkBenchmarks/compare/docker...nbrady-techempower:docker-multi?expand=1#diff-104b04ab89e124380ed9be9c86341479R292). Binding the same port didn't seem to matter in my tests, and I'm wondering if we even need to do that with the `--network` param. My suspicion is we don't need to do it, but I won't be testing it tonight.