### PR TITLE
[ci skip] Try fixing a couple of issues in continuous benchmarking

### DIFF
--- a/toolset/setup/docker/wrk/query.sh
+++ b/toolset/setup/docker/wrk/query.sh
@@ -28,7 +28,7 @@ echo " wrk \"-H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-a
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-wrk "-H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive'" --latency -d $duration -c %max_concurrency --timeout 8 -t $max_threads "$url$c"
+wrk "-H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive'" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "$url$c"
 echo "STARTTIME $STARTTIME"
 echo "ENDTIME $(date +"%s")"
 sleep 2

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -279,6 +279,13 @@ def stop(benchmarker_config=None,
     client.containers.prune()
     client.networks.prune()
     client.volumes.prune()
+    if benchmarker_config.server_docker_host != benchmarker_config.database_docker_host:
+        db_client = docker.DockerClient(
+            base_url=benchmarker_config.database_docker_host)
+        db_client.images.prune()
+        db_client.containers.prune()
+        db_client.networks.prune()
+        db_client.volumes.prune()
 
 
 def find(path, pattern):


### PR DESCRIPTION
I think the tfb.wrk image needs to be republished in order for the `query.sh` fix to do anything.  Not sure how to test that one in the Citrine environment.

I think the `docker_helper.py` fix should be testable.  I'm pointing Citrine at my branch (where this PR is from) and running it now.  Will remove the "Do Not Merge" tag if it looks good.