### PR TITLE
[ci skip] try to free up disk space between continuous runs

### DIFF
--- a/toolset/continuous/tfb-shutdown.sh
+++ b/toolset/continuous/tfb-shutdown.sh
@@ -2,16 +2,18 @@
 
 set -e
 
-sudo service docker restart
-docker ps -aq | xargs --no-run-if-empty docker stop
-docker ps -aq | xargs --no-run-if-empty docker rm -f
-ssh techempower@$TFB_DATABASE_HOST << \EOF
+docker_clean() {
   sudo service docker restart
-  docker ps -aq | xargs --no-run-if-empty docker stop
-  docker ps -aq | xargs --no-run-if-empty docker rm -f
-EOF
-ssh techempower@$TFB_CLIENT_HOST << \EOF
-  sudo service docker restart
-  docker ps -aq | xargs --no-run-if-empty docker stop
-  docker ps -aq | xargs --no-run-if-empty docker rm -f
-EOF
+  docker ps --all --quiet | xargs --no-run-if-empty docker stop
+  docker ps --all --quiet | xargs --no-run-if-empty docker rm --force
+
+  # https://stackoverflow.com/a/38183298/359008
+  FREE=`df -k --output=avail /var/lib/docker | tail -n1`   # df -k not df -h
+  if [[ $FREE -lt 20971520 ]]; then                        # 20G = 20*1024*1024k
+    docker system prune --all --force
+  fi
+}
+
+docker_clean
+ssh techempower@$TFB_DATABASE_HOST "$(typeset -f docker_clean); docker_clean"
+ssh techempower@$TFB_CLIENT_HOST "$(typeset -f docker_clean); docker_clean"


### PR DESCRIPTION
We rely on docker's built-in caching to save on build times.  We never
clear out this cache, so assuming people keep making changes to the
test implementations, we'll eventually run out of disk space.  This
happened most recently in the Citrine environment after 6 or so runs.

With this change, we'll try to clear out docker's cache when we notice
that the available disk space is uncomfortably low.  Currently the script
assumes that 20G is enough space to handle a full run.