### PR TITLE
add: Nim's web framework "mofuw"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ env:
     - "TESTDIR=Lua/octopus"
     - "TESTDIR=Lua/openresty"
     - "TESTDIR=Nim/jester"
+    - "TESTDIR=Nim/mofuw"
     - "TESTDIR=Perl/dancer"
     - "TESTDIR=Perl/kelp"
     - "TESTDIR=Perl/mojolicious"

--- a/frameworks/Nim/mofuw/README.md
+++ b/frameworks/Nim/mofuw/README.md
@@ -1,0 +1,11 @@
+# [mofuw](https://github.com/2vg/mofuw) web framework
+
+## Description
+
+mofuw is *MO*re *F*aster, *U*ltra *W*eb server.
+
+## Test URLs
+
+### Test 1: Plaintext
+
+http://localhost:8080/plaintext

--- a/frameworks/Nim/mofuw/benchmark_config.json
+++ b/frameworks/Nim/mofuw/benchmark_config.json
@@ -1,0 +1,21 @@
+{
+    "framework": "mofuw",
+    "tests": [{
+        "default": {
+            "setup_file": "setup",
+            "plaintext_url": "/plaintext",
+            "port": 8080,
+            "approach": "Realistic",
+            "classification": "Micro",
+            "database": "None",
+            "framework": "mofuw",
+            "language": "Nim",
+            "orm": "Raw",
+            "platform": "Nim",
+            "webserver": "mofuw",
+            "os": "Linux",
+            "database_os": "Linux",
+            "display_name": "mofuw"
+        }
+    }]
+}

--- a/frameworks/Nim/mofuw/setup.sh
+++ b/frameworks/Nim/mofuw/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+fw_depends nim
+
+git clone https://github.com/2vg/mofuw mofuw
+
+cd mofuw/tests/techempower
+
+nim c -d:release --threads:on --path:"../../src" techempower.nim
+
+./techempower &

--- a/toolset/setup/linux/frameworks/jester.sh
+++ b/toolset/setup/linux/frameworks/jester.sh
@@ -8,8 +8,8 @@ JESTER=$IROOT/jester
 
 git clone https://github.com/dom96/jester.git
 cd jester
-# 2015-06-25
-git checkout 71b8cc069a0d271d619c2dc41bc6479047885587
+# 2018-02-28
+git checkout 86744f7dff56522c9baa1b4f4381db44044abd9f
 nimble update
 # If ~/.nimble/pkgs/jester exists, write over it.
 echo 'y' | nimble install

--- a/toolset/setup/linux/languages/nim.sh
+++ b/toolset/setup/linux/languages/nim.sh
@@ -2,8 +2,8 @@
 
 fw_installed nim && return 0
 
-NIM_VERSION="0.11.2"
-NIM_CSOURCES="6bf2282"
+NIM_VERSION="0.18.0"
+NIM_CSOURCES="da97f85"
 
 fw_get -O https://github.com/nim-lang/Nim/archive/v$NIM_VERSION.tar.gz
 fw_untar v$NIM_VERSION.tar.gz

--- a/toolset/setup/linux/systools/nimble.sh
+++ b/toolset/setup/linux/systools/nimble.sh
@@ -4,7 +4,7 @@ fw_depends nim
 
 fw_installed nimble && return 0
   
-NIMBLE_VERSION="0.6.2"
+NIMBLE_VERSION="0.8.10"
 
 cd $NIM_HOME
 # nim's package manager


### PR DESCRIPTION
add Nim's web framework "mofuw", currently include plaintext
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
