### PR TITLE
Log connection timeouts properly

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -124,6 +124,12 @@ class FrameworkTest:
                     log("Verifying test %s for %s caused an exception: %s" %
                         (test_type, self.name, e),
                         color=Fore.RED)
+                except Timeout as e:
+                    results = [('fail', "Connection to server timed out",
+                                base_url)]
+                    log("Verifying test %s for %s caused an exception: %s" %
+                        (test_type, self.name, e),
+                        color=Fore.RED)
                 except Exception as e:
                     results = [('fail', """Caused Exception in TFB
             This almost certainly means your return value is incorrect,


### PR DESCRIPTION
Connection timeouts were falling through and being reported as:

> Caused Exception in TFB
            This almost certainly means your return value is incorrect,
            but also that you have found a bug. Please submit an issue
            including this message

This properly catches both Read and Connect timeout errors thrown by the `requests` module and logs appropriately. http://docs.python-requests.org/en/master/_modules/requests/exceptions/