### PR TITLE
Modified shebang to use bash rather than plain sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The command looks like this: `docker run -it --rm --network tfb -v /var/run/dock
 #### A note on Windows:
 
 - Docker expects Linux-style paths. If you cloned on your `C:\` drive, then `[ABS PATH TO THIS DIR]` would be `/c/FrameworkBenchmarks`.
-- [Docker for Windows](https://www.docker.com/docker-windows) understands `/var/run/docker.sock` even though that is not a valid path on Windows, but only when using Linux containers (it doesn't work with Windows containers and LCOW). [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) **may** not understand `var/run/docker.sock`, even when using Linux containers - use at your own risk.
+- [Docker for Windows](https://www.docker.com/docker-windows) understands `/var/run/docker.sock` even though that is not a valid path on Windows, but only when using Linux containers (it doesn't work with Windows containers and LCOW). [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) **may** not understand `/var/run/docker.sock`, even when using Linux containers - use at your own risk.
 
 ## Quick Start Guide (Vagrant)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The command looks like this: `docker run -it --rm --network tfb -v /var/run/dock
 #### A note on Windows:
 
 - Docker expects Linux-style paths. If you cloned on your `C:\` drive, then `[ABS PATH TO THIS DIR]` would be `/c/FrameworkBenchmarks`.
-- [Docker for Windows](https://www.docker.com/docker-windows) understands `/var/run/docker.sock` even though that is not a valid path on Windows. [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) **may** not - use at your own risk.
+- [Docker for Windows](https://www.docker.com/docker-windows) understands `/var/run/docker.sock` even though that is not a valid path on Windows, but only when using Linux containers (it doesn't work with Windows containers and LCOW). [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) **may** not understand `var/run/docker.sock`, even when using Linux containers - use at your own risk.
 
 ## Quick Start Guide (Vagrant)
 

--- a/tfb
+++ b/tfb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ################## https://github.com/mkropat/sh-realpath #####################
 #


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

`tfb` doesn't work on wsl with the `#!/bin/sh` shebang, `bash` needs to be specified instead.