### PR TITLE
Opcache performance change

### DIFF
--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
 RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/cakephp/deploy/conf/php.ini
+++ b/frameworks/PHP/cakephp/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
 RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null

--- a/frameworks/PHP/clancats/deploy/conf/php.ini
+++ b/frameworks/PHP/clancats/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/codeigniter/deploy/conf/php.ini
+++ b/frameworks/PHP/codeigniter/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/cygnite/deploy/conf/php.ini
+++ b/frameworks/PHP/cygnite/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/fat-free/deploy/conf/php.ini
+++ b/frameworks/PHP/fat-free/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq && apt-get install -yqq software-properties-common  > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
 RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null

--- a/frameworks/PHP/fuel/deploy/conf/php.ini
+++ b/frameworks/PHP/fuel/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/kohana/deploy/conf/php.ini
+++ b/frameworks/PHP/kohana/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq > /dev/null
+RUN apt-get update -yqq  > /dev/null
 RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 RUN mkdir /composer

--- a/frameworks/PHP/laravel/deploy/conf/php.ini
+++ b/frameworks/PHP/laravel/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/limonade/deploy/conf/php.ini
+++ b/frameworks/PHP/limonade/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/lithium/deploy/conf/php.ini
+++ b/frameworks/PHP/lithium/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/lumen/deploy/conf/php.ini
+++ b/frameworks/PHP/lumen/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/phalcon/deploy/conf/php.ini
+++ b/frameworks/PHP/phalcon/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/php/deploy/conf/php.ini
+++ b/frameworks/PHP/php/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/phpixie/deploy/conf/php.ini
+++ b/frameworks/PHP/phpixie/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/phreeze/deploy/conf/php.ini
+++ b/frameworks/PHP/phreeze/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/silex/deploy/conf/php.ini
+++ b/frameworks/PHP/silex/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/slim/deploy/conf/php.ini
+++ b/frameworks/PHP/slim/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/symfony/deploy/conf/php.ini
+++ b/frameworks/PHP/symfony/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/workerman/deploy/conf/php.ini
+++ b/frameworks/PHP/workerman/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/yii2/deploy/conf/php.ini
+++ b/frameworks/PHP/yii2/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/zend/deploy/conf/php.ini
+++ b/frameworks/PHP/zend/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes

--- a/frameworks/PHP/zend1/deploy/conf/php.ini
+++ b/frameworks/PHP/zend1/deploy/conf/php.ini
@@ -1805,7 +1805,7 @@ opcache.validate_timestamps=0
 ;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
-;opcache.enable_file_override=0
+opcache.enable_file_override=1
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes


### PR DESCRIPTION
Will fail in frameworks than create compiled files for views, config, ....
So first check which frameworks can benefit from this change.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
