### PR TITLE
Sleep more intelligently

### DIFF
--- a/benchmark.cfg.example
+++ b/benchmark.cfg.example
@@ -21,7 +21,6 @@ pipeline_concurrency_levels=[256,1024,4096,16384]
 query_levels=[1,5,10,15,20]
 cached_query_levels=[1,10,20,50,100]
 mode=benchmark
-sleep=60
 test=None
 type=all
 verbose=True

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -399,16 +399,17 @@ class Benchmarker:
                 slept = 0
                 max_sleep = 60
                 while not test.is_running() and slept < max_sleep:
+                    if not docker_helper.successfully_running_containers(
+                            test.get_docker_files(), database_container_id,
+                            out):
+                        tee_output(
+                            out,
+                            "ERROR: One or more expected docker container exited early"
+                            + os.linesep)
+                        return sys.exit(1)
+
                     time.sleep(1)
                     slept += 1
-
-                if not docker_helper.successfully_running_containers(
-                        test.get_docker_files(), database_container_id, out):
-                    tee_output(
-                        out,
-                        "ERROR: One or more expected docker container exited early"
-                        + os.linesep)
-                    return sys.exit(1)
 
                 # Debug mode blocks execution here until ctrl+c
                 if self.config.mode == "debug":

--- a/toolset/utils/database_helper.py
+++ b/toolset/utils/database_helper.py
@@ -1,0 +1,40 @@
+import MySQLdb
+import psycopg2
+import pymongo
+
+
+def test_database(config, database_name):
+    if database_name == "mysql":
+        try:
+            db = MySQLdb.connect(config.database_host, "benchmarkdbuser",
+                                 "benchmarkdbpass", "hello_world")
+            cursor = db.cursor()
+            cursor.execute("SELECT 1")
+            results = cursor.fetchall()
+            db.close()
+        except:
+            return False
+    elif database_name == "postgres":
+        try:
+            db = psycopg2.connect(
+                host=config.database_host,
+                port="5432",
+                user="benchmarkdbuser",
+                password="benchmarkdbpass",
+                database="hello_world")
+            cursor = db.cursor()
+            cursor.execute("SELECT 1")
+            results = cursor.fetchall()
+            db.close()
+        except:
+            return False
+    elif database_name == "mongodb":
+        try:
+            connection = pymongo.MongoClient(host=config.database_host)
+            db = connection.hello_world
+            db.world.find()
+            db.close()
+        except:
+            return False
+
+    return True


### PR DESCRIPTION
1. Wait until the database is accepting connections before returning from `start_database`
2. Wait until the application server is accepting requests before verifying instead of sleeping a configurable amount of time
3. After both above checks, then check that the proper number of containers are running