### PR TITLE
Build databases up front

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -51,7 +51,10 @@ class Benchmarker:
         any_failed = False
         # Run tests
         log("Running Tests...", border='=')
+
+        # build wrk and all databases needed for current run
         self.docker_helper.build_wrk()
+        self.docker_helper.build_databases()
 
         with open(os.path.join(self.results.directory, 'benchmark.log'),
                   'w') as benchmark_log:

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -210,7 +210,11 @@ class DockerHelper:
     @staticmethod
     def __stop_container(container):
         try:
+            client = container.client
             container.kill()
+            while container.id in map(
+                    lambda x: x.id, client.containers.list()):
+                pass
         except:
             # container has already been killed
             pass

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -254,7 +254,7 @@ class DockerHelper:
         built = []
         for test in self.benchmarker.tests:
             db = test.database.lower()
-            if db not in built:
+            if db not in built and db != "none":
                 image_name = "techempower/%s:latest" % db
                 log_prefix = image_name + ": "
 

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -247,6 +247,29 @@ class DockerHelper:
             self.server.containers.prune()
             self.client.containers.prune()
 
+    def build_databases(self):
+        '''
+        Builds all the databases necessary to run the list of benchmarker tests
+        '''
+        built = []
+        for test in self.benchmarker.tests:
+            db = test.database.lower()
+            if db not in built:
+                image_name = "techempower/%s:latest" % db
+                log_prefix = image_name + ": "
+
+                database_dir = os.path.join(self.benchmarker.config.db_root, db)
+                docker_file = "%s.dockerfile" % db
+
+                self.__build(
+                    base_url=self.benchmarker.config.database_docker_host,
+                    path=database_dir,
+                    dockerfile=docker_file,
+                    log_prefix=log_prefix,
+                    build_log_file=os.devnull,
+                    tag="techempower/%s" % db)
+                built.append(db)
+
     def start_database(self, database):
         '''
         Sets up a container for the given database and port, and starts said docker
@@ -254,17 +277,6 @@ class DockerHelper:
         '''
         image_name = "techempower/%s:latest" % database
         log_prefix = image_name + ": "
-
-        database_dir = os.path.join(self.benchmarker.config.db_root, database)
-        docker_file = "%s.dockerfile" % database
-
-        self.__build(
-            base_url=self.benchmarker.config.database_docker_host,
-            path=database_dir,
-            dockerfile=docker_file,
-            log_prefix=log_prefix,
-            build_log_file=os.devnull,
-            tag="techempower/%s" % database)
 
         sysctl = {'net.core.somaxconn': 65535, 'kernel.sem': "250 32000 256 512"}
 


### PR DESCRIPTION
This builds all the databases required by any tests found with the `tfb` command up front and then runs them at test time.