### PR TITLE
fix spider-gazelle not launching enough workers

### DIFF
--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -2,7 +2,6 @@ FROM crystallang/crystal:0.27.0
 WORKDIR /usr/src/app
 
 COPY shard.yml ./
-COPY spec spec
 COPY src src
 
 # Build App

--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -1,14 +1,16 @@
 FROM crystallang/crystal:0.27.0
-ADD . /src
-WORKDIR /src
+WORKDIR /usr/src/app
+
+COPY shard.yml ./
+COPY spec spec
+COPY src src
 
 # Build App
-RUN shards build --production
+RUN shards build --release --no-debug
 
 ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
 ENV SG_ENV production
 
 # Run the app binding on port 8080
 EXPOSE 8080
-ENTRYPOINT ["/src/bin/app"]
-CMD ["/src/bin/app", "-b", "0.0.0.0", "-p", "8080", "-w", "0"]
+CMD bin/app -w $(nproc) -b 0.0.0.0 -p 8080


### PR DESCRIPTION
Based on the continuous benchmarks https://tfb-status.techempower.com/
<img width="381" alt="image" src="https://user-images.githubusercontent.com/368013/48318979-dda83180-e65b-11e8-854b-3fd42cfbdaaf.png">

It doesn't look like enough workers were being launched as it should be competitive with Amber.
