### PR TITLE
ASPNET optimizations

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
@@ -150,6 +150,22 @@ namespace Benchmarks
                 app.UseSpanJson();
             }
 
+            // Fortunes endpoints
+            if (Scenarios.DbFortunesRaw)
+            {
+                app.UseFortunesRaw();
+            }
+
+            if (Scenarios.DbFortunesDapper)
+            {
+                app.UseFortunesDapper();
+            }
+
+            if (Scenarios.DbFortunesEf)
+            {
+                app.UseFortunesEf();
+            }
+
             // Single query endpoints
             if (Scenarios.DbSingleQueryRaw)
             {
@@ -196,22 +212,6 @@ namespace Benchmarks
             if (Scenarios.DbMultiUpdateEf)
             {
                 app.UseMultipleUpdatesEf();
-            }
-
-            // Fortunes endpoints
-            if (Scenarios.DbFortunesRaw)
-            {
-                app.UseFortunesRaw();
-            }
-
-            if (Scenarios.DbFortunesDapper)
-            {
-                app.UseFortunesDapper();
-            }
-
-            if (Scenarios.DbFortunesEf)
-            {
-                app.UseFortunesEf();
             }
 
             if (Scenarios.Any("Mvc"))

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
@@ -9,4 +9,4 @@ ENV COMPlus_ReadyToRun 0
 WORKDIR /app
 COPY --from=build /app/out ./
 
-ENTRYPOINT ["dotnet", "Benchmarks.dll", "scenarios=plaintext"]
+ENTRYPOINT ["dotnet", "Benchmarks.dll", "scenarios=json"]

--- a/frameworks/CSharp/aspnetcore/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore/benchmark_config.json
@@ -62,7 +62,6 @@
     },
     "mw": {
       "plaintext_url": "/plaintext",
-      "json_url": "/json",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Micro",
@@ -76,6 +75,24 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "ASP.NET Core, Middleware",
+      "notes": "",
+      "versus": "aspcore"
+    },
+    "mw-json": {
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Micro",
+      "database": "None",
+      "framework": "ASP.NET Core",
+      "language": "C#",
+      "orm": "Raw",
+      "platform": ".NET",
+      "flavor": "CoreCLR",
+      "webserver": "Kestrel",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "ASP.NET Core, Middleware, Json",
       "notes": "",
       "versus": "aspcore"
     },


### PR DESCRIPTION
Two perf improvements by reorganization middeware order:
- Push Fortunes scenarios up the stack such that other db scenarios don't impact routing as much
- Isolate the Json scenario as the plaintext endpoint would also impact overall performance

Benefits are around 2% locally. That could explain the differences between our standard results and the ones from VB (fortunes) and other Json formatters (Utf8Json/SpanJson)