### PR TITLE
Set DB pool size for all Crystal impelementations

### DIFF
--- a/frameworks/Crystal/amber/amber.dockerfile
+++ b/frameworks/Crystal/amber/amber.dockerfile
@@ -9,7 +9,7 @@ COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
 ENV AMBER_ENV production
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
 
 RUN apt install -yqq libyaml-dev
 RUN shards build amber --release --no-debug

--- a/frameworks/Crystal/crystal/crystal-radix.dockerfile
+++ b/frameworks/Crystal/crystal/crystal-radix.dockerfile
@@ -8,6 +8,7 @@ COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
 
 RUN shards install
 RUN crystal build --release --no-debug server_radix.cr -o server_radix.out

--- a/frameworks/Crystal/crystal/crystal.dockerfile
+++ b/frameworks/Crystal/crystal/crystal.dockerfile
@@ -8,6 +8,7 @@ COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
 
 RUN shards install
 RUN crystal build --release --no-debug server.cr -o server.out

--- a/frameworks/Crystal/crystal/server.cr
+++ b/frameworks/Crystal/crystal/server.cr
@@ -3,7 +3,7 @@ require "json"
 require "pg"
 require "ecr"
 
-APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8")
+APPDB = DB.open(ENV["DATABASE_URL"])
 ID_MAXIMUM = 10_000
 
 server = HTTP::Server.new do |context|

--- a/frameworks/Crystal/crystal/server_radix.cr
+++ b/frameworks/Crystal/crystal/server_radix.cr
@@ -89,7 +89,7 @@ tree.add "/queries", queries_handler
 tree.add "/fortunes", fortunes_handler
 tree.add "/updates", updates_handler
 
-APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world")
+APPDB = DB.open(ENV["DATABASE_URL"])
 ID_MAXIMUM = 10_000
 
 server = HTTP::Server.new do |context|

--- a/frameworks/Crystal/kemal/kemal.dockerfile
+++ b/frameworks/Crystal/kemal/kemal.dockerfile
@@ -9,6 +9,7 @@ COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
 ENV KEMAL_ENV production
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
 
 RUN shards install
 RUN crystal build --release --no-debug server-postgres.cr

--- a/frameworks/Crystal/kemal/server-postgres.cr
+++ b/frameworks/Crystal/kemal/server-postgres.cr
@@ -4,7 +4,7 @@ require "pg"
 # Compose Objects (like Hash) to have a to_json method
 require "json/to_json"
 
-APPDB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world")
+APPDB = DB.open(ENV["DATABASE_URL"])
 
 class CONTENT
   UTF8  = "; charset=UTF-8"

--- a/frameworks/Crystal/raze/raze.cr
+++ b/frameworks/Crystal/raze/raze.cr
@@ -1,7 +1,7 @@
 require "raze"
 require "pg"
 
-BENCH_DB = DB.open("postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world")
+BENCH_DB = DB.open(ENV["DATABASE_URL"])
 
 class CONTENT
   ID_MAX = 10_000

--- a/frameworks/Crystal/raze/raze.dockerfile
+++ b/frameworks/Crystal/raze/raze.dockerfile
@@ -7,6 +7,8 @@ COPY raze.cr raze.cr
 COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+
 RUN shards install
 RUN crystal build --release --no-debug raze.cr
 

--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 # Build App
 RUN shards build --production
 
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
 ENV SG_ENV production
 
 # Run the app binding on port 8080


### PR DESCRIPTION
Lower DB pool size from #4160 results in better RPS on Citrine.

Before https://www.techempower.com/benchmarks/#section=test&runid=56076e97-0658-46a1-81bb-6f8890f2e85e
After https://www.techempower.com/benchmarks/#section=test&runid=5191fd86-6a2a-405b-b326-f160fc6781b7
```
                  Before    After    Better
JSON              345k   -> 1016k  ~ 3x
Single query      178k   -> 261k   ~ 1.5x
Multiple queries  9.2k   -> 11.9k  ~ 1.3x
Fortunes          87.5k  -> 258.4k ~ 3x
Data updates      1.2k   -> 3.1k   ~ 2.7x
Plain Text        740k   -> 2025k  ~ 2.7x
```
Note:

Keep an eye on Latency, since it's dropped a lot in some cases.

Might be a good idea to try average latency from multiple runs, as latency numbers seem to be in flux sometimes for no obvious reason.
```
                  Before    After    Worse
JSON              0.2ms  -> 0.7ms  ~ 3x
Single query      0.6ms  -> 0.4 ms
Multiple queries  55ms   -> 309ms  > 5x
Fortunes          1.3ms  -> 173ms  > 100x (!!!)
Data updates      426sm  -> 535ms  ~ 1.2x
Plain Text        4.3ms  -> 13.9ms ~ 3x
```
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->