### PR TITLE
Switch back to NIO1

### DIFF
--- a/frameworks/Scala/blaze/src/main/scala/Main.scala
+++ b/frameworks/Scala/blaze/src/main/scala/Main.scala
@@ -1,14 +1,9 @@
 package blaze.techempower.benchmark
 
-import java.lang.Runtime._
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
-import java.nio.channels.AsynchronousChannelGroup
 import java.nio.charset.StandardCharsets.UTF_8
-import java.util.concurrent.ForkJoinPool
-import java.util.concurrent.ForkJoinPool._
 
-import org.http4s.blaze.channel.nio2.NIO2SocketServerGroup
 import org.http4s.blaze.http._
 import org.http4s.blaze.http.HttpServerStageConfig
 import org.http4s.blaze.http.http1.server.Http1ServerStage
@@ -16,6 +11,7 @@ import org.http4s.blaze.pipeline.LeafBuilder
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import org.http4s.blaze.channel.SocketConnection
+import org.http4s.blaze.channel.nio1.NIO1SocketServerGroup
 import org.http4s.blaze.http.RouteAction._
 
 import scala.concurrent.Future
@@ -24,7 +20,6 @@ case class Message(message: String)
 
 object Main {
   private val config = HttpServerStageConfig()
-  private val fjp = new ForkJoinPool(getRuntime.availableProcessors, defaultForkJoinWorkerThreadFactory, null, true)
   private val jsonHeaders = Seq("server" -> "blaze", "content-type" -> "application/json")
   private val plaintextHeaders = Seq("server" -> "blaze", "content-type" -> "text/plain")
 
@@ -34,16 +29,16 @@ object Main {
     request.url match {
       case "/plaintext" => Ok("Hello, World!".getBytes(UTF_8), plaintextHeaders)
       case "/json" => Ok(writeToArray(Message("Hello, World!")), jsonHeaders)
+      case path => String(s"Not found: $path", 404, "Not Found", Nil)
     }
   }
 
   def connect(conn: SocketConnection): Future[LeafBuilder[ByteBuffer]] =
     Future.successful(LeafBuilder(new Http1ServerStage(serve, config)))
 
-  def main(args: Array[String]): Unit = {
-    NIO2SocketServerGroup(group = Some(AsynchronousChannelGroup.withThreadPool(fjp)))
+  def main(args: Array[String]): Unit =
+    NIO1SocketServerGroup.fixedGroup()
       .bind(new InetSocketAddress(8080), connect)
       .getOrElse(sys.error("Failed to start server."))
       .join()
-  }
 }


### PR DESCRIPTION
Changes in the previous PR ( https://github.com/TechEmpower/FrameworkBenchmarks/pull/3788 ) stepped too far and results of 2 last running on Citrine are worse in 4x times:
Before: https://www.techempower.com/benchmarks/#section=test&runid=60fab9eb-a5ad-49cb-aefe-24ad0f377122&hw=ph&test=json
After: https://www.techempower.com/benchmarks/#section=test&runid=aad43f39-48a2-460c-a363-99cd543a772a&hw=ph&test=json

This PR is a rollback to use NIO1 with a fixed thread pool as was before.