### PR TITLE
Stop running containers if error occurs

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -388,14 +388,11 @@ class Benchmarker:
                 if result != 0:
                     docker_helper.stop(self.config, database_container_id,
                                        test, out)
-                    time.sleep(5)
                     out.write("ERROR: Problem starting {name}\n".format(
                         name=test.name))
                     out.flush()
                     self.results.write_intermediate(test.name,
                                                     "ERROR: Problem starting")
-                    docker_helper.stop(self.config, database_container_id,
-                                       test, out)
                     return sys.exit(1)
 
                 slept = 0
@@ -404,14 +401,13 @@ class Benchmarker:
                     if not docker_helper.successfully_running_containers(
                             test.get_docker_files(), database_container_id,
                             out):
+                        docker_helper.stop(self.config, database_container_id,
+                                           test, out)
                         tee_output(
                             out,
                             "ERROR: One or more expected docker container exited early"
                             + os.linesep)
-                        docker_helper.stop(self.config, database_container_id,
-                                           test, out)
                         return sys.exit(1)
-
                     time.sleep(1)
                     slept += 1
 

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -394,6 +394,8 @@ class Benchmarker:
                     out.flush()
                     self.results.write_intermediate(test.name,
                                                     "ERROR: Problem starting")
+                    docker_helper.stop(self.config, database_container_id,
+                                       test, out)
                     return sys.exit(1)
 
                 slept = 0
@@ -406,6 +408,8 @@ class Benchmarker:
                             out,
                             "ERROR: One or more expected docker container exited early"
                             + os.linesep)
+                        docker_helper.stop(self.config, database_container_id,
+                                           test, out)
                         return sys.exit(1)
 
                     time.sleep(1)


### PR DESCRIPTION
`sys.exit` does weird things in subprocesses.