### PR TITLE
pull base images only if test should run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,14 +198,16 @@ env:
      - "TESTDIR=Vala/valum"
 
 install:
-  - docker pull techempower/tfb.wrk
-  - docker pull techempower/tfb
+
 
 before_script:
 
   # Runs travis_diff, printing the output to the terminal, and searches for travis-diff-continue
   # to determine if the suite should be installed and the current $TESTDIR test should run.
   - export RUN_TESTS=`./toolset/travis/travis_diff.py | tee /dev/tty | grep -oP "travis-run-tests \K(.*)"`
+
+  - if [ "$RUN_TESTS" ]; then docker pull techempower/tfb.wrk; fi
+  - if [ "$RUN_TESTS" ]; then docker pull techempower/tfb; fi
 
   # Stop services that would claim ports we may need
   - sudo service mysql stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,8 +197,6 @@ env:
      - "TESTDIR=Vala/vsgi"
      - "TESTDIR=Vala/valum"
 
-install:
-
 
 before_script:
 


### PR DESCRIPTION
docker pull can take some time on travis. This checks to see if the test is going to run first, then pulls base and wrk images