### PR TITLE
Optimal thread count for aspnetcore plaintext

### DIFF
--- a/frameworks/CSharp/aspnetcore/setup-plaintext.sh
+++ b/frameworks/CSharp/aspnetcore/setup-plaintext.sh
@@ -12,8 +12,8 @@ fi
 
 if [ -z "$threadCount" ]
 then
-    echo "Invalid thread count, aborting"
-    exit 1
+    echo "Invalid thread count ($(nproc)), using default"
+    threadCount=2
 fi
 
 source run-linux.sh plaintext $threadCount

--- a/frameworks/CSharp/aspnetcore/setup-plaintext.sh
+++ b/frameworks/CSharp/aspnetcore/setup-plaintext.sh
@@ -1,3 +1,19 @@
 #!/bin/bash
 
-source run-linux.sh plaintext $(($(nproc)*3/10))
+if [ "$(nproc)" -eq "80" ]
+then
+    threadCount=24
+fi
+
+if [ "$(nproc)" -eq "4" ]
+then
+    threadCount=2
+fi
+
+if [ -z "$threadCount" ]
+then
+    echo "Invalid thread count, aborting"
+    exit 1
+fi
+
+source run-linux.sh plaintext $threadCount


### PR DESCRIPTION
The previous logic would result `1` thread on Azure where `2` is actually the one to use.
Now using an explicit value, and also failing in case the environment changes and needs to be updated.