### PR TITLE
Prevent fortunes output being accumulated across tests by the verifier

### DIFF
--- a/toolset/benchmark/fortune_html_parser.py
+++ b/toolset/benchmark/fortune_html_parser.py
@@ -4,7 +4,10 @@ from difflib import unified_diff
 
 
 class FortuneHTMLParser(HTMLParser):
-    body = []
+
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.body = []
 
     valid_fortune = '''<!doctype html><html>
 <head><title>Fortunes</title></head>


### PR DESCRIPTION
It makes sense to me why it was doing what it did - it was accumulating
the fortunes output into a static class-level variable - and it makes
sense why this change fixes that problem.  What doesn't make sense is
why this problem is new.  How did it ever work?