### PR TITLE
Fix config file exception

### DIFF
--- a/toolset/utils/metadata_helper.py
+++ b/toolset/utils/metadata_helper.py
@@ -5,6 +5,7 @@ import json
 from collections import OrderedDict
 
 from toolset.utils.output_helper import log
+from colorama import Fore
 
 
 def gather_langauges(benchmarker_config):
@@ -88,8 +89,9 @@ def gather_tests(include=[], exclude=[], benchmarker_config=None,
             try:
                 config = json.load(config_file)
             except ValueError:
-                raise Exception(
-                    "Error loading '{!s}'.".format(config_file_name))
+                log("Error loading config: {!s}".format(config_file_name),
+                    color=Fore.RED)
+                raise Exception("Error loading config file")
 
         # Find all tests in the config file
         config_tests = parse_config(config, os.path.dirname(config_file_name),


### PR DESCRIPTION
String formatting in the Exception constructor doesn't work.. leads to:

```
Traceback (most recent call last):
  File "/FrameworkBenchmarks/toolset/run-tests.py", line 253, in <module>
    sys.exit(main())
  File "/FrameworkBenchmarks/toolset/run-tests.py", line 214, in main
    results = Results(config)
  File "/FrameworkBenchmarks/toolset/utils/results_helper.py", line 52, in __init__
    t.name for t in gather_remaining_tests(self.config, self)
  File "/FrameworkBenchmarks/toolset/utils/metadata_helper.py", line 131, in gather_remaining_tests
    return gather_tests(config.test, config.exclude, config, results)
  File "/FrameworkBenchmarks/toolset/utils/metadata_helper.py", line 95, in gather_tests
    "Error loading '{!s}'.".format(config_file_name))
```

Added a log and color

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
