### PR TITLE
Avoid "installing" resin, use the resin home directory directly

### DIFF
--- a/frameworks/Clojure/compojure/compojure-base.dockerfile
+++ b/frameworks/Clojure/compojure/compojure-base.dockerfile
@@ -5,4 +5,4 @@ RUN lein clean
 RUN lein ring uberwar
 
 FROM tfb/resin-java8:latest
-COPY --from=leiningen /compojure/target/hello-compojure-standalone.war /var/resin/webapps/ROOT.war
+COPY --from=leiningen /compojure/target/hello-compojure-standalone.war ${RESIN_HOME}/webapps/ROOT.war

--- a/frameworks/Clojure/compojure/compojure-raw.dockerfile
+++ b/frameworks/Clojure/compojure/compojure-raw.dockerfile
@@ -1,2 +1,2 @@
 FROM tfb/compojure-base:latest
-CMD resinctl console
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Clojure/compojure/compojure.dockerfile
+++ b/frameworks/Clojure/compojure/compojure.dockerfile
@@ -1,2 +1,2 @@
 FROM tfb/compojure-base:latest
-CMD resinctl console
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Groovy/grails/grails.dockerfile
+++ b/frameworks/Groovy/grails/grails.dockerfile
@@ -16,5 +16,5 @@ RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output r
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output compile
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} prod -non-interactive -plain-output war
 
-RUN cp target/hello-0.1.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+RUN cp target/hello-0.1.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/activeweb/activeweb-base.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-base.dockerfile
@@ -4,4 +4,4 @@ WORKDIR /activeweb
 RUN mvn clean package -DskipTests
 
 FROM tfb/resin:latest
-COPY --from=maven /activeweb/target/activeweb.war /var/resin/webapps/ROOT.war
+COPY --from=maven /activeweb/target/activeweb.war ${RESIN_HOME}/webapps/ROOT.war

--- a/frameworks/Java/activeweb/activeweb-jackson.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-jackson.dockerfile
@@ -1,2 +1,2 @@
 FROM tfb/activeweb-base:latest
-CMD resinctl console
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/activeweb/activeweb.dockerfile
+++ b/frameworks/Java/activeweb/activeweb.dockerfile
@@ -1,2 +1,2 @@
 FROM tfb/activeweb-base:latest
-CMD resinctl console
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /curacao
 RUN mvn clean compile war:war
 
 FROM tfb/resin:latest
-COPY --from=maven /curacao/target/curacao.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /curacao/target/curacao.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/gemini/Docroot/WEB-INF/resin.xml
+++ b/frameworks/Java/gemini/Docroot/WEB-INF/resin.xml
@@ -3,7 +3,7 @@
 
   <cluster id="">
     
-    <resin:import path="/etc/resin/app-default.xml" />
+    <resin:import path="${RESIN_HOME}/conf/app-default.xml" />
     <log name="" level="config" path="stdout:" timestamp="[%H:%M:%S.%s] " />
 
     <server id="">

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -17,4 +17,4 @@ FROM tfb/resin:latest
 
 COPY --from=ant /gemini /gemini
 
-CMD ["resinctl", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]
+CMD java -jar ${RESIN_HOME}/lib/resin.jar -conf /gemini/Docroot/WEB-INF/resin.xml console

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -17,4 +17,4 @@ FROM tfb/resin:latest
 
 COPY --from=ant /gemini /gemini
 
-CMD ["resinctl", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]
+CMD java -jar ${RESIN_HOME}/lib/resin.jar -conf /gemini/Docroot/WEB-INF/resin.xml console

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -14,4 +14,4 @@ FROM tfb/resin:latest
 
 COPY --from=ant /gemini /gemini
 
-CMD ["resinctl", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]
+CMD java -jar ${RESIN_HOME}/lib/resin.jar -conf /gemini/Docroot/WEB-INF/resin.xml console

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -13,5 +13,5 @@ RUN rm dsl-compiler.zip
 RUN mvn clean compile war:war
 
 FROM tfb/resin-java8:latest
-COPY --from=maven /revenj-jvm/target/revenj.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /revenj-jvm/target/revenj.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/servlet/servlet-afterburner.dockerfile
+++ b/frameworks/Java/servlet/servlet-afterburner.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /servlet
 RUN mvn clean compile war:war -P afterburner
 
 FROM tfb/resin:latest
