### PR TITLE
Docker logging multiple build lines

### DIFF
--- a/toolset/benchmark/fortune_html_parser.py
+++ b/toolset/benchmark/fortune_html_parser.py
@@ -186,5 +186,5 @@ class FortuneHTMLParser(HTMLParser):
                 headers_left -= 1
                 if headers_left <= 0:
                     output += os.linesep
-            log(output, "%s: " % name)
+            log(output, prefix="%s: " % name)
         return (same, diff_lines)

--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -3,7 +3,7 @@ import subprocess
 import traceback
 from requests import ConnectionError
 
-from toolset.utils.output_helper import header, log, FNULL
+from toolset.utils.output_helper import log, FNULL
 from toolset.utils import docker_helper
 
 # Cross-platform colored text
@@ -129,9 +129,8 @@ class FrameworkTest:
             with open(os.path.join(verificationPath, 'verification.txt'),
                       'w') as verification:
                 test = self.runTests[test_type]
-                header(
-                    message="VERIFYING %s" % test_type.upper(),
-                    log_file=verification)
+                log("VERIFYING %s" % test_type.upper(),
+                    file=verification, border='-', color=Fore.WHITE + Style.BRIGHT)
 
                 base_url = "http://%s:%s" % (
                     self.benchmarker_config.server_host, self.port)
@@ -166,7 +165,7 @@ class FrameworkTest:
                     results = [('fail', "Server did not respond to request",
                                 base_url)]
                     log("Verifying test %s for %s caused an exception: %s" %
-                        (test_type, self.name, e))
+                        (test_type, self.name, e), color=Fore.RED)
                 except Exception as e:
                     results = [('fail', """Caused Exception in TFB
             This almost certainly means your return value is incorrect,
@@ -174,7 +173,7 @@ class FrameworkTest:
             including this message: %s\n%s""" % (e, traceback.format_exc()),
                                 base_url)]
                     log("Verifying test %s for %s caused an exception: %s" %
-                        (test_type, self.name, e))
+                        (test_type, self.name, e), color=Fore.RED)
                     traceback.format_exc()
 
                 test.failed = any(
@@ -193,14 +192,14 @@ class FrameworkTest:
                         color = Fore.RED
 
                     log("   {!s}{!s}{!s} for {!s}".format(
-                        color, result.upper(), Style.RESET_ALL, url), None,
-                        verification)
+                        color, result.upper(), Style.RESET_ALL, url),
+                        file=verification)
                     if reason is not None and len(reason) != 0:
                         for line in reason.splitlines():
-                            log("     " + line, None, verification)
+                            log("     " + line, file=verification)
                         if not test.passed:
                             log("     See {!s}".format(specific_rules_url),
-                                None, verification)
+                                file=verification)
 
                 [output_result(r1, r2, url) for (r1, r2, url) in results]
 

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -8,7 +8,7 @@ import pymongo
 import traceback
 
 from colorama import Fore
-from toolset.utils.output_helper import log, log_error
+from toolset.utils.output_helper import log
 
 
 class FrameworkTestType:
