### PR TITLE
Use pug 2.0.0 in express instead of a release candidate version

### DIFF
--- a/frameworks/JavaScript/express/package.json
+++ b/frameworks/JavaScript/express/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "express": "4.16.2",
     "body-parser": "1.18.2",
-    "pug": "2.0.0-rc.4",
+    "pug": "2.0.0",
     "sequelize": "3.30.0",
     "mysql": "2.15.0",
     "mongoose": "5.0.6"


### PR DESCRIPTION
This fixes the express fortunes tests for me locally.