### PR TITLE
Java/grizzly-jersey fix

### DIFF
--- a/frameworks/Java/grizzly-bm/grizzly-jersey/src/main/java/hello/SessionFactoryProvider.java
+++ b/frameworks/Java/grizzly-bm/grizzly-jersey/src/main/java/hello/SessionFactoryProvider.java
@@ -22,11 +22,11 @@ public class SessionFactoryProvider
 
   private static SessionFactory createSessionFactory(ResourceConfig rc) {
     Configuration configuration = new Configuration().configure();
-    String url = configuration.getProperty("hibernate.hikari.dataSource.url");
-    url = url.replace(
-        "//localhost:3306/",
-        "//" + rc.getProperty("dbhost") + ":" + rc.getProperty("dbport") + "/");
-    configuration.setProperty("hibernate.hikari.dataSource.url", url);
+//    String url = configuration.getProperty("hibernate.hikari.dataSource.url");
+//    url = url.replace(
+//        "//localhost:3306/",
+//        "//" + rc.getProperty("dbhost") + ":" + rc.getProperty("dbport") + "/");
+//    configuration.setProperty("hibernate.hikari.dataSource.url", url);
     configuration.addAnnotatedClass(World.class);
     configuration.addAnnotatedClass(Fortune.class);
     StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder();

--- a/frameworks/Java/grizzly-bm/grizzly-jersey/src/main/resources/hibernate.cfg.xml
+++ b/frameworks/Java/grizzly-bm/grizzly-jersey/src/main/resources/hibernate.cfg.xml
@@ -9,7 +9,7 @@
     <property name="hibernate.hikari.maximumPoolSize">256</property>
     <property name="hibernate.hikari.idleTimeout">30000</property>
     <property name="hibernate.hikari.dataSourceClassName">com.mysql.jdbc.jdbc2.optional.MysqlDataSource</property>
-    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://localhost:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</property>
+    <property name="hibernate.hikari.dataSource.url">jdbc:mysql://TFB-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</property>
     <property name="hibernate.hikari.dataSource.user">benchmarkdbuser</property>
     <property name="hibernate.hikari.dataSource.password">benchmarkdbpass</property>
   </session-factory>


### PR DESCRIPTION
It was using the same code as here: https://github.com/TechEmpower/FrameworkBenchmarks/pull/3333/commits/7fbc1c8fed8e2b715c6eb354dddb8f3ddcdabcf2
Changes:

- Use `TFB-server`
- Comment out the search and replace on the JDBC URL