### PR TITLE
[ci skip] Add SQL Server (on linux) as a database type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:16.04
+FROM buildpack-deps:xenial
 
-# One -q produces output suitable for logging (mostly hides
-# progress indicators)
-RUN apt update -yqq
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/16.04/prod.list)"
 
-# WARNING: DONT PUT A SPACE AFTER ANY BACKSLASH OR APT WILL BREAK
-RUN apt -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+RUN apt update -yqq && ACCEPT_EULA=Y apt -qqy install \
   git-core \
   cloc dstat                    `# Collect resource usage statistics` \
   python-dev \
   python-pip \
   python-software-properties \
   libmysqlclient-dev            `# Needed for MySQL-python` \
-  libpq-dev                     `# Needed for psycopg2`
+  libpq-dev                     `# Needed for psycopg2` \
+  msodbcsql17 unixodbc-dev      `# Needed for pyodbc + SQL Server`
 
-RUN pip install colorama==0.3.1 requests MySQL-python psycopg2-binary pymongo docker==3.1.0
+RUN pip install colorama==0.3.1 requests MySQL-python pyodbc psycopg2-binary pymongo docker==3.1.0
 
 ENV PYTHONPATH /FrameworkBenchmarks
 ENV FWROOT /FrameworkBenchmarks

--- a/frameworks/Java/gemini/benchmark_config.json
+++ b/frameworks/Java/gemini/benchmark_config.json
@@ -64,6 +64,28 @@
         "display_name": "Gemini",
         "notes": "",
         "versus": "servlet"
+      },
+      "sqlserver": {
+        "db_url": "/db",
+        "query_url": "/query?queries=",
+        "cached_query_url": "/cached_query?queries=",
+        "fortune_url": "/fortunes",
+        "update_url": "/update?queries=",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Fullstack",
+        "database": "SQLServer",
+        "framework": "gemini",
+        "language": "Java",
+        "flavor": "None",
+        "orm": "Micro",
+        "platform": "Servlet",
+        "webserver": "Resin",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Gemini",
+        "notes": "",
+        "versus": "servlet"
       }
     }
   ]

