### PR TITLE
Update may-minihttp to use serde_derive for json

### DIFF
--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Xudong Huang <huangxu008@hotmail.com>"]
 [dependencies]
 num_cpus = "1.0"
 serde = "1.0"
+serde_derive = "1.0"
 serde_json = "1.0"
 may = { git = "https://github.com/Xudong-Huang/may" }
 may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp" }

--- a/frameworks/Rust/may-minihttp/src/main.rs
+++ b/frameworks/Rust/may-minihttp/src/main.rs
@@ -1,11 +1,17 @@
 extern crate may;
 extern crate num_cpus;
 #[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate may_minihttp;
 
 use std::io;
 use may_minihttp::{HttpServer, HttpService, Request, Response};
+
+#[derive(Serialize)]
+struct Message<'a> {
+    message: &'a str,
+}
 
 struct Techempower;
 
@@ -18,7 +24,7 @@ impl HttpService for Techempower {
             "/json" => {
                 resp.header("Content-Type", "application/json");
                 *resp.body_mut() =
-                    serde_json::to_vec(&json!({"message": "Hello, World!"})).unwrap();
+                    serde_json::to_vec(&Message { message: "Hello, World!" }).unwrap();
             }
             "/plaintext" => {
                 resp.header("Content-Type", "text/plain")


### PR DESCRIPTION
[This line](https://github.com/TechEmpower/FrameworkBenchmarks/blob/0b2750e70b0fb12eec57a6c07db4022092215d49/frameworks/Rust/may-minihttp/src/main.rs#L21) uses the relatively slow serde_json::Value and allocates two BTreeMap nodes and two Strings.

I used the following microbenchmark to compare `json!` vs serde_derive as used by the hyper and tokio-minihttp implementations. On my machine:

```
test bench_derive     ... bench:          59 ns/iter (+/- 5)
test bench_json_value ... bench:         254 ns/iter (+/- 2)
```

This adds up to (254 ns/response - 59 ns/response) * 1,148,424 responses/second = 0.224 CPU-seconds per second.

```rust
#![feature(test)]

#[macro_use]
extern crate serde_derive;

#[macro_use]
extern crate serde_json;

extern crate serde;
extern crate test;

use test::Bencher;

#[bench]
fn bench_derive(b: &mut Bencher) {
    #[derive(Serialize)]
    struct Message<'a> {
        message: &'a str,
    }

    b.iter(|| {
        serde_json::to_vec(&Message { message: "Hello, World!" }).unwrap();
    });
}

#[bench]
fn bench_json_value(b: &mut Bencher) {
    b.iter(|| {
        serde_json::to_vec(&json!({"message": "Hello, World!"})).unwrap();
    });
}
```

Closes https://github.com/Xudong-Huang/may/issues/43. cc @Xudong-Huang 