### PR TITLE
Try a less vebose apt and composer

### DIFF
--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p app/tmp/cache/persistent
 RUN mkdir -p app/tmp/logs
 RUN chmod -R 777 app/tmp
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php5.6-fpm start && \
     nginx -c /cakephp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /clancats
 WORKDIR /clancats
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN git clone --branch v2.0.6 https://github.com/ClanCats/Framework.git clancatsapp
 RUN cp -r app/ clancatsapp/CCF/

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -23,7 +23,7 @@ WORKDIR /clancats
 
 RUN composer.phar install --quiet
 
-RUN git clone --branch v2.0.6 https://github.com/ClanCats/Framework.git clancatsapp
+RUN git clone --branch v2.0.6 --depth 1 https://github.com/ClanCats/Framework.git clancatsapp
 RUN cp -r app/ clancatsapp/CCF/
 RUN cp -r vendor/ clancatsapp/CCF/
 

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -4,8 +4,8 @@ RUN apt update -yqq && apt install -yqq software-properties-common apt-transport
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -20,7 +20,7 @@ RUN php -r "unlink('composer-setup.php');"
 ADD ./ /codeigniter
 WORKDIR /codeigniter
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD hhvm -m daemon --config /codeigniter/deploy/config.hdf && \
     nginx -c /codeigniter/deploy/nginx-hhvm.conf -g "daemon off;"

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /codeigniter
 WORKDIR /codeigniter
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /codeigniter/deploy/nginx-fpm.conf -g "daemon off;"

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cygnite/cygnite-raw.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/cygnite/cygnite-raw.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite-raw.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cygnite/cygnite-raw.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite-raw.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cygnite/cygnite-raw.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/cygnite/cygnite-raw.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite-raw.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /cygnite
 WORKDIR /cygnite
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php5.6-fpm start && \
     nginx -c /cygnite/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /cygnite
 WORKDIR /cygnite
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php5.6-fpm start && \
     nginx -c /cygnite/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /fuel
 WORKDIR /fuel
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php5.6-fpm start && \
     nginx -c /fuel/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -4,8 +4,8 @@ RUN apt update -yqq && apt install -yqq software-properties-common apt-transport
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /kohana
 WORKDIR /kohana
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /kohana
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /kumbiaphp
 WORKDIR /kumbiaphp
 
-RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
+RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 -q https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 
 CMD service php7.2-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
-RUN apt install -yqq php7.2-mbstring php7.2-xml
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt install -yqq php7.2-mbstring php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /laravel/storage/framework/cache
 
 RUN chmod -R 777 /laravel
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN php artisan config:cache
 RUN php artisan route:cache

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
-RUN apt install -yqq php7.2-mbstring php7.2-xml  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get install -yqq php7.2-mbstring php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /limonade
 WORKDIR /limonade
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /limonade/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /lithium
 WORKDIR /lithium
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /lithium
 

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
-RUN apt install -yqq php7.2-xml php7.2-mbstring
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt install -yqq php7.2-xml php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
-RUN apt install -yqq php7.2-xml php7.2-mbstring  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get install -yqq php7.2-xml php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -21,7 +21,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /lumen
 WORKDIR /lumen
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN mkdir -p /lumen/storage
 RUN mkdir -p /lumen/storage/framework/sessions

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon php7.2-dev
+RUN apt install -yqq php7.2-phalcon php7.2-dev  > /dev/null
 
 RUN mv /phalcon/public/index-micro.php /phalcon/public/index.php
 

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon php7.2-dev  > /dev/null
+RUN apt-get install -yqq php7.2-phalcon php7.2-dev  > /dev/null
 
 RUN mv /phalcon/public/index-micro.php /phalcon/public/index.php
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon
+RUN apt install -yqq php7.2-phalcon  > /dev/null
 
 RUN composer.phar install
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -22,7 +22,7 @@ WORKDIR /phalcon
 
 RUN apt install -yqq php7.2-phalcon  > /dev/null
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 app
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon  > /dev/null
+RUN apt-get install -yqq php7.2-phalcon  > /dev/null
 
 RUN composer.phar install --quiet
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon  > /dev/null
+RUN apt-get install -yqq php7.2-phalcon  > /dev/null
 
 RUN composer.phar install --quiet
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt install -yqq php7.2-phalcon
+RUN apt install -yqq php7.2-phalcon  > /dev/null
 
 RUN composer.phar install
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  php7.2-mongodb  > /dev/null

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -22,7 +22,7 @@ WORKDIR /phalcon
 
 RUN apt install -yqq php7.2-phalcon  > /dev/null
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 app
 

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/5.6/fpm/
 RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/5.6/fpm/
 RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /php
 WORKDIR /php
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
-
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.2/fpm/
 

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
+
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.2/fpm/
 

