### PR TITLE
Bump thruster version and streamline example code

### DIFF
--- a/frameworks/Rust/thruster/Cargo.toml
+++ b/frameworks/Rust/thruster/Cargo.toml
@@ -9,7 +9,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 smallvec = "0.6.2"
-thruster = "0.5.0-beta5"
+thruster = "0.5.0-beta7"
 
 [profile.release]
 codegen-units = 1

--- a/frameworks/Rust/thruster/Cargo.toml
+++ b/frameworks/Rust/thruster/Cargo.toml
@@ -9,7 +9,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 smallvec = "0.6.2"
-thruster = "0.5.0-beta7"
+thruster = "0.5.0-beta8"
 
 [profile.release]
 codegen-units = 1

--- a/frameworks/Rust/thruster/src/main.rs
+++ b/frameworks/Rust/thruster/src/main.rs
@@ -26,7 +26,6 @@ fn json(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareReturnValu
     let val = serde_json::to_string(&json).unwrap();
 
     context.body = val;
-    context.set_header("Server".to_owned(), "thruster".to_owned());
     context.set_header("Content-Type".to_owned(), "application/json".to_owned());
 
     Box::new(future::ok(context))
@@ -36,7 +35,6 @@ fn plaintext(mut context: Ctx, _chain: &MiddlewareChain<Ctx>) -> MiddlewareRetur
     let val = "Hello, world!".to_owned();
 
     context.body = val;
-    context.set_header("Server".to_owned(), "thruster".to_owned());
     context.set_header("Content-Type".to_owned(), "text/plain".to_owned());
 
     Box::new(future::ok(context))


### PR DESCRIPTION
Removing the `server` header, as it's redundant (built into the framework.)