### PR TITLE
Vagrant using xenial

### DIFF
--- a/deployment/vagrant/core.rb
+++ b/deployment/vagrant/core.rb
@@ -30,7 +30,7 @@ end
 def provider_virtualbox(config)
   config.vm.provider :virtualbox do |vb, override|
     override.vm.hostname = "TFB-all"
-    override.vm.box = "ubuntu/trusty64"
+    override.vm.box = "ubuntu/xenial64"
 
     if ENV.fetch('TFB_SHOW_VM', false)
       vb.gui = true


### PR DESCRIPTION
To more accurately reflect the testing environment moving forward, moved vagrant to pull the from ubuntu/xenial instead of trusty. Travis can't run this but I've tested locally:

```
   default: Setting up welcome message
    default: ++ source /etc/profile.d/tfb.sh
    default: + echo 'Setting up welcome message'
    default: + sudo rm -f /etc/update-motd.d/51-cloudguest
    default: + sudo rm -f /etc/update-motd.d/98-cloudguest
    default: + sudo cat
    default: + sudo mv motd /etc/
    default: Setting up client and database machines
    default: + echo 'Setting up client and database machines'
    default: + tfb --init --quiet
    default: + /home/vagrant/FrameworkBenchmarks/toolset/run-tests.py --init --quiet
    default: /usr/local/lib/python2.7/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
    default:   """)

C:\Development\fb3\deployment\vagrant>vagrant ssh
Welcome to Ubuntu 16.04.3 LTS (GNU/Linux 4.4.0-112-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

49 packages can be updated.
15 updates are security updates.
```


```
================================================================================
  Verification Summary

| Test: gemini
|       plaintext     : WARN
|       json          : WARN
================================================================================
```