### PR TITLE
Nginx plaintext bench

### DIFF
--- a/frameworks/C/nginx/README.md
+++ b/frameworks/C/nginx/README.md
@@ -1,0 +1,18 @@
+[![Nginx logo](https://nginx.org/nginx.png)](https://nginx.org)
+
+# Nginx Benchmarking Test
+
+This is the Nginx portion of a [benchmarking test suite](../) comparing a variety of web development platforms.
+
+
+
+## Infrastructure Software Version
+The tests were run with:
+
+* [nginx mainline version](http://nginx.org/)
+
+
+## Test URLs
+### Plaintext Test
+
+http://localhost/hello

--- a/frameworks/C/nginx/benchmark_config.json
+++ b/frameworks/C/nginx/benchmark_config.json
@@ -1,0 +1,25 @@
+{
+  "framework": "nginx",
+  "tests": [
+    {
+      "default": {
+        "plaintext_url": "/hello",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Platform",
+        "framework": "None",
+        "language": "C",
+        "flavor": "None",
+        "orm": "Raw",
+        "platform": "None",
+        "database": "none",
+        "webserver": "nginx",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Nginx",
+        "notes": "",
+        "versus": ""
+      }
+    }
+  ]
+}

--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -4,8 +4,6 @@ error_log stderr error;
 worker_rlimit_nofile 200000;
 daemon off;
 
-load_module modules/ngx_http_echo_module.so;
-
 events {
     worker_connections 16384;
 	multi_accept on;
@@ -35,7 +33,7 @@ http {
 
         location /hello {
           default_type text/plain;
-          echo "Hello, World!";
+          return 200 "Hello, World!";
         }
     }
 }

--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -1,0 +1,41 @@
+user www-data;
+worker_processes  auto;
+error_log stderr error;
+worker_rlimit_nofile 200000;
+daemon off;
+
+load_module modules/ngx_http_echo_module.so;
+
+events {
+    worker_connections 16384;
+	multi_accept on;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    access_log off;
+    server_tokens off;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        root /;
+        
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+
+        location /hello {
+          default_type text/plain;
+          echo "Hello, World!";
+        }
+    }
+}

--- a/frameworks/C/nginx/nginx.dockerfile
+++ b/frameworks/C/nginx/nginx.dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common wget > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/nginx-mainline
+#RUN add-apt-repository -y ppa:nginx/development
+RUN apt-get update -yqq
+RUN apt-get install -y nginx-light
+
+ADD ./ ./
+
+CMD nginx -c /nginx.conf

--- a/frameworks/C/nginx/nginx.dockerfile
+++ b/frameworks/C/nginx/nginx.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq && apt-get install -yqq software-properties-common wget > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/nginx-mainline
 #RUN add-apt-repository -y ppa:nginx/development
 RUN apt-get update -yqq


### PR DESCRIPTION
For check nginx max req/s 

Useful for:
- observe regressions that affect the frameworks using nginx.
- experiment with other configs.
- watch framework overhead.

Perhaps later add a bench for `njs` https://nginx.org/en/docs/njs/index.html.

When creating this bench, also noted that the docker is using nginx v1.10.x and not v1.15.x in all php frameworks.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
