### PR TITLE
Rust/may-minihttp add may-minihttp framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,6 +181,7 @@ env:
     # - "TESTDIR=Rust/iron"
     # - "TESTDIR=Rust/nickel"
     # - "TESTDIR=Rust/hyper"
+    # - "TESTDIR=Rust/may-minihttp"
     # - "TESTDIR=Rust/tokio-minihttp"
     # - "TESTDIR=Rust/rouille"
     # - "TESTDIR=Rust/actix"

--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "may-minihttp"
+version = "0.1.0"
+authors = ["Xudong Huang <huangxu008@hotmail.com>"]
+
+[dependencies]
+num_cpus = "1.0"
+serde = "1.0"
+serde_json = "1.0"
+may = { git = "https://github.com/Xudong-Huang/may" }
+may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp" }

--- a/frameworks/Rust/may-minihttp/README.md
+++ b/frameworks/Rust/may-minihttp/README.md
@@ -1,0 +1,15 @@
+# [may-minihttp](https://github.com/Xudong-Huang/may_minihttp) web framework
+
+## Description
+
+may-minihttp is a small, fast micro http framework based on [May](https://github.com/Xudong-Huang/may)
+
+## Test URLs
+
+### Test 1: JSON Encoding 
+
+    http://localhost:8080/json
+
+### Test 2: Plaintext
+
+    http://localhost:8080/plaintext

--- a/frameworks/Rust/may-minihttp/benchmark_config.json
+++ b/frameworks/Rust/may-minihttp/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework": "may-minihttp",
+  "tests": [
+    {
+      "default": {
+        "setup_file": "setup",
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "None",
+        "framework": "may-minihttp",
+        "language": "Rust",
+        "orm": "raw",
+        "platform": "Rust",
+        "webserver": "may-minihttp",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "may-minihttp"
+      }
+    }
+  ]
+}

--- a/frameworks/Rust/may-minihttp/setup.sh
+++ b/frameworks/Rust/may-minihttp/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+fw_depends postgresql rust
+
+cargo clean
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+./target/release/may-minihttp &

--- a/frameworks/Rust/may-minihttp/src/main.rs
+++ b/frameworks/Rust/may-minihttp/src/main.rs
@@ -1,0 +1,40 @@
+extern crate may;
+extern crate num_cpus;
+#[macro_use]
+extern crate serde_json;
+extern crate may_minihttp;
+
+use std::io;
+use may_minihttp::{HttpServer, HttpService, Request, Response};
+
+struct Techempower;
+
+impl HttpService for Techempower {
+    fn call(&self, req: Request) -> io::Result<Response> {
+        let mut resp = Response::new();
+
+        // Bare-bones router
+        match req.path() {
+            "/json" => {
+                resp.header("Content-Type", "application/json");
+                *resp.body_mut() =
+                    serde_json::to_vec(&json!({"message": "Hello, World!"})).unwrap();
+            }
+            "/plaintext" => {
+                resp.header("Content-Type", "text/plain")
+                    .body("Hello, World!");
+            }
+            _ => {
+                resp.status_code(404, "Not Found");
+            }
+        }
+
+        Ok(resp)
+    }
+}
+
+fn main() {
+    may::config().set_io_workers(num_cpus::get());
+    let server = HttpServer(Techempower).start("0.0.0.0:8080").unwrap();
+    server.join().unwrap();
+}


### PR DESCRIPTION
add may-minihttp framework, currently not include database related test.
