### PR TITLE
Leave test images after stopping them

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ That run script is pretty wordy, but each and every flag is required. Unfortunat
 
 You may not want to call step 4 from above every time. You can add an `alias` to your `~/.bash_aliases` file to shorten it since it will not change once configured:
 
-`$ alias tfb="docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=[ABS PATH TO THIS DIR],target=/FrameworkBenchmarks techempower/tfb"`
+`$ alias tfb="docker network create tfb > /dev/null 2>&1 && docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=[ABS PATH TO THIS DIR],target=/FrameworkBenchmarks techempower/tfb"`
 
 `$ source ~/.bash_aliases`
 

--- a/deployment/vagrant/bootstrap.sh
+++ b/deployment/vagrant/bootstrap.sh
@@ -39,7 +39,7 @@ Welcome to the FrameworkBenchmarks project!
 EOF
 
   cat <<EOF > /home/vagrant/.bash_aliases
-alias tfb="docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=/home/vagrant/FrameworkBenchmarks,target=/FrameworkBenchmarks techempower/tfb"
+alias tfb="docker network create tfb > /dev/null 2>&1 && docker run -it --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=/home/vagrant/FrameworkBenchmarks,target=/FrameworkBenchmarks techempower/tfb"
 EOF
 
   sudo mv motd /etc/

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -83,11 +83,6 @@ def main(argv=None):
 
     # Suite options
     parser.add_argument(
-        '--publish',
-        action='store_true',
-        default=False,
-        help='Builds and publishes all the docker images in the suite')
-    parser.add_argument(
         '--build',
         nargs='+',
         help='Builds the dockerfile(s) for the given test(s)')
@@ -215,9 +210,6 @@ def main(argv=None):
 
     if config.new:
         Scaffolding(config)
-
-    elif config.publish:
-        docker_helper.publish(config)
 
     elif config.build:
         docker_helper.build(config, config.build)

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -29,7 +29,6 @@ class BenchmarkConfig:
 
         self.duration = args.duration
         self.exclude = args.exclude
-        self.publish = args.publish
         self.build = args.build
         self.quiet = args.quiet
         self.server_host = args.server_host


### PR DESCRIPTION
This is in order to keep the cached images between benchmark runs to speed them up.