### PR TITLE
Remove plaintext "optimization" in undertow test

### DIFF
--- a/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
@@ -83,18 +83,9 @@ public final class HelloWebServer {
   }
 
   static HttpHandler plaintextHandler() {
-    // Normally, one would send the string "Hello, World!" directly.  Reusing a
-    // ByteBuffer is a micro-optimization that is explicitly permitted by the
-    // plaintext test requirements.
-
-    var bytes = "Hello, World!".getBytes(US_ASCII);
-    var buffer = ByteBuffer.allocateDirect(bytes.length);
-    buffer.put(bytes);
-    buffer.flip();
-
     return exchange -> {
       exchange.getResponseHeaders().put(CONTENT_TYPE, "text/plain");
-      exchange.getResponseSender().send(buffer.duplicate());
+      exchange.getResponseSender().send("Hello, World!");
     };
   }
 

--- a/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
@@ -1,7 +1,6 @@
 package hello;
 
 import static io.undertow.util.Headers.CONTENT_TYPE;
-import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Comparator.comparing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
The `buffer.duplicate()` line was throwing an OutOfMemoryError for me
locally, so this optimization wasn't safe.