### PR TITLE
Nginx multiaccept off

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -5,7 +5,7 @@ worker_rlimit_nofile 200000;
 
 events {
     worker_connections 16384;
-	multi_accept on;
+	multi_accept off;
 	 
 }
 

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -2,10 +2,11 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 worker_rlimit_nofile 200000;
+pcre_jit on;
 
 events {
     worker_connections 16384;
-	multi_accept on;
+	multi_accept off;
 	 
 }
 

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -2,10 +2,11 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 worker_rlimit_nofile 200000;
+pcre_jit on;
 
 events {
     worker_connections 16384;
-	multi_accept on;
+	multi_accept off;
 	 
 }
 

--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -6,7 +6,7 @@ daemon off;
 
 events {
     worker_connections 16384;
-	multi_accept on;	 
+	multi_accept off;	 
 }
 
 http {
@@ -17,7 +17,7 @@ http {
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
-    keepalive_timeout 65;
+    keepalive_timeout 65s;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;


### PR DESCRIPTION
## Nginx multi_accept off ##
After change nginx conf #4292 , to use the default `multi_accept off;` in the only nginx plaintext benchmark, obtained a **gain of +300K req/s**.

But the best think was **how well scaled**:

| Nginx | 256 | 1,024 | 4,096 | 16,384
|---------| ------: |------: |------:| -------: 
|Multiaccept on | 2,110,449 | 2,049,439 | 1,896,357 | 1,407,945
|Multiaccept off | 2,263,465 | 2,229,436 | 2,274,733 | 2,404,463

Curiously the latency was more than doubled. But `latency != scalability`.
## PHP with Nginx ##
We see the same scale pattern problem in all the php benchmarks that use nginx.
Perhaps it's only the plaintext benchmark that benefit from this change.
So **first we change to php, php-ngx and kumbiaphp, and we will check the numbers**.
If the numbers are better, later we will include the change to the rest of php framewoks.

If the problem was that the load was not distributed among the worker processes, that affect also the upstream keepalive in php. Later we will optimize the keepalive in php.

Unfortunately all optimized nginx.conf for php, that I have seen in internet, recommended `multi_accept on`. The numbers will talk.

**Also included `pcre_jit on;` in the php nginx.conf .**





