### PR TITLE
[ci fw-only Java/act] tune for db tests - 1.8.8b

### DIFF
--- a/frameworks/Java/act/CHANGELOG.md
+++ b/frameworks/Java/act/CHANGELOG.md
@@ -1,0 +1,7 @@
+TechEmpower Framework Benchmark - ActFramework Change log
+
+**1.8.8b**
+
+* Use internal datasource pool to replace druid for Ebean permutations
+* change max connection to 20 for all updates tests
+* change max connection to 5 for ebean-pgsql and hibernate-pgsql updates tests

--- a/frameworks/Java/act/pom.xml
+++ b/frameworks/Java/act/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.techempower</groupId>
   <artifactId>actframework</artifactId>
   <packaging>jar</packaging>
-  <version>1.8.8.4</version>
+  <version>1.8.8b</version>
 
   <name>TEB ActFramework Project</name>
   <description>TEB benchmark project with ActFramework</description>
@@ -113,10 +113,6 @@
           <artifactId>mysql-connector-java</artifactId>
           <version>${mysql.version}</version>
         </dependency>
-        <dependency>
-          <groupId>com.alibaba</groupId>
-          <artifactId>druid</artifactId>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -175,10 +171,6 @@
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
           <version>${postgres-jdbc.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.alibaba</groupId>
-          <artifactId>druid</artifactId>
         </dependency>
       </dependencies>
     </profile>

--- a/frameworks/Java/act/src/main/resources/conf/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/db.properties
@@ -1,8 +1,8 @@
 db.username=benchmarkdbuser
 db.password=benchmarkdbpass
 db.isolationLevel=1
-db.maxConnections=128
-db.minConnections=64
+db.maxConnections=20
+db.minConnections=20
 db.slave.maxConnections=256
 db.slave.minConnections=128
 db.poolServerPrepStmts=true

--- a/frameworks/Java/act/src/main/resources/conf/ebean_pgsql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/ebean_pgsql/db.properties
@@ -4,3 +4,6 @@ db.impl=act.db.ebean.EbeanPlugin
 db.url=jdbc:postgresql://${pgsql.host}:5432/hello_world?loggerLevel=OFF
 db.isolationLevel=4
 app.batch.save=true
+
+db.maxConnections=5
+db.minConnections=5

--- a/frameworks/Java/act/src/main/resources/conf/hibernate_pgsql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/hibernate_pgsql/db.properties
@@ -4,6 +4,6 @@ app.batch.save=false
 db.impl=act.db.hibernate.HibernatePlugin
 db.url=jdbc:postgresql://${pgsql.host}:5432/hello_world?loggerLevel=OFF
 
-db.maxConnections=10
-db.minConnections=10
-db.autoCommit=true
+db.maxConnections=5
+db.minConnections=5
+#db.autoCommit=true


### PR DESCRIPTION
* Use internal datasource pool to replace druid for Ebean permutations
* change max connection to 20 for all updates tests
* change max connection to 5 for ebean-pgsql and hibernate-pgsql updates tests