### PR TITLE
Fix process count error.

### DIFF
--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -12,7 +12,7 @@ function get_processor_cores_number() {
 }
 
 $http_worker = new Worker('http://0.0.0.0:8080');
-$http_worker->count = ($count = get_processor_cores_number()) ? $count : 40;
+$http_worker->count = ($count = get_processor_cores_number()) ? $count : 64;
 $http_worker->onWorkerStart = function()
 {
   global $pdo;

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -12,7 +12,7 @@ function get_processor_cores_number() {
 }
 
 $http_worker = new Worker('http://0.0.0.0:8080');
-$http_worker->count = (get_processor_cores_number() * 2) || 64;
+$http_worker->count = ($count = get_processor_cores_number()) ? $count : 40;
 $http_worker->onWorkerStart = function()
 {
   global $pdo;


### PR DESCRIPTION
```php
$http_worker->count = (get_processor_cores_number() * 2) || 64;
```
The value of `$http_worker->count` will be `true` and only one process will be created which is not we want.