### PR TITLE
Add new Kitura tests in the KITURA_NIO mode

### DIFF
--- a/frameworks/Swift/kitura/README.md
+++ b/frameworks/Swift/kitura/README.md
@@ -10,6 +10,7 @@ The benchmark is split up into multiple executable targets, demonstrating differ
 - `kitura-postgres-orm`: Equivalent implementation with Postgres and Swift-Kuery-ORM
 - `kitura-postgres-orm-codable`: Equivalent implementation with Postgres, using [Codable Routing together with Swift-Kuery-ORM](https://developer.ibm.com/swift/2018/03/01/introducing-swift-kuery-orm/)
 - `kitura-mongodb`: Implementation of database tests, using MongoDB with MongoKitten (no ORM)
+- `kitura-nio`: `kitura` implementations of Plaintext and JSON run on [Kitura-NIO](https://github.com/IBM-Swift/Kitura-NIO)
 
 There are additional variants for each of the above implementations, with the '-gcd' suffix: These are compiled from the same source, but use the Grand Central Dispatch threading model (used by default on macOS) instead of a direct epoll implementation (the default on Linux).
 

--- a/frameworks/Swift/kitura/README.md
+++ b/frameworks/Swift/kitura/README.md
@@ -11,6 +11,7 @@ The benchmark is split up into multiple executable targets, demonstrating differ
 - `kitura-postgres-orm-codable`: Equivalent implementation with Postgres, using [Codable Routing together with Swift-Kuery-ORM](https://developer.ibm.com/swift/2018/03/01/introducing-swift-kuery-orm/)
 - `kitura-mongodb`: Implementation of database tests, using MongoDB with MongoKitten (no ORM)
 - `kitura-nio`: `kitura` implementations of Plaintext and JSON run on [Kitura-NIO](https://github.com/IBM-Swift/Kitura-NIO)
+- `kitura-nio-postgres`: Testing `kitura` implementations of database tests using Postgres on [Kitura-NIO](https://github.com/IBM-Swift/Kitura-NIO)
 
 There are additional variants for each of the above implementations, with the '-gcd' suffix: These are compiled from the same source, but use the Grand Central Dispatch threading model (used by default on macOS) instead of a direct epoll implementation (the default on Linux).
 

--- a/frameworks/Swift/kitura/benchmark_config.json
+++ b/frameworks/Swift/kitura/benchmark_config.json
@@ -186,6 +186,23 @@
       "database_os": "Linux",
       "display_name": "Kitura",
       "notes": ""
+    },
+    "nio": {
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Micro",
+      "database": "none",
+      "framework": "Kitura",
+      "language": "Swift",
+      "orm": "none",
+      "platform": "Kitura",
+      "webserver": "Kitura",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Kitura",
+      "notes": ""
     }
   }]
 }

--- a/frameworks/Swift/kitura/benchmark_config.json
+++ b/frameworks/Swift/kitura/benchmark_config.json
@@ -203,6 +203,25 @@
       "database_os": "Linux",
       "display_name": "Kitura",
       "notes": ""
+    },
+    "nio-postgres": {
+      "db_url": "/db",
+      "query_url": "/queriesParallel?queries=",
+      "fortune_url": "/fortunes",
+      "update_url": "/updatesParallel?queries=",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Micro",
+      "database": "Postgres",
+      "framework": "Kitura",
+      "language": "Swift",
+      "orm": "Raw",
+      "platform": "Kitura",
+      "webserver": "Kitura",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Kitura",
+      "notes": ""
     }
   }]
 }

--- a/frameworks/Swift/kitura/kitura-nio-postgres.dockerfile
+++ b/frameworks/Swift/kitura/kitura-nio-postgres.dockerfile
@@ -1,0 +1,8 @@
+FROM swift:4.1
+
+ADD ./ /kitura
+WORKDIR /kitura
+RUN apt update -yqq && apt install -yqq libpq-dev
+ENV KITURA_NIO=1
+RUN swift build -c release
+CMD .build/release/TechEmpowerPostgres

--- a/frameworks/Swift/kitura/kitura-nio.dockerfile
+++ b/frameworks/Swift/kitura/kitura-nio.dockerfile
@@ -1,0 +1,8 @@
+FROM swift:4.1
+
+ADD ./ /kitura
+WORKDIR /kitura
+RUN apt update -yqq && apt install -yqq libpq-dev
+ENV KITURA_NIO=1
+RUN swift build -c release
+CMD .build/release/TechEmpower


### PR DESCRIPTION
Starting version 2.5, Kitura may be optionally run using a new NIO mode. In this mode, the networking package is switched to [Kitura-NIO](https://github.com/IBM-Swift/Kitura-NIO) instead of the default [Kitura-net](https://github.com/IBM-Swift/Kitura-net). `Kitura-NIO` is based on [swift-nio](https://github.com/apple/swift-nio).