### PR TITLE
Update JLHTTP 2.4

### DIFF
--- a/frameworks/Java/jlhttp/README.md
+++ b/frameworks/Java/jlhttp/README.md
@@ -9,23 +9,20 @@ and a trade-off must be made between size (complexity) and performance.
 JLHTTP usually sides with the smaller size.
 
 
-### Plaintext Test
+### Test Type Implementation Source Code
 
-* [Plaintext test source](src/main/java/hello/HelloWebServer.java)
+* [JSON](src/main/java/benchmarks/Server.java)
+* [Plaintext](src/main/java/benchmarks/Server.java)
 
-### JSON Encoding Test
-
-The JSON encoding is performed using Jackson.
-
-* [JSON test source](src/main/java/hello/HelloWebServer.java)
-
+## Important Libraries
+The tests were run with:
+* [Jackson](https://github.com/FasterXML/jackson)
 
 ## Test URLs
-
-### Plaintext Test
-
-http://localhost:8080/plaintext
-
-### JSON Encoding Test
+### JSON
 
 http://localhost:8080/json
+
+### Plaintext
+
+http://localhost:8080/plaintext

--- a/frameworks/Java/jlhttp/benchmark_config.json
+++ b/frameworks/Java/jlhttp/benchmark_config.json
@@ -1,24 +1,26 @@
 {
   "framework": "jlhttp",
-  "tests": [{
-    "default": {
-      "json_url": "/json",
-      "plaintext_url": "/plaintext",
-      "port": 8080,
-      "approach": "Realistic",
-      "classification": "Platform",
-      "database": "None",
-      "framework": "None",
-      "flavor": "None",
-      "language": "Java",
-      "orm": "Raw",
-      "platform": "JLHTTP",
-      "webserver": "None",
-      "os": "Linux",
-      "database_os": "Linux",
-      "display_name": "JLHTTP",
-      "notes": "",
-      "versus": "jlhttp"
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Platform",
+        "database": "None",
+        "framework": "None",
+        "language": "Java",
+        "flavor": "None",
+        "orm": "Raw",
+        "platform": "JLHTTP",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "JLHTTP",
+        "notes": "",
+        "versus": ""
+      }
     }
-  }]
+  ]
 }

--- a/frameworks/Java/jlhttp/pom.xml
+++ b/frameworks/Java/jlhttp/pom.xml
@@ -18,16 +18,16 @@
             <artifactId>jlhttp</artifactId>
             <version>2.3</version>
         </dependency>
-    <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.9.5</version>
-    </dependency>
-    <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-afterburner</artifactId>
-        <version>2.9.5</version>
-    </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+            <version>2.9.5</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -50,7 +50,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>hello.HelloWebServer</mainClass>
+                            <mainClass>benchmarks.Server</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>

--- a/frameworks/Java/jlhttp/pom.xml
+++ b/frameworks/Java/jlhttp/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>net.freeutils</groupId>
             <artifactId>jlhttp</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <optimize>true</optimize>
                     <debug>false</debug>
                 </configuration>

--- a/frameworks/Java/jlhttp/src/main/java/benchmarks/Message.java
+++ b/frameworks/Java/jlhttp/src/main/java/benchmarks/Message.java
@@ -1,4 +1,4 @@
-package hello;
+package benchmarks;
 
 public class Message {
 

--- a/frameworks/Java/jlhttp/src/main/java/benchmarks/Server.java
+++ b/frameworks/Java/jlhttp/src/main/java/benchmarks/Server.java
@@ -1,6 +1,5 @@
 package benchmarks;
 
-import java.io.IOException;
 import java.util.concurrent.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
@@ -11,55 +10,52 @@ public class Server {
 
     private static final String HELLO_TEXT = "Hello, World!";
     private static final byte[] HELLO_BYTES = HELLO_TEXT.getBytes();
-    private static final String HELLO_LENGTH = Long.toString(HELLO_BYTES.length);
+    private static final String HELLO_LENGTH = Integer.toString(HELLO_BYTES.length);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static {
         MAPPER.registerModule(new AfterburnerModule());
     }
 
+    private static ContextHandler createPlaintextHandler() {
+        return (req, resp) -> {
+            resp.getHeaders().add("Content-Type", "text/plain");
+            resp.getHeaders().add("Content-Length", HELLO_LENGTH);
+            resp.sendHeaders(200);
+            resp.getOutputStream().write(HELLO_BYTES);
+            return 0;
+        };
+    }
+
+    private static ContextHandler createJSONHandler() {
+        return (req, resp) -> {
+            Message msg = new Message(HELLO_TEXT);
+            byte[] bytes;
+            try {
+                bytes = MAPPER.writeValueAsBytes(msg);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            resp.getHeaders().add("Content-Type", "application/json");
+            resp.getHeaders().add("Content-Length", Integer.toString(bytes.length));
+            resp.sendHeaders(200);
+            resp.getOutputStream().write(bytes);
+            return 0;
+        };
+    }
+
     public static void main(String[] args) throws Exception {
         // parse arguments
         int port = args.length > 0 ? Integer.parseInt(args[0]) : 8080;
-
         // create server
         HTTPServer server = new HTTPServer(port);
         server.setExecutor(new ThreadPoolExecutor(
-            8, Integer.MAX_VALUE, 300, TimeUnit.SECONDS, new SynchronousQueue<Runnable>()));
+            8, Integer.MAX_VALUE, 300, TimeUnit.SECONDS, new SynchronousQueue<>()));
         VirtualHost host = server.getVirtualHost(null); // default virtual host
-
-        // add plaintext test handler
-        host.addContext("/plaintext", new ContextHandler() {
-            @Override
-            public int serve(Request req, Response resp) throws IOException {
-                resp.getHeaders().add("Content-Type", "text/plain");
-                resp.getHeaders().add("Content-Length", HELLO_LENGTH);
-                resp.sendHeaders(200);
-                resp.getOutputStream().write(HELLO_BYTES);
-                return 0;
-            }
-        });
-
-        // add json test handler
-        host.addContext("/json", new ContextHandler() {
-            @Override
-            public int serve(Request req, Response resp) throws IOException {
-                Message msg = new Message(HELLO_TEXT);
-                byte[] bytes;
-                try {
-                    bytes = MAPPER.writeValueAsBytes(msg);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-
-                resp.getHeaders().add("Content-Type", "application/json");
-                resp.getHeaders().add("Content-Length", Long.toString(bytes.length));
-                resp.sendHeaders(200);
-                resp.getOutputStream().write(bytes);
-                return 0;
-            }
-        });
-
+        // add context handlers
+        host.addContext("/plaintext", createPlaintextHandler());
+        host.addContext("/json", createJSONHandler());
         // start server
         server.start();
     }

--- a/frameworks/Java/jlhttp/src/main/java/benchmarks/Server.java
+++ b/frameworks/Java/jlhttp/src/main/java/benchmarks/Server.java
@@ -1,4 +1,4 @@
-package hello;
+package benchmarks;
 
 import java.io.IOException;
 import java.util.concurrent.*;
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import net.freeutils.httpserver.HTTPServer;
 import net.freeutils.httpserver.HTTPServer.*;
 
-public class HelloWebServer {
+public class Server {
 
     private static final String HELLO_TEXT = "Hello, World!";
     private static final byte[] HELLO_BYTES = HELLO_TEXT.getBytes();


### PR DESCRIPTION
Standardize and organize JLHTTP config, metadata and benchmark code, and upgrade to latest 2.4 release. The benchmark code itself has not meaningfully changed, only its structure/syntax has. The config and readme have changed to be in line with the new framework auto-generated templates, no significant content changes here either.