### PR TITLE
Timeout on docker builds

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -38,6 +38,7 @@ class DockerHelper:
                     dockerfile=dockerfile,
                     tag=tag,
                     forcerm=True,
+                    timeout=3600,
                     pull=True)
                 buffer = ""
                 for token in output:


### PR DESCRIPTION
Resolves #3684 

Throws a timeout error if the build hangs on something for an hour. 

Tested by changing the timeout to 1 second.