### PR TITLE
H2O: Yet another batch of changes

### DIFF
--- a/frameworks/C/h2o/README.md
+++ b/frameworks/C/h2o/README.md
@@ -1,20 +1,28 @@
 # h2o
 
-This is a framework implementation using the [H2O](https://h2o.examp1e.net/) HTTP server.
+This is a framework implementation using the [H2O](https://h2o.examp1e.net) HTTP server. It builds directly on top of `libh2o` instead of running the standalone server.
 
 ## Requirements
 
-CMake, H2O, libpq, mustache-c, OpenSSL, YAJL
+[CMake](https://cmake.org), [H2O](https://h2o.examp1e.net), [libpq](https://www.postgresql.org), [mustache-c](https://github.com/x86-64/mustache-c), [OpenSSL](https://www.openssl.org), [YAJL](https://lloyd.github.io/yajl)
 
 ## Performance issues
 
+### Database tests
+
+`libpq` does not support command pipelining, and implementing anything equivalent on top of it conflicts with the requirements.
+
+### Database updates
+
+In the Citrine environment the database connection settings that improve the performance on the updates test make the other database results worse, and vice versa.
+
 ### Plaintext
 
-H2O performs at least one system call per pipelined response.
+`libh2o` performs at least one system call per pipelined response.
 
 ### Cached queries
 
-The in-memory caching mechanism provided by libh2o uses mutexes even for read-only access, so when the application is running multithreaded, cache usage is serialized.
+Most of the operations that the in-memory caching mechanism provided by `libh2o` supports modify the cache (in particular, `h2o_cache_fetch()` updates a list of least recently used entries, and may remove expired ones), so when the application is running multithreaded, cache access must be serialized.
 
 ## Contact
 

--- a/frameworks/C/h2o/src/utility.h
+++ b/frameworks/C/h2o/src/utility.h
@@ -22,6 +22,7 @@
 #define UTILITY_H_
 
 #include <h2o.h>
+#include <pthread.h>
 #include <stdint.h>
 #include <h2o/cache.h>
 #include <openssl/ssl.h>
@@ -73,6 +74,7 @@ typedef struct {
 	int signal_fd;
 	bool shutdown;
 	h2o_globalconf_t h2o_config;
+	pthread_mutex_t world_cache_lock;
 } global_data_t;
 
 typedef struct {

--- a/frameworks/C/h2o/start-servers.sh
+++ b/frameworks/C/h2o/start-servers.sh
@@ -18,7 +18,7 @@ if [[ "$CPU_COUNT" -gt 16 ]]; then
 else
 	echo "Running h2o_app in the cloud environment."
 	USE_PROCESSES=false
-	DB_CONN=4
+	DB_CONN=8
 fi
 
 build_h2o_app()


### PR DESCRIPTION
* Optimize the cached queries test - the cache implementation provided by libh2o does not support batch operations, so when the cache is multithreaded, the locking cost is paid for every entry. The solution is to use a non-concurrent cache, and to wrap all interfaces with custom locking. The trade-off is that critical sections become longer.
* Adjust the number of database connections in the cloud environment.
* Expand the documentation.
* Fix a file descriptor leak.