### PR TITLE
Suave => Core2.1, Server GC

### DIFF
--- a/frameworks/FSharp/suave/src/App/App.fsproj
+++ b/frameworks/FSharp/suave/src/App/App.fsproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Server GC can also be enabled by changing 
`<Project Sdk="Microsoft.NET.Sdk">` => `<Project Sdk="Microsoft.NET.Sdk.Web">`

However, since I believe `Suave` is not an ASP.NET Core based framework and I'm not sure what else the `Web` Sdk does; I'm just enabling it directly.

/cc @ademar 