### PR TITLE
Finagle: Skip validation for static headers (always valid)

### DIFF
--- a/frameworks/Scala/finagle/src/main/scala/Main.scala
+++ b/frameworks/Scala/finagle/src/main/scala/Main.scala
@@ -16,14 +16,14 @@ object Main extends App {
     .withHandler("/json", Service.mk { req: Request =>
       val rep = Response()
       rep.content = Buf.ByteArray.Owned(mapper.writeValueAsBytes(Map("message" -> "Hello, World!")))
-      rep.contentType = "application/json"
+      rep.headerMap.setUnsafe("Content-Type", "application/json")
 
       Future.value(rep)
     })
     .withHandler("/plaintext", Service.mk { req: Request => 
       val rep = Response()
       rep.content = helloWorld
-      rep.contentType = "text/plain"
+      rep.headerMap.setUnsafe("Content-Type", "text/plain")
 
       Future.value(rep)
     })
@@ -32,8 +32,8 @@ object Main extends App {
     new SimpleFilter[Request, Response] with (Response => Response) {
 
     def apply(rep: Response): Response = {
-      rep.headerMap.set("Server", "Finagle")
-      rep.headerMap.set("Date", currentTime())
+      rep.headerMap.setUnsafe("Server", "Finagle")
+      rep.headerMap.setUnsafe("Date", currentTime())
 
       rep
     }


### PR DESCRIPTION
We set a few static headers as required by a benchmark. These are the headers we control and we know they are always valid hence no need for header validation.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
