### PR TITLE
Php-fpm change to static

### DIFF
--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /cakephp
 WORKDIR /cakephp
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN mkdir -p app/tmp/cache/models
 RUN mkdir -p app/tmp/cache/persistent
 RUN mkdir -p app/tmp/logs

--- a/frameworks/PHP/cakephp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/cakephp/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /clancats
 WORKDIR /clancats
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN git clone --branch v2.0.6 --depth 1 https://github.com/ClanCats/Framework.git clancatsapp

--- a/frameworks/PHP/clancats/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/clancats/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /codeigniter
 WORKDIR /codeigniter
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /cygnite
 WORKDIR /cygnite
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php5.6-fpm start && \

--- a/frameworks/PHP/cygnite/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/cygnite/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/fat-free/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/fat-free/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -17,6 +17,8 @@ ENV F3DIR="/fat-free/src"
 RUN git clone "https://github.com/bcosca/fatfree-core.git" src
 RUN cd src && git checkout -q "069ccd84afd2461c7ebb67f660c142f97577e661" # v3.5.2-dev
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN chmod -R 777 /fat-free
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -17,6 +17,8 @@ ENV F3DIR="/fat-free/src"
 RUN git clone "https://github.com/bcosca/fatfree-core.git" src
 RUN cd src && git checkout -q "069ccd84afd2461c7ebb67f660c142f97577e661" # v3.5.2-dev
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN chmod -R 777 /fat-free
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/fuel/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/fuel/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /fuel
 WORKDIR /fuel
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php5.6-fpm start && \

--- a/frameworks/PHP/kohana/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kohana/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/kohana/kohana.dockerfile
+++ b/frameworks/PHP/kohana/kohana.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /kohana
 WORKDIR /kohana
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /kohana

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -14,5 +14,7 @@ WORKDIR /kumbiaphp
 
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 -q https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 CMD service php7.2-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -15,5 +15,7 @@ WORKDIR /kumbiaphp
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 RUN git clone -b v0.4.0 --single-branch --depth 1 https://github.com/KumbiaPHP/ActiveRecord.git vendor/Kumbia/ActiveRecord
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 CMD service php7.2-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/laravel/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/laravel/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -15,6 +15,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /laravel
 WORKDIR /laravel
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN mkdir -p /laravel/bootstrap/cache
 RUN mkdir -p /laravel/storage/framework/sessions
 RUN mkdir -p /laravel/storage/framework/views

--- a/frameworks/PHP/limonade/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/limonade/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /limonade
 WORKDIR /limonade
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/lithium/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/lithium/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /lithium
 WORKDIR /lithium
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /lithium

--- a/frameworks/PHP/lumen/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/lumen/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -15,6 +15,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /lumen
 WORKDIR /lumen
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN mkdir -p /lumen/storage

--- a/frameworks/PHP/phalcon/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phalcon/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -12,6 +12,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN apt-get install -yqq php7.2-phalcon php7.2-dev  > /dev/null
 
 RUN mv /phalcon/public/index-micro.php /phalcon/public/index.php

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phalcon
 WORKDIR /phalcon
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN apt-get install -yqq php7.2-phalcon  > /dev/null
 
 RUN composer install --quiet

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -16,6 +16,8 @@ WORKDIR /phalcon
 
 RUN apt-get install -yqq php7.2-phalcon  > /dev/null
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 app

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -13,6 +13,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /php
 WORKDIR /php
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN chmod -R 777 /php
 
 CMD service php5.6-fpm start && \

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /php
 WORKDIR /php
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /php

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -15,6 +15,8 @@ WORKDIR /php
 RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.2/fpm/php-fpm.conf
 RUN sed -i "s|server unix:/var/run/php/php7.2-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN chmod -R 777 /php
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -12,6 +12,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /php
 WORKDIR /php
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN chmod -R 777 /php
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /php
 WORKDIR /php
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /php

--- a/frameworks/PHP/phpixie/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phpixie/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /phpixie
 WORKDIR /phpixie
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/phreeze/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/phreeze/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /phreeze
 WORKDIR /phreeze
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php5.6-fpm start && \

--- a/frameworks/PHP/silex/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/silex/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /silex
 WORKDIR /silex
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN mv /silex/web/index_raw.php /silex/web/index.php

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /silex
 WORKDIR /silex
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/slim/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/slim/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -15,6 +15,8 @@ RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /slim
 WORKDIR /slim
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /slim

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /slim
 WORKDIR /slim
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 RUN chmod -R 777 /slim

--- a/frameworks/PHP/symfony/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/symfony/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -15,6 +15,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /symfony
 WORKDIR /symfony
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 ENV APP_ENV=prod
 
 RUN composer install --quiet

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -15,6 +15,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /symfony
 WORKDIR /symfony
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 ENV APP_ENV=prod
 
 RUN composer install --quiet

--- a/frameworks/PHP/workerman/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/workerman/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -14,6 +14,8 @@ RUN apt-get install -yqq composer > /dev/null
 ADD ./ /yii2
 WORKDIR /yii2
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD hhvm -m daemon --config /yii2/deploy/config.hdf && \

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /yii2
 WORKDIR /yii2
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \

--- a/frameworks/PHP/zend/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/zend/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -15,6 +15,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /zend
 WORKDIR /zend
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN mkdir -p data/cache
 RUN chmod 777 data/cache
 

--- a/frameworks/PHP/zend1/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/zend1/deploy/conf/php-fpm.conf
@@ -227,7 +227,7 @@ listen.group = www-data
 ;             pm.process_idle_timeout   - The number of seconds after which
 ;                                         an idle process will be killed.
 ; Note: This value is mandatory.
-pm = dynamic
+pm = static
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.

--- a/frameworks/PHP/zend1/zend1.dockerfile
+++ b/frameworks/PHP/zend1/zend1.dockerfile
@@ -14,6 +14,8 @@ COPY deploy/conf/* /etc/php/7.2/fpm/
 ADD ./ /zend1
 WORKDIR /zend1
 
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
+
 RUN composer install --quiet
 
 CMD service php7.2-fpm start && \


### PR DESCRIPTION
## Php-fpm from dynamic to static
Dynamic is very useful for shared hosting, where different app pools can share at peak time. But also all will have a minimum always available.
Completely unnecessary for a server with only 1 app.
PHP will have more req/s with this change.

## Limit children number for the vagrant box
With 2 cpu cores can sustain more than 1024 children easily. 
The problem is the memory. In 3Gb need to run the database, web server, php, wrk,...
The easiest way is check for the `nproc = 2`, and limit to 512.

I think that will be no problem with the azure server, that it have enough memory.
If we see a problem in the azure preview, we will change it too.

## To do
After check the results, especially the latency, add more children.

Actually the latency results are really low, so we could double the children at least.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
