### PR TITLE
New JS framework - restify

### DIFF
--- a/frameworks/JavaScript/restify/README.md
+++ b/frameworks/JavaScript/restify/README.md
@@ -1,0 +1,24 @@
+# Restify Benchmarking Test
+
+From [restify.com](http://restify.com):
+
+> A Node.js web service framework optimized for building semantically correct RESTful web services ready for production use at scale. restify optimizes for introspection and performance, and is used in some of the largest Node.js deployments on Earth.
+
+### Test Type Implementation Source Code
+
+* [JSON](server.js)
+* [PLAINTEXT](server.js)
+
+## Important Libraries
+The tests were run with:
+* [Restify](http://restify.com/)
+* [NodeJS](https://nodejs.org/en/)
+
+## Test URLs
+### JSON
+
+http://localhost:8080/json
+
+### PLAINTEXT
+
+http://localhost:8080/plaintext

--- a/frameworks/JavaScript/restify/benchmark_config.json
+++ b/frameworks/JavaScript/restify/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework": "restify",
+  "tests": [{
+    "default": {
+      "plaintext_url": "/plaintext",
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "restify",
+      "language": "JavaScript",
+      "flavor": "NodeJS",
+      "orm": "Raw",
+      "platform": "nodejs",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "restify",
+      "notes": "",
+      "versus": "nodejs"
+    }
+  }]
+}

--- a/frameworks/JavaScript/restify/package.json
+++ b/frameworks/JavaScript/restify/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "restify",
+  "dependencies": {
+    "restify": "7.1.1"
+  },
+  "main": "app.js"
+}

--- a/frameworks/JavaScript/restify/package.json
+++ b/frameworks/JavaScript/restify/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "restify": "7.1.1"
   },
-  "main": "app.js"
+  "main": "server.js"
 }

--- a/frameworks/JavaScript/restify/restify.dockerfile
+++ b/frameworks/JavaScript/restify/restify.dockerfile
@@ -1,0 +1,8 @@
+FROM node:9.10.1
+
+WORKDIR /nextjs
+ADD ./ ./
+
+RUN npm install
+
+CMD node server.js

--- a/frameworks/JavaScript/restify/server.js
+++ b/frameworks/JavaScript/restify/server.js
@@ -1,0 +1,17 @@
+const cluster = require('cluster');
+const cpus = require('os').cpus();
+const server = require('restify').createServer();
+
+server.get('/plaintext', (req, res) =>
+  res.send('Hello, World!'));
+
+server.get('/json', (req, res) =>
+  res.json({ message: 'Hello, World!' }));
+
+
+if (cluster.isMaster) {
+  cpus.forEach(() => cluster.fork());
+} else {
+  server.listen(8080, () =>
+    console.log('%s listening at %s', server.name, server.url));
+}

--- a/frameworks/JavaScript/restify/source_code
+++ b/frameworks/JavaScript/restify/source_code
@@ -1,0 +1,1 @@
+.server.js


### PR DESCRIPTION
http://restify.com

I was impressed with how little code was needed to start serving the desired responses. If I wasn't forking server processes, the plaintext and json tests would simply be:

```
const server = require('restify').createServer();

server.get('/plaintext', (req, res) => res.send('Hello, World!'));
server.get('/json', (req, res) => res.json({ message: 'Hello, World!' }));
```
and one `package.json` entry.

I'll take this on as a pet project later, but for the database tests I'd like to use GraphQL.

This is for @michaelhixson - I think he was just saying how we should have more JS frameworks.