### PR TITLE
Updated and aligned common python frameworks' components

### DIFF
--- a/frameworks/Python/aiohttp/aiohttp-pg-raw.dockerfile
+++ b/frameworks/Python/aiohttp/aiohttp-pg-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /aiohttp
 

--- a/frameworks/Python/aiohttp/aiohttp.dockerfile
+++ b/frameworks/Python/aiohttp/aiohttp.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /aiohttp
 

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -3,8 +3,8 @@ aiohttp-jinja2==0.17.0
 aiopg==0.13.2
 asyncpg==0.15.0
 cchardet==2.1.1
-gunicorn==19.7.1
-psycopg2==2.7.4
+gunicorn==19.9.0
+psycopg2==2.7.5
 SQLAlchemy==1.1.10
 ujson==1.35
 uvloop==0.9.1

--- a/frameworks/Python/api_hour/api_hour-dbs.dockerfile
+++ b/frameworks/Python/api_hour/api_hour-dbs.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./yocto_http /yocto_http
 ADD ./requirements.txt /yocto_http

--- a/frameworks/Python/api_hour/api_hour-json.dockerfile
+++ b/frameworks/Python/api_hour/api_hour-json.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./yocto_http /yocto_http
 ADD ./requirements.txt /yocto_http

--- a/frameworks/Python/api_hour/api_hour-mysql.dockerfile
+++ b/frameworks/Python/api_hour/api_hour-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./aiohttp.web /aiohttp.web
 ADD ./requirements.txt /aiohttp.web

--- a/frameworks/Python/api_hour/api_hour-plaintext.dockerfile
+++ b/frameworks/Python/api_hour/api_hour-plaintext.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./yocto_http /yocto_http
 ADD ./requirements.txt /yocto_http

--- a/frameworks/Python/api_hour/api_hour.dockerfile
+++ b/frameworks/Python/api_hour/api_hour.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./aiohttp.web /aiohttp.web
 ADD ./requirements.txt /aiohttp.web

--- a/frameworks/Python/api_hour/requirements.txt
+++ b/frameworks/Python/api_hour/requirements.txt
@@ -4,12 +4,12 @@ aiopg==0.7.0
 -e git+https://github.com/Eyepea/API-Hour.git@577abbdcbb8cc2810dad46e260b338b15db4d0e3#egg=api_hour-master
 asyncio-redis==0.13.4
 chardet==2.3.0
-gunicorn==19.3.0
+gunicorn==19.9.0
 hiredis==0.2.0
 Jinja2==2.7.3
 MarkupSafe==0.23
 piprot==0.9.1
-psycopg2==2.6
+psycopg2==2.7.5
 PyYAML==3.11
 requests==2.7.0
 requests-futures==0.9.5

--- a/frameworks/Python/apistar/apistar.dockerfile
+++ b/frameworks/Python/apistar/apistar.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /apistar
 

--- a/frameworks/Python/apistar/requirements.txt
+++ b/frameworks/Python/apistar/requirements.txt
@@ -1,4 +1,4 @@
-gunicorn==19.8.1
+gunicorn==19.9.0
 meinheld==0.6.1
 apistar==0.5.39
 ujson==1.35

--- a/frameworks/Python/bottle/bottle-nginx-uwsgi.dockerfile
+++ b/frameworks/Python/bottle/bottle-nginx-uwsgi.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 WORKDIR /bottle
 COPY views views
@@ -8,8 +8,8 @@ COPY requirements.txt requirements.txt
 COPY uwsgi.ini uwsgi.ini
 
 RUN curl -s http://nginx.org/keys/nginx_signing.key | apt-key add -
-RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
-RUN echo "deb-src http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
+RUN echo "deb-src http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
 
 RUN apt update -yqq && apt install -yqq nginx
 

--- a/frameworks/Python/bottle/bottle-raw.dockerfile
+++ b/frameworks/Python/bottle/bottle-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 WORKDIR /bottle
 COPY views views

--- a/frameworks/Python/bottle/bottle.dockerfile
+++ b/frameworks/Python/bottle/bottle.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 WORKDIR /bottle
 COPY views views

--- a/frameworks/Python/bottle/requirements-pypy.txt
+++ b/frameworks/Python/bottle/requirements-pypy.txt
@@ -1,6 +1,6 @@
 bottle==0.12.13
 bottle-sqlalchemy==0.4.3
-gunicorn==19.7.1
+gunicorn==19.9.0
 PyMySQL==0.8.0
 SQLAlchemy==1.2.2
 tornado==4.5.3

