### PR TITLE
Clean nginx.conf

### DIFF
--- a/frameworks/PHP/cakephp/deploy/conf/php.ini
+++ b/frameworks/PHP/cakephp/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -52,7 +52,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 
 events {

--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -4,7 +4,7 @@ worker_processes  auto;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/clancats/deploy/conf/php.ini
+++ b/frameworks/PHP/clancats/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -33,7 +33,7 @@ http {
 		}
 
 		location ~ \.php$ {
-			try_files $uri =404;
+			 
 			fastcgi_pass   fastcgi_backend;
 			fastcgi_keep_conn on;
 			fastcgi_index  index.php;

--- a/frameworks/PHP/codeigniter/deploy/conf/php.ini
+++ b/frameworks/PHP/codeigniter/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -31,7 +31,7 @@ http {
     }
 
     location ~ \.php$ {
-      try_files $uri =404;
+       
       fastcgi_pass fastcgi_backend;
       fastcgi_keep_conn on;
       fastcgi_index index.php;

--- a/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user www-data;
+user root;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
@@ -31,7 +31,7 @@ http {
     }
 
     location ~ \.php$ {
-      try_files $uri =404;
+       
       fastcgi_pass fastcgi_backend;
       fastcgi_keep_conn on;
       fastcgi_index index.php;

--- a/frameworks/PHP/cygnite/deploy/conf/php.ini
+++ b/frameworks/PHP/cygnite/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/fat-free/deploy/conf/php.ini
+++ b/frameworks/PHP/fat-free/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/fuel/deploy/conf/php.ini
+++ b/frameworks/PHP/fuel/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/hhvm/deploy/nginx.conf
+++ b/frameworks/PHP/hhvm/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/hhvm/deploy/nginx.conf
+++ b/frameworks/PHP/hhvm/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user www-data;
+user root;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/kohana/deploy/conf/php.ini
+++ b/frameworks/PHP/kohana/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/laravel/deploy/conf/php.ini
+++ b/frameworks/PHP/laravel/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/limonade/deploy/conf/php.ini
+++ b/frameworks/PHP/limonade/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/lithium/deploy/conf/php.ini
+++ b/frameworks/PHP/lithium/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/lumen/deploy/conf/php.ini
+++ b/frameworks/PHP/lumen/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/phalcon/deploy/conf/php.ini
+++ b/frameworks/PHP/phalcon/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/php/deploy/conf/php.ini
+++ b/frameworks/PHP/php/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -49,7 +49,7 @@ http {
         index  index.php;
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -49,7 +49,7 @@ http {
         index  index.php;
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/phpixie/deploy/conf/php.ini
+++ b/frameworks/PHP/phpixie/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/phpixie/deploy/nginx.conf
+++ b/frameworks/PHP/phpixie/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/phpixie/deploy/nginx.conf
+++ b/frameworks/PHP/phpixie/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/phpixie/deploy/nginx.conf
+++ b/frameworks/PHP/phpixie/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/phreeze/deploy/conf/php.ini
+++ b/frameworks/PHP/phreeze/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/silex/deploy/conf/php.ini
+++ b/frameworks/PHP/silex/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/slim/deploy/conf/php.ini
+++ b/frameworks/PHP/slim/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -52,7 +52,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index index.php;

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user www-data;
+user root;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/symfony/deploy/conf/php.ini
+++ b/frameworks/PHP/symfony/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -53,7 +53,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -5,7 +5,7 @@ error_log stderr error;
 events {
     worker_connections 16384;
 	multi_accept on;
-	use epoll;
+	 
 }
 
 http {

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/workerman/deploy/conf/php.ini
+++ b/frameworks/PHP/workerman/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/yii2/deploy/conf/php.ini
+++ b/frameworks/PHP/yii2/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/yii2/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-fpm.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes auto;
 error_log stderr error;
 

--- a/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user www-data;
+user root;
 worker_processes auto;
 error_log stderr error;
 

--- a/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes auto;
 error_log stderr error;
 

--- a/frameworks/PHP/zend/deploy/conf/php.ini
+++ b/frameworks/PHP/zend/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -34,7 +34,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 

--- a/frameworks/PHP/zend1/deploy/conf/php.ini
+++ b/frameworks/PHP/zend1/deploy/conf/php.ini
@@ -773,7 +773,7 @@ enable_dl = Off
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo
-;cgi.fix_pathinfo=1
+ cgi.fix_pathinfo=0
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.

--- a/frameworks/PHP/zend1/deploy/nginx.conf
+++ b/frameworks/PHP/zend1/deploy/nginx.conf
@@ -34,7 +34,7 @@ http {
         }
 
         location ~ \.php$ {
-            try_files $uri =404;
+             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/zend1/deploy/nginx.conf
+++ b/frameworks/PHP/zend1/deploy/nginx.conf
@@ -1,4 +1,4 @@
-user root;
+user www-data;
 worker_processes  auto;
 error_log stderr error;
 


### PR DESCRIPTION
### Now use the `www-data` user.
More secure and production ready.

### Remove `use epoll;`
Nginx will by default use the most efficient method.
So it will work in any OS and avoid problems.
If we see a regression, we will change it again.

### Performance change

**Remove extra try_files**
This is for an old security bug. And only work if php-fpm and web server run in the same system.
The correct way is change the `path_info` config in php.ini (I don't know why not come so in the php.ini for php-fpm)
Also all the people send de path_info from nginx directly. And the bug was resolved in php 5.3.9.
This change remove extra `stat()`s in each request.

Later I will add more performance changes.
But one for each run. So all the people can check the differences.
In a small server is insignificant, but in _citrine_ we can see easily the differences.





<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
