### PR TITLE
Faster Fastcgi in nginx

### DIFF
--- a/frameworks/PHP/kumbiaphp/README.md
+++ b/frameworks/PHP/kumbiaphp/README.md
@@ -1,8 +1,8 @@
-[![KumbiaPHP logo](https://rawgit.com/kumbiaphp/kumbiaphp/1.0/default/public/img/kumbiaphp.svg)](https://github.com/KumbiaPHP/KumbiaPHP) 
+[![KumbiaPHP logo](https://rawgit.com/kumbiaphp/kumbiaphp/master/default/public/img/kumbiaphp.svg)](https://github.com/KumbiaPHP/KumbiaPHP) 
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/KumbiaPHP/KumbiaPHP/badges/quality-score.png?b=1.0)](https://scrutinizer-ci.com/g/KumbiaPHP/KumbiaPHP/?branch=1.0)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/KumbiaPHP/KumbiaPHP/badges/quality-score.png)](https://scrutinizer-ci.com/g/KumbiaPHP/KumbiaPHP/?branch=1.0)
 [![Code Climate](https://codeclimate.com/github/KumbiaPHP/KumbiaPHP/badges/gpa.svg)](https://codeclimate.com/github/KumbiaPHP/KumbiaPHP)
-![PHP7 ready](https://rawgit.com/kumbiaphp/kumbiaphp/1.0/default/public/img/php7.svg)
+![PHP7 ready](https://rawgit.com/kumbiaphp/kumbiaphp/master/default/public/img/php7.svg)
 
 # KumbiaPHP Benchmarking Test
 

--- a/frameworks/PHP/kumbiaphp/bench/public/index.php
+++ b/frameworks/PHP/kumbiaphp/bench/public/index.php
@@ -79,13 +79,13 @@ const PUBLIC_PATH = '/';
  /**
   * Obtiene la url usando PATH_INFO.
   */
-//$url = empty($_SERVER['PATH_INFO']) ? '/' : $_SERVER['PATH_INFO'];
+$url = $_SERVER['PATH_INFO'];
 
  /**
   * Obtiene la url usando $_GET['_url']
   * Cambiar también en el .htaccess.
   */
- $url = $_GET['_url'] ?? '/';
+ //$url = $_GET['_url'] ?? '/';
 
 /**
  * Carga el gestor de arranque

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -39,7 +39,7 @@ http {
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;
-        keepalive 50;
+        keepalive 40;
     }
 
     server {

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -50,16 +50,16 @@ http {
         index  index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?_url=$uri&$args;
-        }
-
-        location ~ \.php$ {
-             
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            include        /etc/nginx/fastcgi_params;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/index.php;
+            fastcgi_param  PATH_INFO          $uri;
+            fastcgi_param  QUERY_STRING       $query_string;
+            #fastcgi_param  QUERY_STRING      _url=$uri&$query_string;
+            fastcgi_param  REQUEST_METHOD     $request_method;
+            fastcgi_param  CONTENT_TYPE       $content_type;
+            fastcgi_param  CONTENT_LENGTH     $content_length;
+            #include        /etc/nginx/fastcgi_params;
         }
     }
 }


### PR DESCRIPTION
# Normal config for applications with php files
It is very easy, using try_files, but with poor performance. The one that you see everywhere.
And also used in almost all php frameworks.

```
location / {
            try_files $uri $uri/ /index.php?_url=$uri&$args;
            # 1 stat() $uri
            # 2 stat() $uri/
            # 3 redirect  index.php....
            # 4 check locations
            # 5 check regexp locations
        }

location ~ \.php$ {
             
            fastcgi_pass   fastcgi_backend;
            fastcgi_keep_conn on;
            fastcgi_index  index.php;
            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
            include        /etc/nginx/fastcgi_params;
}

```
--------------------------------------

# Most php frameworks use the front controller pattern
## Faster and more segure
No regexp only execute index.php (front controller) no other files.
No fastcgi_index after /.

```
location / {
            try_files $uri $uri/ /index.php?_url=$uri&$args;
            # 1 stat() $uri
            # 2 stat() $uri/
            # 3 redirect  index.php....
            # 4 check locations
        }

location = /index.php {
             
            fastcgi_pass   fastcgi_backend;
            fastcgi_keep_conn on;
            #fastcgi_index  index.php;
            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
            include        /etc/nginx/fastcgi_params;
}

```
## Better alternative
Only check for $uri (file) and using named location @php.
In this way the front controller file can be anywhere, outside of the root.
Advert: if you leaf the index.php in the root, will be dowloaded not executed.
```
location / {
            try_files $uri @php;
            # 1 stat() $uri
            # 2 redirect  @php
            
        }

location @php {
             
            fastcgi_pass   fastcgi_backend;
            fastcgi_keep_conn on;
            #fastcgi_index  index.php;
            fastcgi_param  SCRIPT_FILENAME  /path/to/index.php;
            fastcgi_param  PATH_INFO        $uri;
            fastcgi_param  QUERY_STRING     _url=$uri&$query_string;
            include        /etc/nginx/fastcgi_params;
}
```
-------------------------


## Fastest
The one that I use normally, and I have not seen elsewhere.
Normally a lot of apps don't use static files, so it is optional.
Also most websites use cdn for static files.

No stat() that are very expensive and use filesystem, no redirect, no regexp
No index.php

```
location / {
            fastcgi_pass   fastcgi_backend;
            fastcgi_keep_conn on;
            fastcgi_param  SCRIPT_FILENAME    $document_root/index.php;
            fastcgi_param  PATH_INFO          $uri;
            fastcgi_param  QUERY_STRING       $query_string;
            #fastcgi_param  QUERY_STRING      _url=$uri&$query_string;
            include        /etc/nginx/fastcgi_params;
        }

location ^~ /static/ {
            sendfile on;
            tcp_nopush on;
            # Your stuff: cache, log,....
        }

```