### PR TITLE
Align all stable Rust versions on 1.29.1

### DIFF
--- a/frameworks/Rust/actix/actix-diesel.dockerfile
+++ b/frameworks/Rust/actix/actix-diesel.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29.0
+FROM rust:1.29.1
 
 ADD ./ /actix
 WORKDIR /actix

--- a/frameworks/Rust/actix/actix-pg.dockerfile
+++ b/frameworks/Rust/actix/actix-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29.0
+FROM rust:1.29.1
 
 ADD ./ /actix
 WORKDIR /actix

--- a/frameworks/Rust/actix/actix-raw.dockerfile
+++ b/frameworks/Rust/actix/actix-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29.0
+FROM rust:1.29.1
 
 ADD ./ /actix
 WORKDIR /actix

--- a/frameworks/Rust/actix/actix.dockerfile
+++ b/frameworks/Rust/actix/actix.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29.0
+FROM rust:1.29.1
 
 ADD ./ /actix
 WORKDIR /actix

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 WORKDIR /gotham
 COPY ./src ./src

--- a/frameworks/Rust/hyper/hyper.dockerfile
+++ b/frameworks/Rust/hyper/hyper.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 ADD ./ /hyper
 WORKDIR /hyper

--- a/frameworks/Rust/iron/iron.dockerfile
+++ b/frameworks/Rust/iron/iron.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 ADD ./ /iron
 WORKDIR /iron

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 ADD ./ /may
 WORKDIR /may

--- a/frameworks/Rust/nickel/nickel.dockerfile
+++ b/frameworks/Rust/nickel/nickel.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 ADD ./ /nickel
 WORKDIR /nickel

--- a/frameworks/Rust/rouille/rouille.dockerfile
+++ b/frameworks/Rust/rouille/rouille.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 WORKDIR /rouille
 COPY src src

--- a/frameworks/Rust/thruster/thruster.dockerfile
+++ b/frameworks/Rust/thruster/thruster.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 WORKDIR /thruster
 COPY ./src ./src

--- a/frameworks/Rust/tokio-minihttp/tokio-minihttp.dockerfile
+++ b/frameworks/Rust/tokio-minihttp/tokio-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.27
+FROM rust:1.29.1
 
 ADD ./ /tokio
 WORKDIR /tokio


### PR DESCRIPTION
This PR will align all stable Rust images on `1.29.1` - previously there were a couple of different versions used, which doesn't really provide a fair benchmark. I would suggest in future that versions are not changed without changing all others.