### PR TITLE
Ensure to use N4 timer in Finagle

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,15 +1,17 @@
-name := "finagle"
+lazy val finagleVersion = "18.8.0"
 
+name := "finagle-benchmark"
 scalaVersion := "2.12.5"
-
-version := "18.8.0"
+version := finagleVersion
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finagle-http" % "18.8.0",
+  "com.twitter" %% "finagle-http" % finagleVersion,
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4"
 )
 
+assemblyJarName in assembly := "finagle-benchmark.jar"
 assemblyMergeStrategy in assembly := {
- case PathList("META-INF", xs @ _*) => MergeStrategy.discard
- case x => MergeStrategy.first
+ case PathList("META-INF", "services", _*) => MergeStrategy.last
+ case PathList("META-INF", _*) => MergeStrategy.discard
+ case _ => MergeStrategy.first
 }

--- a/frameworks/Scala/finagle/finagle.dockerfile
+++ b/frameworks/Scala/finagle/finagle.dockerfile
@@ -4,4 +4,4 @@ COPY project project
 COPY src src
 COPY build.sbt build.sbt
 RUN sbt assembly -batch
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dcom.twitter.finagle.tracing.enabled=false", "-Dio.netty.recycler.maxCapacityPerThread=0", "-Dio.netty.leakDetection.level=disabled", "-jar", "target/scala-2.12/finagle-assembly-18.8.0.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dcom.twitter.finagle.tracing.enabled=false", "-Dio.netty.recycler.maxCapacityPerThread=0", "-Dio.netty.leakDetection.level=disabled", "-jar", "target/scala-2.12/finagle-benchmark.jar"]

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,6 +1,8 @@
+lazy val finatraVersion = "18.8.0"
+
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"
-version := "18.8.0"
+version := finatraVersion
 
 scalaVersion := "2.12.5"
 
@@ -16,7 +18,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "18.8.0",
+  "com.twitter" %% "finatra-http" % finatraVersion,
   "org.slf4j" % "slf4j-nop" % "1.7.25",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.4",
   "javax.activation" % "activation" % "1.1.1"


### PR DESCRIPTION
Adjusting OneJar's settings such that proper timer is loaded at runtime. Basically, this fixes the warning for Finagle benchmark:

```
$ java -jar target/scala-2.12/finagle-benchmark.jar 
Aug 14, 2018 4:21:59 PM com.twitter.finagle.Init$ $anonfun$once$1
INFO: Finagle version 18.8.0 (rev=b12759650084cd4eaa890045f1f921127b368d20) built at 20180806-152739
Aug 14, 2018 4:21:59 PM com.twitter.finagle.util.DefaultTimer$ <init>
WARNING: Can not service-load a timer. Using JavaTimer instead.
```

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
