### PR TITLE
Upgrade to Blaze 0.14.0-M3 + replace Jackson by jsoniter-scala

### DIFF
--- a/frameworks/Scala/blaze/README.md
+++ b/frameworks/Scala/blaze/README.md
@@ -3,8 +3,8 @@
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Java Oracle 1.8.0_101](http://www.oracle.com/technetwork/java/javase)
-* [blaze 0.13.0](https://github.com/http4s/blaze/)
+* [Java Oracle 1.8.0](http://www.oracle.com/technetwork/java/javase)
+* [blaze 0.14.0-M3](https://github.com/http4s/blaze/)
 
 ## Test URLs
 ### JSON Encoding Test
@@ -16,6 +16,7 @@ http://localhost:8080/json
 http://localhost:8080/plaintext
 
 ## How to run
-sbt 'oneJar'
+sbt assembly
 
-java -jar target/scala-2.11/blaze_2.11-1.0-SNAPSHOT-one-jar.jar
+java -server -Xms2g -Xmx2g -XX:NewSize=1g -XX:MaxNewSize=1g -XX:InitialCodeCacheSize=256m -XX:ReservedCodeCacheSize=256m -XX:+UseParallelGC -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.12/blaze-assembly-1.0.jar
+

--- a/frameworks/Scala/blaze/README.md
+++ b/frameworks/Scala/blaze/README.md
@@ -18,5 +18,5 @@ http://localhost:8080/plaintext
 ## How to run
 sbt assembly
 
-java -server -Xms2g -Xmx2g -XX:NewSize=1g -XX:MaxNewSize=1g -XX:InitialCodeCacheSize=256m -XX:ReservedCodeCacheSize=256m -XX:+UseParallelGC -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.12/blaze-assembly-1.0.jar
+java -server -Xms2g -Xmx2g -XX:NewSize=1g -XX:MaxNewSize=1g -XX:InitialCodeCacheSize=256m -XX:ReservedCodeCacheSize=256m -XX:+UseParallelGC -XX:+UseNUMA -XX:+AggressiveOpts -XX:-UseBiasedLocking -XX:+AlwaysPreTouch -jar target/scala-2.12/blaze-assembly-1.0.jar
 

--- a/frameworks/Scala/blaze/blaze.dockerfile
+++ b/frameworks/Scala/blaze/blaze.dockerfile
@@ -4,4 +4,4 @@ COPY project project
 COPY src src
 COPY build.sbt build.sbt
 RUN sbt assembly -batch
-CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:NewSize=1g", "-XX:MaxNewSize=1g", "-XX:+UseParallelGC", "-XX:InitialCodeCacheSize=256m", "-XX:ReservedCodeCacheSize=256m", "-XX:-UseBiasedLocking", "-XX:+AlwaysPreTouch", "-jar", "target/scala-2.12/blaze-assembly-1.0.jar"]
+CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:NewSize=1g", "-XX:MaxNewSize=1g", "-XX:InitialCodeCacheSize=256m", "-XX:ReservedCodeCacheSize=256m", "-XX:+UseParallelGC", "-XX:+UseNUMA", "-XX:+AggressiveOpts", "-XX:-UseBiasedLocking", "-XX:+AlwaysPreTouch", "-jar", "target/scala-2.12/blaze-assembly-1.0.jar"]

--- a/frameworks/Scala/blaze/blaze.dockerfile
+++ b/frameworks/Scala/blaze/blaze.dockerfile
@@ -4,4 +4,4 @@ COPY project project
 COPY src src
 COPY build.sbt build.sbt
 RUN sbt assembly -batch
-CMD ["java", "-jar", "target/scala-2.12/blaze-assembly-1.0.jar"]
+CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:NewSize=1g", "-XX:MaxNewSize=1g", "-XX:+UseParallelGC", "-XX:InitialCodeCacheSize=256m", "-XX:ReservedCodeCacheSize=256m", "-XX:-UseBiasedLocking", "-XX:+AlwaysPreTouch", "-jar", "target/scala-2.12/blaze-assembly-1.0.jar"]

--- a/frameworks/Scala/blaze/build.sbt
+++ b/frameworks/Scala/blaze/build.sbt
@@ -2,11 +2,9 @@ name := "blaze"
 
 version := "1.0"
 
-scalaVersion := "2.12.5"
-
-val blazeVersion = "0.13.0"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
-	"org.http4s" %% "blaze-http" % blazeVersion,
-	"com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4"
+	"org.http4s" %% "blaze-http" % "0.14.0-M3",
+	"com.github.plokhotnyuk.jsoniter-scala" %% "macros" % "0.27.1"
 )

--- a/frameworks/Scala/blaze/src/main/scala/Main.scala
+++ b/frameworks/Scala/blaze/src/main/scala/Main.scala
@@ -1,50 +1,49 @@
 package blaze.techempower.benchmark
 
+import java.lang.Runtime._
 import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.AsynchronousChannelGroup
 import java.nio.charset.StandardCharsets.UTF_8
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.ForkJoinPool._
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-
-import org.http4s.blaze.channel.SocketConnection
+import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
 import org.http4s.blaze.http._
+import org.http4s.blaze.http.HttpServerStageConfig
+import org.http4s.blaze.http.http1.server.Http1ServerStage
+import org.http4s.blaze.pipeline.LeafBuilder
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import org.http4s.blaze.channel.SocketConnection
+import org.http4s.blaze.http.RouteAction._
 
 import scala.concurrent.Future
 
+case class Message(message: String)
+
 object Main {
+  private val config = HttpServerStageConfig()
+  private val fjp = new ForkJoinPool(getRuntime.availableProcessors, defaultForkJoinWorkerThreadFactory, null, true)
+  private val jsonHeaders = Seq("server" -> "blaze", "content-type" -> "text/plain")
+  private val plaintextHeaders = Seq("server" -> "blaze", "content-type" -> "application/json")
 
-  private val mapper: ObjectMapper = new ObjectMapper().registerModule(DefaultScalaModule)
+  private implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make[Message](CodecMakerConfig())
 
-  private val plaintextResult = Future.successful {
-    val hs = Seq("server" -> "blaze", "content-type" -> "text/plain")
-    RouteAction.Ok("Hello, World!".getBytes(UTF_8), hs)
-  }
-
-  private def notFound(path: String) = Future.successful {
-    RouteAction.String(s"Not found: $path", 404, "Not Found", Nil)
-  }
-
-  // HTTP service definition
-  private def service(request: HttpRequest): Future[RouteAction] = request.uri match {
-    case "/plaintext" => plaintextResult
-
-    case "/json" => Future.successful {
-      val msg = mapper.writeValueAsBytes(Map("message" -> "Hello, World!"))
-      RouteAction.Ok(msg, Seq("server" -> "blaze", "content-type" -> "application/json"))
+  def serve(request: HttpRequest): Future[RouteAction] = Future.successful {
+    request.url match {
+      case "/plaintext" => Ok("Hello, World!".getBytes(UTF_8), plaintextHeaders)
+      case "/json" => Ok(writeToArray(Message("Hello, World!")), jsonHeaders)
     }
-
-    case other => notFound(other)
   }
+
+  def connect(conn: SocketConnection): Future[LeafBuilder[ByteBuffer]] =
+    Future.successful(LeafBuilder(new Http1ServerStage(serve, config)))
 
   def main(args: Array[String]): Unit = {
-    val srvc = { _: SocketConnection => service(_:HttpRequest) }
-    val server = Http1Server(srvc, new InetSocketAddress(8080), HttpServerStageConfig())
-      .getOrElse(sys.error("Failed to bind socket"))
-
-    try server.channel.join()
-    finally {
-      server.group.closeGroup()
-    }
+    NIO2SocketServerGroup(group = Some(AsynchronousChannelGroup.withThreadPool(fjp)))
+      .bind(new InetSocketAddress(8080), connect)
+      .getOrElse(sys.error("Failed to start server."))
+      .join()
   }
 }
-

--- a/frameworks/Scala/blaze/src/main/scala/Main.scala
+++ b/frameworks/Scala/blaze/src/main/scala/Main.scala
@@ -25,8 +25,8 @@ case class Message(message: String)
 object Main {
   private val config = HttpServerStageConfig()
   private val fjp = new ForkJoinPool(getRuntime.availableProcessors, defaultForkJoinWorkerThreadFactory, null, true)
-  private val jsonHeaders = Seq("server" -> "blaze", "content-type" -> "text/plain")
-  private val plaintextHeaders = Seq("server" -> "blaze", "content-type" -> "application/json")
+  private val jsonHeaders = Seq("server" -> "blaze", "content-type" -> "application/json")
+  private val plaintextHeaders = Seq("server" -> "blaze", "content-type" -> "text/plain")
 
   private implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make[Message](CodecMakerConfig())
 


### PR DESCRIPTION
It should be the most efficient setup for JSON and plaintext benchmarks of the Blaze server.
On my notebook I got quite acceptable results at 250K rate of incoming requests.
Here is output of wrk2 client:
```sh
$ ./wrk -c50 -d1m -t4 -R250000 -L -v http://localhost:8080/json
wrk 4.0.0 [epoll] Copyright (C) 2012 Will Glozer
Running 1m test @ http://localhost:8080/json
  4 threads and 50 connections
  Thread calibration: mean lat.: 8.455ms, rate sampling interval: 39ms
  Thread calibration: mean lat.: 9.254ms, rate sampling interval: 40ms
  Thread calibration: mean lat.: 5.579ms, rate sampling interval: 18ms
  Thread calibration: mean lat.: 6.755ms, rate sampling interval: 30ms
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.84ms    2.32ms  39.36ms   92.85%
    Req/Sec    63.84k     5.80k  107.94k    82.25%
  Latency Distribution (HdrHistogram - Recorded Latency)
 50.000%    1.27ms
 75.000%    2.07ms
 90.000%    3.43ms
 99.000%   12.78ms
 99.900%   23.87ms
 99.990%   32.56ms
 99.999%   36.61ms
100.000%   39.39ms

  Detailed Percentile spectrum:
       Value   Percentile   TotalCount 1/(1-Percentile)

       0.016     0.000000            1         1.00
       0.368     0.100000      1250756         1.11
       0.616     0.200000      2497982         1.25
       0.847     0.300000      3748208         1.43
       1.060     0.400000      4994390         1.67
       1.270     0.500000      6243721         2.00
       1.390     0.550000      6869745         2.22
       1.526     0.600000      7494431         2.50
       1.681     0.650000      8117148         2.86
       1.860     0.700000      8741071         3.33
       2.069     0.750000      9367343         4.00
       2.189     0.775000      9677651         4.44
       2.331     0.800000      9989385         5.00
       2.509     0.825000     10303180         5.71
       2.735     0.850000     10613151         6.67
       3.033     0.875000     10925990         8.00
       3.217     0.887500     11081075         8.89
       3.435     0.900000     11236485        10.00
       3.705     0.912500     11393370        11.43
       4.047     0.925000     11549169        13.33
       4.499     0.937500     11705488        16.00
       4.787     0.943750     11783137        17.78
       5.135     0.950000     11861397        20.00
       5.559     0.956250     11938762        22.86
       6.119     0.962500     12016974        26.67
       6.847     0.968750     12094805        32.00
       7.315     0.971875     12134034        35.56
       7.859     0.975000     12172776        40.00
       8.527     0.978125     12212091        45.71
       9.279     0.981250     12250853        53.33
      10.239     0.984375     12289932        64.00
      10.815     0.985938     12309493        71.11
      11.479     0.987500     12328894        80.00
      12.255     0.989062     12348495        91.43
      13.159     0.990625     12367994       106.67
      14.255     0.992188     12387407       128.00
      14.903     0.992969     12397194       142.22
      15.583     0.993750     12406908       160.00
      16.311     0.994531     12416670       182.86
      17.119     0.995313     12426474       213.33
      18.015     0.996094     12436282       256.00
      18.527     0.996484     12441113       284.44
      19.087     0.996875     12445985       320.00
      19.775     0.997266     12450842       365.71
      20.591     0.997656     12455704       426.67
      21.327     0.998047     12460531       512.00
      21.695     0.998242     12462999       568.89
      22.111     0.998437     12465448       640.00
      22.591     0.998633     12467880       731.43
      23.183     0.998828     12470310       853.33
      23.983     0.999023     12472730      1024.00
      24.463     0.999121     12473924      1137.78
      25.007     0.999219     12475147      1280.00
      25.711     0.999316     12476358      1462.86
      26.511     0.999414     12477589      1706.67
      27.295     0.999512     12478811      2048.00
      27.727     0.999561     12479406      2275.56
      28.239     0.999609     12480019      2560.00
      28.767     0.999658     12480643      2925.71
      29.375     0.999707     12481243      3413.33
      29.983     0.999756     12481844      4096.00
      30.303     0.999780     12482150      4551.11
      30.623     0.999805     12482459      5120.00
      30.959     0.999829     12482767      5851.43
      31.423     0.999854     12483068      6826.67
      32.015     0.999878     12483371      8192.00
      32.351     0.999890     12483525      9102.22
      32.607     0.999902     12483675     10240.00
      32.991     0.999915     12483834     11702.86
      33.343     0.999927     12483978     13653.33
      33.791     0.999939     12484136     16384.00
      34.015     0.999945     12484208     18204.44
      34.303     0.999951     12484292     20480.00
      34.655     0.999957     12484363     23405.71
      35.039     0.999963     12484439     27306.67
      35.295     0.999969     12484511     32768.00
      35.391     0.999973     12484570     36408.89
      35.455     0.999976     12484598     40960.00
      35.615     0.999979     12484628     46811.43
      35.871     0.999982     12484670     54613.33
      36.095     0.999985     12484702     65536.00
      36.223     0.999986     12484723     72817.78
      36.319     0.999988     12484740     81920.00
      36.511     0.999989     12484760     93622.86
      36.735     0.999991     12484780    109226.67
      37.023     0.999992     12484797    131072.00
      37.151     0.999993     12484807    145635.56
      37.311     0.999994     12484818    163840.00
      37.439     0.999995     12484827    187245.71
      37.599     0.999995     12484837    218453.33
      37.759     0.999996     12484846    262144.00
      37.823     0.999997     12484850    291271.11
      37.919     0.999997     12484855    327680.00
      37.983     0.999997     12484860    374491.43
      38.079     0.999998     12484864    436906.67
      38.239     0.999998     12484870    524288.00
      38.303     0.999998     12484871    582542.22
      38.335     0.999998     12484873    655360.00
      38.431     0.999999     12484878    748982.86
      38.431     0.999999     12484878    873813.33
      38.591     0.999999     12484881   1048576.00
      38.687     0.999999     12484882   1165084.44
      38.751     0.999999     12484883   1310720.00
      38.815     0.999999     12484884   1497965.71
      38.879     0.999999     12484885   1747626.67
      39.039     1.000000     12484887   2097152.00
      39.039     1.000000     12484887   2330168.89
      39.135     1.000000     12484888   2621440.00
      39.135     1.000000     12484888   2995931.43
      39.199     1.000000     12484889   3495253.33
      39.263     1.000000     12484890   4194304.00
      39.263     1.000000     12484890   4660337.78
      39.263     1.000000     12484890   5242880.00
      39.263     1.000000     12484890   5991862.86
      39.327     1.000000     12484891   6990506.67
      39.327     1.000000     12484891   8388608.00
      39.327     1.000000     12484891   9320675.55
      39.327     1.000000     12484891  10485760.00
      39.327     1.000000     12484891  11983725.71
      39.391     1.000000     12484892  13981013.34
      39.391     1.000000     12484892          inf
#[Mean    =        1.840, StdDeviation   =        2.318]
#[Max     =       39.360, Total count    =     12484892]
#[Buckets =           27, SubBuckets     =         2048]
----------------------------------------------------------
  14992553 requests in 1.00m, 2.01GB read
Requests/sec: 249877.24
Transfer/sec:     34.32MB
```
