### PR TITLE
Upgrade from Java 9 to 10

### DIFF
--- a/toolset/setup/docker/languages/java.dockerfile
+++ b/toolset/setup/docker/languages/java.dockerfile
@@ -2,6 +2,6 @@ FROM tfb/base:latest
 
 RUN mkdir /java
 WORKDIR /java
-RUN curl -sL https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz | tar xz
-ENV JAVA_HOME=/java/jdk-9.0.4
+RUN curl -sL https://download.java.net/java/GA/jdk10/10/binaries/openjdk-10_linux-x64_bin.tar.gz | tar xz
+ENV JAVA_HOME=/java/jdk-10
 ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/toolset/setup/docker/languages/java.dockerfile
+++ b/toolset/setup/docker/languages/java.dockerfile
@@ -2,6 +2,6 @@ FROM tfb/base:latest
 
 RUN mkdir /java
 WORKDIR /java
-RUN curl -s https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz | tar xz
+RUN curl -sL https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz | tar xz
 ENV JAVA_HOME=/java/jdk-9.0.4
 ENV PATH="${JAVA_HOME}/bin:${PATH}"

--- a/toolset/setup/docker/systools/maven-java8.dockerfile
+++ b/toolset/setup/docker/systools/maven-java8.dockerfile
@@ -2,7 +2,7 @@ FROM tfb/java8:latest
 
 RUN mkdir /maven
 WORKDIR /maven
-RUN curl -s http://mirrors.advancedhosters.com/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz | tar xz
+RUN curl -sL http://mirrors.advancedhosters.com/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz | tar xz
 ENV MAVEN_HOME=/maven/apache-maven-3.5.2
 ENV PATH="${MAVEN_HOME}/bin:${PATH}"
 

--- a/toolset/setup/docker/systools/maven.dockerfile
+++ b/toolset/setup/docker/systools/maven.dockerfile
@@ -2,7 +2,7 @@ FROM tfb/java:latest
 
 RUN mkdir /maven
 WORKDIR /maven
-RUN curl -s http://mirrors.advancedhosters.com/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz | tar xz
+RUN curl -sL http://mirrors.advancedhosters.com/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz | tar xz
 ENV MAVEN_HOME=/maven/apache-maven-3.5.2
 ENV PATH="${MAVEN_HOME}/bin:${PATH}"
 

--- a/toolset/setup/docker/webservers/resin-java8.dockerfile
+++ b/toolset/setup/docker/webservers/resin-java8.dockerfile
@@ -2,7 +2,7 @@ FROM tfb/java8:latest
 
 RUN mkdir /resin
 WORKDIR /resin
-RUN curl -s http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
+RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
 
 ENV RESIN_HOME=/resin/resin-4.0.55
 

--- a/toolset/setup/docker/webservers/resin.dockerfile
+++ b/toolset/setup/docker/webservers/resin.dockerfile
@@ -2,7 +2,7 @@ FROM tfb/java:latest
 
 RUN mkdir /resin
 WORKDIR /resin
-RUN curl -s http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
+RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz
 
 ENV RESIN_HOME=/resin/resin-4.0.55
 

--- a/toolset/setup/docker/webservers/tomcat.dockerfile
+++ b/toolset/setup/docker/webservers/tomcat.dockerfile
@@ -2,7 +2,7 @@ FROM tfb/java:latest
 
 RUN mkdir /tomcat
 WORKDIR /tomcat
-RUN curl -s http://mirror.stjschools.org/public/apache/tomcat/tomcat-9/v9.0.6/bin/apache-tomcat-9.0.6.tar.gz | tar xz
+RUN curl -sL http://mirror.stjschools.org/public/apache/tomcat/tomcat-9/v9.0.6/bin/apache-tomcat-9.0.6.tar.gz | tar xz
 
 # Remove the default app so that frameworks using Tomcat don't have to.
 RUN rm -rf /tomcat/apache-tomcat-9.0.6/webapps/*


### PR DESCRIPTION
This breaks everyone using Resin because Resin isn't compatible with Java
10 yet.  So this change should not be merged until a new version of
Resin is released that fixes that problem.  I'm doing this now to get a
head start on other Java 9->10 upgrade issues, in case there are any, by
having travis tell me what the issues are.