### PR TITLE
Don't consider a server up after 5xx

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -336,7 +336,7 @@ class DockerHelper:
         try:
             self.client.containers.run(
                 'techempower/tfb.wrk',
-                'curl --max-time 5 %s' % url,
+                'curl --fail --max-time 5 %s' % url,
                 remove=True,
                 log_config={'type': None},
                 network=self.benchmarker.config.network,


### PR DESCRIPTION
Without this change, we consider a server ready for verification if it
responds to a curl command with any HTTP response, even if that response
indicates a failure like 502 Bad Gateway.  (This particular response can
happen with frameworks that use nginx, when nginx has started but the
back end server isn't ready yet.)  With this change, we wait for a
successful response.

I added the fw-only tags because these two frameworks are currently
failing on master due to this issue.  They should pass now with this
change.