### PR TITLE
Bump Finagle benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -2,11 +2,11 @@ name := "finagle"
 
 scalaVersion := "2.11.12"
 
-version := "17.11.0"
+version := "18.3.0"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "17.11.0",
+  "com.twitter" %% "finagle-http" % "18.3.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4"
 )

--- a/frameworks/Scala/finagle/finagle.dockerfile
+++ b/frameworks/Scala/finagle/finagle.dockerfile
@@ -4,4 +4,4 @@ COPY ./ ./
 
 RUN sbt 'oneJar' -batch
 
-CMD java -jar target/scala-2.11/*finagle*one-jar.jar
+CMD java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.leakDetection.level=disabled -jar target/scala-2.11/*finagle*one-jar.jar

--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -43,7 +43,6 @@ object Main extends App {
   }
 
   Await.ready(Http.server
-    .configured(Http.Netty3Impl)
     .withCompressionLevel(0)
     .withStack(nilStack)
     .serve(":8080", serverAndDate.andThen(muxer))

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,6 +1,6 @@
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"
-version := "2.11.0"
+version := "18.3.0"
 
 scalaVersion := "2.12.4"
 
@@ -16,7 +16,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "17.12.0",
+  "com.twitter" %% "finatra-http" % "18.3.0",
   "org.slf4j" % "slf4j-nop" % "1.7.25",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4",
   "javax.activation" % "activation" % "1.1.1"

--- a/frameworks/Scala/finatra/finatra.dockerfile
+++ b/frameworks/Scala/finatra/finatra.dockerfile
@@ -4,4 +4,4 @@ COPY ./ ./
 
 RUN sbt clean assembly -batch
 
-CMD java -Dcom.twitt.finagle.netty4.numWorkers=1 -Dcom.twitter.util.events.sinkEnabled=false -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -jar target/scala-2.12/finatra-benchmark.jar -log.level=ERROR -http.response.charset.enabled=false
+CMD java -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.leakDetection.level=disabled -Dcom.twitter.util.events.sinkEnabled=false -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -jar target/scala-2.12/finatra-benchmark.jar -log.level=ERROR -http.response.charset.enabled=false

--- a/frameworks/Scala/finatra/src/main/scala/Main.scala
+++ b/frameworks/Scala/finatra/src/main/scala/Main.scala
@@ -1,4 +1,4 @@
-import com.twitter.finagle.Http.{Netty3Impl, Server}
+import com.twitter.finagle.Http.Server
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.stack.nilStack
 import com.twitter.finagle.stats.NullStatsReceiver
@@ -11,7 +11,6 @@ object FinatraBenchmarkServerMain extends FinatraBenchmarkServer
 class FinatraBenchmarkServer extends HttpServer {
   override def configureHttpServer(server: Server): Server = {
     server
-      .configured(Netty3Impl)
       .withCompressionLevel(0)
       .withStatsReceiver(NullStatsReceiver)
       .withStack(nilStack)

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,12 +1,12 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.16.0-M5"
+version := "0.18.0"
 
 scalaVersion := "2.11.12"
 
 com.github.retronym.SbtOneJar.oneJarSettings
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.16.0-M5",
-  "com.github.finagle" %% "finch-circe" % "0.16.0-M5"
+  "com.github.finagle" %% "finch-core" % "0.18.0",
+  "com.github.finagle" %% "finch-circe" % "0.18.0"
 )

--- a/frameworks/Scala/finch/finch.dockerfile
+++ b/frameworks/Scala/finch/finch.dockerfile
@@ -4,4 +4,4 @@ COPY ./ ./
 
 RUN sbt 'oneJar' -batch
 
-CMD java -jar target/scala-2.11/*finch*one-jar.jar
+CMD java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.leakDetection.level=disabled -jar target/scala-2.11/*finch*one-jar.jar

--- a/frameworks/Scala/finch/src/main/scala/Main.scala
+++ b/frameworks/Scala/finch/src/main/scala/Main.scala
@@ -7,6 +7,7 @@ import com.twitter.util.Await
 
 import io.circe.Json
 import io.finch._
+import io.finch.syntax._
 import io.finch.circe._
 
 object Main extends App {
@@ -27,10 +28,10 @@ object Main extends App {
       .serve[Text.Plain](plaintext)
       .toService
 
-  Await.ready(Http.server
-    .configured(Http.Netty3Impl)
-    .withCompressionLevel(0)
-    .withStack(nilStack)
-    .serve(":9000", service)
+  Await.ready(
+    Http.server
+      .withCompressionLevel(0)
+      .withStack(nilStack)
+      .serve(":9000", service)
   )
 }


### PR DESCRIPTION
This PR bumps Finagle-based benchmarks to new versions:

 - Finch was bumped to 0.18
 - Finatra was bumped to 18.3
 - Finagle was bumped to 18.3

It also introduces new JVM options for Finch and Finagle benchmarks (inspired by what Finatra uses) as well as migrates all of the above to the Netty 4 version.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
