### PR TITLE
Change h2o_mruby webserver

### DIFF
--- a/frameworks/Ruby/h2o_mruby/benchmark_config.json
+++ b/frameworks/Ruby/h2o_mruby/benchmark_config.json
@@ -12,7 +12,7 @@
       "language": "Ruby",
       "orm": "Raw",
       "platform": "None",
-      "webserver": "H2O",
+      "webserver": "h2o",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "h2o_mruby",


### PR DESCRIPTION
In the resuls page don't filter by h2o

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
