### PR TITLE
try to avoid launching do-nothing travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ jobs:
         - FOO=foo
       script:
         - echo "tests to run = [$RUN_TESTS]"
-        - export TRAVIS_TEST_RESULT=1
-        - travis_terminate 0
+        - export TRAVIS_TEST_RESULT=0
+        - travis_terminate 1
 
 stages:
   - quicktest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ jobs:
       env:
         - FOO=foo
       script:
-        - echo 'In the quicktest stage:' && echo $RUN_TESTS
+        - echo "tests to run = [$RUN_TESTS]"
+        - travis_terminate 0
 
 stages:
   - quicktest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
       env:
         - FOO=foo
       script:
-        - echo "In the quicktest stage: ${RUN_TESTS}"
+        - echo 'In the quicktest stage:' && echo $RUN_TESTS
 
 stages:
   - quicktest

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
         - FOO=foo
       script:
         - echo "tests to run = [$RUN_TESTS]"
+        - export TRAVIS_TEST_RESULT=1
         - travis_terminate 0
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,7 @@ jobs:
       env:
         - FOO=foo
       script:
-        - echo "tests to run = [$RUN_TESTS]"
-        - export TRAVIS_TEST_RESULT=0
-        - travis_terminate 1
+        - travis_result 1 && travis_terminate 0
 
 stages:
   - quicktest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,18 @@ python:
 services:
   - docker
 
+jobs:
+  include:
+    - stage: quicktest
+      env:
+        - FOO=foo
+      script:
+        - echo "In the quicktest stage: ${RUN_TESTS}"
+
+stages:
+  - quicktest
+  - test
+
 env:
   matrix:
      - "TESTLANG=C"


### PR DESCRIPTION
I'm experimenting with travis to see if we can speed up build times using a combination of build stages and `travis_terminate`.  It might not work out.