### PR TITLE
Extra connections for upstream

### DIFF
--- a/frameworks/PHP/cakephp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/cakephp/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/clancats/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/clancats/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
 	worker_connections  16384;

--- a/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
   worker_connections 16384;

--- a/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
@@ -1,6 +1,7 @@
 user root;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
   worker_connections 16384;

--- a/frameworks/PHP/cygnite/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/cygnite/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/fat-free/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/fat-free/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/fuel/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/fuel/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/hhvm/deploy/nginx.conf
+++ b/frameworks/PHP/hhvm/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user root;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections  16384;

--- a/frameworks/PHP/kohana/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kohana/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/kohana/deploy/nginx.conf
+++ b/frameworks/PHP/kohana/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
-error_log stderr error;
+
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/laravel/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/laravel/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/limonade/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/limonade/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/lithium/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/lithium/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/lumen/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/lumen/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/phalcon/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phalcon/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/phpixie/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phpixie/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/phpixie/deploy/nginx.conf
+++ b/frameworks/PHP/phpixie/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/phreeze/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phreeze/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/phreeze/deploy/nginx.conf
+++ b/frameworks/PHP/phreeze/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/silex/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/silex/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/silex/deploy/nginx.conf
+++ b/frameworks/PHP/silex/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/slim/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/slim/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -1,6 +1,7 @@
 user root;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/symfony/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/symfony/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/workerman/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/workerman/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/yii2/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-fpm.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections  16384;

--- a/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-hhvm.conf
@@ -1,6 +1,7 @@
 user root;
 worker_processes auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections  16384;

--- a/frameworks/PHP/zend/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/zend/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections  16384;

--- a/frameworks/PHP/zend1/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/zend1/deploy/conf/php-fpm.conf
@@ -165,7 +165,7 @@ listen = /run/php/php7.2-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 4096
+listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many

--- a/frameworks/PHP/zend1/deploy/nginx.conf
+++ b/frameworks/PHP/zend1/deploy/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+worker_rlimit_nofile 200000;
 
 events {
     worker_connections  16384;


### PR DESCRIPTION
Try to solve the upstream connect() problem.

If the problem persist, we will need to change to TCP sockets again.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

*** PLEASE READ ***

We are transitioning the testing suite to use docker. If you are opening a pull request to update a framework, please check the docker branch first to make sure the test hasn't already been converted. If you notice the test has a dockerfile, the pull request should be made against the docker branch. 

Any new framework tests should be made against the docker branch. Round 16 and beyond will use this new setup. As it will take some time to update the documentation to reflect these changes, feel free to ping any of us for guidance.

Thanks!


If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
-->
