### PR TITLE
Fix Gemini and cURL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@ Thank you for submitting to the TechEmpower Framework Benchmarks!
 
 If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.
 
-If you are editing an existing test, please update the `README.md` for that test where appropriate. The original contributor will most likely be pinged for feedback with `mention-bot`.
+If you are editing an existing test, please update the `README.md` for that test where appropriate.
 -->

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -9,7 +9,7 @@ RUN mv src/main/webapp/WEB-INF/gemini-mysql.conf src/main/webapp/WEB-INF/GeminiH
 RUN mvn -q compile
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk-slim
+FROM openjdk:10-jdk
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -5,8 +5,8 @@ WORKDIR /gemini
 COPY src src
 COPY pom.xml pom.xml
 
-RUN mv src/main/webapp/WEB-INF/gemini-mysql.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q compile
+RUN mv src/main/webapp/WEB-INF/gemini-mysql.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q war:war
 
 FROM openjdk:10-jdk

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -9,7 +9,7 @@ RUN mv src/main/webapp/WEB-INF/gemini-postgres.conf src/main/webapp/WEB-INF/Gemi
 RUN mvn -q compile
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk-slim
+FROM openjdk:10-jdk
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -5,8 +5,8 @@ WORKDIR /gemini
 COPY src src
 COPY pom.xml pom.xml
 
-RUN mv src/main/webapp/WEB-INF/gemini-postgres.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q compile
+RUN mv src/main/webapp/WEB-INF/gemini-postgres.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q war:war
 
 FROM openjdk:10-jdk

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -5,8 +5,8 @@ WORKDIR /gemini
 COPY src src
 COPY pom.xml pom.xml
 
-RUN mv src/main/webapp/WEB-INF/gemini.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q compile
+RUN mv src/main/webapp/WEB-INF/gemini.conf src/main/webapp/WEB-INF/GeminiHello.conf
 RUN mvn -q war:war
 
 FROM openjdk:10-jdk

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -9,7 +9,7 @@ RUN mv src/main/webapp/WEB-INF/gemini.conf src/main/webapp/WEB-INF/GeminiHello.c
 RUN mvn -q compile
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk-slim
+FROM openjdk:10-jdk
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin


### PR DESCRIPTION
The Docker image `openjdk:10-jdk-slim` was ninja-updated within the last few days such that `apt install curl` would no longer work. Luckily, only Gemini used this image (for reasons I do not know). Also luckily, simply using the non-slim image does not appear to be affected similarly.