### PR TITLE
Quality of life improvements for docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Docker relies on lf - force it
-* text eol=lf

--- a/README.md
+++ b/README.md
@@ -22,36 +22,20 @@ To get started developing you'll need to install [docker](https://docs.docker.co
 
         $ git clone https://github.com/TechEmpower/FrameworkBenchmarks.git
 
-2. Create the TFB Docker virtual network
+2. Run a test.
 
-        $ docker network create tfb
+        $ ./tfb --mode verify --test gemini
 
-3. Run a test.
+### Explanation of the `./tfb` script
 
-        $ docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=[ABS PATH TO THIS DIR],target=/FrameworkBenchmarks techempower/tfb --mode verify --test gemini
-
-### Explanation of the run script
-
-That run script is pretty wordy, but each and every flag is required. Unfortunately, because of the way that Docker runs processes, you **cannot** put this inside of a shell script without breaking how `ctrl+c` and `SIGTERM` work (the shell script would receive the signal, do nothing with the underlying python suite running, and exit, orphaning the toolset to continue running).
+The run script is pretty wordy, but each and every flag is required. If you are using windows, either adapt the docker command at the end of the `./tfb` shell script (replacing `${SCRIPT_ROOT}` with `/c/path/to/FrameworkBenchmarks`), or use vagrant.
 
 - `-it` tells docker to run this in 'interactive' mode and simulate a TTY, so that `ctrl+c` is propagated.
+- `--rm` tells docker to remove the container as soon as the toolset finishes running, meaning there aren't hundreds of stopped containers lying around.
 - `--network=tfb` tells the container to join the 'tfb' Docker virtual network
-- `-v` specifies which Docker socket path to mount as a volume in the running container. This allows docker commands run inside this container to use the host container's docker to create/run/stop/remove containers.
-- `--mount` mounts the FrameworkBenchmarks source directory as a volume to share with the container so that rebuilding the toolset image is unnecessary and any changes you make on the host system are available in the running toolset container.
+- The first `-v` specifies which Docker socket path to mount as a volume in the running container. This allows docker commands run inside this container to use the host container's docker to create/run/stop/remove containers.
+- The second `-v` mounts the FrameworkBenchmarks source directory as a volume to share with the container so that rebuilding the toolset image is unnecessary and any changes you make on the host system are available in the running toolset container.
 - `techempower/tfb` is the name of toolset container to run
-- `--mode verify --test gemini` are the command to pass to the toolset.
-
-#### A note on Linux:
-
-You may not want to call step 4 from above every time. You can add an `alias` to your `~/.bash_aliases` file to shorten it since it will not change once configured:
-
-`$ alias tfb="docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=[ABS PATH TO THIS DIR],target=/FrameworkBenchmarks techempower/tfb"`
-
-`$ source ~/.bash_aliases`
-
-Now you can run the toolset via `tfb`:
-
-`$ tfb --mode verify --test gemini`
 
 #### A note on Windows:
 
@@ -84,9 +68,9 @@ required.
 
 ## Add a New Test
 
-Once you open an SSH connection to your vagrant box, start the new test initialization wizard.
+Either on your computer, or once you open an SSH connection to your vagrant box, start the new test initialization wizard.
 
-        vagrant@TFB-all:~/FrameworkBenchmarks$ tfb --new
+        vagrant@TFB-all:~/FrameworkBenchmarks$ ./tfb --new
 
 This will walk you through the entire process of creating a new test to include in the suite.
 

--- a/deployment/vagrant/bootstrap.sh
+++ b/deployment/vagrant/bootstrap.sh
@@ -39,10 +39,9 @@ Welcome to the FrameworkBenchmarks project!
 EOF
 
   cat <<EOF > /home/vagrant/.bash_aliases
-alias tfb="docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=/home/vagrant/FrameworkBenchmarks,target=/FrameworkBenchmarks techempower/tfb"
+alias tfb="/home/vagrant/FrameworkBenchmarks/tfb"
 EOF
 
   sudo mv motd /etc/
   sudo chmod 777 /var/run/docker.sock
-  docker network create tfb
 fi

