### PR TITLE
Allow text/html as a Content-Type in headers

### DIFF
--- a/toolset/benchmark/test_types/verifications.py
+++ b/toolset/benchmark/test_types/verifications.py
@@ -71,7 +71,7 @@ def verify_headers(headers, url, should_be='json'):
     if content_type is not None:
         types = {
             'json':      '^application/json(; ?charset=(UTF|utf)-8)?$',
-            'html':      '^text/html; ?charset=(UTF|utf)-8$',
+            'html':      '^text/html(; ?charset=(UTF|utf)-8)?$',
             'plaintext': '^text/plain(; ?charset=(UTF|utf)-8)?$'
         }
         expected_type = types[should_be]


### PR DESCRIPTION
Modified verifications.py to allow html content type of "text/html", "text/html; chartset=UTF-8", or "text/html; chartset=utf-8". Brought up in issue [77](https://github.com/TechEmpower/TFB-Documentation/issues/77) from docs repo.