### PR TITLE
Enable benchmark tests for libhttpserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
      - 'TESTDIR="C++/cppcms C++/cpoll_cppsp C++/poco"'
      - "TESTDIR=C++/ffead-cpp"
      - "TESTDIR=C++/cutelyst"
+     - "TESTDIR=C++/libhttpserver"
      - "TESTDIR=C++/silicon"
      - "TESTDIR=C++/treefrog"
      - "TESTDIR=C++/ulib"

--- a/frameworks/C++/libhttpserver/README.md
+++ b/frameworks/C++/libhttpserver/README.md
@@ -1,0 +1,31 @@
+# libhttpserver
+Only the plaintext test is implemented.
+
+## What is libhttpserver
+libhttpserver is a Free High-Performance library aimed at rapid development of embedded C++ servers:
+
+- It is designed and tuned to handle extremely high loads (tested with > 10k connections).
+- It uses modern C++ as the primary development language in order to achieve the first goal.
+- It is designed with REST as a primary design principle
+
+It is available under open source LGPLv2 license.
+
+libhttpserver lives here: https://github.com/etr/libhttpserver
+
+# libhttpserver Benchmarking Test
+
+### Test Type Implementation Source Code
+
+* [PLAINTEXT](frameworks/C++/libhttpserver/benchmark.cpp)
+
+## Important Libraries
+libhttpserver uses libmicrohttpd as base library:
+* [Software](https://www.gnu.org/software/libmicrohttpd/)
+
+## Test URLs
+### PLAINTEXT
+
+http://localhost:8080/plaintext
+
+## Links
+[Homepage](https://github.com/etr/libhttpserver)

--- a/frameworks/C++/libhttpserver/README.md
+++ b/frameworks/C++/libhttpserver/README.md
@@ -16,11 +16,11 @@ libhttpserver lives here: https://github.com/etr/libhttpserver
 
 ### Test Type Implementation Source Code
 
-* [PLAINTEXT](frameworks/C++/libhttpserver/benchmark.cpp)
+* [PLAINTEXT](benchmark.cpp)
 
 ## Important Libraries
 libhttpserver uses libmicrohttpd as base library:
-* [Software](https://www.gnu.org/software/libmicrohttpd/)
+* [libmicrohttpd](https://www.gnu.org/software/libmicrohttpd/)
 
 ## Test URLs
 ### PLAINTEXT

--- a/frameworks/C++/libhttpserver/benchmark.cpp
+++ b/frameworks/C++/libhttpserver/benchmark.cpp
@@ -1,0 +1,33 @@
+#include <httpserver.hpp>
+#include <cstdlib>
+
+#define PATH "/plaintext"
+#define BODY "Hello, World!"
+
+using namespace httpserver;
+
+class hello_world_resource : public http_resource {
+	public:
+        const http_response render(const http_request&);
+};
+
+const http_response hello_world_resource::render(const http_request& req)
+{
+    http_response_builder hrb(BODY, 200);
+    hrb.with_header("Server", "libhttpserver");
+    return hrb.string_response();
+}
+
+int main(int argc, char** argv)
+{
+    webserver ws = create_webserver(atoi(argv[1]))
+        .start_method(http::http_utils::INTERNAL_SELECT)
+        .max_threads(atoi(argv[2]));
+
+    hello_world_resource hwr;
+    ws.register_resource(PATH, &hwr, false);
+
+    ws.start(true);
+
+    return 0;
+}

--- a/frameworks/C++/libhttpserver/benchmark_config.json
+++ b/frameworks/C++/libhttpserver/benchmark_config.json
@@ -1,0 +1,25 @@
+{
+  "framework": "libhttpserver",
+  "tests": [
+    {
+      "default": {
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Fullstack",
+        "database": "None",
+        "framework": "libhttpserver",
+        "language": "C++",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "None",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "libhttpserver",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/C++/libhttpserver/libhttpserver.dockerfile
+++ b/frameworks/C++/libhttpserver/libhttpserver.dockerfile
@@ -1,0 +1,24 @@
+FROM buildpack-deps:xenial
+
+RUN apt update -yqq && apt install -yqq software-properties-common unzip cmake
+
+ENV LHT_HOME /libhttpserver
+
+WORKDIR ${LHT_HOME}
+
+ENV LIBMICROHTTPD_VERSION 0.9.59
+ENV LIBHTTPSERVER_VERSION 0.16.0
+
+RUN curl https://s3.amazonaws.com/libhttpserver/libmicrohttpd_releases/libmicrohttpd-${LIBMICROHTTPD_VERSION}.tar.gz -o libmicrohttpd-${LIBMICROHTTPD_VERSION}.tar.gz
+RUN tar -xvzf libmicrohttpd-${LIBMICROHTTPD_VERSION}.tar.gz
+RUN cd libmicrohttpd-${LIBMICROHTTPD_VERSION} && ./configure --disable-examples && make && make install
+RUN curl -L https://github.com/etr/libhttpserver/archive/${LIBHTTPSERVER_VERSION}.tar.gz -o libhttpserver-${LIBHTTPSERVER_VERSION}.tar.gz
+RUN tar -xvzf libhttpserver-${LIBHTTPSERVER_VERSION}.tar.gz
+RUN cd libhttpserver-${LIBHTTPSERVER_VERSION} && ./bootstrap && mkdir build && cd build && ../configure --enable-fastopen && make && make install
+
+COPY benchmark.cpp benchmark.cpp
+
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+RUN g++ -O3 -o benchmark benchmark.cpp -lhttpserver -L/usr/local/lib
+CMD ./benchmark 8080 $(nproc)


### PR DESCRIPTION
This PR adds benchmark tests for the [libhttpserver](https://github.com/etr/libhttpserver) framework.