### PR TITLE
Minijax version 0.1.4

### DIFF
--- a/frameworks/Java/minijax/README.md
+++ b/frameworks/Java/minijax/README.md
@@ -2,7 +2,7 @@
 
 [Minijax](https://minijax.org) - Lightweight subset of JAX-RS and JSR 330.
 
-* Jetty for HTTP server
+* Undertow for HTTP server
 * Mustache for HTML templates
 * MySQL for database
 * Eclipselink for ORM

--- a/frameworks/Java/minijax/benchmark_config.json
+++ b/frameworks/Java/minijax/benchmark_config.json
@@ -18,7 +18,7 @@
       "flavor": "None",
       "orm": "Full",
       "platform": "JAX-RS",
-      "webserver": "Jetty",
+      "webserver": "Undertow",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "Minijax"

--- a/frameworks/Java/minijax/pom.xml
+++ b/frameworks/Java/minijax/pom.xml
@@ -10,8 +10,7 @@
     <properties>
         <eclipselink.version>2.7.0</eclipselink.version>
         <jpa.version>2.1.1</jpa.version>
-        <logback.version>1.2.3</logback.version>
-        <minijax.version>0.0.30</minijax.version>
+        <minijax.version>0.1.4</minijax.version>
         <mysql-connector.version>6.0.6</mysql-connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <shade.version>3.1.0</shade.version>
@@ -27,6 +26,10 @@
             <artifactId>eclipselink</artifactId>
             <version>${eclipselink.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.persistence</groupId>
                     <artifactId>javax.persistence</artifactId>
@@ -98,6 +101,30 @@
                             <goal>sort</goal>
                         </goals>
                         <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>de.empulse.eclipselink</groupId>
+                <artifactId>staticweave-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.persistence</groupId>
+                        <artifactId>org.eclipse.persistence.jpa</artifactId>
+                        <version>${eclipselink.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>weave</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <persistenceXMLLocation>META-INF/persistence.xml</persistenceXMLLocation>
+                            <logLevel>FINE</logLevel>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/frameworks/Java/minijax/setup.sh
+++ b/frameworks/Java/minijax/setup.sh
@@ -6,4 +6,4 @@ sed -i 's|localhost|'${DBHOST}'|g' minijax.properties
 
 mvn clean package
 
-java -XX:+UseNUMA -XX:+UseParallelGC -jar target/minijax-techempower-0.0.1.jar &
+java -server -Xms512m -Xmx2g -XX:+AggressiveOpts -XX:+UseNUMA -XX:+UseParallelGC -jar target/minijax-techempower-0.0.1.jar &

--- a/frameworks/Java/minijax/src/main/java/com/techempower/minijax/MinijaxBenchmark.java
+++ b/frameworks/Java/minijax/src/main/java/com/techempower/minijax/MinijaxBenchmark.java
@@ -12,6 +12,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MediaType;
 
 import org.minijax.Minijax;
@@ -78,6 +81,13 @@ public class MinijaxBenchmark {
         return worlds;
     }
 
+    private static class ServerHeaderFilter implements ContainerResponseFilter {
+        @Override
+        public void filter(final ContainerRequestContext request, final ContainerResponseContext response) {
+            response.getHeaders().add("Server", "M");
+        }
+    }
+
     private static int parseCount(final String count) {
         if (count == null || count.isEmpty()) {
             return 1;
@@ -96,6 +106,7 @@ public class MinijaxBenchmark {
                 .register(JsonFeature.class)
                 .register(MustacheFeature.class)
                 .register(MinijaxBenchmark.class)
-                .run();
+                .register(ServerHeaderFilter.class)
+                .start();
     }
 }

--- a/frameworks/Java/minijax/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/minijax/src/main/resources/META-INF/persistence.xml
@@ -1,12 +1,13 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd" version="2.0">
     <persistence-unit name="minijax" transaction-type="RESOURCE_LOCAL">
-        <shared-cache-mode>NONE</shared-cache-mode>
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>com.techempower.minijax.Fortune</class>
         <class>com.techempower.minijax.World</class>
+        <shared-cache-mode>NONE</shared-cache-mode>
         <properties>
             <property name="eclipselink.jdbc.batch-writing" value="JDBC" />
             <property name="eclipselink.jdbc.cache-statements" value="true" />
+            <property name="eclipselink.weaving" value="static" />
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
Updates:
 * Now using Undertow instead of Jetty
 * Enabled Eclipselink static weaving
 * Enabled Jackson Afterburner module
 * Added JVM performance settings to setup.sh
