### PR TITLE
Try lower DB pool size for Crystal

### DIFF
--- a/frameworks/Crystal/crystal/server.cr
+++ b/frameworks/Crystal/crystal/server.cr
@@ -3,7 +3,7 @@ require "json"
 require "pg"
 require "ecr"
 
-APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=256&max_pool_size=256&max_idle_pool_size=256")
+APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8")
 ID_MAXIMUM = 10_000
 
 server = HTTP::Server.new do |context|


### PR DESCRIPTION
I've spent some time looking at the results before and after #3209 was merged where DB pool settings were added to one of Crystal implementations as a workaround.

Before #3209 https://www.techempower.com/benchmarks/#section=test&runid=ddc974dc-8f1a-4773-b609-c9c226fb42c2&hw=ph&test=json&l=hma7sv
After #3209 https://www.techempower.com/benchmarks/#section=test&runid=e70ce78c-fa34-4007-b3be-fee596ddb09e&hw=ph&test=json&l=hma7sv

**Things I've noticed on physical hardware (Server Central):**

**RPS**
It's ruined for endpoints with no DB involved:
- Plaintext (2000k -> 200k)
- JSON serialization (650k -> 85k)

Dropped for DB endpoints:
- Single query (77k -> 45k)
- Multiple queries (3.7k -> 3.2k)
- Fortunes (87k -> 25k)
- Data updates (0.9k -> 0.7k)

**Latency**
Became worse for
- Data updates (550ms -> 750ms)

Improved for
- Multiple queries (430ms -> 160ms)

Improved a lot for
- Single query (250ms -> 1.5ms)
- Fortunes (230ms -> 2.5ms)

I'm also taking into account the latest results where it's clear that every Crystal implementation except for one with DB pool settings has quite a lot of errors. So #3209 seems to prevent errors.

I'm also aware that in Cloud environment (Azure) it now performs very good after this fix. Especially for Single query and Fortunes endpoints.

I've seen other implementations are using 3-4 pool size per CPU for physical environment and 8 for cloud and produce very good results.

So what I want to try is a much lower DB pool size to see if it will start to perform better on physical hardware and at the same time not worse in cloud environment.

If this gives good results I'm going to add DB pool settings (maybe with some autotuning) for other Crystal implementations as a separate PR to prevent errors and improve results.