-COPY --from=maven /servlet/target/servlet.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /servlet/target/servlet.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/servlet/servlet-cjs.dockerfile
+++ b/frameworks/Java/servlet/servlet-cjs.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /servlet
 RUN mvn clean compile war:war -P cjs
 
 FROM tfb/resin:latest
-COPY --from=maven /servlet/target/servlet.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /servlet/target/servlet.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /servlet
 RUN mvn clean compile war:war -P mysql
 
 FROM tfb/resin:latest
-COPY --from=maven /servlet/target/servlet.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /servlet/target/servlet.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/servlet/servlet-postgresql.dockerfile
+++ b/frameworks/Java/servlet/servlet-postgresql.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /servlet
 RUN mvn clean compile war:war -P postgresql
 
 FROM tfb/resin:latest
-COPY --from=maven /servlet/target/servlet.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /servlet/target/servlet.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/servlet/servlet.dockerfile
+++ b/frameworks/Java/servlet/servlet.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /servlet
 RUN mvn clean compile war:war
 
 FROM tfb/resin:latest
-COPY --from=maven /servlet/target/servlet.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /servlet/target/servlet.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/spark/spark.dockerfile
+++ b/frameworks/Java/spark/spark.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /spark
 RUN mvn clean package
 
 FROM tfb/resin-java8
-COPY --from=maven /spark/target/spark.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /spark/target/spark.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/tapestry/tapestry.dockerfile
+++ b/frameworks/Java/tapestry/tapestry.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /tapestry
 RUN mvn clean compile war:war
 
 FROM tfb/resin-java8:latest
-COPY --from=maven /tapestry/target/tapestry.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /tapestry/target/tapestry.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/frameworks/Java/wicket/wicket.dockerfile
+++ b/frameworks/Java/wicket/wicket.dockerfile
@@ -4,5 +4,5 @@ WORKDIR /wicket
 RUN mvn clean compile war:war
 
 FROM tfb/resin:latest
-COPY --from=maven /wicket/target/hellowicket-1.0.war /var/resin/webapps/ROOT.war
-CMD resinctl console
+COPY --from=maven /wicket/target/hellowicket-1.0.war ${RESIN_HOME}/webapps/ROOT.war
+CMD java -jar ${RESIN_HOME}/lib/resin.jar console

--- a/toolset/setup/docker/webservers/resin-java8.dockerfile
+++ b/toolset/setup/docker/webservers/resin-java8.dockerfile
@@ -3,12 +3,8 @@ FROM tfb/java8:latest
 RUN mkdir /resin
 WORKDIR /resin
 RUN curl -s http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
-WORKDIR /resin/resin-4.0.55
-RUN ./configure
-RUN make
-RUN make install
-
-# Remove the default app so that frameworks using Resin don't have to.
-RUN rm -rf /var/resin/webapps/*
 
 ENV RESIN_HOME=/resin/resin-4.0.55
+
+# Remove the default app so that frameworks using Resin don't have to.
+RUN rm -rf ${RESIN_HOME}/webapps/*

--- a/toolset/setup/docker/webservers/resin.dockerfile
+++ b/toolset/setup/docker/webservers/resin.dockerfile
@@ -3,12 +3,8 @@ FROM tfb/java:latest
 RUN mkdir /resin
 WORKDIR /resin
 RUN curl -s http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
-WORKDIR /resin/resin-4.0.55
-RUN ./configure
-RUN make
-RUN make install
-
-# Remove the default app so that frameworks using Resin don't have to.
-RUN rm -rf /var/resin/webapps/*
 
 ENV RESIN_HOME=/resin/resin-4.0.55
+
+# Remove the default app so that frameworks using Resin don't have to.
+RUN rm -rf ${RESIN_HOME}/webapps/*


### PR DESCRIPTION
One of the `configure`, `make`, or `make install` steps was failing for
me locally with a weird error when I tried using a new version of Java.
It made me realize that we don't really need those steps.  They take a
little while and are another point of failure.  I believe they also bind
the resin installation to a particular version of Java, when otherwise
there shouldn't be anything stopping us from reusing one resin
installation in all Java versions, though I didn't try that here.