--- a/frameworks/PHP/php/php-swoole.dockerfile
+++ b/frameworks/PHP/php/php-swoole.dockerfile
@@ -4,7 +4,7 @@ ENV SWOOLE_VERSION=2.0.9
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \
-        && phpize && ./configure && make && make install --quiet \
+        && phpize && ./configure --quiet && make --quiet && make install --quiet \
         && docker-php-ext-enable swoole
 
 ADD ./ /swoole

--- a/frameworks/PHP/php/php-swoole.dockerfile
+++ b/frameworks/PHP/php/php-swoole.dockerfile
@@ -4,7 +4,7 @@ ENV SWOOLE_VERSION=2.0.9
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \
-        && phpize && ./configure && make && make install \
+        && phpize && ./configure && make && make install --quiet \
         && docker-php-ext-enable swoole
 
 ADD ./ /swoole

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /php
 WORKDIR /php
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get  update -yqq && apt-get  install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get  update -yqq  > /dev/null
-RUN apt-get  install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get  update -yqq && apt-get  install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
 RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phpixie
 WORKDIR /phpixie
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /phpixie/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get  update -yqq && apt-get  install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get  update -yqq  > /dev/null
+RUN apt-get  install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /phreeze
 WORKDIR /phreeze
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php5.6-fpm start && \
     nginx -c /phreeze/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /silex
 WORKDIR /silex
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN mv /silex/web/index_raw.php /silex/web/index.php
 

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /silex
 WORKDIR /silex
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /silex/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -4,8 +4,8 @@ RUN apt update -yqq && apt install -yqq software-properties-common apt-transport
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq
-RUN apt install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -20,7 +20,7 @@ RUN php -r "unlink('composer-setup.php');"
 ADD ./ /slim
 WORKDIR /slim
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /slim
 

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -21,7 +21,7 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /slim
 WORKDIR /slim
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /slim
 

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /slim
 WORKDIR /slim
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN chmod -R 777 /slim
 

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
-RUN apt install php7.2-xml
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt install php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -23,7 +23,7 @@ WORKDIR /symfony
 
 ENV APP_ENV=prod
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN php bin/console cache:clear --env=prod --no-debug --no-warmup
 RUN php bin/console cache:warmup --env=prod --no-debug

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
-RUN apt install php7.2-xml  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get install php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
-RUN apt install php7.2-xml
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt install php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -23,7 +23,7 @@ WORKDIR /symfony
 
 ENV APP_ENV=prod
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 RUN php bin/console cache:clear --env=prod --no-debug --no-warmup
 RUN php bin/console cache:warmup --env=prod --no-debug

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
-RUN apt install php7.2-xml  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get install php7.2-xml  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -20,6 +20,6 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /workerman
 WORKDIR /workerman
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD php /workerman/server.php start

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -20,7 +20,7 @@ RUN php -r "unlink('composer-setup.php');"
 ADD ./ /yii2
 WORKDIR /yii2
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD hhvm -m daemon --config /yii2/deploy/config.hdf && \
     nginx -c /yii2/deploy/nginx-hhvm.conf -g "daemon off;"

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -4,8 +4,8 @@ RUN apt update -yqq && apt install -yqq software-properties-common apt-transport
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq hhvm nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.2-mongodb  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-transport-https > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mbstring
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /yii2
 WORKDIR /yii2
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /yii2/deploy/nginx-fpm.conf -g "daemon off;"

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mbstring  > /dev/null

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mbstring  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
-RUN apt install -yqq php7.2-xml php7.2-mbstring
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt install -yqq php7.2-xml php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
-RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
-RUN apt install -yqq php7.2-xml php7.2-mbstring  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get install -yqq php7.2-xml php7.2-mbstring  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -24,7 +24,7 @@ WORKDIR /zend
 RUN mkdir -p data/cache
 RUN chmod 777 data/cache
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /zend/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common
+RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt update -yqq  > /dev/null
 RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -20,7 +20,7 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /zend1
 WORKDIR /zend1
 
-RUN composer.phar install
+RUN composer.phar install --quiet
 
 CMD service php7.2-fpm start && \
     nginx -c /zend1/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt update -yqq && apt install -yqq software-properties-common > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq  > /dev/null
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 
 RUN apt update -yqq && apt install -yqq software-properties-common
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql
+RUN apt update -yqq  > /dev/null
+RUN apt install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer
 WORKDIR /composer


### PR DESCRIPTION
Now that the tests are joined by language, it's too verbose for check the fails in travis.
I will try in the php dir, and check the result.

apt  STDOUT  > /dev/null
STDERROR will still show

Composer --quiet
It will only show errors.


Later, perhaps will be better to build the docker containers quietly.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
