### PR TITLE
Try DB pool size = CPU count * 2 for Crystal

### DIFF
--- a/frameworks/Crystal/amber/amber.dockerfile
+++ b/frameworks/Crystal/amber/amber.dockerfile
@@ -9,7 +9,7 @@ COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
 ENV AMBER_ENV production
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
 RUN apt install -yqq libyaml-dev
 RUN shards build amber --release --no-debug

--- a/frameworks/Crystal/crystal/crystal-radix.dockerfile
+++ b/frameworks/Crystal/crystal/crystal-radix.dockerfile
@@ -8,7 +8,7 @@ COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
 RUN shards install
 RUN crystal build --release --no-debug server_radix.cr -o server_radix.out

--- a/frameworks/Crystal/crystal/crystal.dockerfile
+++ b/frameworks/Crystal/crystal/crystal.dockerfile
@@ -8,7 +8,7 @@ COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
 RUN shards install
 RUN crystal build --release --no-debug server.cr -o server.out

--- a/frameworks/Crystal/kemal/kemal.dockerfile
+++ b/frameworks/Crystal/kemal/kemal.dockerfile
@@ -9,7 +9,7 @@ COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
 ENV KEMAL_ENV production
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
 RUN shards install
 RUN crystal build --release --no-debug server-postgres.cr

--- a/frameworks/Crystal/raze/raze.dockerfile
+++ b/frameworks/Crystal/raze/raze.dockerfile
@@ -7,7 +7,7 @@ COPY raze.cr raze.cr
 COPY shard.lock shard.lock
 COPY shard.yml shard.yml
 
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
 RUN shards install
 RUN crystal build --release --no-debug raze.cr

--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -7,7 +7,7 @@ COPY src src
 # Build App
 RUN shards build --release --no-debug
 
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=8&max_pool_size=8&max_idle_pool_size=8
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 ENV SG_ENV production
 
 # Run the app binding on port 8080


### PR DESCRIPTION
Changing DB pool size again to gather more data in order to find a sweat spot for Crystal.

As #4189 has shown lowering DB pool size from 256 to 8 results in much better RPS. The latency however dropped. Let's  try setting DB pool size to `number of CPUs * 2` (56 on Citrine, close to the middle between 256 and 8).