### PR TITLE
Temporarily disable the multi-query test for ulib-postgres

### DIFF
--- a/frameworks/C++/ulib/benchmark_config.json
+++ b/frameworks/C++/ulib/benchmark_config.json
@@ -92,7 +92,6 @@
     },
     "postgres": {
       "db_url": "/db",
-      "query_url": "/query?queries=",
       "fortune_url": "/fortune",
       "update_url": "/update?queries=",
       "cached_query_url": "/cached_worlds?queries=",
@@ -113,7 +112,6 @@
     },
     "postgres_fit": {
       "db_url": "/db",
-      "query_url": "/query?queries=",
       "fortune_url": "/fortune",
       "update_url": "/update?queries=",
       "port": 8080,


### PR DESCRIPTION
In the past couple of continuous benchmarking runs, ulib-postgres moved
into first place in the multi-query test by a wide margin while being
much further down the list in the single query test.  This is symptomatic
of batch queries, which are disallowed.

As far as I can tell by looking at the implementation and framework, the
same batching logic that I rejected in earlier PRs is still there, except
the batching logic was moved into the framework itself.

We can re-enable these tests for ulib later if someone convinces us that
it's not doing batch queries.