### PR TITLE
fasthttp: increase connection pool size for postgresql

### DIFF
--- a/frameworks/Go/fasthttp/src/server-postgresql/server.go
+++ b/frameworks/Go/fasthttp/src/server-postgresql/server.go
@@ -26,7 +26,7 @@ func main() {
 	flag.Parse()
 
 	var err error
-	maxConnectionCount := runtime.NumCPU() * 2
+	maxConnectionCount := runtime.NumCPU() * 4
 	if db, err = initDatabase("localhost", "benchmarkdbuser", "benchmarkdbpass", "hello_world", 5432, maxConnectionCount); err != nil {
 		log.Fatalf("Error opening database: %s", err)
 	}


### PR DESCRIPTION
Round 15 results suggest that the connection pool size is too small
for 512 concurrent requests. Double the size of the connection pool
and let's see how it performs in the Round 16.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