@@ -86,7 +86,7 @@ class FrameworkTestType:
         Downloads a URL and returns the HTTP response headers
         and body content as a tuple
         '''
-        log("{!s}Accessing URL {!s}:{!s}".format(Fore.CYAN, url, Fore.RESET))
+        log("Accessing URL {!s}: ".format(url), color=Fore.CYAN)
 
         headers = {'Accept': self.accept_header}
         r = requests.get(url, timeout=15, headers=headers)
@@ -164,8 +164,8 @@ class FrameworkTestType:
                 db.close()
             except Exception:
                 tb = traceback.format_exc()
-                log("ERROR: Unable to load current MySQL World table.")
-                log_error(tb)
+                log("ERROR: Unable to load current MySQL World table.", color=Fore.RED)
+                log(tb)
         elif database_name == "postgres":
             try:
                 db = psycopg2.connect(
@@ -185,8 +185,8 @@ class FrameworkTestType:
                 db.close()
             except Exception:
                 tb = traceback.format_exc()
-                log("ERROR: Unable to load current Postgres World table.")
-                log_error(tb)
+                log("ERROR: Unable to load current Postgres World table.", color=Fore.RED)
+                log(tb)
         elif database_name == "mongodb":
             try:
                 worlds_json = {}
@@ -205,8 +205,8 @@ class FrameworkTestType:
                 connection.close()
             except Exception:
                 tb = traceback.format_exc()
-                log("ERROR: Unable to load current MongoDB World table.")
-                log_error(tb)
+                log("ERROR: Unable to load current MongoDB World table.", color=Fore.RED)
+                log(tb)
         else:
             raise ValueError(
                 "Database: {!s} does not exist".format(database_name))

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -7,6 +7,7 @@ import psycopg2
 import pymongo
 import traceback
 
+from colorama import Fore
 from toolset.utils.output_helper import log, log_error
 
 
@@ -85,7 +86,7 @@ class FrameworkTestType:
         Downloads a URL and returns the HTTP response headers
         and body content as a tuple
         '''
-        log("Accessing URL {!s}:".format(url))
+        log("{!s}Accessing URL {!s}:{!s}".format(Fore.CYAN, url, Fore.RESET))
 
         headers = {'Accept': self.accept_header}
         r = requests.get(url, timeout=15, headers=headers)
@@ -94,7 +95,6 @@ class FrameworkTestType:
         body = r.content
         log(str(headers))
         log(body)
-        log("  Response: \"{!s}\"".format(body))
         return headers, body
 
     def verify(self, base_url):

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -94,10 +94,7 @@ class FrameworkTestType:
         body = r.content
         log(str(headers))
         log(body)
-        b = 40
-        log("  Response (trimmed to {:d} bytes): \"{!s}\"".format(
-            b,
-            body.strip()[:b]))
+        log("  Response: \"{!s}\"".format(body))
         return headers, body
 
     def verify(self, base_url):

--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -2,7 +2,7 @@ import json
 import re
 import traceback
 
-from toolset.utils.output_helper import log_error
+from toolset.utils.output_helper import log
 
 
 def basic_body_verification(body, url, is_json_check=True):
@@ -280,7 +280,7 @@ def verify_updates(old_worlds, new_worlds, updates_expected, url):
                         successful_updates += 1
             except Exception:
                 tb = traceback.format_exc()
-                log_error(tb)
+                log(tb)
         n += 1
 
     if successful_updates == 0:

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -41,8 +41,8 @@ class StoreSeqAction(argparse.Action):
             try:
                 (start, step, end) = sequence.split(':')
             except ValueError:
-                log("  Invalid: {!s}".format(sequence))
-                log("  Requires start:step:end, e.g. 1:2:10")
+                log("  Invalid: {!s}".format(sequence), color=Fore.RED)
+                log("  Requires start:step:end, e.g. 1:2:10", color=Fore.RED)
                 raise
             result.remove(sequence)
             result = result + range(int(start), int(end), int(step))
@@ -103,7 +103,7 @@ def main(argv=None):
                     os.environ['FWROOT'],
                     args.conf_file)) and not os.path.exists(
                         os.path.join(os.environ['FWROOT'] + 'benchmark.cfg')):
-            log("No config file found. Aborting!")
+            log("No config file found. Aborting!", Fore.RED)
             exit(1)
         with open(os.path.join(os.environ['FWROOT'], args.conf_file)):
             config = ConfigParser.SafeConfigParser()
@@ -116,7 +116,7 @@ def main(argv=None):
                 except Exception:
                     pass
     except IOError:
-        log("Configuration file not found!")
+        log("Configuration file not found!", Fore.RED)
         exit(1)
 
     ##########################################################
@@ -125,7 +125,7 @@ def main(argv=None):
 
     # Verify and massage options
     if defaults['client_user'] is None or defaults['client_host'] is None:
