### PR TITLE
Try to fix Revenj build on Citrine

### DIFF
--- a/frameworks/CSharp/revenj/revenj.dockerfile
+++ b/frameworks/CSharp/revenj/revenj.dockerfile
@@ -1,4 +1,4 @@
-FROM mono:5.10.0.160
+FROM mono:5.12.0.226
 RUN apt update -yqq && apt install -yqq unzip
 
 RUN mkdir /java
@@ -31,7 +31,7 @@ RUN java -jar dsl-clc.jar \
 	no-prompt \
 	dependencies:revenj.net=/revenj/exe
 
-RUN msbuild /revenj/Revenj.Bench/Revenj.Bench.csproj /t:Rebuild /p:Configuration=Release
+RUN xbuild /revenj/Revenj.Bench/Revenj.Bench.csproj /t:Rebuild /p:Configuration=Release
 
 RUN mv /revenj/Revenj.Http.exe.config /revenj/exe/Revenj.Http.exe.config
 


### PR DESCRIPTION
Mono hangs during the build. Revert to previous build tool and upgrade Mono to latest version

https://tfb-status.techempower.com/unzip/results.2018-05-25-20-11-22-271.zip/results/20180523080155/revenj/build/revenj.log

