### PR TITLE
Mark octane as stripped, don't hardcode Content-Length

### DIFF
--- a/frameworks/C/octane/benchmark_config.json
+++ b/frameworks/C/octane/benchmark_config.json
@@ -5,7 +5,7 @@
       "plaintext_url": "/plaintext",
       "json_url": "/json",
       "port": 8000,
-      "approach": "Realistic",
+      "approach": "Stripped",
       "classification": "Platform",
       "database": "None",
       "framework": "None",

--- a/frameworks/C/octane/src/responders/sds_responder.cpp
+++ b/frameworks/C/octane/src/responders/sds_responder.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <uv.h>
 #include "sds.h"
 #include "sds_responder.hpp"
@@ -8,13 +9,15 @@ using namespace rapidjson;
 
 extern char* current_time;
 
+const char* PLAINTEXT_CONTENT = "Hello, World!";
+
 void create_plaintext_response_sds(write_batch* batch) {
     sds response_buffer = sdsnew("HTTP/1.1 200 OK\r\n");
     response_buffer = sdscat(response_buffer, "Server: octane\r\n");
     response_buffer = sdscat(response_buffer, "Content-Type: text/plain\r\n");
-    response_buffer = sdscat(response_buffer, "Content-Length: 13\r\n");
+    response_buffer = sdscatprintf(response_buffer, "Content-Length: %d\r\n", strlen(PLAINTEXT_CONTENT));
     response_buffer = sdscatprintf(response_buffer, "Date: %s\r\n", current_time);
-    response_buffer = sdscat(response_buffer, "Hello, World!");
+    response_buffer = sdscat(response_buffer, PLAINTEXT_CONTENT);
 
     batch->buffers[batch->number_of_used_buffers].base = response_buffer;
     batch->buffers[batch->number_of_used_buffers].len = sdslen(response_buffer);


### PR DESCRIPTION
We said we'd mark it stripped but we never followed through:
https://github.com/TechEmpower/FrameworkBenchmarks/issues/2783