### PR TITLE
H2O: Another batch of changes

### DIFF
--- a/frameworks/C/h2o/benchmark_config.json
+++ b/frameworks/C/h2o/benchmark_config.json
@@ -18,7 +18,7 @@
       "flavor": "None",
       "orm": "Raw",
       "platform": "None",
-      "webserver": "H2O",
+      "webserver": "None",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "H2O",

--- a/frameworks/C/h2o/h2o.dockerfile
+++ b/frameworks/C/h2o/h2o.dockerfile
@@ -8,10 +8,11 @@ RUN apt update && \
 
 ### Install mustache-c
 
+ENV MUSTACHE_C_BUILD_DIR=mustache-c
 ENV MUSTACHE_C_HOME=/mustache-c
 
-RUN git clone https://github.com/x86-64/mustache-c.git && \
-    cd mustache-c && \
+RUN git clone "https://github.com/x86-64/mustache-c.git" "$MUSTACHE_C_BUILD_DIR" && \
+    cd "$MUSTACHE_C_BUILD_DIR" && \
     git checkout 01f1e4732c4862071bbf07242128abf1e28cc105 && \
     CFLAGS="-O3 -flto -march=native" ./autogen.sh --prefix="$MUSTACHE_C_HOME" && \
     make -j "$(nproc)" install
@@ -24,7 +25,7 @@ ENV YAJL_VERSION=2.1.0
 ENV YAJL_ARCHIVE="${YAJL_VERSION}.tar.gz"
 ENV YAJL_HOME=/yajl
 
-RUN wget -q "https://github.com/lloyd/yajl/archive/$YAJL_ARCHIVE" && \
+RUN wget -qO "$YAJL_ARCHIVE" "https://github.com/lloyd/yajl/archive/$YAJL_ARCHIVE" && \
     tar xf "$YAJL_ARCHIVE" && \
     cd "yajl-$YAJL_VERSION" && \
     ./configure -p "$YAJL_HOME" && \
@@ -38,7 +39,7 @@ ENV H2O_VERSION=2.2.4
 ENV H2O_ARCHIVE="v${H2O_VERSION}.tar.gz"
 ENV H2O_HOME=/h2o
 
-RUN wget -q "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" && \
+RUN wget -qO "$H2O_ARCHIVE" "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" && \
     tar xf "$H2O_ARCHIVE" && \
     cd "h2o-$H2O_VERSION" && \
     cmake -DCMAKE_INSTALL_PREFIX="$H2O_HOME" -DCMAKE_C_FLAGS="-flto -march=native" \

--- a/frameworks/C/h2o/start-servers.sh
+++ b/frameworks/C/h2o/start-servers.sh
@@ -17,7 +17,7 @@ if [[ "$CPU_COUNT" -gt 16 ]]; then
 	# In the physical hardware environment the number of threads used by the application is not
 	# the same as the number of logical CPU cores that the database server has, so we need to
 	# adjust the maximum number of database connections per thread accordingly.
-	DB_CONN=8
+	DB_CONN=6
 else
 	echo "Running h2o_app in the cloud environment."
 	USE_PROCESSES=false


### PR DESCRIPTION
* Reduce the number of database connections in the physical hardware environment.
* Unset again the Web server in the framework metadata - now that there is another framework that uses the standalone H2O Web server (h2o_mruby), setting it is a little deceiving.
* Make some defensive changes to the Dockerfile.