### PR TITLE
[ci skip] Upgrade to wrk 4.1.0

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -383,7 +383,7 @@ def benchmark(benchmarker_config, script, variables, raw_file):
     watch_container(
         client.containers.run(
             "techempower/tfb.wrk",
-            "/bin/bash /%s" % script,
+            "/bin/bash %s" % script,
             environment=variables,
             network=benchmarker_config.network,
             network_mode=benchmarker_config.network_mode,

--- a/toolset/wrk/pipeline.sh
+++ b/toolset/wrk/pipeline.sh
@@ -24,11 +24,11 @@ do
 echo ""
 echo "---------------------------------------------------------"
 echo " Concurrency: $c for $name"
-echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $c --timeout 8 -t $(($c>$max_threads?$max_threads:$c)) $url -s /pipeline.lua -- $pipeline"
+echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-alive' --latency -d $duration -c $c --timeout 8 -t $(($c>$max_threads?$max_threads:$c)) $url -s pipeline.lua -- $pipeline"
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s /pipeline.lua -- $pipeline
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s pipeline.lua -- $pipeline
 echo "STARTTIME $STARTTIME"
 echo "ENDTIME $(date +"%s")"
 sleep 2

--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,16 +1,15 @@
 FROM buildpack-deps:xenial
 
-# wrk
-RUN curl -sL -o wrk-4.0.1.tar.gz https://github.com/wg/wrk/archive/4.0.1.tar.gz
-RUN tar xzf wrk-4.0.1.tar.gz
-RUN cd wrk-4.0.1 && make
-RUN cp wrk-4.0.1/wrk /usr/local/bin
+WORKDIR /wrk
+RUN curl -sL https://github.com/wg/wrk/archive/4.1.0.tar.gz | tar xz --strip-components=1
+RUN make > /dev/null
+RUN cp wrk /usr/local/bin
 
 # Required scripts for benchmarking
-ADD pipeline.lua pipeline.lua
-ADD concurrency.sh concurrency.sh
-ADD pipeline.sh pipeline.sh
-ADD query.sh query.sh
+COPY pipeline.lua pipeline.lua
+COPY concurrency.sh concurrency.sh
+COPY pipeline.sh pipeline.sh
+COPY query.sh query.sh
 
 RUN chmod 777 pipeline.lua concurrency.sh pipeline.sh query.sh
 


### PR DESCRIPTION
This is the most recent version of wrk, released in January 2018.  There are no particular new features or fixes we want out of this release compared to the last one, which was from 2015.  I'm upgrading just because.

Looking at the commit history, the changes are mostly dependency updates. https://github.com/wg/wrk/commits/master