### PR TITLE
[ci skip] Fix wrk's Host and Accept headers

### DIFF
--- a/toolset/wrk/concurrency.sh
+++ b/toolset/wrk/concurrency.sh
@@ -7,7 +7,7 @@ echo " Running Primer $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 $url"
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 $url
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d 5 -c 8 --timeout 8 -t 8 $url
 sleep 5
 
 echo ""
@@ -16,7 +16,7 @@ echo " Running Warmup $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads \"$url\""
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads $url
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads $url
 sleep 5
 
 for c in $levels
@@ -28,7 +28,7 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url
 echo "STARTTIME $STARTTIME"
 echo "ENDTIME $(date +"%s")"
 sleep 2

--- a/toolset/wrk/pipeline.sh
+++ b/toolset/wrk/pipeline.sh
@@ -7,7 +7,7 @@ echo " Running Primer $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 $url"
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 $url
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d 5 -c 8 --timeout 8 -t 8 $url
 sleep 5
 
 echo ""
@@ -16,7 +16,7 @@ echo " Running Warmup $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads $url"
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads $url
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads $url
 sleep 5
 
 for c in $levels
@@ -28,7 +28,7 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s /pipeline.lua -- $pipeline
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s /pipeline.lua -- $pipeline
 echo "STARTTIME $STARTTIME"
 echo "ENDTIME $(date +"%s")"
 sleep 2

--- a/toolset/wrk/query.sh
+++ b/toolset/wrk/query.sh
@@ -7,7 +7,7 @@ echo " Running Primer $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 \"${url}2\""
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d 5 -c 8 --timeout 8 -t 8 "${url}2"
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d 5 -c 8 --timeout 8 -t 8 "${url}2"
 sleep 5
 
 echo ""
@@ -16,7 +16,7 @@ echo " Running Warmup $name"
 echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads \"${url}2\""
 echo "---------------------------------------------------------"
 echo ""
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "${url}2"
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "${url}2"
 sleep 5
 
 for c in $levels
@@ -28,7 +28,7 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "$url$c"
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "$url$c"
 echo "STARTTIME $STARTTIME"
 echo "ENDTIME $(date +"%s")"
 sleep 2


### PR DESCRIPTION
Assuming this change looks good, we'll need to publish a new `tfb.wrk`
image.

The variable substitution for these header values wasn't happening
because those parts of the script were single quoted.  So we were
sending literally "Accept: $accept" as a header, for example.  I noticed
this because dropwizard was responding with 100% errors when benchmarked
with wrk.  Turns out that every response was "406 Not Acceptable" because
of the malformed Accept header.

I tested this locally by building the `tfb.wrk` image like this:

```
docker build -t techempower/tfb.wrk -f toolset/wrk/wrk.dockerfile toolset/wrk
```