### PR TITLE
Updated to v2.2.5 included mruby-json

### DIFF
--- a/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
+++ b/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
@@ -4,7 +4,7 @@ ADD ./h2o.conf ./
 
 RUN apt update && apt install -yqq bison cmake libssl-dev make
 
-ENV H2O_VERSION=2.2.4
+ENV H2O_VERSION=2.2.5
 ENV H2O_ARCHIVE="v${H2O_VERSION}.tar.gz"
 ENV H2O_HOME=/h2o
 


### PR DESCRIPTION
Performant and well maintained C libraries than mruby-iijson which Yannick found an increase in 2-30x throughputs in small JSON test.

Manually update the dependency is preferred as a replacement.
https://github.com/mattn/mruby-json

https://github.com/h2o/h2o/pull/1668

