### PR TITLE
Fix FrameworkTest.is_running URL format to remove extra slash in path

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -84,9 +84,9 @@ class FrameworkTest:
             test_type = any_type
             break
 
-        url = "http://%s:%s/%s" % (self.benchmarker_config.server_host,
-                                   self.port,
-                                   self.runTests[test_type].get_url())
+        url = "http://%s:%s%s" % (self.benchmarker_config.server_host,
+                                  self.port,
+                                  self.runTests[test_type].get_url())
 
         try:
             subprocess.check_call(


### PR DESCRIPTION
The previous code was producing URLs like "http://127.0.0.1:8080//db",
whereas with this change that would be "http://127.0.0.1:8080/db".  I
noticed this with PHP/zend which was trying to respond with a 404 error
page to those "//db" requests.  So this should result in some framemworks
like PHP/zend starting up faster (because the toolset will hit a valid
URL immediately and recognize the app as started immediately).

All test type URLs begin with a "/".  I'm pretty the toolset enforces
this.  I tried removing the leading slash from one of those URLs and the
toolset wouldn't recognize my benchmark_config.json as valid.