--- a/deployment/vagrant/core.rb
+++ b/deployment/vagrant/core.rb
@@ -21,9 +21,7 @@ def provider_libvirt(config)
     virt.memory = ENV.fetch('TFB_KVM_MEM', 3022)
     virt.cpus = ENV.fetch('TFB_KVM_CPU', 2)
 
-    override.vm.synced_folder "../../toolset", "/home/vagrant/FrameworkBenchmarks/toolset", type: "nfs", nfs_udp: false
-    override.vm.synced_folder "../../frameworks", "/home/vagrant/FrameworkBenchmarks/frameworks", type: "nfs", nfs_udp: false
-    override.vm.synced_folder "../../results", "/home/vagrant/FrameworkBenchmarks/results", type: "nfs", nfs_udp: false, create: true
+    override.vm.synced_folder "../..", "/home/vagrant/FrameworkBenchmarks", type: "nfs", nfs_udp: false
   end
 end
 
@@ -55,8 +53,6 @@ def provider_virtualbox(config)
     # See mitchellh/vagrant#4997
     # See http://superuser.com/a/640028/136050
 
-    override.vm.synced_folder "../../toolset", "/home/vagrant/FrameworkBenchmarks/toolset"
-    override.vm.synced_folder "../../frameworks", "/home/vagrant/FrameworkBenchmarks/frameworks"
-    override.vm.synced_folder "../../results", "/home/vagrant/FrameworkBenchmarks/results", create: true
+    override.vm.synced_folder "../..", "/home/vagrant/FrameworkBenchmarks"
   end
 end

--- a/tfb
+++ b/tfb
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+################## https://github.com/mkropat/sh-realpath #####################
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2014 Michael Kropat
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+realpath() {
+    canonicalize_path "$(resolve_symlinks "$1")"
+}
+
+resolve_symlinks() {
+    _resolve_symlinks "$1"
+}
+
+_resolve_symlinks() {
+    _assert_no_path_cycles "$@" || return
+
+    local dir_context path
+    path=$(readlink -- "$1")
+    if [ $? = 0 ]; then
+        dir_context=$(dirname -- "$1")
+        _resolve_symlinks "$(_prepend_dir_context_if_necessary "$dir_context" "$path")" "$@"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+_prepend_dir_context_if_necessary() {
+    if [ "$1" = . ]; then
+        printf '%s\n' "$2"
+    else
+        _prepend_path_if_relative "$1" "$2"
+    fi
+}
+
+_prepend_path_if_relative() {
+    case "$2" in
+        /* ) printf '%s\n' "$2" ;;
+         * ) printf '%s\n' "$1/$2" ;;
+    esac
+}
+
+_assert_no_path_cycles() {
+    local target path
+
+    target=$1
+    shift
+
+    for path in "$@"; do
+        if [ "$path" = "$target" ]; then
+            return 1
+        fi
+    done
+}
+
+canonicalize_path() {
+    if [ -d "$1" ]; then
+        _canonicalize_dir_path "$1"
+    else
+        _canonicalize_file_path "$1"
+    fi
+}
+
+_canonicalize_dir_path() {
+    (cd "$1" 2>/dev/null && pwd -P)
+}
+
+_canonicalize_file_path() {
+    local dir file
+    dir=$(dirname -- "$1")
+    file=$(basename -- "$1")
+    (cd "$dir" 2>/dev/null >/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
+}
+
+##############################################################################
+
+SCRIPT_PATH="$(realpath "$0")"
+SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
+
+if ! docker network inspect tfb >/dev/null 2>&1; then
+  docker network create tfb >/dev/null
+fi
+
+exec docker run -it --rm --network tfb -v /var/run/docker.sock:/var/run/docker.sock -v ${SCRIPT_ROOT}:/FrameworkBenchmarks techempower/tfb "${@}"


### PR DESCRIPTION
Adds a script to automatically set up the docker network and call the docker container. The sigterm issue is solved by using `exec` in the bash script to replace the shell process with the docker process, instead of spawning it underneath. No solution is provided for windows yet, except for using vagrant.

I couldn't reproduce the sigterm issues on my laptop, it'd be useful if you could test this script to verify i've solved the problem. I've also simplified the readme.