### PR TITLE
Add php-raw7-tcp

### DIFF
--- a/frameworks/PHP/php/benchmark_config.json
+++ b/frameworks/PHP/php/benchmark_config.json
@@ -43,6 +43,27 @@
       "notes": "",
       "versus": "php"
     },
+    "raw7-tcp": {
+      "db_url": "/dbraw.php",
+      "query_url": "/dbraw.php?queries=",
+      "fortune_url": "/fortune.php",
+      "update_url": "/updateraw.php?queries=",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
+      "framework": "None",
+      "language": "PHP",
+      "flavor": "PHP7",
+      "orm": "Raw",
+      "platform": "None",
+      "webserver": "nginx",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "PHP-raw-tcp",
+      "notes": "TCP sockets",
+      "versus": "php"
+    },
     "php5": {
       "json_url": "/json.php",
       "plaintext_url": "/plaintext.php",

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+
+COPY deploy/conf/* /etc/php/7.2/fpm/
+
+ADD ./ /php
+WORKDIR /php
+
+RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.2/fpm/php-fpm.conf
+RUN sed -i "s|server unix:/var/run/php/php7.2-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
+
+RUN chmod -R 777 /php
+
+CMD service php7.2-fpm start && \
+    nginx -c /php/deploy/nginx7.conf -g "daemon off;"


### PR DESCRIPTION
To check the differences with tcp sockets and unix sockets.

Normally unix sockets are faster, but tcp sockets scale better.
We will try to resolve a typical question.

Ping @nbrady-techempower 
I need to change from dynamic to static children, and add more children as the latency is still very low.
No problem with citrine or azure.
But it's a problem in the vagrant box, max 512 children.

I know that other frameworks change the processes number with the number of cores.
Could you pass me any example?
Thanks

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
