### PR TITLE
Log Less

### DIFF
--- a/frameworks/Java/gemini/src/main/webapp/WEB-INF/resin.xml
+++ b/frameworks/Java/gemini/src/main/webapp/WEB-INF/resin.xml
@@ -1,0 +1,15 @@
+<resin xmlns="http://caucho.com/ns/resin"
+       xmlns:resin="http://caucho.com/ns/resin/core">
+
+    <cluster id="">
+        <access-log path="/dev/null" />
+        <log name="" level="config" path="stdout:" timestamp="[%H:%M:%S.%s] " />
+
+        <server id="">
+            <jvm-arg>-Xms1g</jvm-arg>
+            <jvm-arg>-Xmx1g</jvm-arg>
+
+            <http port="8080" />
+        </server>
+    </cluster>
+</resin>


### PR DESCRIPTION
Gemini got hit pretty bad in the last few plaintext benchmarks on Citrine, and we suspect that it was due to removing the resin.xml which configured logging.

This commit attempts to turn off access logging entirely, although in prior builds, the `access-log` directive was not required; may remove in a future commit.