### PR TITLE
Update facil.io version

### DIFF
--- a/frameworks/C/facil.io/setup-common.sh
+++ b/frameworks/C/facil.io/setup-common.sh
@@ -17,7 +17,7 @@ if [[ (! -d facil_app) ||  (-n "${FIO_EDGE}") ]] ; then
 	# Setting FIO_EDGE will test against the master branch on the development machine. i.e.:
 	#     $ FIO_EDGE=1 tfb --mode verify --test facil.io
 	if [[ -z "${FIO_EDGE}" ]]; then
-	  FIO_URL="https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.1"
+	  FIO_URL="https://api.github.com/repos/boazsegev/facil.io/tarball/0.6.2"
 	else
 		echo "INFO: development mode detected, loading facil.io from master."
 		FIO_URL="https://github.com/boazsegev/facil.io/archive/master.tar.gz"


### PR DESCRIPTION
Please update the facil.io version.

The 0.6.2 facil.io version includes many fixes and changes, including
security concerns for the shutdown / hot-restart feature and and issue
where large response data might not get sent to the clients (causing
connections to hang on larger payloads).

The fixes might effect performance (for better or worst).

Thanks!

P.S.

Congratulations on a major milestone in the docker transition 👍🏻