### PR TITLE
Re-apply the undertow plaintext ByteBuffer optimization

### DIFF
--- a/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/undertow/src/main/java/hello/HelloWebServer.java
@@ -1,6 +1,7 @@
 package hello;
 
 import static io.undertow.util.Headers.CONTENT_TYPE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Comparator.comparing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -84,9 +85,15 @@ public final class HelloWebServer {
   }
 
   static HttpHandler plaintextHandler() {
+    var text = "Hello, World!";
+    var bytes = text.getBytes(US_ASCII);
+    var buffer = ByteBuffer.allocateDirect(bytes.length)
+                           .put(bytes)
+                           .flip();
+
     return exchange -> {
       exchange.getResponseHeaders().put(CONTENT_TYPE, "text/plain");
-      exchange.getResponseSender().send("Hello, World!");
+      exchange.getResponseSender().send(buffer.duplicate());
     };
   }
 


### PR DESCRIPTION
Undertow's relative placement in the plaintext test dropped after
changing this handler to use a regular string.  This coincided with our
move to docker and a switch to new benchmarking hardware, so there are
certainly other variables in the mix, but it's reasonable to assume the
ByteBuffer->string change is partially to blame.  Also IIRC it was the
Undertow authors themselves who originally wrote the ByteBuffer
optimization, so it probably doesn't make sense for me to second guess
them.