### PR TITLE
Bumps the Hapi version to fix an npm vulnerability warning

### DIFF
--- a/frameworks/JavaScript/hapi/package.json
+++ b/frameworks/JavaScript/hapi/package.json
@@ -6,7 +6,7 @@
     "async": "2.1.5",
     "bluebird": "3.4.7",
     "handlebars": "4.0.6",
-    "hapi": "16.1.0",
+    "hapi": "16.1.1",
     "vision": "4.1.0",
     "mongoose": "5.0.6",
     "mysql": "2.13.0",


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
