### PR TITLE
Mono Json, use defined struct, rather than anon class

### DIFF
--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -31,7 +31,7 @@ namespace PlatformBenchmarks
 
             // Content-Length header
             writer.Write(_headerContentLength);
-            var jsonPayload = JsonSerializer.SerializeUnsafe(new { message = "Hello, World!" });
+            var jsonPayload = JsonSerializer.SerializeUnsafe(new JsonMessage() { message = "Hello, World!" });
             writer.WriteNumeric((uint)jsonPayload.Count);
 
             // End of headers

--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/Data/JsonMessage.cs
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/Data/JsonMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace PlatformBenchmarks
+{
+    public struct JsonMessage
+    {
+        public string message { get; set; }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
