### PR TITLE
[ci fw-only Rust/actix] Avoid splitting apart lines in docker build output

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -89,6 +89,7 @@ def build(benchmarker_config, test_names, build_log_dir=os.devnull):
                             file=build_log,
                             color=Fore.WHITE + Style.BRIGHT \
                                 if re.match(r'^Step \d+\/\d+', line) else '')
+
                 if buffer:
                     log(buffer,
                         prefix=log_prefix,

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -65,21 +65,35 @@ def build(benchmarker_config, test_names, build_log_dir=os.devnull):
                 "%s.log" % test_docker_file.replace(".dockerfile", "").lower())
         with open(build_log_file, 'w') as build_log:
             try:
-                for line in docker.APIClient(
-                        base_url=benchmarker_config.server_docker_host).build(
-                            path=test.directory,
-                            dockerfile=test_docker_file,
-                            tag="techempower/tfb.test.%s" %
-                            test_docker_file.replace(".dockerfile", ""),
-                            forcerm=True):
-                    if line.startswith('{"stream":'):
-                        line = json.loads(line)
-                        line = line[line.keys()[0]].encode('utf-8')
+                client = docker.APIClient(
+                    base_url=benchmarker_config.server_docker_host)
+                output = client.build(
+                    path=test.directory,
+                    dockerfile=test_docker_file,
+                    tag="techempower/tfb.test.%s" %
+                        test_docker_file.replace(".dockerfile", ""),
+                    forcerm=True)
+                buffer = ""
+                for token in output:
+                    if token.startswith('{"stream":'):
+                        token = json.loads(token)
+                        token = token[token.keys()[0]].encode('utf-8')
+                    buffer += token
+                    while "\n" in buffer:
+                        index = buffer.index("\n")
+                        line = buffer[:index]
+                        buffer = buffer[index + 1:]
                         log(line,
                             prefix=log_prefix,
                             file=build_log,
                             color=Fore.WHITE + Style.BRIGHT \
                                 if re.match(r'^Step \d+\/\d+', line) else '')
+                if buffer:
+                    log(buffer,
+                        prefix=log_prefix,
+                        file=build_log,
+                        color=Fore.WHITE + Style.BRIGHT \
+                            if re.match(r'^Step \d+\/\d+', line) else '')
             except Exception:
                 tb = traceback.format_exc()
                 log("Docker build failed; terminating",

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -93,7 +93,7 @@ def build(benchmarker_config, test_names, build_log_dir=os.devnull):
                         prefix=log_prefix,
                         file=build_log,
                         color=Fore.WHITE + Style.BRIGHT \
-                            if re.match(r'^Step \d+\/\d+', line) else '')
+                            if re.match(r'^Step \d+\/\d+', buffer) else '')
             except Exception:
                 tb = traceback.format_exc()
                 log("Docker build failed; terminating",


### PR DESCRIPTION
We're logging pieces of lines from the build output so the logs tend to look messed up.  It's worse for some frameworks than others.  This change buffers the build output and only writes to the log once we have a full line to write.

I added `[ci fw-only Rust/actix]` because that's a framework whose build logs show the behavior I'm trying to fix.  For example, here's one section of actix's build logs *without* this change when I build actix locally:
```
actix:     Updating registry `https://github.com/rust-lang/crates.io-index`
actix:
actix:  Downloading actix v0.5.5
actix:
actix:  Downloading askama
actix:  v0
actix: .6.1
actix:
actix:
actix:  Downloading serde v1.0.38
actix:
actix:  Downloading diesel v1.2.2
actix:
actix:  Downloading tokio-core v0.1.12
actix:
actix:  Downloading serde_derive v1.0.38
actix:
actix:  Downloading actix-web v0.5.2
actix:
actix:  Downloading postgres v0.15.2
actix:
actix:  Downloading rand v0.4.2
actix:
actix:
actix: Downloading
actix:
actix: bytes
actix:  v
actix: 0
actix: .
actix: 4
actix: .
actix: 6
```

Here's that same section of actix's build logs with this change applied:
```
actix:     Updating registry `https://github.com/rust-lang/crates.io-index`
actix:  Downloading serde_json v1.0.14
actix:  Downloading serde_derive v1.0.38
actix:  Downloading futures v0.1.21
actix:  Downloading actix-web v0.5.2
actix:  Downloading rand v0.4.2
actix:  Downloading diesel v1.2.2
actix:  Downloading serde v1.0.38
actix:  Downloading actix v0.5.5
actix:  Downloading num_cpus v1.8.0
actix:  Downloading http v0.1.5
actix:  Downloading askama v0.6.1
actix:  Downloading bytes v0.4.6
```