### PR TITLE
Fix off by one errors in rust random world ids

### DIFF
--- a/frameworks/Rust/actix/src/db.rs
+++ b/frameworks/Rust/actix/src/db.rs
@@ -41,7 +41,7 @@ impl Handler<RandomWorld> for DbExecutor {
     fn handle(&mut self, _: RandomWorld, _: &mut Self::Context) -> Self::Result {
         use schema::world::dsl::*;
 
-        let random_id = self.rng.gen_range(1, 10_000);
+        let random_id = self.rng.gen_range(1, 10_001);
         match world
             .filter(id.eq(random_id))
             .load::<models::World>(&self.conn)
@@ -66,7 +66,7 @@ impl Handler<RandomWorlds> for DbExecutor {
 
         let mut worlds = Vec::with_capacity(msg.0 as usize);
         for _ in 0..msg.0 {
-            let w_id = self.rng.gen_range(1, 10_000);
+            let w_id = self.rng.gen_range(1, 10_001);
             let w = match world.filter(id.eq(w_id)).load::<models::World>(&self.conn) {
                 Ok(mut items) => items.pop().unwrap(),
                 Err(_) => {
@@ -93,7 +93,7 @@ impl Handler<UpdateWorld> for DbExecutor {
 
         let mut worlds = Vec::with_capacity(msg.0);
         for _ in 0..msg.0 {
-            let w_id = self.rng.gen_range::<i32>(1, 10_000);
+            let w_id = self.rng.gen_range::<i32>(1, 10_001);
             let mut w = match world.filter(id.eq(w_id)).load::<models::World>(&self.conn)
             {
                 Ok(mut items) => items.pop().unwrap(),
@@ -101,7 +101,7 @@ impl Handler<UpdateWorld> for DbExecutor {
                     return Err(io::Error::new(io::ErrorKind::Other, "Database error"))
                 }
             };
-            w.randomnumber = self.rng.gen_range(1, 10_000);
+            w.randomnumber = self.rng.gen_range(1, 10_001);
             worlds.push(w);
         }
         worlds.sort_by_key(|w| w.id);

--- a/frameworks/Rust/actix/src/db_pg.rs
+++ b/frameworks/Rust/actix/src/db_pg.rs
@@ -86,7 +86,7 @@ impl Handler<RandomWorld> for PgConnection {
     type Result = ResponseFuture<World, io::Error>;
 
     fn handle(&mut self, _: RandomWorld, _: &mut Self::Context) -> Self::Result {
-        let random_id = self.rng.gen_range::<i32>(1, 10_000);
+        let random_id = self.rng.gen_range::<i32>(1, 10_001);
 
         Box::new(
             self.cl
@@ -118,7 +118,7 @@ impl Handler<RandomWorlds> for PgConnection {
     fn handle(&mut self, msg: RandomWorlds, _: &mut Self::Context) -> Self::Result {
         let mut worlds = Vec::with_capacity(msg.0 as usize);
         for _ in 0..msg.0 {
-            let w_id: i32 = self.rng.gen_range(1, 10_000);
+            let w_id: i32 = self.rng.gen_range(1, 10_001);
             worlds.push(
                 self.cl
                     .as_mut()
@@ -152,8 +152,8 @@ impl Handler<UpdateWorld> for PgConnection {
     fn handle(&mut self, msg: UpdateWorld, _: &mut Self::Context) -> Self::Result {
         let mut worlds = Vec::with_capacity(msg.0 as usize);
         for _ in 0..msg.0 {
-            let id: i32 = self.rng.gen_range(1, 10_000);
-            let w_id: i32 = self.rng.gen_range(1, 10_000);
+            let id: i32 = self.rng.gen_range(1, 10_001);
+            let w_id: i32 = self.rng.gen_range(1, 10_001);
             worlds.push(
                 self.cl
                     .as_mut()

--- a/frameworks/Rust/actix/src/db_pg_direct.rs
+++ b/frameworks/Rust/actix/src/db_pg_direct.rs
@@ -49,7 +49,7 @@ impl PgConnection {
 impl PgConnection {
 
     pub fn get_world(&self) -> impl Future<Item=World, Error=io::Error> {
-        let random_id = thread_rng().gen_range::<i32>(1, 10_000);
+        let random_id = thread_rng().gen_range::<i32>(1, 10_001);
 
         self.cl
             .query(&self.world, &[&random_id])
@@ -67,7 +67,7 @@ impl PgConnection {
     pub fn get_worlds(&self, num: usize) -> impl Future<Item=Vec<World>, Error=io::Error> {
         let mut worlds = Vec::with_capacity(num);
         for _ in 0..num {
-            let w_id: i32 = thread_rng().gen_range(1, 10_000);
+            let w_id: i32 = thread_rng().gen_range(1, 10_001);
             worlds.push(
                 self.cl
                     .query(&self.world, &[&w_id])
@@ -89,8 +89,8 @@ impl PgConnection {
     pub fn update(&self, num: usize) -> impl Future<Item=Vec<World>, Error=io::Error> {
         let mut worlds = Vec::with_capacity(num);
         for _ in 0..num {
-            let id: i32 = thread_rng().gen_range(1, 10_000);
-            let w_id: i32 =thread_rng().gen_range(1, 10_000);
+            let id: i32 = thread_rng().gen_range(1, 10_001);
+            let w_id: i32 = thread_rng().gen_range(1, 10_001);
             worlds.push(
                 self.cl
                     .query(&self.update, &[&w_id])

--- a/frameworks/Rust/tokio-minihttp/src/main.rs
+++ b/frameworks/Rust/tokio-minihttp/src/main.rs
@@ -122,7 +122,7 @@ impl Techempower {
     }
 
     fn random_world_row(&self) -> CpuFuture<WorldRow, io::Error> {
-        let random_id = rand::thread_rng().gen_range(1, 10_000);
+        let random_id = rand::thread_rng().gen_range(1, 10_001);
         let db = self.db_pool.clone();
         self.thread_pool.spawn_fn(move || {
             let conn = db.get().map_err(|e| {


### PR DESCRIPTION
The maximum world id is 10000.  This code was generating a maximum
random id of 9999.

https://rust-num.github.io/num/rand/trait.Rng.html#method.gen_range