### PR TITLE
[swift-nio] use add instead of replaceOrAdd

### DIFF
--- a/frameworks/Swift/swift-nio/Sources/swift-nio-tfb-default/main.swift
+++ b/frameworks/Swift/swift-nio/Sources/swift-nio-tfb-default/main.swift
@@ -90,10 +90,10 @@ private final class HTTPHandler: ChannelInboundHandler {
 
     private func responseHead(contentType: String, contentLength: String) -> HTTPResponseHead {
         var headers = HTTPHeaders()
-        headers.replaceOrAdd(name: "content-type", value: contentType)
-        headers.replaceOrAdd(name: "content-length", value: contentLength)
-        headers.replaceOrAdd(name: "server", value: Constants.serverName)
-        headers.replaceOrAdd(name: "date", value: dateFormatter.getDate())
+        headers.add(name: "content-type", value: contentType)
+        headers.add(name: "content-length", value: contentLength)
+        headers.add(name: "server", value: Constants.serverName)
+        headers.add(name: "date", value: dateFormatter.getDate())
 
         return HTTPResponseHead(version: Constants.httpVersion,
                                 status: .ok,


### PR DESCRIPTION
This is a small performance improvement for the Swift / Swift-NIO benchmark. `replaceOrAdd` does an unnecessary scan to check if the header already exists. This code is clearly creating an empty headers array before adding the values, so we can be sure we do not need to replace any existing values.