### PR TITLE
Fix config file exception

### DIFF
--- a/toolset/utils/metadata_helper.py
+++ b/toolset/utils/metadata_helper.py
@@ -1,19 +1,23 @@
+import ConfigParser
 import os
 import glob
 import json
 
+from ast import literal_eval
 from collections import OrderedDict
+
+from colorama import Fore
 
 from toolset.utils.output_helper import log
 
 
-def gather_langauges(benchmarker_config):
+def gather_langauges():
     '''
     Gathers all the known languages in the suite via the folder names
     beneath FWROOT.
     '''
 
-    lang_dir = os.path.join(benchmarker_config.fwroot, "frameworks")
+    lang_dir = os.path.join(os.getenv('FWROOT'), "frameworks")
     langs = []
     for dir in glob.glob(os.path.join(lang_dir, "*")):
         langs.append(dir.replace(lang_dir, "")[1:])
@@ -88,8 +92,10 @@ def gather_tests(include=[], exclude=[], benchmarker_config=None,
             try:
                 config = json.load(config_file)
             except ValueError:
+                log("Error loading '{!s}".format(config_file_name),
+                    color=Fore.RED)
                 raise Exception(
-                    "Error loading '{!s}'.".format(config_file_name))
+                    "Error loading config file")
 
         # Find all tests in the config file
         config_tests = parse_config(config, os.path.dirname(config_file_name),


### PR DESCRIPTION
String formatting in the Exception constructor doesn't work.. leads to:

```
Traceback (most recent call last):
  File "/FrameworkBenchmarks/toolset/run-tests.py", line 253, in <module>
    sys.exit(main())
  File "/FrameworkBenchmarks/toolset/run-tests.py", line 214, in main
    results = Results(config)
  File "/FrameworkBenchmarks/toolset/utils/results_helper.py", line 52, in __init__
    t.name for t in gather_remaining_tests(self.config, self)
  File "/FrameworkBenchmarks/toolset/utils/metadata_helper.py", line 131, in gather_remaining_tests
    return gather_tests(config.test, config.exclude, config, results)
  File "/FrameworkBenchmarks/toolset/utils/metadata_helper.py", line 95, in gather_tests
    "Error loading '{!s}'.".format(config_file_name))
```

Added a log and color:
![image](https://user-images.githubusercontent.com/1304934/38585385-8623dd06-3cce-11e8-888e-228b50e14d80.png)

