### PR TITLE
Build wrk and only once at the start of all tests

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -129,7 +129,7 @@ class Benchmarker:
             # Start database container
             if test.database.lower() != "none":
                 database_container = docker_helper.start_database(
-                    self.config, test, test.database.lower())
+                    self.config, test.database.lower())
                 if database_container is None:
                     message = "ERROR: Problem building/running database container"
                     self.results.write_intermediate(test.name, message)
@@ -271,7 +271,7 @@ class Benchmarker:
 
     def __begin_logging(self, framework_test, test_type):
         '''
-        Starts a thread to monitor the resource usage, to be synced with the 
+        Starts a thread to monitor the resource usage, to be synced with the
         client's time.
         TODO: MySQL and InnoDB are possible. Figure out how to implement them.
         '''
@@ -295,7 +295,7 @@ class Benchmarker:
 
     def __is_port_bound(self, port):
         '''
-        Check if the requested port is available. If it isn't available, then a 
+        Check if the requested port is available. If it isn't available, then a
         previous test probably didn't shutdown properly.
         '''
         port = int(port)

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -42,6 +42,8 @@ class Benchmarker:
         any_failed = False
         # Run tests
         log("Running Tests...", border='=')
+        docker_helper.build_wrk(self.config)
+
         with open(os.path.join(self.results.directory, 'benchmark.log'),
                   'w') as benchmark_log:
             for test in all_tests:

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -46,8 +46,7 @@ def clean(benchmarker_config):
 
 def __build(base_url, path, build_log_file, log_prefix, dockerfile, tag):
     '''
-    Builds the dependency chain as well as the test implementation docker images
-    for the given tests.
+    Builds docker containers using docker-py low-level api
     '''
 
     with open(build_log_file, 'w') as build_log:
@@ -96,8 +95,7 @@ def __build(base_url, path, build_log_file, log_prefix, dockerfile, tag):
 
 def build(benchmarker_config, test_names, build_log_dir=os.devnull):
     '''
-    Builds the dependency chain as well as the test implementation docker images
-    for the given tests.
+    Builds the test docker containers
     '''
     tests = gather_tests(
         include=test_names, benchmarker_config=benchmarker_config)

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -303,6 +303,17 @@ def start_database(benchmarker_config, database):
 
     return container
 
+def build_wrk(benchmarker_config):
+    '''
+    Builds the techempower/tfb.wrk container
+    '''
+    __build(
+        base_url=benchmarker_config.client_docker_host,
+        path=os.path.join(benchmarker_config.fwroot, "toolset", "wrk"),
+        dockerfile="wrk.dockerfile",
+        log_prefix="wrk: ",
+        build_log_file=os.devnull,
+        tag="techempower/tfb.wrk")
 
 def test_client_connection(benchmarker_config, url):
     '''
@@ -311,13 +322,6 @@ def test_client_connection(benchmarker_config, url):
     '''
     client = docker.DockerClient(
         base_url=benchmarker_config.client_docker_host)
