### PR TITLE
Use Java 10 instead of 9 where possible, downgrade to 8 when not

### DIFF
--- a/frameworks/Java/activeweb/activeweb-jackson.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-jackson.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /activeweb
 COPY pom.xml pom.xml
 COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/activeweb/activeweb.dockerfile
+++ b/frameworks/Java/activeweb/activeweb.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /activeweb
 COPY pom.xml pom.xml
 COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/baratine/baratine.dockerfile
+++ b/frameworks/Java/baratine/baratine.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /baratine
 COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:9-jre-slim
+FROM openjdk:10-jre-slim
 WORKDIR /baratine
 COPY --from=maven /baratine/target/testTechempowerBaratine-0.0.1-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar", "tfb-database"]

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-8-slim as maven
 WORKDIR /curacao
 COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile war:war -q
 
-FROM openjdk:9-jdk
+FROM openjdk:8-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:9-jdk-slim as ant
+FROM openjdk:10-jdk-slim
 RUN apt update -qqy && apt install -yqq ant curl
 
 WORKDIR /gemini

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:9-jdk-slim as ant
+FROM openjdk:10-jdk-slim
 RUN apt update -qqy && apt install -yqq ant curl
 
 WORKDIR /gemini

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:9-jdk-slim as ant
+FROM openjdk:10-jdk-slim
 RUN apt update -qqy && apt install -yqq ant curl
 
 WORKDIR /gemini

--- a/frameworks/Java/jooby/jooby.dockerfile
+++ b/frameworks/Java/jooby/jooby.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-8-slim as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src
 COPY public public
 RUN mvn package -q
 
-FROM openjdk:9-jre-slim
+FROM openjdk:8-jre-slim
 WORKDIR /jooby
 COPY --from=maven /jooby/target/jooby-1.0.jar app.jar
 COPY conf conf

--- a/frameworks/Java/servlet/servlet-afterburner.dockerfile
+++ b/frameworks/Java/servlet/servlet-afterburner.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P afterburner
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-cjs.dockerfile
+++ b/frameworks/Java/servlet/servlet-cjs.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P cjs
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P mysql
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-postgresql.dockerfile
+++ b/frameworks/Java/servlet/servlet-postgresql.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P postgresql
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet.dockerfile
+++ b/frameworks/Java/servlet/servlet.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:9-jdk
+FROM openjdk:10-jdk
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet3/servlet3-sync.dockerfile
+++ b/frameworks/Java/servlet3/servlet3-sync.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet3
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P sync
 
-FROM tomcat:9.0.6-jre9-slim
+FROM tomcat:9.0.7-jre10-slim
 WORKDIR /servlet3
 RUN rm -rf ${CATALINA_HOME}/webapps/*
 COPY --from=maven /servlet3/target/servlet3.war ${CATALINA_HOME}/webapps/ROOT.war

--- a/frameworks/Java/servlet3/servlet3.dockerfile
+++ b/frameworks/Java/servlet3/servlet3.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-10-slim as maven
 WORKDIR /servlet3
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM tomcat:9.0.6-jre9-slim
+FROM tomcat:9.0.7-jre10-slim
 WORKDIR /servlet3
 RUN rm -rf ${CATALINA_HOME}/webapps/*
 COPY --from=maven /servlet3/target/servlet3.war ${CATALINA_HOME}/webapps/ROOT.war

--- a/frameworks/Java/spring/spring.dockerfile
+++ b/frameworks/Java/spring/spring.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-8-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:9-jre-slim
+FROM openjdk:8-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring.war app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/wicket/wicket.dockerfile
+++ b/frameworks/Java/wicket/wicket.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-9-slim as maven
+FROM maven:3.5.3-jdk-8-slim as maven
 WORKDIR /wicket
 COPY src src
 COPY pom.xml pom.xml


### PR DESCRIPTION
As I understand it, 10 is supported because it's the latest release,
and 8 is supported because it's the latest LTS release, but 9 is not
supported.  Therefore using 9 is probably not representative of a
production setup.