### PR TITLE
Php/bump versions

### DIFF
--- a/frameworks/PHP/cakephp/benchmark_config.json
+++ b/frameworks/PHP/cakephp/benchmark_config.json
@@ -14,7 +14,7 @@
             "database": "MySQL",
             "framework": "cakephp",
             "language": "PHP",
-            "flavor": "PHP5",
+            "flavor": "PHP7",
             "orm": "Full",
             "platform": "None",
             "webserver": "nginx",
@@ -22,7 +22,7 @@
             "database_os": "Linux",
             "display_name": "CakePHP 2.10 (PHP5)",
             "notes": "",
-            "versus": "php-php5"
+            "versus": "php"
         }
     }]
 }

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -5,17 +5,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/5.6/fpm/
-RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf
+COPY deploy/conf/* /etc/php/7.2/fpm/
+RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php7.2-fpm.sock|g" /etc/php/7.2/fpm/php-fpm.conf
 
 ADD ./ /cakephp
 WORKDIR /cakephp
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
 
 RUN mkdir -p app/tmp/cache/models
 RUN mkdir -p app/tmp/cache/persistent
@@ -24,5 +24,5 @@ RUN chmod -R 777 app/tmp
 
 RUN composer install --quiet
 
-CMD service php5.6-fpm start && \
+CMD service php7.2-fpm start && \
     nginx -c /cakephp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -4,7 +4,7 @@ worker_processes  auto;
 events {
     worker_connections 16384;
 	multi_accept on;
-	 
+
 }
 
 http {
@@ -36,7 +36,7 @@ http {
 
 
     upstream fastcgi_backend {
-        server unix:/var/run/php/php5.6-fpm.sock;
+        server unix:/var/run/php/php7.2-fpm.sock;
         keepalive 50;
     }
 
@@ -52,7 +52,7 @@ http {
         }
 
         location ~ \.php$ {
-             
+
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/clancats/benchmark_config.json
+++ b/frameworks/PHP/clancats/benchmark_config.json
@@ -14,7 +14,7 @@
 		  "database": "MySQL",
 		  "framework": "clancatsframework",
 		  "language": "PHP",
-		  "flavor": "PHP5",
+		  "flavor": "PHP7",
 		  "orm": "Raw",
 		  "platform": "None",
 		  "webserver": "nginx",
@@ -22,7 +22,7 @@
 		  "database_os": "Linux",
 		  "display_name": "clancatsframework",
 		  "notes": "",
-		  "versus": "php-php5"
+		  "versus": "php"
 		}
   }]
 }

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -5,17 +5,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/5.6/fpm/
-RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf
+COPY deploy/conf/* /etc/php/7.2/fpm/
+RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php7.2-fpm.sock|g" /etc/php/7.2/fpm/php-fpm.conf
 
 ADD ./ /clancats
 WORKDIR /clancats
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --quiet
 
@@ -23,5 +23,5 @@ RUN git clone --branch v2.0.6 --depth 1 https://github.com/ClanCats/Framework.gi
 RUN cp -r app/ clancatsapp/CCF/
 RUN cp -r vendor/ clancatsapp/CCF/
 
-CMD service php5.6-fpm start && \
+CMD service php7.2-fpm start && \
     nginx -c /clancats/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/clancats/deploy/nginx.conf
+++ b/frameworks/PHP/clancats/deploy/nginx.conf
@@ -18,7 +18,7 @@ http {
 	keepalive_timeout  65;
 
 	upstream fastcgi_backend {
-		server unix:/var/run/php/php5.6-fpm.sock;
+		server unix:/var/run/php/php7.2-fpm.sock;
 		keepalive 50;
 	}
 
@@ -34,7 +34,7 @@ http {
 		}
 
 		location ~ \.php$ {
-			 
+
 			fastcgi_pass   fastcgi_backend;
 			fastcgi_keep_conn on;
 			fastcgi_index  index.php;

--- a/frameworks/PHP/fuel/benchmark_config.json
+++ b/frameworks/PHP/fuel/benchmark_config.json
@@ -12,7 +12,7 @@
       "database": "MySQL",
       "framework": "Fuel",
       "language": "PHP",
-      "flavor": "PHP5",
+      "flavor": "PHP7",
       "orm": "Raw",
       "platform": "None",
       "webserver": "nginx",
@@ -20,7 +20,7 @@
       "database_os": "Linux",
       "display_name": "fuel",
       "notes": "",
-      "versus": "php-php5"
+      "versus": "php"
     }
   }]
 }

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -6,7 +6,7 @@ worker_rlimit_nofile 200000;
 events {
     worker_connections 16384;
 	multi_accept on;
-	 
+
 }
 
 http {
@@ -38,7 +38,7 @@ http {
 
 
     upstream fastcgi_backend {
-        server unix:/var/run/php/php5.6-fpm.sock;
+        server unix:/var/run/php/php7.2-fpm.sock;
         keepalive 50;
     }
 
@@ -54,7 +54,7 @@ http {
         }
 
         location ~ \.php$ {
-             
+
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
             fastcgi_index  index.php;

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -5,19 +5,19 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-xml php7.2-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/5.6/fpm/
-RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf
+COPY deploy/conf/* /etc/php/7.2/fpm/
+RUN sed -i "s|listen = /run/php/php7.2-fpm.sock|listen = /run/php/php7.2-fpm.sock|g" /etc/php/7.2/fpm/php-fpm.conf
 
 ADD ./ /fuel
 WORKDIR /fuel
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --quiet
 
-CMD service php5.6-fpm start && \
+CMD service php7.2-fpm start && \
     nginx -c /fuel/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/lumen/benchmark_config.json
+++ b/frameworks/PHP/lumen/benchmark_config.json
@@ -38,7 +38,7 @@
 			"database": "MySQL",
 			"framework": "lumen",
 			"language": "PHP",
-			"flavor": "None",
+			"flavor": "PHP7",
 			"orm": "Full",
 			"platform": "None",
 			"webserver": "swoole",


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

This PR purely bumps the PHP version of some PHP projects. It may be a good idea to have a PHP5 version alongside the PHP 7 version for comparison, but I digress.