### PR TITLE
Upgrade to resin 4.0.56

### DIFF
--- a/frameworks/Clojure/compojure/compojure-raw.dockerfile
+++ b/frameworks/Clojure/compojure/compojure-raw.dockerfile
@@ -6,7 +6,7 @@ RUN lein ring uberwar
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=lein /compojure/target/hello-compojure-standalone.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Clojure/compojure/compojure.dockerfile
+++ b/frameworks/Clojure/compojure/compojure.dockerfile
@@ -6,7 +6,7 @@ RUN lein ring uberwar
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=lein /compojure/target/hello-compojure-standalone.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Groovy/grails/grails.dockerfile
+++ b/frameworks/Groovy/grails/grails.dockerfile
@@ -19,7 +19,7 @@ RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output c
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} prod -non-interactive -plain-output war
 
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 RUN cp /grails/target/hello-0.1.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/activeweb/activeweb-jackson.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-jackson.dockerfile
@@ -7,7 +7,7 @@ RUN mvn package -DskipTests -q
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /activeweb/target/activeweb.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/activeweb/activeweb.dockerfile
+++ b/frameworks/Java/activeweb/activeweb.dockerfile
@@ -7,7 +7,7 @@ RUN mvn package -DskipTests -q
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /activeweb/target/activeweb.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /curacao/target/curacao.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -15,6 +15,6 @@ RUN ant resolve
 RUN ant compile
 
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 CMD ["java", "-jar", "lib/resin.jar", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -15,6 +15,6 @@ RUN ant resolve
 RUN ant compile
 
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 CMD ["java", "-jar", "lib/resin.jar", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -15,6 +15,6 @@ RUN ant resolve
 RUN ant compile
 
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 CMD ["java", "-jar", "lib/resin.jar", "-conf", "/gemini/Docroot/WEB-INF/resin.xml", "console"]

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -16,7 +16,7 @@ RUN mvn compile war:war -q
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /revenj-jvm/target/revenj.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/servlet/servlet-afterburner.dockerfile
+++ b/frameworks/Java/servlet/servlet-afterburner.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q -P afterburner
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/servlet/servlet-cjs.dockerfile
+++ b/frameworks/Java/servlet/servlet-cjs.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q -P cjs
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q -P mysql
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/servlet/servlet-postgresql.dockerfile
+++ b/frameworks/Java/servlet/servlet-postgresql.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q -P postgresql
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/servlet/servlet.dockerfile
+++ b/frameworks/Java/servlet/servlet.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q
 
 FROM openjdk:9-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/spark/spark.dockerfile
+++ b/frameworks/Java/spark/spark.dockerfile
@@ -6,7 +6,7 @@ RUN mvn package -q
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /spark/target/spark.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/tapestry/tapestry.dockerfile
+++ b/frameworks/Java/tapestry/tapestry.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /tapestry/target/tapestry.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/wicket/wicket.dockerfile
+++ b/frameworks/Java/wicket/wicket.dockerfile
@@ -6,7 +6,7 @@ RUN mvn compile war:war -q
 
 FROM openjdk:8-jdk
 WORKDIR /resin
-RUN curl -sL http://www.caucho.com/download/resin-4.0.55.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /wicket/target/hellowicket-1.0.war webapps/ROOT.war
 CMD ["java", "-jar", "lib/resin.jar", "console"]


### PR DESCRIPTION
This version is compatible with Java 10, unlike resin 4.0.55.