### PR TITLE
[h2o.cr] update docker base (fixes #4156)

### DIFF
--- a/frameworks/Crystal/h2o.cr/h2o.cr.dockerfile
+++ b/frameworks/Crystal/h2o.cr/h2o.cr.dockerfile
@@ -1,12 +1,6 @@
-FROM debian:testing
+FROM alpine:edge
 
-RUN apt update \
-  && apt install -yqq libh2o-evloop-dev libwslay-dev libyaml-0-2 libevent-dev libpcre3-dev \
-    gcc wget git libssl-dev libuv1-dev ca-certificates --no-install-recommends
-
-RUN wget -q https://github.com/crystal-lang/crystal/releases/download/0.26.1/crystal-0.26.1-1-linux-x86_64.tar.gz \
-  && tar --strip-components=1 -xzf crystal-0.26.1-1-linux-x86_64.tar.gz -C /usr/ \
-  && rm -f *.tar.gz
+RUN apk --update --no-cache add gcc git ca-certificates libc-dev openssl1.0-dev h2o-dev wslay-dev crystal shards
 
 WORKDIR /crystal
 
@@ -16,7 +10,7 @@ COPY ./ ./
 
 RUN shards install
 RUN gcc -shared -O3 lib/h2o/src/ext/h2o.c -I/usr/include -fPIC -o h2o.o
-ENV CRYSTAL_PATH=lib:/usr/share/crystal/src
+ENV CRYSTAL_PATH=lib:/usr/lib/crystal/core
 RUN crystal build --prelude=empty --no-debug --release -Dgc_none -Dfiber_none -Dexcept_none -Dhash_none -Dtime_none -Dregex_none -Dextreme h2o_evloop_hello.cr --link-flags="-Wl,-s $PWD/h2o.o -DH2O_USE_LIBUV=0" -o server.out
 
-CMD bash run.sh
+CMD sh run.sh

--- a/frameworks/Crystal/h2o.cr/run.sh
+++ b/frameworks/Crystal/h2o.cr/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 for i in $(seq 1 $(nproc --all)); do
   ./server.out &


### PR DESCRIPTION
debian:testing no longer provide libh2o-evloop-dev at the moment, so I changed it to alpine.