--- a/frameworks/Java/gemini/gemini-sqlserver.dockerfile
+++ b/frameworks/Java/gemini/gemini-sqlserver.dockerfile
@@ -1,0 +1,20 @@
+FROM maven:3.5.3-jdk-10-slim as maven
+
+WORKDIR /gemini
+
+COPY src src
+COPY pom.xml pom.xml
+
+RUN mvn -q compile
+RUN mv src/main/webapp/WEB-INF/gemini-sqlserver.conf src/main/webapp/WEB-INF/GeminiHello.conf
+RUN mvn -q war:war
+
+FROM openjdk:10-jdk
+RUN apt update -qqy && apt install -yqq curl > /dev/null
+
+WORKDIR /resin
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN rm -rf webapps/*
+COPY --from=maven /gemini/target/HelloWorld-0.0.1.war webapps/ROOT.war
+COPY resin.xml conf/resin.xml
+CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Java/gemini/pom.xml
+++ b/frameworks/Java/gemini/pom.xml
@@ -27,6 +27,11 @@
             <version>42.1.4</version>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>6.4.0.jre9</version>
+        </dependency>
+        <dependency>
             <groupId>com.techempower</groupId>
             <artifactId>gemini</artifactId>
             <version>2.21.1</version>

--- a/frameworks/Java/gemini/src/main/webapp/WEB-INF/gemini-sqlserver.conf
+++ b/frameworks/Java/gemini/src/main/webapp/WEB-INF/gemini-sqlserver.conf
@@ -1,0 +1,522 @@
+# -----------------------------------------------------------------------
+# GEMINIHELLO configuration file
+#
+# BASELINE Configuration
+#
+# This configuration file specifies application default behavior that is
+# suitable where not superseded by deployment-specific configuration
+# files.  Refer to the separate deployment-specific configuration files
+# (such as GeminiHello-Dev.conf).
+#
+# The automatically-generated configuration files align with generic
+# deployment "roles" (Development, Test, and Production).  It is common
+# practice, however, to have additional machine-specific configuration
+# files.  This allows for configuration attributes to be distributed
+# between so that, for example, all development environments can use
+# attributes specific in a Development configuration file.  For example:
+#
+#    GeminiHello.conf - Baseline configuration
+#    GeminiHello-Dev.conf - Standard development configuration specifics
+#    GeminiHello-BLACKPARK.conf - Specifics for a machine named Blackpark.
+#
+# -----------------------------------------------------------------------
+#
+# AUTO GENERATED CONFIGURATION FILE NOTICE:
+#   Search for lines that contain "EDIT THIS" for AUTO-GENERATED items
+#   that you cam edit for additional functionality.
+#
+# Notes:
+#   Lines that begin with # are comments.  Empty lines are ignored.  Each
+#   entry in this file is described immediately above the provided value.
+#
+#   Directories must have their back-slashes (\) escaped as \\.
+#
+# -----------------------------------------------------------------------
+#
+# STANDARD PROPERTIES
+#   Gemini provides the following standard properties dynamically at
+#   runtime, derived from the deployment environment.
+#
+#   All Servlet Initialization Parameters in the following form:
+#   Servlet.Parameter.(ParamName) = (Value)
+#
+#   All Server Attributes in the following form:
+#   Servlet.Attribute.(AttribtueName) = (Value)
+#
+#   Servlet.ContextName - The deployment context name for the web-app.
+#   Servlet.DeploymentRoot - The physical file system location for the
+#     "document root" of the web-app.
+#   Servlet.WebInf - The physical file system location of the web-app's
+#     WEB-INF directory.
+#   Servlet.MachineName - The discovered machine name of the server.
+#   Servlet.ApplicationRoot - One directory above the DeploymentRoot.
+#
+# -----------------------------------------------------------------------
+
+# -----------------------------------------------------------------------
+# DEPLOYMENT SETTINGS
+# -----------------------------------------------------------------------
+
+# ApplicationRoot
+#   Specifies the file system root of the application.  This value is
+#   not actually used by Gemini, but is used as a macro in several
+#   other property values.
+
+ApplicationRoot = ${Servlet.ApplicationRoot}
+
+# DeploymentDescription
+#   A simple descriptive name or label for this deployment of the
+#   application (e.g., Production, Test, Development, and so on).  This
+#   description is used to identify the installation in some system-
+#   generated messages such as exception report e-mails.
+
+DeploymentDescription = Production
+
+
+# -----------------------------------------------------------------------
+# DATABASE SETTINGS
+# -----------------------------------------------------------------------
+
+# Connection information can be found in the separate deployment-
+# specific configuration files.
+
+# MySQL/ConnectorJ
+db.Driver.Class = com.microsoft.sqlserver.jdbc.SQLServerDriver
+db.Driver.UrlPrefix = jdbc:sqlserver://
+db.Driver.SupportsAbsolute = yes
+db.Driver.SupportsGetRow = yes
+db.Driver.Jdbc1 = no
+
+db.ConnectString = tfb-database:1433;database=hello_world;
+db.LoginName = benchmarkdbuser
+db.LoginPass = benchmarkdbpass
+
+# db.Driver.Pooling
+#   How many Connections to maintain to the database.  The default is 1.
+# db.Driver.MaxPooling
+#   How many concurrent Connections to allow at maximum.
+
+db.Driver.Pooling = 256
+db.Driver.MaxPooling = 256
+
+# BasicConnectionListener properties
+
+# cl.RetriesOnDisconnect
+#   How many automatic retries on database connection (socket) failures
+#   should be made before aborting a query attempt?
+
+cl.RetriesOnDisconnect = 1
+
+# cl.AlertFile
+#   File to write database connector alerts to.
+
+cl.AlertLogFile = ${ApplicationRoot}/jdbc-alerts.log
+
+
+# -----------------------------------------------------------------------
+# CLUSTER SETTINGS
+# -----------------------------------------------------------------------
+
+# The cluster settings are left commented here.  Gemini clustering can
+# be enabled either (a) by defining cluster connectivity information here
+# in a configuration file or (b) by having application instances fetch
+# their configuration from the cluster master.  In case (b), this
+# configuration file won't be used and there's no point in un-commenting
+# and modifying the lines below.
+
+#ClusterClient.TransportClassname = com.techempower.gemini.cluster.transport.kryonet.KryoClientTransport
+#ClusterClient.Authentication.Key = shared-secret
+#Kryo.Client.Host = localhost
+#Kryo.Client.TcpPort = 54555
+
+
+# -----------------------------------------------------------------------
+# DIRECTORY SETTINGS
+# -----------------------------------------------------------------------
+
+# JSPDirectory
+#   Specifies the relative URL base for JSP files.
+
+JSPDirectory = /WEB-INF/jsp/
+
+# JSPPhysicalDirectory
+#   Specifies the physical directory that is referenced by JSPDirectory
+#   above.
+
+JSPPhysicalDirectory = ${Servlet.WebInf}/jsp/
+
+# HTMLDirectory
+#   Specifies the relative URL base for HTML files.  If HTML files are
+#   served by a separate host, an asbolute URL base can be specified.
+
+HTMLDirectory = /html/
+
+# ImagesDirectory
+#   Specifies the relative URL base for image files.  If images are
+#   served by a separate host, an asbolute URL base can be specified.
+
+ImageDirectory = /images/
+
+# CSSDirectory
+#   Specifies the relative URL base for style sheet files.  If CSS
+#   files are served by a separate host, an asbolute URL base can be
+#   specified.
+
+CSSDirectory = /css/
+
+# JavaScriptDirectory
+#   Specifies the relative URL base for JavaScript (.js) files.  If
+#   JS files are served by a separate host, an asbolute URL base can be
+#   specified.
+
+JavaScriptDirectory = /js/
+
+# ServletURL
+#   Specifies the relative URL for the dispatcher servlet.  For many
+#   applications, this will be set to the root (just /).  This requires
+#   that the application server direct request to the Servlet only when
+#   the URL matches the root and the root only.  In Resin, the way
+#   this is accomplished is by setting a Servlet Mapping as below:
+#     <servlet-mapping url-regexp='^/$' servlet-name='...'/>
+
+ServletURL = /
+
+
+# -----------------------------------------------------------------------
+# LOGGING SETTINGS
+# -----------------------------------------------------------------------
+
+# Log.File - Log file settings
+# Log.File.On
+#   Enables or disables logging to log files.
+# Log.Console.On
+#   Enables or disables logging to the console.
+
+Log.File.On = no
+Log.Console.On = yes
+
+# Log.File.LogDirectory
+#   Specifies the directory to which logfiles should be written.  By
+#   default this is just a subdirectory named "logs" off of whatever
+#   is the active directory.  The directory must exist for the log files
+#   to work.
+
+Log.File.LogDirectory = ${ApplicationRoot}/Logs/
+
+# Log.File.LogDebugThreshold -and-
+# Log.Console.LogDebugThreshold
+#   Specify the minimum log level (0 to 100, inclusive) to require for
+#   writing items to this log listener.
+#
+# 20 is recommended to start out.
+
+Log.File.LogDebugThreshold = 20
+Log.Console.LogDebugThreshold = 20
+
+
+# -----------------------------------------------------------------------
+# IP/DNS/URL SETTINGS
+# -----------------------------------------------------------------------
+
+# StandardDomain
+#   Species the URL base for the standard (non-secure) domain name.
+#   This should not end with a trailing /, which would otherwise be
+#   standard practice.
+
+# TODO: EDIT THIS
+StandardDomain = http://${Servlet.MachineName}
+
+# SecureDomain
+#   Specifies the URL base for the secure (SSL) domain name.
+#   This should not end with a trailing /, which would otherwise be
+#   standard practice.
+
+# TODO: EDIT THIS
+SecureDomain = https://${Servlet.MachineName}
+
+
+# -----------------------------------------------------------------------
+# LOGIN HANDLER
+# -----------------------------------------------------------------------
+
+# LoginHandler.CmdLogin
+#   The command to recognize for the login page (default: "login"). The
+#   login page can be invoked directly via this command or via a peer
+#   Handler, such as subclasses of SecureHandler.
+
+LoginHandler.CmdLogin = login
+
+# LoginHandler.CmdLogout
+#   The command to recognize for logout requests. The default is
+#   "logout".
+
+LoginHandler.CmdLogout = logout
+
+# LoginHandler.CmdPostLogin
+#   The command to redispatch to after a successful login. This command
+#   will only be used if a prior request was not preempted by a forced
+#   login. The default is "home".
+
+LoginHandler.CmdPostLogin = home
+
+# LoginHandler.JspLogin
+#   The JSP page name to use for rendering the login form. The default
+#   is "login.jsp" within the root of your application's JSP directory.
+
+LoginHandler.JspLogin = accounts/login.jsp
+
+# LoginHandler.JspLogout
+#   The JSP page name to use for rendering the logout screen. The default
+#   is "logout.jsp" within the root of your application's JSP directory.
+
+LoginHandler.JspLogout = accounts/logout.jsp
+
+# LoginHandler.CookieNameSuffix - You can change the suffix of the cookie
+#   name used to save automatic login credentials. The default is
+#   "-automatic-login".
+
+LoginHandler.CookieNameSuffix = -automatic-login
+
+# LoginHandler.LogoutDeletesCookie
+#   Delete automatic login cookie after logout.
+
+LoginHandler.LogoutDeletesCookie = yes
+
+# LoginHandler.EmailTemplateName
+#   You can change the template name of the e-mail used to send a user a
+#   replacement password (in the event that they forget their current
+#   password). The default template name is "E-NewPassword".
+
+LoginHandler.EmailTemplateName = E-NewPassword
+
+# LoginHandler.FailedAttemptLimit
+#   Limits the number of sequential failed attempts before an IP address
+#   cannot make any further login attempts (until a timeout period has
+#   expired).
+
+LoginHandler.FailedAttemptLimit = 25
+
+# LoginHandler.FailedResetSeconds
+#   An interval of time after which an IP address that had been blocked
+#   will be permitted to login again.
+
+LoginHandler.FailedResetSeconds = 60
+
+
+# -----------------------------------------------------------------------
+# STANDARD ADMIN SETTINGS
+# -----------------------------------------------------------------------
+
+# Admin.RelativeJspPath
+#   Specifies the relative path to JSP files for the Admin section.
+
+Admin.RelativeJspPath = admin/
+
+# Admin.ScratchEnabled
+#   Should the admin section allow the execution of arbitrary JSP
+#   fragments?
+
+Admin.ScratchEnabled = no
+
+# Admin.ScratchIP
+#   If scratches are enabled, from what IPs are they permitted?
+
+Admin.ScratchIP = 127.0.0.1,172.16.98.14
+
+
+# -----------------------------------------------------------------------
+# PYXIS USERS AND GROUPS SETTINGS
+# -----------------------------------------------------------------------
+
+# Pyxis.UsersTable
+#   The name of the Users table for this database.
+Pyxis.UsersTable = GhUsers
+
+# Pyxis.GroupsTable
+#   The name of the Groups table for this database.
+Pyxis.GroupsTable = GhGroups
+
+# Pyxis.UsersToGroupsTable
+#   The name of the table mapping Users to Groups for this database.
+Pyxis.UsersToGroupsTable = MapUserToGroup
+
+# BasicSecurity.PasswordCryptographer
+#   Specifies the fully-qualified classname of a PasswordCryptographer
+#   implementation that can hash user passwords.  A common implementation
+#   is com.techempower.security.BCryptPasswordCryptographer.
+BasicSecurity.PasswordCryptographer = com.techempower.security.BCryptPasswordCryptographer
+
+
+# -----------------------------------------------------------------------
+# JSP PRECOMPILATION (optional; not enabled in this auto-generated file)
+# -----------------------------------------------------------------------
+
+# Precomp.Group1
+#   Defines a comma-separated list of directories (relative URLs) that
+#   contain JSP files (relative to the JSPDirectory).  Multiple groups
+#   can be defined as Group2; Group3; etc.
+#   ex. Precomp.Group1 = /,/includes/,/admin/
+
+#Precomp.Group1 = /
+
+# Precomp.AuthorizedIP
+#   An IP address that is authorized to invoke the Precompilation
+#   process.
+
+#Precomp.AuthorizedIP = 65.115.126.13
+
+
+# -----------------------------------------------------------------------
+# MAIL SETTINGS
+# -----------------------------------------------------------------------
+
+# MailServerCount
+#   The number of mail servers to use in fail-over.  If no fail-over is
+#   used, this should be 1.
+
+MailServerCount = 1
+
+# EmailerThreadsDaemon
+#   Set to no to force e-mail servicer threads to completely deliver their
+#   queues even when the application stops.  Set to yes to allow threads
+#   to stop immediately when the application stops, resulting in the
+#   possibility of undelivered e-mails.
+
+EmailerThreadsDaemon = yes
+
+# Mail Server blocks (where 'X' is a sequential ID of the mail servers
+# used by the application).
+#
+# MailServerX.ServerAddress
+#   Specify each mail server's DNS name or IP address.  Make sure the
+#   mail server will relay e-mail for this application.
+# MailServerX.SmtpPort
+#   Specify an SMTP port number if used for Outbound mail.
+# MailServerX.PopPort
+#   Specify a POP3 port number if used for Inbound mail.
+# MailServerX.Username
+#   Used if an SMTP username is required to send or receive mail
+# MailServerX.Password
+#   The password for the user specified above
+# MailServerX.Role
+#   Outbound, Inbound, or Both
+
+# No mail servers specified in baseline configuration.  See environment-
+# specific configuration files.
+#MailServer1.ServerAddress = mail.techempower.com
+#MailServer1.SmtpPort = 25
+#MailServer1.Username = username
+#MailServer1.Password = password
+#MailServer1.ServerRole = Outbound
+
+# FromEmailAddress
+#   The e-mail address to use as an "author" when sending e-mails.
+
+FromEmailAddress = dev@techempower.com
+
+
+# -----------------------------------------------------------------------
+# ERROR HANDLING SETTINGS
+# -----------------------------------------------------------------------
+
+# Should exceptions caught by the Gemini infrastructure while handling
+# web requests be written to the log file?
+
+BasicExceptionHandler.LogExceptions = yes
+BasicExceptionHandler.LogStackTraces = yes
+
+# Should the stack trace of exceptions caught by the Gemini
+# Infrastructure be clearly visible to users?  This is generally
+# acceptable only in a development environment.  In a Production
+# environment, set this value to 'no'.  Stack traces will still be
+# visible within the HTML source sent to the client.
+
+BasicExceptionHandler.RevealStackTrace = no
+
+# BasicExceptionHandler.ErrorPage
+#   Specifies the filename of the error page that should be rendered
+#   to display an exception.  If empty, the internal "page" will be
+#   used.
+
+BasicExceptionHandler.ErrorPage = error-page.jsp
+
+# Feature.exc-email
+# (Formerly EmailExceptionHandler.Enabled)
+#   The EmailExceptionHandler can be enabled or disabled.
+
+Feature.exc-email = false
+
+# EmailExceptionHandler.ToEmailAddress
+#   The e-mail address to which to send exception reports.
+
+EmailExceptionHandler.ToEmailAddress = dev@techempower.com
+
+# EmailExceptionHandler.FromEmailAddress
+#   The e-mail address from which to send exception reports.
+
+EmailExceptionHandler.FromEmailAddress = dev@techempower.com
+
+# EmailExceptionHandler.MinimumInterval
+#   The minimum number of seconds that must pass since the previous
+#   exception report in order to allow another report to be sent.  This
+#   helps mitigate an avalanche of reports from a critical error.  The
+#   interval is specified in seconds.  A good default is 600 (10
+#   minutes).
+
+EmailExceptionHandler.MinimumInterval = 600
+
+
+# -----------------------------------------------------------------------
+# MISCELLANEOUS SETTINGS
+# -----------------------------------------------------------------------
+
+# Character encoding settings
+#
+# Encoding.RequestCharset
+#   What character encoding are we expecting for requests?
+# Encoding.ResponseType
+#   The full MIME-Type name for responses.
+
+Encoding.RequestCharset = UTF-8
+Encoding.ResponseType = text/html;charset=utf-8
+
+# RequestCounting
+#   Specifies that requests should be counted and that threads
+#   processing requests should be assigned names that include the
+#   request ID number for the scope of the request.
+
+RequestCounting = yes
+
+# SchedulerSleepSeconds
+#   Seconds to sleep between scheduler checks.
+
+SchedulerSleepSeconds = 10
+
+# SessionTimeout
+#   Sets the number of seconds before a session should time out on
+#   the web site.
+
+SessionTimeout = 3600
+
+# SessionTracking
+#   If enabled, sessions will be tracked.  This allows the application
+#   to get a count of active sessions.
+
+SessionTracking = Yes
+
+# ThreadDump.DumpOnStopLocation
+#   Specifies a file system location to write thread dump text files
+#   when the application is unloaded by the application server (such
+#   as when the server stops).
+
+ThreadDump.DumpOnStopLocation = ${ApplicationRoot}/Thread Dumps/
+
+# Robots.File
+#   Specifies the file that should be returned when /robots.txt is
+#   requested.  See hello.home.RobotsHandler.
+
+Robots.File = ${Servlet.WebInf}/robots-disallowed.txt
+
+# Feature.monitor
+#   Set to yes to enable performance monitoring
+Feature.monitor = no

--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -5,6 +5,7 @@ import requests
 import MySQLdb
 import psycopg2
 import pymongo
+import pyodbc
 import traceback
 
 from colorama import Fore
@@ -206,6 +207,25 @@ class FrameworkTestType:
             except Exception:
                 tb = traceback.format_exc()
                 log("ERROR: Unable to load current MongoDB World table.",
+                    color=Fore.RED)
+                log(tb)
+        elif database_name == "sqlserver":
+            try:
+                db = pyodbc.connect(
+                    "Driver={{ODBC Driver 17 for SQL Server}};"
+                    "Server={0};"
+                    "Port=1433;"
+                    "Database=hello_world;"
+                    "UID=benchmarkdbuser;"
+                    "PWD=benchmarkdbpass;".format(self.config.database_host))
+                cursor = db.cursor()
+                cursor.execute("SELECT * FROM world")
+                results = cursor.fetchall()
+                results_json.append(json.loads(json.dumps(dict(results))))
+                db.close()
+            except Exception:
+                tb = traceback.format_exc()
+                log("ERROR: Unable to load current SQL Server World table.",
                     color=Fore.RED)
                 log(tb)
         else:

--- a/toolset/databases/sqlserver/create.sql
+++ b/toolset/databases/sqlserver/create.sql
@@ -1,0 +1,52 @@
+create database hello_world;
+go
+use hello_world;
+go
+create table world (
+  id int not null identity(1,1) primary key,
+  randomnumber int not null
+);
+go
+set nocount on;
+go
+declare @i int = 0;
+while @i < 10000
+begin
+  insert into world (randomnumber) values (1 + cast(rand(checksum(newid())) * 10000 as int));
+  set @i = @i + 1;
+end;
+go
+create table fortune (
+  id int not null identity(1,1) primary key,
+  message nvarchar(2048) not null
+);
+go
+insert into fortune (message) values
+(N'fortune: No such file or directory'),
+(N'A computer scientist is someone who fixes things that aren''t broken.'),
+(N'After enough decimal places, nobody gives a damn.'),
+(N'A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1'),
+(N'A computer program does what you tell it to do, not what you want it to do.'),
+(N'Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen'),
+(N'Any program that runs right is obsolete.'),
+(N'A list is only as strong as its weakest link. — Donald Knuth'),
+(N'Feature: A bug with seniority.'),
+(N'Computers make very fast, very accurate mistakes.'),
+(N'<script>alert("This should not be displayed in a browser alert box.");</script>'),
+(N'フレームワークのベンチマーク');
+go
+set nocount off;
+go
+exec sp_configure 'contained database authentication', 1
+go
+reconfigure
+go
+alter database hello_world set containment = partial;
+go
+create login benchmarkdbuser with password = 'benchmarkdbpass', check_policy = off;
+go
+create user benchmarkdbuser for login benchmarkdbuser;
+go
+grant select, update on world to benchmarkdbuser;
+grant select on fortune to benchmarkdbuser;
+go

--- a/toolset/databases/sqlserver/sqlserver.dockerfile
+++ b/toolset/databases/sqlserver/sqlserver.dockerfile
@@ -1,0 +1,21 @@
+FROM buildpack-deps:xenial
+
+RUN apt update -yqq && apt install -yqq software-properties-common apt-transport-https locales
+
+RUN locale-gen en_US.UTF-8
+RUN update-locale LANG=en_US.UTF-8
+
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list)"
+RUN add-apt-repository "$(wget -qO- https://packages.microsoft.com/config/ubuntu/16.04/prod.list)"
+
+RUN apt update -yqq && ACCEPT_EULA=Y apt install -yqq mssql-server mssql-tools unixodbc-dev
+
+WORKDIR /sqlserver
+COPY create.sql create.sql
+
+RUN SA_PASSWORD=OneTwoThree123! ACCEPT_EULA=Y nohup /opt/mssql/bin/sqlservr & \
+    until /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'OneTwoThree123!' -Q "select @@VERSION"; do sleep 1; done && \
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'OneTwoThree123!' -i create.sql
+
+CMD ACCEPT_EULA=Y /opt/mssql/bin/sqlservr

--- a/toolset/utils/database_helper.py
+++ b/toolset/utils/database_helper.py
@@ -1,6 +1,7 @@
 import MySQLdb
 import psycopg2
 import pymongo
+import pyodbc
 
 
 def test_database(config, database_name):
@@ -33,6 +34,21 @@ def test_database(config, database_name):
             connection = pymongo.MongoClient(host=config.database_host)
             db = connection.hello_world
             db.world.find()
+            db.close()
+        except:
+            return False
+    elif database_name == "sqlserver":
+        try:
+            db = pyodbc.connect(
+                "Driver={{ODBC Driver 17 for SQL Server}};"
+                "Server={0};"
+                "Port=1433;"
+                "Database=hello_world;"
+                "UID=benchmarkdbuser;"
+                "PWD=benchmarkdbpass;".format(config.database_host))
+            cursor = db.cursor()
+            cursor.execute("SELECT 1")
+            cursor.fetchall()
             db.close()
         except:
             return False

--- a/toolset/utils/metadata.py
+++ b/toolset/utils/metadata.py
@@ -15,7 +15,8 @@ class Metadata:
          'One of the most popular databases around the web and in TFB'),
         ('Postgres',
          'An advanced SQL database with a larger feature set than MySQL'),
-        ('MongoDB', 'A popular document-store database')]
+        ('MongoDB', 'A popular document-store database'),
+        ('SQLServer', 'Microsoft''s SQL database')]
 
     def __init__(self, benchmarker = None):
         self.benchmarker = benchmarker


### PR DESCRIPTION
I added [ci skip] because this requires a new techempower/tfb image, so
the travis build would fail I think.

I don't know whether this will work out because of licensing.  See the
places where I put "ACCEPT_EULA=Y" in the dockerfiles.  I don't know what
EULA that refers to and it's possible we won't be able to accept it.
I put this together anyway just to see if it's technically possible (it
is) and to get review feedback.

I added a variant of gemini that uses SQL Server and passes all tests.

I did not measure performance at all or do any performance tuning on the
database side.

Fixes #3786