### PR TITLE
Avoid waiting too long for a response after the build completes

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -145,16 +145,14 @@ class Benchmarker:
                     prefix=log_prefix,
                     file=benchmark_log)
 
-            slept = 0
-            max_sleep = 60
-            accepting_requests = False
-            while not accepting_requests and slept < max_sleep:
-                if not self.docker_helper.server_container_exists(
-                        container.id):
-                    break
+            max_time = time.time() + 60
+            while True:
                 accepting_requests = test.is_accepting_requests()
+                if accepting_requests \
+                        or time.time() >= max_time \
+                        or not self.docker_helper.server_container_exists(container.id):
+                    break
                 time.sleep(1)
-                slept += 1
 
             if not accepting_requests:
                 self.docker_helper.stop([container, database_container])

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -339,7 +339,7 @@ class DockerHelper:
         try:
             self.client.containers.run(
                 'techempower/tfb.wrk',
-                'curl %s' % url,
+                'curl --max-time 5 %s' % url,
                 remove=True,
                 log_config={'type': None},
                 network=self.benchmarker.config.network,


### PR DESCRIPTION
curl can wait for a long time for a response, potentially forever, so
there was no upper bound on how long each test.is_accepting_requests()
call could take.  Now each call is being limited to 5 seconds.

Also, our "while not accepting requests" loop was intended to wait up to
60 seconds for the app server to start accepting requests, but it was
actually giving it 60 chances to respond to a request, which might take
much longer than 60 seconds.  Now it's really waiting 60 seconds,
approximately.