### PR TITLE
Fixing command line parameters for aspnetcore

### DIFF
--- a/frameworks/CSharp/aspnetcore/run-linux.sh
+++ b/frameworks/CSharp/aspnetcore/run-linux.sh
@@ -11,4 +11,4 @@ cp appsettings.postgresql.json appsettings.json
 dotnet restore
 dotnet publish --configuration Release --output bin/Release/publish
 
-dotnet bin/Release/publish/Benchmarks.dll server.urls=http://*:8080 scenarios=$1 server=kestrel threadCount=$threadCount NonInteractive=true
+dotnet bin/Release/publish/Benchmarks.dll urls=http://*:8080 scenarios=$1 server=kestrel threadCount=$threadCount NonInteractive=true


### PR DESCRIPTION
`urls` is the documented way to configure the ports. `server-urls` should not have worked since 2.0.