### PR TITLE
Change in Opcache for use less memory

### DIFF
--- a/frameworks/PHP/cakephp/deploy/conf/php.ini
+++ b/frameworks/PHP/cakephp/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/clancats/deploy/conf/php.ini
+++ b/frameworks/PHP/clancats/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/codeigniter/deploy/conf/php.ini
+++ b/frameworks/PHP/codeigniter/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/cygnite/deploy/conf/php.ini
+++ b/frameworks/PHP/cygnite/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/fat-free/deploy/conf/php.ini
+++ b/frameworks/PHP/fat-free/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/fuel/deploy/conf/php.ini
+++ b/frameworks/PHP/fuel/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/kohana/deploy/conf/php.ini
+++ b/frameworks/PHP/kohana/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/laravel/deploy/conf/php.ini
+++ b/frameworks/PHP/laravel/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/limonade/deploy/conf/php.ini
+++ b/frameworks/PHP/limonade/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/lithium/deploy/conf/php.ini
+++ b/frameworks/PHP/lithium/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/lumen/deploy/conf/php.ini
+++ b/frameworks/PHP/lumen/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/phalcon/deploy/conf/php.ini
+++ b/frameworks/PHP/phalcon/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/php/deploy/conf/php.ini
+++ b/frameworks/PHP/php/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/phpixie/deploy/conf/php.ini
+++ b/frameworks/PHP/phpixie/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/phreeze/deploy/conf/php.ini
+++ b/frameworks/PHP/phreeze/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/silex/deploy/conf/php.ini
+++ b/frameworks/PHP/silex/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/slim/deploy/conf/php.ini
+++ b/frameworks/PHP/slim/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/symfony/deploy/conf/php.ini
+++ b/frameworks/PHP/symfony/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/symfony/deploy/conf/php.ini
+++ b/frameworks/PHP/symfony/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-opcache.save_comments=0
+;opcache.save_comments=1
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/workerman/deploy/conf/php.ini
+++ b/frameworks/PHP/workerman/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/yii2/deploy/conf/php.ini
+++ b/frameworks/PHP/yii2/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/zend/deploy/conf/php.ini
+++ b/frameworks/PHP/zend/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/frameworks/PHP/zend1/deploy/conf/php.ini
+++ b/frameworks/PHP/zend1/deploy/conf/php.ini
@@ -1802,7 +1802,7 @@ opcache.validate_timestamps=0
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0


### PR DESCRIPTION
This change will fail for frameworks that use comment parsing for annotations.
So first check which frameworks can benefit from this change.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