--- a/frameworks/Python/bottle/requirements.txt
+++ b/frameworks/Python/bottle/requirements.txt
@@ -1,9 +1,9 @@
 bottle==0.12.9
 bottle-sqlalchemy==0.4.3
-greenlet==0.4.13
-gunicorn==19.4.5
+greenlet==0.4.14
+gunicorn==19.9.0
 meinheld==0.6.1
 mysqlclient==1.3.12
 SQLAlchemy==1.0.12
 ujson==1.35
-uWSGI==2.0.15
+uWSGI==2.0.17.1

--- a/frameworks/Python/cherrypy/cherrypy-py3.dockerfile
+++ b/frameworks/Python/cherrypy/cherrypy-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /cherrypy
 

--- a/frameworks/Python/cherrypy/cherrypy.dockerfile
+++ b/frameworks/Python/cherrypy/cherrypy.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /cherrypy
 

--- a/frameworks/Python/django/django-postgresql.dockerfile
+++ b/frameworks/Python/django/django-postgresql.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /django
 

--- a/frameworks/Python/django/django-py3.dockerfile
+++ b/frameworks/Python/django/django-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /django
 

--- a/frameworks/Python/django/django.dockerfile
+++ b/frameworks/Python/django/django.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /django
 

--- a/frameworks/Python/django/requirements.txt
+++ b/frameworks/Python/django/requirements.txt
@@ -1,8 +1,8 @@
 Django==1.11.9
-greenlet==0.4.12
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 meinheld==0.6.1
 mysqlclient==1.3.12
-psycopg2==2.7.3.2
+psycopg2==2.7.5
 pytz==2017.3
 ujson==1.35

--- a/frameworks/Python/django/requirements_py3.txt
+++ b/frameworks/Python/django/requirements_py3.txt
@@ -1,8 +1,8 @@
 Django==2.0.1
-greenlet==0.4.12
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 meinheld==0.6.1
 mysqlclient==1.3.12
-psycopg2==2.7.3.2
+psycopg2==2.7.5
 pytz==2017.3
 ujson==1.35

--- a/frameworks/Python/falcon/falcon-py3.dockerfile
+++ b/frameworks/Python/falcon/falcon-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 WORKDIR /falcon
 COPY app.py app.py

--- a/frameworks/Python/falcon/falcon.dockerfile
+++ b/frameworks/Python/falcon/falcon.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 WORKDIR /falcon
 COPY app.py app.py

--- a/frameworks/Python/falcon/requirements-pypy.txt
+++ b/frameworks/Python/falcon/requirements-pypy.txt
@@ -1,6 +1,6 @@
 falcon==1.4.1
-greenlet==0.4.12
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 python-mimeparse==1.6.0
 readline==6.2.4.1
 six==1.11.0

--- a/frameworks/Python/falcon/requirements.txt
+++ b/frameworks/Python/falcon/requirements.txt
@@ -1,7 +1,7 @@
 Cython==0.27.3
 falcon==1.4.1
-greenlet==0.4.13
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 meinheld==0.6.1
 python-mimeparse==1.6.0
 six==1.11.0

--- a/frameworks/Python/flask/flask-nginx-uwsgi.dockerfile
+++ b/frameworks/Python/flask/flask-nginx-uwsgi.dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 RUN curl -s http://nginx.org/keys/nginx_signing.key | apt-key add -
-RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
-RUN echo "deb-src http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
+RUN echo "deb-src http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
 
 RUN apt update -yqq && apt install -yqq nginx
 

--- a/frameworks/Python/flask/flask-raw.dockerfile
+++ b/frameworks/Python/flask/flask-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /flask
 

--- a/frameworks/Python/flask/flask.dockerfile
+++ b/frameworks/Python/flask/flask.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /flask
 

--- a/frameworks/Python/flask/requirements-pypy.txt
+++ b/frameworks/Python/flask/requirements-pypy.txt
@@ -4,8 +4,8 @@ cffi==1.11.2
 click==6.7
 Flask==0.12.2
 Flask-SQLAlchemy==2.3.2
-greenlet==0.4.12
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0

--- a/frameworks/Python/flask/requirements.txt
+++ b/frameworks/Python/flask/requirements.txt
@@ -1,13 +1,13 @@
 click==6.7
 Flask==0.12.2
 Flask-SQLAlchemy==2.3.2
-greenlet==0.4.13
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
 meinheld==0.6.1
 mysqlclient==1.3.12
 SQLAlchemy==1.2.2
-uWSGI==2.0.15
+uWSGI==2.0.17.1
 Werkzeug==0.14.1

--- a/frameworks/Python/japronto/japronto.dockerfile
+++ b/frameworks/Python/japronto/japronto.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /japronto
 

