### PR TITLE
Increase Undertow IO thread count, update dependencies

### DIFF
--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -14,12 +14,12 @@
     <maven.compiler.source>10</maven.compiler.source>
     <maven.compiler.target>10</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <hikaricp.version>3.1.0</hikaricp.version>
-    <jackson.version>2.9.5</jackson.version>
+    <hikaricp.version>3.2.0</hikaricp.version>
+    <jackson.version>2.9.6</jackson.version>
     <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
     <mustache.version>0.9.5</mustache.version>
-    <postgresql.version>42.2.2</postgresql.version>
-    <undertow.version>2.0.7.Final</undertow.version>
+    <postgresql.version>42.2.4</postgresql.version>
+    <undertow.version>2.0.13.Final</undertow.version>
   </properties>
 
   <prerequisites>

--- a/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
@@ -38,6 +38,7 @@ public final class HelloWebServer {
     Undertow
         .builder()
         .addHttpListener(8080, "0.0.0.0")
+        .setIoThreads(Runtime.getRuntime().availableProcessors() * 2)
         // In HTTP/1.1, connections are persistent unless declared otherwise.
         // Adding a "Connection: keep-alive" header to every response would only
         // add useless bytes.


### PR DESCRIPTION
Locally the increased thread count gives much better results in the JSON
and plaintext tests.