### PR TITLE
Vagrant Fix for WSL

### DIFF
--- a/deployment/vagrant/Vagrantfile
+++ b/deployment/vagrant/Vagrantfile
@@ -19,4 +19,10 @@ Vagrant.configure("2") do |config|
   provider_virtualbox(config)
   provider_libvirt(config)
 
+  config.ssh.insert_key = false
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
+  end
+  
 end


### PR DESCRIPTION
$ turing@mnt/d/FrameworkBenchmarks/deployment/vagrant$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Checking if box 'ubuntu/xenial64' is up to date...
==> default: A newer version of the box 'ubuntu/xenial64' for provider 'virtualbox' is
==> default: available! You currently have version '20180529.0.0'. The latest is version
==> default: '20180602.0.0'. Run `vagrant box update` to update.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 8080 (guest) => 28080 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "3c632095-ea95-4cba-ba5e-d4815a1c0436", "--type", "headless"]

Stderr: VBoxManage.exe: error: RawFile#0 failed to create the raw output file /mnt/d/Cloud/OneDrive/Dev/FrameworkBenchmarks/deployment/vagrant/ubuntu-xenial-16.04-cloudimg-console.log (VERR_PATH_NOT_FOUND)
VBoxManage.exe: error: Details: code E_FAIL (0x80004005), component ConsoleWrap, interface IConsole