### PR TITLE
Updated aspnetcore benchmarks to ASP.NET Core 2.2 

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -14,10 +14,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Dapper" Version="1.50.5" />
-    <PackageReference Include="MySqlConnector" Version="0.47.1" />
-    <PackageReference Include="Npgsql" Version="4.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
-    <PackageReference Include="SpanJson" Version="1.3.2" />
+    <PackageReference Include="MySqlConnector" Version="0.48.2" />
+    <PackageReference Include="Npgsql" Version="4.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="SpanJson" Version="1.3.3" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
@@ -96,7 +96,7 @@ namespace Benchmarks.Data
 
         }
 
-        public async Task<IEnumerable<Fortune>> LoadFortunesRows()
+        public async Task<List<Fortune>> LoadFortunesRows()
         {
             List<Fortune> result;
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
@@ -84,7 +84,7 @@ namespace Benchmarks.Data
         private static readonly Func<ApplicationDbContext, AsyncEnumerable<Fortune>> _fortunesQuery
             = EF.CompileAsyncQuery((ApplicationDbContext context) => context.Fortune);
 
-        public async Task<IEnumerable<Fortune>> LoadFortunesRows()
+        public async Task<List<Fortune>> LoadFortunesRows()
         {
             var result = await _fortunesQuery(_dbContext).ToListAsync();
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/IDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/IDb.cs
@@ -14,6 +14,6 @@ namespace Benchmarks.Data
 
         Task<World[]> LoadMultipleUpdatesRows(int count);
 
-        Task<IEnumerable<Fortune>> LoadFortunesRows();
+        Task<List<Fortune>> LoadFortunesRows();
     }
 }

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
@@ -137,7 +137,7 @@ namespace Benchmarks.Data
             }
         }
 
-        public async Task<IEnumerable<Fortune>> LoadFortunesRows()
+        public async Task<List<Fortune>> LoadFortunesRows()
         {
             var result = new List<Fortune>();
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Views/Fortunes/Fortunes.cshtml
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Views/Fortunes/Fortunes.cshtml
@@ -1,5 +1,5 @@
 ﻿@using Benchmarks.Data
-@model IEnumerable<Fortune>
+@model List<Fortune>
 <!DOCTYPE html>
 <html>
 <head><title>Fortunes</title></head>

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.2.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="Npgsql" Version="4.0.3" />
-    <PackageReference Include="MySqlConnector" Version="0.47.1" />
+    <PackageReference Include="Npgsql" Version="4.0.4" />
+    <PackageReference Include="MySqlConnector" Version="0.48.2" />
     <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="2.1.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="MySqlConnector" Version="0.48.2" />
-    <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="2.1.0-*" />
+    <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="2.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore/aspcore-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-my.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-dap-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-dap-my.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-spanjson.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-spanjson.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-utf8json.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-utf8json.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-mw.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app

--- a/frameworks/CSharp/aspnetcore/aspcore.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore.dockerfile
@@ -1,9 +1,9 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.2-sdk AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app


### PR DESCRIPTION
As usual, nothing worked as expected. It seems there were some breaking changes in Kestrel and LinuxTransport doesn't work on ASP.NET 2.2, so I've added a workaround. 
P.S. That made me very sad as my Saturday morning turned out as a usual day at work: nothing worked without some if statements. Three years with ASP.NET Core and every package update make me thrilled as the first time. 