### PR TITLE
Print runtime errors in dropwizard, update dependencies

### DIFF
--- a/frameworks/Java/dropwizard/hello-world-jdbi-postgres.yml
+++ b/frameworks/Java/dropwizard/hello-world-jdbi-postgres.yml
@@ -7,14 +7,16 @@ server:
     useServerHeader: true
     # There is no proxy in front of the server
     useForwardedHeaders: false
-  # Test requirements forgid gzip compression of the replies
+  # Test requirements forbid gzip compression of the replies
   gzip:
     enabled: false
   requestLog:
     appenders: []
 
 logging:
-  appenders: []
+  level: WARN
+  appenders:
+    - type: console
 
 database:
   # the name of your JDBC driver

--- a/frameworks/Java/dropwizard/hello-world-mongo.yml
+++ b/frameworks/Java/dropwizard/hello-world-mongo.yml
@@ -14,7 +14,9 @@ server:
     appenders: []
 
 logging:
-  appenders: []
+  level: WARN
+  appenders:
+    - type: console
 
 mongo:
   host: tfb-database

--- a/frameworks/Java/dropwizard/hello-world-mysql.yml
+++ b/frameworks/Java/dropwizard/hello-world-mysql.yml
@@ -14,7 +14,9 @@ server:
     appenders: []
 
 logging:
-  appenders: []
+  level: WARN
+  appenders:
+    - type: console
 
 database:
   # the name of your JDBC driver

--- a/frameworks/Java/dropwizard/hello-world-postgres.yml
+++ b/frameworks/Java/dropwizard/hello-world-postgres.yml
@@ -14,7 +14,9 @@ server:
     appenders: []
 
 logging:
-  appenders: []
+  level: WARN
+  appenders:
+    - type: console
 
 database:
   # the name of your JDBC driver

--- a/frameworks/Java/dropwizard/pom.xml
+++ b/frameworks/Java/dropwizard/pom.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.xekm</groupId>
@@ -9,15 +12,16 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jdk.version>1.8</jdk.version>
-		<dropwizard.version>1.3.0</dropwizard.version>
-		<jaxb-api.version>2.3.0</jaxb-api.version>
+		<jdk.version>10</jdk.version>
+		<dropwizard.version>1.3.1</dropwizard.version>
+		<javax-activation.version>1.1.1</javax-activation.version>
+		<jaxb.version>2.3.0</jaxb.version>
 		<mysql-connector-java.version>5.1.45</mysql-connector-java.version>
 		<mongojack.version>2.8.2</mongojack.version>
 		<postgres-jdbc.version>42.1.4</postgres-jdbc.version>
 		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-		<maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
+		<maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
+		<maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
 		<main.class>com.example.helloworld.HelloWorldService</main.class>
 	</properties>
 
@@ -105,7 +109,12 @@
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>${jaxb-api.version}</version>
+			<version>${jaxb.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>${javax-activation.version}</version>
 		</dependency>
 	</dependencies>
 
@@ -159,10 +168,8 @@
 						</goals>
 						<configuration>
 							<transformers>
-								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-								<transformer
-									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>${main.class}</mainClass>
 								</transformer>
 							</transformers>


### PR DESCRIPTION
Printing the errors revealed it was having issues related to missing
javax.activation classes, so I added that as a dependency.