### PR TITLE
rename config parameters

### DIFF
--- a/frameworks/Lua/octopus/app/config.lua
+++ b/frameworks/Lua/octopus/app/config.lua
@@ -1,6 +1,6 @@
 local config = {} -- extension configuration
 
-config.locations = {
+config.location = {
 	{name = "/plaintext", script = "PlaintextController.lua"},
 	{name = "/json", script = "JsonSerializationController.lua"},
 	{name = "/db", script = "SingleQueryController.lua"},
@@ -9,7 +9,7 @@ config.locations = {
 	{name = "/update", script = "UpdateController.lua"},
 }
 
-config.types = {
+config.type = {
 	"types.lua"
 }
 


### PR DESCRIPTION
I changed some names of the configurations, if some build breaks, this will fix it
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
