### PR TITLE
add Nim's web framework "mofuw" on Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,7 @@ env:
     # - "TESTDIR=Lua/octopus"
     # - "TESTDIR=Lua/openresty"
      - "TESTDIR=Nim/jester"
+     - "TESTDIR=Nim/mofuw"
     # - "TESTDIR=Perl/dancer"
     # - "TESTDIR=Perl/kelp"
     # - "TESTDIR=Perl/mojolicious"

--- a/frameworks/Nim/jester/jester.dockerfile
+++ b/frameworks/Nim/jester/jester.dockerfile
@@ -1,9 +1,9 @@
 FROM tfb/nimble:latest
 
-# 2015-06-25
+# 2018-02-28
 RUN git clone https://github.com/dom96/jester.git && \
     cd jester && \
-    git checkout 71b8cc069a0d271d619c2dc41bc6479047885587 && \
+    git checkout 86744f7dff56522c9baa1b4f4381db44044abd9f && \
     nimble update && \
     echo 'y' | nimble install
 

--- a/frameworks/Nim/mofuw/README.md
+++ b/frameworks/Nim/mofuw/README.md
@@ -1,0 +1,11 @@
+# [mofuw](https://github.com/2vg/mofuw) web framework
+
+## Description
+
+mofuw is *MO*re *F*aster, *U*ltra *W*eb server.
+
+## Test URLs
+
+### Test 1: Plaintext
+
+http://localhost:8080/plaintext

--- a/frameworks/Nim/mofuw/benchmark_config.json
+++ b/frameworks/Nim/mofuw/benchmark_config.json
@@ -1,0 +1,21 @@
+{
+    "framework": "mofuw",
+    "tests": [{
+        "default": {
+            "setup_file": "setup",
+            "plaintext_url": "/plaintext",
+            "port": 8080,
+            "approach": "Realistic",
+            "classification": "Micro",
+            "database": "None",
+            "framework": "mofuw",
+            "language": "Nim",
+            "orm": "Raw",
+            "platform": "Nim",
+            "webserver": "mofuw",
+            "os": "Linux",
+            "database_os": "Linux",
+            "display_name": "mofuw"
+        }
+    }]
+}

--- a/frameworks/Nim/mofuw/mofuw.dockerfile
+++ b/frameworks/Nim/mofuw/mofuw.dockerfile
@@ -1,0 +1,11 @@
+FROM tfb/nimble:latest
+
+RUN git clone https://github.com/2vg/mofuw.git && \
+    cd mofuw && \
+    echo 'y' | nimble install
+
+COPY ./ ./
+
+RUN nim c -d:release --threads:on techempower.nim
+
+CMD ./techempower

--- a/frameworks/Nim/mofuw/techempower.nim
+++ b/frameworks/Nim/mofuw/techempower.nim
@@ -1,0 +1,9 @@
+import mofuw
+
+proc h(req: mofuwReq, res: mofuwRes) {.async.} =
+  if req.getPath == "/plaintext":
+    mofuwResp(HTTP200, "text/plain", "Hello, World!")
+  else:
+    mofuwResp(HTTP200, "text/plain", "404 NOT FOUND")
+
+h.mofuwRun(port = 8080, bufSize = 512)

--- a/toolset/setup/docker/languages/nim.dockerfile
+++ b/toolset/setup/docker/languages/nim.dockerfile
@@ -1,7 +1,7 @@
 FROM tfb/nginx:latest
 
-ENV NIM_VERSION="0.11.2"
-ENV NIM_CSOURCES="6bf2282"
+ENV NIM_VERSION="0.18.0"
+ENV NIM_CSOURCES="da97f85"
 
 RUN wget https://github.com/nim-lang/Nim/archive/v$NIM_VERSION.tar.gz
 RUN tar xvf v$NIM_VERSION.tar.gz

--- a/toolset/setup/docker/systools/nimble.dockerfile
+++ b/toolset/setup/docker/systools/nimble.dockerfile
@@ -1,6 +1,6 @@
 FROM tfb/nim:latest
   
-ENV NIMBLE_VERSION="0.6.2"
+ENV NIMBLE_VERSION="0.8.10"
 
 RUN cd $NIM_HOME && \
     wget https://github.com/nim-lang/nimble/archive/v$NIMBLE_VERSION.tar.gz && \


### PR DESCRIPTION
add Nim's web framework "mofuw", currently include plaintext
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
