### PR TITLE
Improve template handling in akka-http fortunes

### DIFF
--- a/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/App.scala
+++ b/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/App.scala
@@ -21,8 +21,5 @@ class App extends Infrastructure with RandomGenerator with MySqlDataStore with P
   val executionContext: ExecutionContext = system.dispatcher
   val materializer: Materializer = ActorMaterializer()
   val appConfig: Config = ConfigFactory.load
-
-  def layout(uri: String, attributes: Map[String, Any], extraBindings: Traversable[Binding]): String =
-    templateEngine.layout(uri, attributes, extraBindings)
 }
 

--- a/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/Templating.scala
+++ b/frameworks/Scala/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/Templating.scala
@@ -1,7 +1,7 @@
 package com.typesafe.akka.http.benchmark
 
-import org.fusesource.scalate.Binding
+import org.fusesource.scalate.TemplateEngine
 
 trait Templating {
-  def layout(uri: String, attributes: Map[String, Any] = Map.empty, extraBindings: Traversable[Binding] = Nil): String
+  def templateEngine: TemplateEngine
 }


### PR DESCRIPTION
- Load fortunes template on startup, in order to to avoid expensive and mutually exclusive file modification timestamp checks performed by scalate cache on each use.
- Declare a marshaller instead of directly constructing `HttpResponse`, to achieve more idiomatic akka-http code style.

On my machine this change yields performance improvement in fortunes test from 3060.44 requests/second (before the change) to 4899.97 requests/second  (after the change).
