### PR TITLE
Removed direct connection test (for #3643). Tested postgresql test.

### DIFF
--- a/frameworks/C++/cppcms/README.md
+++ b/frameworks/C++/cppcms/README.md
@@ -14,9 +14,8 @@ It is available under open source LGPLv3 license and alternative Commercial Lice
 
 
 ## Problems/DOTO
-- Test PostgreSQL
 - Test 7 CachedWorld uses normal worlds table
-- Fix direct conection WARNING: Required response size header missing, please include either "Content-Length" or "Transfer-Encoding"
+
 
 
 

--- a/frameworks/C++/cppcms/benchmark_config.json
+++ b/frameworks/C++/cppcms/benchmark_config.json
@@ -46,29 +46,6 @@
       "database_os": "Linux",
       "display_name": "CppCMS-PostgreSQL-nginx",
       "notes": ""
-    },
-    "direct": {
-      "json_url": "/json",
-      "db_url": "/db",
-      "query_url": "/queries/",
-      "update_url": "/updates/",
-      "fortune_url": "/fortunes",
-      "plaintext_url": "/plaintext",
-      "cached_query_url": "/cached-worlds/",
-      "port": 8080,
-      "approach": "Realistic",
-      "classification": "Platform",
-      "database": "MySQL",
-      "framework": "None",
-      "language": "C++",
-      "flavor": "None",
-      "orm": "Raw",
-      "platform": "None",
-      "webserver": "None",
-      "os": "Linux",
-      "database_os": "Linux",
-      "display_name": "CppCMS-MySQL-NoFront",
-      "notes": "HTTP 1.0 and no Content-length header"
     }
   }]
 }

--- a/frameworks/C++/cppcms/nginx.conf
+++ b/frameworks/C++/cppcms/nginx.conf
@@ -43,7 +43,7 @@ http {
 
         location / {
             fastcgi_pass unix:/var/tmp/cppcms.sock;
-            
+            fastcgi_keep_conn on;
             fastcgi_split_path_info ^()((?:/.*))?$;  
             fastcgi_param  PATH_INFO       $fastcgi_path_info;
         }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
