### PR TITLE
Play Framework version updated to 2.6.20

### DIFF
--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-ebean-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-ebean-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayEbean, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "4.1.3")

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-jooq-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-jooq-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 val jOOQVersion = "3.10.3"
 

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-jpa-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java-jpa-hikaricp .
 

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Java/play2-java/play2-java-netty.dockerfile
+++ b/frameworks/Java/play2-java/play2-java-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java .
 

--- a/frameworks/Java/play2-java/play2-java.dockerfile
+++ b/frameworks/Java/play2-java/play2-java.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-java .
 

--- a/frameworks/Java/play2-java/play2-java/build.sbt
+++ b/frameworks/Java/play2-java/play2-java/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies += guice

--- a/frameworks/Java/play2-java/play2-java/project/build.properties
+++ b/frameworks/Java/play2-java/play2-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Java/play2-java/play2-java/project/plugins.sbt
+++ b/frameworks/Java/play2-java/play2-java/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Scala/play2-scala/play2-scala-anorm-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-anorm .
 

--- a/frameworks/Scala/play2-scala/play2-scala-anorm.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-anorm .
 

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Scala/play2-scala/play2-scala-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala .
 

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-reactivemongo .
 

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-reactivemongo .
 

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies ++= Seq(
   "org.reactivemongo" %% "play2-reactivemongo" % "0.12.7-play26",

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Scala/play2-scala/play2-scala-slick-netty.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-slick-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-slick .
 

--- a/frameworks/Scala/play2-scala/play2-scala-slick.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala-slick.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala-slick .
 

--- a/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies ++= Seq(
   guice,

--- a/frameworks/Scala/play2-scala/play2-scala-slick/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Scala/play2-scala/play2-scala-slick/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")

--- a/frameworks/Scala/play2-scala/play2-scala.dockerfile
+++ b/frameworks/Scala/play2-scala/play2-scala.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.1
+FROM hseeberger/scala-sbt:8u181_2.12.7_1.2.3
 WORKDIR /play2
 COPY play2-scala .
 

--- a/frameworks/Scala/play2-scala/play2-scala/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 libraryDependencies += guice

--- a/frameworks/Scala/play2-scala/play2-scala/project/build.properties
+++ b/frameworks/Scala/play2-scala/play2-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/frameworks/Scala/play2-scala/play2-scala/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")


### PR DESCRIPTION
Docker image updated to latest in its series.

As a result:
Scala version used by the projects has been updated to version 2.12.7
SBT version to use has been set to version 1.2.3

A single test run with ftb was done on play2-java-ebean-hikaricp, confirmed that build used correct versions, build succeeded and passed.
