### PR TITLE
Build techempower/tfb Dockerfile for tests if changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
      - "TESTDIR=Java/jlhttp"
      - "TESTDIR=Java/jooby"
      - "TESTDIR=Java/light-java"
-     - "TESTDIR=Java/micronaut"     
+     - "TESTDIR=Java/micronaut"
      - "TESTDIR=Java/minijax"
      - "TESTDIR=Java/nanohttpd"
      - "TESTDIR=Java/netty"
@@ -104,8 +104,6 @@ before_script:
   # Runs travis_diff, printing the output to the terminal, and searches for travis-diff-continue
   # to determine if the suite should be installed and the current $TESTDIR test should run.
   - export RUN_TESTS=`./toolset/travis/travis_diff.py | tee /dev/tty | grep -oP "travis-run-tests \K(.*)"`
-
-  - if [ "$RUN_TESTS" ]; then docker pull techempower/tfb; fi
 
   # Stop services that would claim ports we may need
   - sudo service mysql stop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM buildpack-deps:xenial
 
 # One -q produces output suitable for logging (mostly hides
 # progress indicators)
@@ -6,13 +6,11 @@ RUN apt update -yqq
 
 # WARNING: DONT PUT A SPACE AFTER ANY BACKSLASH OR APT WILL BREAK
 RUN apt -qqy install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
-  git-core \
   cloc dstat                    `# Collect resource usage statistics` \
   python-dev \
   python-pip \
   python-software-properties \
-  libmysqlclient-dev            `# Needed for MySQL-python` \
-  libpq-dev                     `# Needed for psycopg2`
+  libmysqlclient-dev            `# Needed for MySQL-python`
 
 RUN pip install colorama==0.3.1 requests MySQL-python psycopg2-binary pymongo docker==3.1.0
 


### PR DESCRIPTION
From the work done on #3807 @michaelhixson pointed out that the main `Dockerfile` tagged as `techempower/tfb` isn't being built during the travis run if it has changed. This is because we're pulling the image directly from dockerhub.

This PR checks to see if the `Dockerfile` is among the files changed and builds it before each test.

Since that Dockerfile still needs to be published to dockerhub if changed, I've added a new tag to identify that need when a PR is merged.

To test this PR, I've made a couple of minor changes to the base `Dockerfile`