--- a/frameworks/Python/klein/klein.dockerfile
+++ b/frameworks/Python/klein/klein.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /klein
 

--- a/frameworks/Python/morepath/morepath.dockerfile
+++ b/frameworks/Python/morepath/morepath.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /japronto
 

--- a/frameworks/Python/morepath/requirements.txt
+++ b/frameworks/Python/morepath/requirements.txt
@@ -1,6 +1,6 @@
 dectate==0.13
-greenlet==0.4.12
-gunicorn==19.7.1
+greenlet==0.4.14
+gunicorn==19.9.0
 importscan==0.1
 Jinja2==2.9.6
 MarkupSafe==1.0
@@ -9,7 +9,7 @@ more.jinja2==0.2
 more.pony==0.1
 morepath==0.18.1
 pony==0.7.1
-psycopg2==2.7.1
+psycopg2==2.7.5
 reg==0.11
 repoze.lru==0.6
 WebOb==1.7.2

--- a/frameworks/Python/pyramid/pyramid-py2.dockerfile
+++ b/frameworks/Python/pyramid/pyramid-py2.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /pyramid
 

--- a/frameworks/Python/pyramid/pyramid.dockerfile
+++ b/frameworks/Python/pyramid/pyramid.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /pyramid
 

--- a/frameworks/Python/pyramid/requirements.txt
+++ b/frameworks/Python/pyramid/requirements.txt
@@ -1,7 +1,7 @@
-psycopg2==2.6.1
-gunicorn==19.4.5
+psycopg2==2.7.5
+gunicorn==19.9.0
 meinheld==0.6.1
 SQLAlchemy==1.0.12
 pyramid==1.6.1
 pyramid_chameleon==0.3
-greenlet==0.4.9
+greenlet==0.4.14

--- a/frameworks/Python/sanic/sanic.dockerfile
+++ b/frameworks/Python/sanic/sanic.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /sanic
 

--- a/frameworks/Python/starlette/starlette.dockerfile
+++ b/frameworks/Python/starlette/starlette.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /starlette
 

--- a/frameworks/Python/tornado/tornado-postgresql-raw.dockerfile
+++ b/frameworks/Python/tornado/tornado-postgresql-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /tornado
 

--- a/frameworks/Python/tornado/tornado-py3.dockerfile
+++ b/frameworks/Python/tornado/tornado-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /pyramid
 

--- a/frameworks/Python/tornado/tornado.dockerfile
+++ b/frameworks/Python/tornado/tornado.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /tornado
 

--- a/frameworks/Python/turbogears/requirements.txt
+++ b/frameworks/Python/turbogears/requirements.txt
@@ -5,6 +5,6 @@ zope.sqlalchemy==0.7.6
 mysqlclient==1.3.7
 jinja2==2.8
 
-gunicorn==19.4.5
+gunicorn==19.9.0
 meinheld==0.6.1
-greenlet==0.4.9
+greenlet==0.4.14

--- a/frameworks/Python/turbogears/turbogears.dockerfile
+++ b/frameworks/Python/turbogears/turbogears.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /turbogears
 

--- a/frameworks/Python/uvicorn/uvicorn.dockerfile
+++ b/frameworks/Python/uvicorn/uvicorn.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /uvicorn
 

--- a/frameworks/Python/uwsgi/requirements.txt
+++ b/frameworks/Python/uwsgi/requirements.txt
@@ -1,3 +1,3 @@
 gevent==1.1.0
-uwsgi==2.0.12
+uwsgi==2.0.17.1
 ujson==1.35

--- a/frameworks/Python/uwsgi/uwsgi-nginx-uwsgi.dockerfile
+++ b/frameworks/Python/uwsgi/uwsgi-nginx-uwsgi.dockerfile
@@ -1,8 +1,8 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 RUN curl -s http://nginx.org/keys/nginx_signing.key | apt-key add -
-RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
-RUN echo "deb-src http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
+RUN echo "deb-src http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
 
 RUN apt update -yqq && apt install -yqq nginx
 

--- a/frameworks/Python/uwsgi/uwsgi.dockerfile
+++ b/frameworks/Python/uwsgi/uwsgi.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /uw
 

--- a/frameworks/Python/web2py/requirements.txt
+++ b/frameworks/Python/web2py/requirements.txt
@@ -1,4 +1,4 @@
 mysqlclient==1.3.12
-gunicorn==19.7.1
+gunicorn==19.9.0
 meinheld==0.6.1
-greenlet==0.4.12
+greenlet==0.4.14

--- a/frameworks/Python/web2py/requirements.txt
+++ b/frameworks/Python/web2py/requirements.txt
@@ -1,4 +1,4 @@
 mysqlclient==1.3.12
