### PR TITLE
Update facil.io version + add common setup script

### DIFF
--- a/frameworks/C/facil.io/bench_app.c
+++ b/frameworks/C/facil.io/bench_app.c
@@ -1,9 +1,9 @@
 /*
-This is an incomplete example meant to be used as a benchmark application for
-the TechEmpower Framework Benchmarks. See:
+This is a short implementation fo the TechEmpower Framework Benchmarks. See:
 http://frameworkbenchmarks.readthedocs.io/en/latest/
 
-At the moment it's incomplete and might be broken.
+At the moment it's incomplete and only answers the plaintext and json tests
+using the full HTTP framework stack (without any DB support).
 */
 #include "http.h"
 

--- a/frameworks/C/facil.io/facil.io.dockerfile
+++ b/frameworks/C/facil.io/facil.io.dockerfile
@@ -2,13 +2,17 @@ FROM tfb/base:latest
 
 COPY ./ ./
 
-RUN mkdir facil_app && \
-    cd facil_app && \
-    curl -s -o facil.io.tar.gz -LJO https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.6 && \
-    tar --strip-components=1 -xzf facil.io.tar.gz
+# using a common installation script will allow implementation variations (in future updates)
+RUN ./setup-common.sh
 
 # compile test
-RUN mkdir facil_app/src && cp bench_app.c facil_app/src
+RUN cp -f bench_app.c facil_app/src/app.c
+
+# compile test
+RUN cp bench_app.c facil_app/src
+
+# set compiler to gcc-6 (avoid gcc-4.8.4)... do we need this?
+# ENV CC="gcc-6"
 
 # we don't need more than 32K concurrent connections
 ENV CFLAGS="-DLIB_SOCK_MAX_CAPACITY=32768"
@@ -17,4 +21,4 @@ ENV CFLAGS="-DLIB_SOCK_MAX_CAPACITY=32768"
 RUN cd facil_app && make -j build
 
 # Run the app
-CMD ["./facil_app/tmp/demo", "-p", "8080", "-db \"TFB-database\"", "-w", "-1", "-t", "1"]
+CMD ["./facil_app/tmp/demo", "-p", "8080", "-db \"TFB-database\"", "-w", "-1", "-t", "-1"]

--- a/frameworks/C/facil.io/facil.io.dockerfile
+++ b/frameworks/C/facil.io/facil.io.dockerfile
@@ -5,17 +5,14 @@ COPY ./ ./
 # using a common installation script will allow implementation variations (in future updates)
 RUN ./setup-common.sh
 
-# compile test
-RUN cp -f bench_app.c facil_app/src/app.c
-
-# compile test
-RUN cp bench_app.c facil_app/src
-
 # set compiler to gcc-6 (avoid gcc-4.8.4)... do we need this?
 # ENV CC="gcc-6"
 
 # we don't need more than 32K concurrent connections
 ENV CFLAGS="-DLIB_SOCK_MAX_CAPACITY=32768"
+
+# compile test
+RUN cp -f bench_app.c facil_app/src/app.c
 
 # Build the app
 RUN cd facil_app && make -j build

--- a/frameworks/C/facil.io/setup-common.sh
+++ b/frameworks/C/facil.io/setup-common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Don't redownload facil.io unless using the FIO_EDGE flag.
+if [[ (! -d facil_app) ||  (-n "${FIO_EDGE}") ]] ; then
+	# remove existing installation, if any
+	if [ -e facil_app ] ; then
+		rm -R facil_app
+	fi
+
+	# create new installation folder
+	mkdir facil_app
+	cd facil_app
+
+	#### Download and unpack
+
+	# Download source selection
+	# Setting FIO_EDGE will test against the master branch on the development machine. i.e.:
+	#     $ FIO_EDGE=1 tfb --mode verify --test facil.io
+	if [[ -z "${FIO_EDGE}" ]]; then
+	  FIO_URL="https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.0.beta.8"
+	else
+		echo "INFO: development mode detected, loading facil.io from master."
+		FIO_URL="https://github.com/boazsegev/facil.io/archive/master.tar.gz"
+	fi
+	# Download
+	curl -s -o facil.io.tar.gz -LJO $FIO_URL
+	# Unpack
+	tar --strip-components=1 -xzf facil.io.tar.gz
+	if [ $? -ne 0 ]; then echo "Couldn't extract tar."; exit 1; fi
+	# Cleanup
+	rm facil.io.tar.gz
+	./scripts/new/cleanup
+	cd ..
+fi
+
+# remove any existing source files, such as boiler plate
+rm -R facil_app/src
+mkdir facil_app/src


### PR DESCRIPTION
The main relevant difference in the updated facil.io version is the
memory allocator (I wrote a custom memory allocator that should
minimize lock contention).

It's possible to test the new version without the multi-threaded memory
allocator by using:

```sh
export CFLAGS="${CFLAGS} -DFIO_FORCE_MALLOC"
```

I tried testing the dockerfile locally, but couldn’t make it work.

For some reason the vagrant machine refuses to find the tfb command
(`vagrant up` complains with a number of errors as well, this being one
of them).

I might open a separate issue for that, but I’m not sure if it isn’t
something I’m doing wrong.

---
Note (edit): this replaces PR #3359