### PR TITLE
Update php to Ubuntu18.10

### DIFF
--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 COPY ./ ./
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:16.04
 
 COPY ./ ./
 

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
First modern kernel.

But more important is that **ubuntu 18.10 use nginx 1.15.5, with 16.04 was nginx 1.10.3**.

Only h2o fail the build, so use again ubuntu 16.04.

And phalcon only to ubuntu 18.04 now.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
