### PR TITLE
TreeFrog: Minor optimalizations

### DIFF
--- a/frameworks/C++/treefrog/controllers/jsoncontroller.cpp
+++ b/frameworks/C++/treefrog/controllers/jsoncontroller.cpp
@@ -9,7 +9,7 @@ void JsonController::index()
 void JsonController::json()
 {
     QVariantMap obj;
-    obj["message"] = "Hello, World!";
+    obj[QStringLiteral("message")] = "Hello, World!";
     renderJson(obj);
 }
 

--- a/frameworks/C++/treefrog/models/fortune.cpp
+++ b/frameworks/C++/treefrog/models/fortune.cpp
@@ -9,7 +9,7 @@ Fortune::Fortune()
 }
 
 Fortune::Fortune(const Fortune &other)
-    : TAbstractModel(), d(new FortuneObject(*other.d))
+    : TAbstractModel(), d(other.d)
 { }
 
 Fortune::Fortune(const FortuneObject &object)

--- a/frameworks/C++/treefrog/models/mngfortune.cpp
+++ b/frameworks/C++/treefrog/models/mngfortune.cpp
@@ -9,7 +9,7 @@ MngFortune::MngFortune()
 }
 
 MngFortune::MngFortune(const MngFortune &other)
-    : TAbstractModel(), d(new MngFortuneObject(*other.d))
+    : TAbstractModel(), d(other.d)
 { }
 
 MngFortune::MngFortune(const MngFortuneObject &object)

--- a/frameworks/C++/treefrog/models/mngworld.cpp
+++ b/frameworks/C++/treefrog/models/mngworld.cpp
@@ -10,7 +10,7 @@ MngWorld::MngWorld()
 }
 
 MngWorld::MngWorld(const MngWorld &other)
-    : TAbstractModel(), d(new MngWorldObject(*other.d))
+    : TAbstractModel(), d(other.d)
 { }
 
 MngWorld::MngWorld(const MngWorldObject &object)

--- a/frameworks/C++/treefrog/models/mongoobjects/mngfortuneobject.h
+++ b/frameworks/C++/treefrog/models/mongoobjects/mngfortuneobject.h
@@ -18,7 +18,7 @@ public:
         Message,
     };
 
-    virtual QString collectionName() const { return "fortune"; }
+    virtual QString collectionName() const { return QStringLiteral("fortune"); }
     virtual QString objectId() const { return _id; }
     virtual QString &objectId() { return _id; }
 

--- a/frameworks/C++/treefrog/models/mongoobjects/mngworldobject.h
+++ b/frameworks/C++/treefrog/models/mongoobjects/mngworldobject.h
@@ -18,7 +18,7 @@ public:
         RandomNumber,
     };
 
-    virtual QString collectionName() const { return "world"; }
+    virtual QString collectionName() const { return QStringLiteral("world"); }
     virtual QString objectId() const { return _id; }
     virtual QString &objectId() { return _id; }
 

--- a/frameworks/C++/treefrog/models/sqlobjects/fortuneobject.h
+++ b/frameworks/C++/treefrog/models/sqlobjects/fortuneobject.h
@@ -18,7 +18,7 @@ public:
 
     int primaryKeyIndex() const { return Id; }
     int autoValueIndex() const { return Id; }
-    QString tableName() const { return QLatin1String("Fortune"); }
+    QString tableName() const { return QStringLiteral("Fortune"); }
 
 private:    /*** Don't modify below this line ***/
     Q_OBJECT

--- a/frameworks/C++/treefrog/models/sqlobjects/worldobject.h
+++ b/frameworks/C++/treefrog/models/sqlobjects/worldobject.h
@@ -18,7 +18,7 @@ public:
 
     int primaryKeyIndex() const { return Id; }
     int autoValueIndex() const { return Id; }
-    QString tableName() const { return QLatin1String("World"); }
+    QString tableName() const { return QStringLiteral("World"); }
 
 private:    /*** Don't modify below this line ***/
     Q_OBJECT

--- a/frameworks/C++/treefrog/models/world.cpp
+++ b/frameworks/C++/treefrog/models/world.cpp
@@ -10,7 +10,7 @@ World::World()
 }
 
 World::World(const World &other)
-    : TAbstractModel(), d(new WorldObject(*other.d))
+    : TAbstractModel(), d(other.d)
 { }
 
 World::World(const WorldObject &object)


### PR DESCRIPTION
Minor optimalizations:
* avoid allocation in model copy contructor
* use QStringLiteral where possible
