### PR TITLE
Swoole: Enable PHP opcache for cli

### DIFF
--- a/frameworks/PHP/swoole/php.ini
+++ b/frameworks/PHP/swoole/php.ini
@@ -1,0 +1,2 @@
+opcache.enable_cli=1
+opcache.validate_timestamps=0

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -11,7 +11,7 @@ RUN docker-php-ext-install pdo_mysql > /dev/null
 
 WORKDIR /swoole
 COPY swoole-server.php swoole-server.php
-COPY php.ini /etc/php/7.2/cli/conf.d/
+COPY php.ini /usr/local/etc/php/
 
 CMD sed -i 's|NUMCORES|'"$(nproc)"'|g' swoole-server.php && \
     php swoole-server.php

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -11,6 +11,7 @@ RUN docker-php-ext-install pdo_mysql > /dev/null
 
 WORKDIR /swoole
 COPY swoole-server.php swoole-server.php
+COPY php.ini /etc/php/7.2/cli/conf.d/
 
 CMD sed -i 's|NUMCORES|'"$(nproc)"'|g' swoole-server.php && \
     php swoole-server.php


### PR DESCRIPTION
By default Cli Opcache is disabled. As Swoole relies on Cli instead of normal, this provides a speed boost.