### PR TITLE
Attempt to fix container not stopped errors

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -215,7 +215,7 @@ class DockerHelper:
     def __stop_container(container):
         try:
             container.kill()
-            container.wait()
+            time.sleep(2)
         except:
             # container has already been killed
             pass

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -214,11 +214,8 @@ class DockerHelper:
     @staticmethod
     def __stop_container(container):
         try:
-            client = container.client
             container.kill()
-            while container.id in map(lambda x: x.id,
-                                      client.containers.list()):
-                pass
+            container.wait()
         except:
             # container has already been killed
             pass


### PR DESCRIPTION
~~Hopefully this works since it's a much cleaner solution. docker-py provides a blocking operation that waits until the container state is `not-running`~~

That didn't work. Going to try a 2 second sleep. Not a huge fan of this solution, but for some reason checking the list and waiting aren't working all the time either.