### PR TITLE
[ci fw-only Java/act] tune for db tests - 1.8.8c

### DIFF
--- a/frameworks/Java/act/CHANGELOG.md
+++ b/frameworks/Java/act/CHANGELOG.md
@@ -1,5 +1,11 @@
 TechEmpower Framework Benchmark - ActFramework Change log
 
+**1.8.8c**
+
+* revert max connection to 48 for eclipselink-pgsql and eclipselink-mysql update test
+* revert max connection to 10 for hibernate-pgsql update test
+* change max connection to 48 for ebean-xxx read tests
+
 **1.8.8b**
 
 * Use internal datasource pool to replace druid for Ebean permutations

--- a/frameworks/Java/act/src/main/resources/conf/ebean_mysql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/ebean_mysql/db.properties
@@ -4,3 +4,6 @@ app.batch_save=false
 
 db.impl=act.db.ebean.EbeanPlugin
 db.url=jdbc:mysql://${mysql.host}:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&serverTimezone=UTC&useSSL=false
+
+db.slave.maxConnections=48
+db.slave.minConnections=48

--- a/frameworks/Java/act/src/main/resources/conf/ebean_mysql_rythm/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/ebean_mysql_rythm/db.properties
@@ -4,3 +4,6 @@ app.batch_save=false
 
 db.impl=act.db.ebean.EbeanPlugin
 db.url=jdbc:mysql://${mysql.host}:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&serverTimezone=UTC&useSSL=false
+
+db.slave.maxConnections=48
+db.slave.minConnections=48

--- a/frameworks/Java/act/src/main/resources/conf/ebean_pgsql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/ebean_pgsql/db.properties
@@ -7,3 +7,6 @@ app.batch.save=true
 
 db.maxConnections=5
 db.minConnections=5
+
+db.slave.maxConnections=48
+db.slave.minConnections=48

--- a/frameworks/Java/act/src/main/resources/conf/ebean_pgsql_rythm/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/ebean_pgsql_rythm/db.properties
@@ -4,3 +4,6 @@ app.batch.save=false
 
 db.impl=act.db.ebean.EbeanPlugin
 db.url=jdbc:postgresql://${pgsql.host}:5432/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true
+
+db.slave.maxConnections=48
+db.slave.minConnections=48

--- a/frameworks/Java/act/src/main/resources/conf/eclipselink_mysql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/eclipselink_mysql/db.properties
@@ -3,3 +3,6 @@ app.batch_save=false
 
 db.impl=act.db.eclipselink.EclipseLinkPlugin
 db.url=jdbc:mysql://${mysql.host}:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&serverTimezone=UTC&useSSL=false
+
+db.maxConnections=48
+db.minConnections=24

--- a/frameworks/Java/act/src/main/resources/conf/eclipselink_pgsql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/eclipselink_pgsql/db.properties
@@ -4,3 +4,6 @@ app.batch.save=false
 
 db.impl=act.db.eclipselink.EclipseLinkPlugin
 db.url=jdbc:postgresql://${pgsql.host}:5432/hello_world?logLevel=OFF
+
+db.maxConnections=48
+db.minConnections=24

--- a/frameworks/Java/act/src/main/resources/conf/hibernate_pgsql/db.properties
+++ b/frameworks/Java/act/src/main/resources/conf/hibernate_pgsql/db.properties
@@ -4,6 +4,5 @@ app.batch.save=false
 db.impl=act.db.hibernate.HibernatePlugin
 db.url=jdbc:postgresql://${pgsql.host}:5432/hello_world?loggerLevel=OFF
 
-db.maxConnections=5
-db.minConnections=5
-#db.autoCommit=true
+db.maxConnections=10
+db.minConnections=10


### PR DESCRIPTION
**1.8.8c**

* revert max connection to 48 for eclipselink-pgsql and eclipselink-mysql update test
* revert max connection to 10 for hibernate-pgsql update test
* change max connection to 48 for ebean-xxx read tests