-        log("client_user and client_host are required!")
+        log("client_user and client_host are required!", color=Fore.RED)
         log("Please check your configuration file.")
         log("Aborting!")
         exit(1)

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -37,7 +37,7 @@ def header(message,
         if color is not None:
             result += color
         result += "%s%s" % (os.linesep, bottomheader)
-    log(result + os.linesep, log_file, True, quiet)
+    log(result + os.linesep, '', log_file, quiet)
 
 
 def log(log_text=None,

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -65,7 +65,7 @@ def log(log_text=None,
             sys.stdout.flush()
 
         if log_file is not None:
-            log_file.write(seq.sub('', new_log_text))
+            log_file.write(seq.sub('', log_text))
             log_file.flush()
     except:
         pass

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -10,13 +10,7 @@ seq = re.compile(r'\x1B\[\d+m')
 FNULL = open(os.devnull, 'w')
 
 
-def log(log_text=None,
-        color='',
-        prefix='',
-        border=None,
-        border_bottom=None,
-        file=None,
-        quiet=False):
+def log(log_text=None, **kwargs):
     '''
     Logs the given text and optional prefix to stdout (if quiet is False) and
     to an optional log file. By default, we strip out newlines in order to 
@@ -25,13 +19,13 @@ def log(log_text=None,
     '''
 
     # set up some defaults
-    # color = kwargs.get('color', '')
+    color = kwargs.get('color', '')
     color_reset = Style.RESET_ALL if color else ''
-    # prefix = kwargs.get('prefix', '')
-    # border = kwargs.get('border')
-    # border_bottom = kwargs.get('border_bottom')
-    # file = kwargs.get('file')
-    # quiet = kwargs.get('quiet')
+    prefix = kwargs.get('prefix', '')
+    border = kwargs.get('border')
+    border_bottom = kwargs.get('border_bottom')
+    file = kwargs.get('file')
+    quiet = kwargs.get('quiet')
 
     if border is not None:
         border = color + (border * 80) + os.linesep + color_reset

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -10,7 +10,13 @@ seq = re.compile(r'\x1B\[\d+m')
 FNULL = open(os.devnull, 'w')
 
 
-def log(log_text=None, **kwargs):
+def log(log_text=None,
+        color='',
+        prefix='',
+        border=None,
+        border_bottom=None,
+        file=None,
+        quiet=False):
     '''
     Logs the given text and optional prefix to stdout (if quiet is False) and
     to an optional log file. By default, we strip out newlines in order to 
@@ -19,13 +25,13 @@ def log(log_text=None, **kwargs):
     '''
 
     # set up some defaults
-    color = kwargs.get('color', '')
+    # color = kwargs.get('color', '')
     color_reset = Style.RESET_ALL if color else ''
-    prefix = kwargs.get('prefix', '')
-    border = kwargs.get('border')
-    border_bottom = kwargs.get('border_bottom')
-    file = kwargs.get('file')
-    quiet = kwargs.get('quiet')
+    # prefix = kwargs.get('prefix', '')
+    # border = kwargs.get('border')
+    # border_bottom = kwargs.get('border_bottom')
+    # file = kwargs.get('file')
+    # quiet = kwargs.get('quiet')
 
     if border is not None:
         border = color + (border * 80) + os.linesep + color_reset

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -37,13 +37,12 @@ def header(message,
         if color is not None:
             result += color
         result += "%s%s" % (os.linesep, bottomheader)
-    log(result + os.linesep, None, log_file, True, quiet)
+    log(result + os.linesep, log_file, True, quiet)
 
 
 def log(log_text=None,
-        prefix=None,
+        prefix='',
         log_file=None,
-        allow_newlines=False,
         quiet=False):
     '''
     Logs the given text and optional prefix to stdout (if quiet is False) and
@@ -54,18 +53,12 @@ def log(log_text=None,
     if not log_text:
         return
 
-    if not allow_newlines:
-        log_text = log_text.splitlines()[0] + os.linesep
-
-        if log_text.splitlines()[0].strip() is '':
-            return
-
     try:
         if not quiet:
-            if prefix is not None:
-                sys.stdout.write(prefix + log_text)
-            else:
-                sys.stdout.write(log_text)
+            for line in log_text.splitlines():
+                if line.strip() is '':
+                    return
+                sys.stdout.write(prefix + line + os.linesep)
             sys.stdout.flush()
 
         if log_file is not None:

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -54,15 +54,18 @@ def log(log_text=None,
         return
 
     try:
+        new_log_text = ''
+        for line in log_text.splitlines():
+            if line.strip() is '':
+                return
+            new_log_text = new_log_text + prefix + line + os.linesep
+
         if not quiet:
-            for line in log_text.splitlines():
-                if line.strip() is '':
-                    return
-                sys.stdout.write(prefix + line + os.linesep)
+            sys.stdout.write(new_log_text)
             sys.stdout.flush()
 
         if log_file is not None:
-            log_file.write(seq.sub('', log_text))
+            log_file.write(seq.sub('', new_log_text))
             log_file.flush()
     except:
         pass

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -51,7 +51,6 @@ def log(log_text=None, **kwargs):
             file.write(seq.sub('', log_text))
             file.flush()
     except:
-        print('error')
         pass
 
 

--- a/toolset/utils/output_helper.py
+++ b/toolset/utils/output_helper.py
@@ -28,9 +28,9 @@ def log(log_text=None, **kwargs):
     quiet = kwargs.get('quiet')
 
     if border is not None:
-        border = color + (border * 80) + os.linesep
+        border = color + (border * 80) + os.linesep + color_reset
         border_bottom = border if border_bottom is None else \
-            color + (border_bottom * 80) + os.linesep
+            color + (border_bottom * 80) + os.linesep + color_reset
     elif not log_text:
         return
 

--- a/toolset/utils/results_helper.py
+++ b/toolset/utils/results_helper.py
@@ -1,8 +1,7 @@
 from toolset.utils.metadata_helper import gather_remaining_tests, gather_frameworks
-from toolset.utils.output_helper import header, log, FNULL
+from toolset.utils.output_helper import log, FNULL
 
 import os
-import logging
 import subprocess
 import uuid
 import time
@@ -294,8 +293,8 @@ class Results:
             # Normally you don't have to use Fore.BLUE before each line, but
             # Travis-CI seems to reset color codes on newline (see travis-ci/travis-ci#2692)
             # or stream flush, so we have to ensure that the color code is printed repeatedly
-            header(
-                "Verification Summary", top='=', bottom='-', color=Fore.CYAN)
+            log(
+                "Verification Summary", border='=', border_bottom='-', color=Fore.CYAN)
             for test in tests:
                 log(Fore.CYAN + "| {!s}".format(test.name))
                 if test.name in self.verify.keys():
@@ -312,7 +311,7 @@ class Results:
                 else:
                     log(Fore.CYAN + "|      " + Fore.RED +
                         "NO RESULTS (Did framework launch?)")
-            header('', top='=', bottom='', color=Fore.CYAN)
+            log('', border='=', border_bottom='', color=Fore.CYAN)
 
         log("%sTime to complete: %s seconds" %
             (Style.RESET_ALL, str(int(time.time() - self.config.start_time))))


### PR DESCRIPTION
So I did a few things here:

 - Instead of using ordered arguments I used `kwargs`. This made everywhere we're doing logging a lot more readable.
 - I combined `header()` into `log()` by allowing a `border` and `border_bottom` option.
 - I added a color option for logging. This makes coloring output a lot easier. It will handle styling before and after, and it will do it after any `prefix`. It also colors the borders.
 - I've highlighted the build steps from the docker build process. This will help out a ton when trudging back through the logs to see which step caused a problem.

I think this makes logging a bit easier and gives us the ability to bake in additional options down the road worrying about ordering args, etc.
