### PR TITLE
Fix json verify error

### DIFF
--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -104,8 +104,11 @@ def verify_helloworld_object(json_object, url):
 
     problems = []
 
-    # Make everything case insensitive
-    json_object = {k.lower(): v.lower() for k, v in json_object.iteritems()}
+    try:
+        # Make everything case insensitive
+        json_object = {k.lower(): v.lower() for k, v in json_object.iteritems()}
+    except:
+        return [('fail', "Not a valid JSON object", url)]
 
     if 'message' not in json_object:
         return [('fail', "Missing required key 'message'", url)]


### PR DESCRIPTION
While working on a new framework test I noticed that if the response during the json verification was not a valid json object, the toolset would throw an error about a missing method `iteritems`. This catches that and displays a more useful error message

From:
```
"{\"message\":\"Hello, World!\"}"
Verifying test json for restify caused an exception: 'unicode' object has no attribute 'iteritems'
   FAIL for http://tfb-server:8080
     Caused Exception in TFB
                 This almost certainly means your return value is incorrect,
                 but also that you have found a bug. Please submit an issue
                 including this message: 'unicode' object has no attribute 'iteritems'
     Traceback (most recent call last):
       File "/FrameworkBenchmarks/toolset/benchmark/framework_test.py", line 117, in verify_type
         results = test.verify(base_url)
       File "/FrameworkBenchmarks/toolset/benchmark/test_types/json_type.py", line 34, in verify
         problems += verify_helloworld_object(response, url)
       File "/FrameworkBenchmarks/toolset/benchmark/test_types/verifications.py", line 108, in verify_helloworld_object
         json_object = {k.lower(): v.lower() for k, v in json_object.iteritems()}
     AttributeError: 'unicode' object has no attribute 'iteritems'
     See http://frameworkbenchmarks.readthedocs.org/en/latest/Project-Information/Framework-Tests/#specific-test-requirements
```

To:
```
"{\"message\":\"Hello, World!\"}"
   FAIL for http://tfb-server:8080/json
     Not a valid JSON object
     See http://frameworkbenchmarks.readthedocs.org/en/latest/Project-Information/Framework-Tests/#specific-test-requirements
```