### PR TITLE
update: upgrade gcc version and Nim's version and buffer size UP.

### DIFF
--- a/frameworks/Nim/mofuw/mofuw.dockerfile
+++ b/frameworks/Nim/mofuw/mofuw.dockerfile
@@ -1,13 +1,29 @@
-FROM nimlang/nim:0.18.0
+FROM gcc:7
 
-RUN apt update -yqq
+RUN apt update -yqq &&                                                  \
+    mkdir -p /nim &&                                                    \
+    cd /nim &&                                                          \
+    git clone -b devel https://github.com/nim-lang/Nim.git nim-devel && \
+    cd nim-devel &&                                                     \
+    git clone --depth 1 https://github.com/nim-lang/csources.git &&     \
+    cd csources &&                                                      \
+    sh build.sh &&                                                      \
+    cd ../ &&                                                           \
+    bin/nim c koch &&                                                   \
+    ./koch boot -d:release &&                                           \
+    ./koch nimble &&                                                    \
+    ./koch tools
+
+ENV PATH=$PATH:/nim/nim-devel/bin:/root/.nimble/bin
 
 RUN git clone https://github.com/2vg/mofuw.git && \
     cd mofuw && \
     nimble update && \
     echo 'y' | nimble install
 
-COPY ./ ./
+WORKDIR /app
+
+COPY ./ /app
 
 RUN chmod a+wrx start-servers.sh
 

--- a/frameworks/Nim/mofuw/techempower.nim
+++ b/frameworks/Nim/mofuw/techempower.nim
@@ -6,4 +6,4 @@ proc h(req: mofuwReq, res: mofuwRes) {.async.} =
   else:
     mofuwResp(HTTP404, "text/plain", "NOT FOUND")
 
-h.mofuwRun(port = 8080, bufSize = 512)
+h.mofuwRun(port = 8080, bufSize = 1024)


### PR DESCRIPTION
upgraded gcc version to 7 and used Nim of devel branch.
although the devel branch is a development version, in fact it has more bug fixes and features added, so it can be said that it is more stable than the stable version.
and since Nim depends on C language compiler, I think that this change will improve some performance.(ya, maybe ;))
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
