### PR TITLE
Update the Play Framework projects to more recent version

### DIFF
--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-ebean-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayEbean, PlayNettyServer)/.enablePlugins(PlayJava, PlayEbean, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-ebean-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-ebean-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-ebean-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayEbean, PlayNettyServer)/.enablePlugins(PlayJava, PlayEbean).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-ebean-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-ebean-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayEbean, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "4.0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "4.1.3")

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-jooq-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-jooq-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-jooq-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-jooq-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-jooq-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-jooq-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 val jOOQVersion = "3.10.3"
 

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-jpa-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-jpa-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-jpa-hikaricp", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java-jpa-hikaricp .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java-jpa-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-java-jpa-hikaricp", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/README.md
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/README.md
@@ -12,7 +12,7 @@ This is the Play portion of a [benchmarking test suite](../) comparing a variety
 The tests were run with:
 
 * Java 8
-* [Play 2.6.7](https://www.playframework.com/)
+* [Play 2.6.15](https://www.playframework.com/)
 
 ## Test URLs
 ### Data-Store/Database Mapping Test

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Java/play2-java/play2-java-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD target/universal/stage/bin/play2-java -Dplay.server.provider=play.core.server.NettyServerProvider
+CMD ["target/universal/stage/bin/play2-java", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java.dockerfile
+++ b/frameworks/Java/play2-java/play2-java.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-java .
+
+RUN sed -i 's/.enablePlugins(PlayJava, PlayNettyServer)/.enablePlugins(PlayJava).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-java", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-java", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Java/play2-java/play2-java/README.md
+++ b/frameworks/Java/play2-java/play2-java/README.md
@@ -10,7 +10,7 @@ This is the Play portion of a [benchmarking test suite](../) comparing a variety
 The tests were run with:
 
 * Java 8
-* [Play 2.6.7](https://www.playframework.com/)
+* [Play 2.6.15](https://www.playframework.com/)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/Java/play2-java/play2-java/build.sbt
+++ b/frameworks/Java/play2-java/play2-java/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies += guice

--- a/frameworks/Java/play2-java/play2-java/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Java/play2-java/play2-java/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Java/play2-java/play2-java/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Scala/play2-scala/play2-scala-anorm-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-anorm .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-anorm", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-anorm", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-anorm.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-anorm .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-anorm", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-anorm", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/conf/application.conf
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Scala/play2-scala/play2-scala-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
 CMD ["target/universal/stage/bin/play2-scala", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-reactivemongo .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-reactivemongo", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-reactivemongo", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-reactivemongo .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-reactivemongo", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-reactivemongo", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   "org.reactivemongo" %% "play2-reactivemongo" % "0.12.7-play26",

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/conf/application.conf
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Scala/play2-scala/play2-scala-slick-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-slick-netty.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-slick .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala, PlayNettyServer).disablePlugins(PlayAkkaHttpServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-slick", "-Dplay.server.provider=play.core.server.NettyServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-slick", "-Dplay.server.provider=play.core.server.NettyServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-slick.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-slick.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala-slick .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
-CMD ["target/universal/stage/bin/play2-scala-slick", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider"]
+CMD ["target/universal/stage/bin/play2-scala-slick", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Scala/play2-scala/play2-scala-slick/conf/application.conf
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Scala/play2-scala/play2-scala-slick/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Scala/play2-scala/play2-scala-slick/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")

--- a/frameworks/Scala/play2-scala/play2-scala.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala.dockerfile
@@ -1,5 +1,8 @@
-FROM hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+FROM hseeberger/scala-sbt:8u171_2.12.6_1.1.5
 WORKDIR /play2
 COPY play2-scala .
+
+RUN sed -i 's/.enablePlugins(PlayScala, PlayNettyServer)/.enablePlugins(PlayScala).disablePlugins(PlayNettyServer)/g' build.sbt
+
 RUN sbt stage
 CMD ["target/universal/stage/bin/play2-scala", "-Dplay.server.provider=play.core.server.AkkaHttpServerProvider", "-J-server", "-J-Xms1g", "-J-Xmx1g", "-J-XX:NewSize=512m", "-J-XX:+UseG1GC", "-J-XX:MaxGCPauseMillis=30", "-J-XX:-UseBiasedLocking", "-J-XX:+AlwaysPreTouch"]

--- a/frameworks/Scala/play2-scala/play2-scala/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala/build.sbt
@@ -4,9 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.6"
 
-libraryDependencies ++= Seq(
-  guice,
-  "com.typesafe.play" %% "play-json" % "2.6.7"
-)
+libraryDependencies += guice

--- a/frameworks/Scala/play2-scala/play2-scala/conf/application.conf
+++ b/frameworks/Scala/play2-scala/play2-scala/conf/application.conf
@@ -19,6 +19,9 @@ play.server {
   netty {
     transport = "native"
 
+    # Whether the Netty wire should be logged
+    log.wire = false
+
     option {
       SO_BACKLOG = 256
 
@@ -43,7 +46,15 @@ akka {
         # That is 40 physical cores / 80 hyperthreaded cores
         # https://www.techempower.com/benchmarks/#section=environment
         parallelism-max = 40
+
+        task-peeking-mode="LIFO" # based on https://www.playframework.com/documentation/2.6.x/Migration24#Thread-pool-configuration
       }
+
+      # https://doc.akka.io/docs/akka/2.5.11/dispatchers.html#looking-up-a-dispatcher
+      # Throughput defines the maximum number of messages to be
+      # processed per actor before the thread jumps to the next actor.
+      # Set to 1 for as fair as possible.
+      throughput = 1
     }
   }
 }

--- a/frameworks/Scala/play2-scala/play2-scala/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.5

--- a/frameworks/Scala/play2-scala/play2-scala/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")


### PR DESCRIPTION
Update the configurations of the play framework to their current latest version: 2.6.15

Also update the dockerfiles to use a more recent base, allowing use of Scala 2.12.6 and sbt 1.1.5

Apart from that, I noticed some docker files providing extra JVM options. Considering these are all using the same framework, I feel either all dockerfiles should use it or non of them. Otherwise, the comparison between them is off.

Lastly, I added some code to the dockerfile to properly disable the http server that's not being used in the build that will be done by the dockerfile.
For instance: when running netty server, it's perfectly fine to disable the AkkaHttpPlugin. And vice versa. This prevents their jars from being put on the classpath.