-gunicorn==19.9.0
+gunicorn==19.7.1
 meinheld==0.6.1
 greenlet==0.4.14

--- a/frameworks/Python/web2py/web2py-optimized.dockerfile
+++ b/frameworks/Python/web2py/web2py-optimized.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /web2py
 

--- a/frameworks/Python/web2py/web2py.dockerfile
+++ b/frameworks/Python/web2py/web2py.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /web2py
 

--- a/frameworks/Python/webware/webware.dockerfile
+++ b/frameworks/Python/webware/webware.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /webware
 

--- a/frameworks/Python/weppy/benchmark_config.json
+++ b/frameworks/Python/weppy/benchmark_config.json
@@ -42,7 +42,7 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "weppy-Py3",
-      "notes": "CPython 3.4",
+      "notes": "CPython 3.6",
       "versus": "wsgi"
     },
     "pypy2": {
@@ -87,7 +87,7 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "weppy-nginx-uWSGI",
-      "notes": "CPython 2.7",
+      "notes": "CPython 3.6",
       "versus": "wsgi"
     }
   }]

--- a/frameworks/Python/weppy/requirements-pypy.txt
+++ b/frameworks/Python/weppy/requirements-pypy.txt
@@ -1,4 +1,4 @@
 pg8000==1.10.6
 weppy==1.2.11
-gunicorn==19.4.5
+gunicorn==19.9.0
 tornado==4.3

--- a/frameworks/Python/weppy/requirements.txt
+++ b/frameworks/Python/weppy/requirements.txt
@@ -1,6 +1,6 @@
-psycopg2==2.6.1
+psycopg2==2.7.5
 weppy==1.2.11
-gunicorn==19.4.5
+gunicorn==19.9.0
 meinheld==0.6.1
-uwsgi==2.0.12
-greenlet==0.4.9
+uwsgi==2.0.17.1
+greenlet==0.4.14

--- a/frameworks/Python/weppy/weppy-nginx-uwsgi.dockerfile
+++ b/frameworks/Python/weppy/weppy-nginx-uwsgi.dockerfile
@@ -1,8 +1,8 @@
-FROM python:2.7.14
+FROM python:3.6.6-stretch
 
 RUN curl -s http://nginx.org/keys/nginx_signing.key | apt-key add -
-RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
-RUN echo "deb-src http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
+RUN echo "deb-src http://nginx.org/packages/debian/ stretch nginx" >> /etc/apt/sources.list
 
 RUN apt update -yqq && apt install -yqq nginx
 

--- a/frameworks/Python/weppy/weppy-py3.dockerfile
+++ b/frameworks/Python/weppy/weppy-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /weppy
 

--- a/frameworks/Python/weppy/weppy.dockerfile
+++ b/frameworks/Python/weppy/weppy.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /weppy
 

--- a/frameworks/Python/wheezyweb/requirements.lock
+++ b/frameworks/Python/wheezyweb/requirements.lock
@@ -1,5 +1,5 @@
-greenlet==0.4.13
-gunicorn==19.4.5
+greenlet==0.4.14
+gunicorn==19.9.0
 meinheld==0.6.1
 mysqlclient==1.3.7
 SQLAlchemy==1.0.12

--- a/frameworks/Python/wheezyweb/wheezyweb-py3.dockerfile
+++ b/frameworks/Python/wheezyweb/wheezyweb-py3.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /wheezyweb
 

--- a/frameworks/Python/wheezyweb/wheezyweb.dockerfile
+++ b/frameworks/Python/wheezyweb/wheezyweb.dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.15-stretch
 
 ADD ./ /wheezyweb
 

--- a/frameworks/Python/wsgi/requirements.txt
+++ b/frameworks/Python/wsgi/requirements.txt
@@ -1,4 +1,4 @@
 ujson==1.35
-gunicorn==19.4.5
+gunicorn==19.9.0
 meinheld==0.6.1
-greenlet==0.4.9
+greenlet==0.4.14

--- a/frameworks/Python/wsgi/wsgi.dockerfile
+++ b/frameworks/Python/wsgi/wsgi.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.5
+FROM python:3.6.6-stretch
 
 ADD ./ /wsgi
 


### PR DESCRIPTION
The aim is to have the same conditions on all the frameworks for common requirements.

Alignments:
- using same docker images (updated to 2.7.15-stretch and 3.6.6-stretch)
- using same platform requirements

The only exception is for *web2py* framework, which refuses to start with gunicorn 19.9.0.

The update of docker images is also fixing the issues with nginx-uwsgi tests.