### PR TITLE
travis diff fix

### DIFF
--- a/frameworks/C++/ffead-cpp/ffead-cpp-httpd.sh
+++ b/frameworks/C++/ffead-cpp/ffead-cpp-httpd.sh
@@ -80,3 +80,4 @@ FFEAD_CPP_PATH '"${FFEADROOT}"'
 	</Directory>
 </VirtualHost>
 EOL'
+


### PR DESCRIPTION
This fixes an issue where a C++ framework wouldn't be identified as changed because of regex characters in "C++" and would only run if a full run kicked off or if you specified the framework. Proving it out here by making an empty change in ffead.

This also removes the process of searching through the dependency chain for changes, as each dockerfile now extends from a published dockerhub image.