-
-    try:
-        client.images.get('techempower/tfb.wrk:latest')
-    except:
-        log("Attempting docker pull for image (this can take some time)",
-            prefix="techempower/tfb.wrk:latest: ")
-        client.images.pull('techempower/tfb.wrk:latest')
 
     try:
         client.containers.run(

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -44,6 +44,55 @@ def clean(benchmarker_config):
                 client.images.remove(image.id, force=True)
     client.images.prune()
 
+def __build(base_url, path, build_log_file, log_prefix, dockerfile, tag):
+    '''
+    Builds the dependency chain as well as the test implementation docker images
+    for the given tests.
+    '''
+
+    with open(build_log_file, 'w') as build_log:
+        try:
+            client = docker.APIClient(base_url=base_url)
+            output = client.build(
+                path=path,
+                dockerfile=dockerfile,
+                tag=tag,
+                forcerm=True,
+                pull=True)
+            buffer = ""
+            for token in output:
+                if token.startswith('{"stream":'):
+                    token = json.loads(token)
+                    token = token[token.keys()[0]].encode('utf-8')
+                    buffer += token
+                elif token.startswith('{"errorDetail":'):
+                    token = json.loads(token)
+                    raise Exception(token['errorDetail']['message'])
+                while "\n" in buffer:
+                    index = buffer.index("\n")
+                    line = buffer[:index]
+                    buffer = buffer[index + 1:]
+                    log(line,
+                        prefix=log_prefix,
+                        file=build_log,
+                        color=Fore.WHITE + Style.BRIGHT \
+                            if re.match(r'^Step \d+\/\d+', line) else '')
+
+            if buffer:
+                log(buffer,
+                    prefix=log_prefix,
+                    file=build_log,
+                    color=Fore.WHITE + Style.BRIGHT \
+                        if re.match(r'^Step \d+\/\d+', buffer) else '')
+        except Exception:
+            tb = traceback.format_exc()
+            log("Docker build failed; terminating",
+                prefix=log_prefix,
+                file=build_log,
+                color=Fore.RED)
+            log(tb, prefix=log_prefix, file=build_log)
+            raise
+
 
 def build(benchmarker_config, test_names, build_log_dir=os.devnull):
     '''
@@ -63,50 +112,18 @@ def build(benchmarker_config, test_names, build_log_dir=os.devnull):
             build_log_file = os.path.join(
                 build_log_dir,
                 "%s.log" % test_docker_file.replace(".dockerfile", "").lower())
-        with open(build_log_file, 'w') as build_log:
-            try:
-                client = docker.APIClient(
-                    base_url=benchmarker_config.server_docker_host)
-                output = client.build(
-                    path=test.directory,
-                    dockerfile=test_docker_file,
-                    tag="techempower/tfb.test.%s" %
-                        test_docker_file.replace(".dockerfile", ""),
-                    forcerm=True,
-                    pull=True)
-                buffer = ""
-                for token in output:
-                    if token.startswith('{"stream":'):
-                        token = json.loads(token)
-                        token = token[token.keys()[0]].encode('utf-8')
-                        buffer += token
-                    elif token.startswith('{"errorDetail":'):
-                        token = json.loads(token)
-                        raise Exception(token['errorDetail']['message'])
-                    while "\n" in buffer:
-                        index = buffer.index("\n")
-                        line = buffer[:index]
-                        buffer = buffer[index + 1:]
-                        log(line,
-                            prefix=log_prefix,
-                            file=build_log,
-                            color=Fore.WHITE + Style.BRIGHT \
-                                if re.match(r'^Step \d+\/\d+', line) else '')
 
-                if buffer:
-                    log(buffer,
-                        prefix=log_prefix,
-                        file=build_log,
-                        color=Fore.WHITE + Style.BRIGHT \
-                            if re.match(r'^Step \d+\/\d+', buffer) else '')
-            except Exception:
-                tb = traceback.format_exc()
-                log("Docker build failed; terminating",
-                    prefix=log_prefix,
-                    file=build_log,
-                    color=Fore.RED)
-                log(tb, prefix=log_prefix, file=build_log)
-                return 1
+        try:
+            __build(
+                base_url=benchmarker_config.server_docker_host,
+                build_log_file=build_log_file,
+                log_prefix=log_prefix,
+                path=test.directory,
+                dockerfile=test_docker_file,
+                tag="techempower/tfb.test.%s" %
+                    test_docker_file.replace(".dockerfile", ""))
+        except Exception:
+            return 1
 
     return 0
 
@@ -236,7 +253,7 @@ def find(path, pattern):
                 return os.path.join(root, name)
 
 
-def start_database(benchmarker_config, test, database):
+def start_database(benchmarker_config, database):
     '''
     Sets up a container for the given database and port, and starts said docker
     container.
@@ -248,29 +265,13 @@ def start_database(benchmarker_config, test, database):
                                 "databases", database)
     docker_file = "%s.dockerfile" % database
 
-    client = docker.DockerClient(
-        base_url=benchmarker_config.database_docker_host)
-    try:
-        # Don't pull if we have it
-        client.images.get(image_name)
-        log("Found published image; skipping build", prefix=log_prefix)
-    except:
-        # Build the database image
-        for line in docker.APIClient(
-                base_url=benchmarker_config.database_docker_host).build(
-                    path=database_dir,
-                    dockerfile=docker_file,
-                    tag="techempower/%s" % database):
-            if line.startswith('{"stream":'):
-                line = json.loads(line)
-                line = line[line.keys()[0]].encode('utf-8')
-                log(line,
-                    prefix=log_prefix,
-                    color=Fore.WHITE + Style.BRIGHT \
-                        if re.match(r'^Step \d+\/\d+', line) else '')
-            elif line.startswith('{"errorDetail":'):
-                line = json.loads(line)
-                raise Exception(line['errorDetail']['message'])
+    __build(
+        base_url=benchmarker_config.database_docker_host,
+        path=database_dir,
+        dockerfile=docker_file,
+        log_prefix=log_prefix,
+        build_log_file=os.devnull,
+        tag="techempower/%s" % database)
 
     client = docker.DockerClient(
         base_url=benchmarker_config.database_docker_host)

--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,11 +1,4 @@
-FROM ubuntu:16.04
-
-# One -q produces output suitable for logging (mostly hides
-# progress indicators)
-RUN apt-get -yq update
-
-RUN apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-    build-essential git libev-dev libpq-dev libreadline6-dev curl
+FROM buildpack-deps:xenial
 
 # wrk
 RUN curl -sL -o wrk-4.0.1.tar.gz https://github.com/wg/wrk/archive/4.0.1.tar.gz


### PR DESCRIPTION
This does a couple of things:

 - this is a fork of #3605 so includes the changes there 
    - Remove duplicate build code
    - Properly build display errors and exit appropriately
 - this allows us to make changes to `wrk` locally without pushing to dockerhub and allowing to easily troubleshoot/iterate
 - Instead of attempting to pull `wrk` between every test request, this builds `tfb.wrk` once and then just runs it during the `test_client_connection` calls
 - pulled from `buildpack-deps:xenial` and wrk build time is much faster

Again, this won't have any affect on citrine or local dev after the first test.

Edit: closing #3605 