### PR TITLE
Catch more errors during the benchmarking process

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -212,11 +212,11 @@ class Benchmarker:
                     file=benchmark_log,
                     color=Fore.RED)
                 return False
-        except (OSError, IOError, subprocess.CalledProcessError) as e:
+        except Exception as e:
             tb = traceback.format_exc()
             self.results.write_intermediate(test.name,
                                             "error during test: " + str(e))
-            log("Subprocess Error %s" % test.name,
+            log("Error during test: %s" % test.name,
                 file=benchmark_log,
                 border='-',
                 color=Fore.RED)


### PR DESCRIPTION
These specific errors probably made sense before, but since a lot has changed I'm opening this up to catch more errors. @michaelhixson pointed out an uncaught exception that caused the continuous run to crash. This won't be done in place of handling the errors closer to the action. As we find them, we should handle and log them in the correct places.