### PR TITLE
Update SpanJson to V1.2

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="MySqlConnector" Version="0.40.3" />
     <PackageReference Include="Npgsql" Version="4.0.0-rc1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0-rc1" />
-    <PackageReference Include="SpanJson" Version="1.1.0" />
+    <PackageReference Include="SpanJson" Version="1.2.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update SpanJson (again) to V1.2 to get around attribute name writing regression.