### PR TITLE
Add basic benchmarks for Gotham/Rust

### DIFF
--- a/frameworks/Rust/gotham/Cargo.toml
+++ b/frameworks/Rust/gotham/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gotham_techempower"
+version = "0.1.0"
+authors = ["Isaac Whitfield <iw@whitfin.io>"]
+
+[dependencies]
+gotham = "0.2"
+hyper = "0.11"
+mime = "0.3"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true

--- a/frameworks/Rust/gotham/README.md
+++ b/frameworks/Rust/gotham/README.md
@@ -1,0 +1,15 @@
+# Gotham Benchmarking Test
+
+### Test Type Implementation Source Code
+
+* [JSON](src/main.rs)
+* [PLAINTEXT](src/main.rs)
+
+## Test URLs
+### JSON
+
+http://localhost:8080/json
+
+### PLAINTEXT
+
+http://localhost:8080/plaintext

--- a/frameworks/Rust/gotham/benchmark_config.json
+++ b/frameworks/Rust/gotham/benchmark_config.json
@@ -1,0 +1,26 @@
+{
+  "framework": "gotham",
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "None",
+        "framework": "Gotham",
+        "language": "Rust",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "Rust",
+        "webserver": "Hyper",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Gotham",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -8,4 +8,4 @@ COPY ./Cargo.lock ./Cargo.lock
 ENV RUSTFLAGS "-C target-cpu=native"
 RUN cargo build --release
 
-CMD ["./target/release/gotham"]
+CMD ["./target/release/gotham_techempower"]

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.26
+
+WORKDIR /gotham
+COPY ./src ./src
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./Cargo.lock ./Cargo.lock
+
+ENV RUSTFLAGS "-C target-cpu=native"
+RUN cargo build --release
+
+CMD ["./target/release/gotham"]

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -3,7 +3,6 @@ FROM rust:1.26
 WORKDIR /gotham
 COPY ./src ./src
 COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
 
 ENV RUSTFLAGS "-C target-cpu=native"
 RUN cargo build --release

--- a/frameworks/Rust/gotham/src/main.rs
+++ b/frameworks/Rust/gotham/src/main.rs
@@ -1,0 +1,56 @@
+extern crate gotham;
+extern crate hyper;
+extern crate mime;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+
+use gotham::http::response::create_response;
+use gotham::router::builder::*;
+use gotham::state::State;
+use hyper::{header, Response, StatusCode};
+
+static HELLO_WORLD: &'static [u8] = b"Hello, world!";
+
+#[derive(Serialize)]
+struct Message<'a> {
+    message: &'a str,
+}
+
+fn json(state: State) -> (State, Response) {
+    let message = Message {
+        message: "Hello, World!",
+    };
+
+    let body = serde_json::to_vec(&message).unwrap();
+    let mut res = create_response(&state, StatusCode::Ok, Some((body, mime::APPLICATION_JSON)));
+
+    res.headers_mut().set(header::Server::new("Gotham"));
+
+    (state, res)
+}
+
+fn plaintext(state: State) -> (State, Response) {
+    let mut res = create_response(
+        &state,
+        StatusCode::Ok,
+        Some((HELLO_WORLD.to_vec(), mime::TEXT_PLAIN)),
+    );
+
+    res.headers_mut().set(header::Server::new("Gotham"));
+
+    (state, res)
+}
+
+pub fn main() {
+    let addr = "0.0.0.0:8080";
+    println!("Listening for requests at http://{}", addr);
+
+    let router = build_simple_router(|route| {
+        route.get("/plaintext").to(plaintext);
+        route.get("/json").to(json);
+    });
+
+    gotham::start(addr, router)
+}


### PR DESCRIPTION
As one of the new maintainers of Gotham, here is a simple benchmark for Gotham. Previously @bradleybeddoes objected to inclusion due to the benchmarks being provided from another party, but seeing as we're providing our own I think it's fine. Certainly myself and @nyarly are all for it.

This is a simple benchmark, but I think I might need some help debugging an issue with the LOC counter - it errors out with a seemingly vague Python crash.