### PR TITLE
Use persistent db connections in plain php

### DIFF
--- a/frameworks/PHP/php/dborm.php
+++ b/frameworks/PHP/php/dborm.php
@@ -9,6 +9,7 @@ header("Content-type: application/json");
 # inclue the ActiveRecord library
 require_once 'vendor/php-activerecord/php-activerecord/ActiveRecord.php';
 
+ActiveRecord\Connection::$PDO_OPTIONS[PDO::ATTR_PERSISTENT] = true;
 ActiveRecord\Config::initialize(function($cfg)
 {
   $cfg->set_model_directory('models');


### PR DESCRIPTION
In the Citrine environment, with this line we get about 30,000 RPS on the single query db test with zero errors.  Without this line we get terrible RPS and a ton of errors like this:

```
php: 2018/04/26 21:52:50 [error] 82#82: *14186 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught ActiveRecord\DatabaseException: PDOException: SQLSTATE[HY000] [2002] Cannot assign requested address in /php/vendor/php-activerecord/php-activerecord/lib/Connection.php:260
php: Stack trace:
php: #0 /php/vendor/php-activerecord/php-activerecord/lib/Connection.php(260): PDO->__construct('mysql:host=tfb-...', 'benchmarkdbuser', 'benchmarkdbpass', Array)
php: #1 /php/vendor/php-activerecord/php-activerecord/lib/Connection.php(122): ActiveRecord\Connection->__construct(Object(stdClass))
php: #2 /php/vendor/php-activerecord/php-activerecord/lib/ConnectionManager.php(33): ActiveRecord\Connection::instance('mysql://benchma...')
php: #3 /php/vendor/php-activerecord/php-activerecord/lib/Table.php(114): ActiveRecord\ConnectionManager::get_connection('development')
php: #4 /php/vendor/php-activerecord/php-activerecord/lib/Table.php(90): ActiveRecord\Table->reestablish_connection(false)
php: #5 /php/vendor/php-activerecord/php-activerecord/lib/Table.php(71): ActiveRecord\Table->__construct('World'
```

I think other PHP frameworks are encountering a similar problem right now on Citrine.  In the latest results, PHP frameworks occupy most of the bottom slots for all db test results.  https://tfb-status.techempower.com/results/c0de5c69-d51c-482c-be3e-75ff8e6d7d16

It's likely that we introduced a problem into many PHP frameworks somehow with our transition to docker.  But I don't think we removed any "use persistent connection" lines like the one I'm adding in this PR.  What did we do wrong?

Adding "PR: Do Not Merge" tag initially until we understand the problem better.

pinging @joanhey in case you have ideas.