### PR TITLE
Bump Finch to 0.22

### DIFF
--- a/frameworks/Scala/finch/README.md
+++ b/frameworks/Scala/finch/README.md
@@ -26,5 +26,5 @@ http://localhost:9000/plaintext
 ## How to run
 sbt 'oneJar'
 
-`java -jar target/scala-2.11/*finch*one-jar.jar`
+`java -jar target/scala-2.12/*finch*one-jar.jar`
 

--- a/frameworks/Scala/finch/build.sbt
+++ b/frameworks/Scala/finch/build.sbt
@@ -1,12 +1,12 @@
 name := """techempower-benchmarks-finch"""
 
-version := "0.19.0"
+version := "0.22.0"
 
 scalaVersion := "2.12.5"
 
 libraryDependencies ++= Seq(
-  "com.github.finagle" %% "finch-core" % "0.19.0",
-  "com.github.finagle" %% "finch-circe" % "0.19.0"
+  "com.github.finagle" %% "finch-core" % "0.22.0",
+  "com.github.finagle" %% "finch-circe" % "0.22.0"
 )
 
 assemblyMergeStrategy in assembly := {

--- a/frameworks/Scala/finch/finch.dockerfile
+++ b/frameworks/Scala/finch/finch.dockerfile
@@ -4,4 +4,4 @@ COPY project project
 COPY src src
 COPY build.sbt build.sbt
 RUN sbt assembly -batch
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dio.netty.recycler.maxCapacityPerThread=0", "-Dio.netty.leakDetection.level=disabled", "-jar", "target/scala-2.12/techempower-benchmarks-finch-assembly-0.19.0.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dio.netty.recycler.maxCapacityPerThread=0", "-Dcom.twitter.finagle.tracing.enabled=false", "-Dio.netty.leakDetection.level=disabled", "-jar", "target/scala-2.12/techempower-benchmarks-finch-assembly-0.22.0.jar"]


### PR DESCRIPTION
This bumps Finch to 0.22 and disables tracing (not relevant in the benchmarking environment).

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
