### PR TITLE
 Rust/rocket: update rocket version to latest

### DIFF
--- a/frameworks/Rust/rocket/Cargo.toml
+++ b/frameworks/Rust/rocket/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Marcelo Barbosa <mbarbosa@gmail.com>"]
 diesel = { version = "1.3.2", features = ["postgres", "r2d2"] }
 rand = "0.5.5"
 rocket = "0.4.0"
-rocket_codegen = "0.4.0"
 serde = "1.0.71"
 serde_json = "1.0.24"
 serde_derive = "1.0.71"

--- a/frameworks/Rust/rocket/Cargo.toml
+++ b/frameworks/Rust/rocket/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Marcelo Barbosa <mbarbosa@gmail.com>"]
 [dependencies]
 diesel = { version = "1.3.2", features = ["postgres", "r2d2"] }
 rand = "0.5.5"
-rocket = "0.3.15"
-rocket_codegen = "0.3.15"
+rocket = "0.4.0"
+rocket_codegen = "0.4.0"
 serde = "1.0.71"
 serde_json = "1.0.24"
 serde_derive = "1.0.71"

--- a/frameworks/Rust/rocket/src/main.rs
+++ b/frameworks/Rust/rocket/src/main.rs
@@ -16,11 +16,6 @@ mod db;
 mod models;
 mod schema;
 
-#[derive(FromForm)]
-struct QueryString {
-    q: u16,
-}
-
 fn random_number() -> i32 {
     rand::thread_rng().gen_range(1, 10_001)
 }
@@ -52,16 +47,20 @@ fn db(conn: db::DbConn) -> Json<models::World> {
 
 #[get("/queries")]
 fn queries_empty(conn: db::DbConn) -> Json<Vec<models::World>> {
-    queries(conn, QueryString { q: 1 })
+    queries(conn, 1)
 }
 
-#[get("/queries?<qs>")]
-fn queries(conn: db::DbConn, qs: QueryString) -> Json<Vec<models::World>> {
+#[get("/queries?<q>")]
+fn queries(conn: db::DbConn, q: u16) -> Json<Vec<models::World>> {
     use schema::world::dsl::*;
 
-    let mut q = qs.q;
-    if q == 0 { q = 1 }
-    if q > 500 { q = 500; }
+    let q = if q == 0 {
+        1
+    } else if q > 500 {
+        500
+    } else {
+        q
+    };
 
     let mut results = Vec::with_capacity(q as usize);
 
@@ -96,16 +95,20 @@ fn fortunes(conn: db::DbConn) -> Template {
 
 #[get("/updates")]
 fn updates_empty(conn: db::DbConn) -> Json<Vec<models::World>> {
-    updates(conn, QueryString { q: 1 })
+    updates(conn, 1)
 }
 
-#[get("/updates?<qs>")]
-fn updates(conn: db::DbConn, qs: QueryString) -> Json<Vec<models::World>> {
+#[get("/updates?<q>")]
+fn updates(conn: db::DbConn, q: u16) -> Json<Vec<models::World>> {
     use schema::world::dsl::*;
 
-    let mut q = qs.q;
-    if q == 0 { q = 1 }
-    if q > 500 { q = 500; }
+    let q = if q == 0 {
+        1
+    } else if q > 500 {
+        500
+    } else {
+        q
+    };
 
     let mut results = Vec::with_capacity(q as usize);
 

--- a/frameworks/Rust/rocket/src/main.rs
+++ b/frameworks/Rust/rocket/src/main.rs
@@ -1,8 +1,7 @@
-#![feature(plugin, custom_derive)]
-#![plugin(rocket_codegen)]
+#![feature(proc_macro_hygiene, decl_macro)]
 
 extern crate rand;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 extern crate rocket_contrib;
 #[macro_use] extern crate diesel;
 #[macro_use] extern crate serde_derive;

--- a/frameworks/Rust/rocket/src/main.rs
+++ b/frameworks/Rust/rocket/src/main.rs
@@ -9,8 +9,8 @@ extern crate rocket_contrib;
 use diesel::prelude::*;
 use diesel::result::Error;
 use rand::Rng;
-use rocket_contrib::Json;
-use rocket_contrib::Template;
+use rocket_contrib::json::Json;
+use rocket_contrib::templates::Template;
 
 mod db;
 mod models;


### PR DESCRIPTION
Can't build it anymore with the old version:
```
$ cargo build --release
    Updating crates.io index
error: failed to select a version for the requirement `ring = "^0.11.0"`
  candidate versions found which didn't match: 0.14.0, 0.13.5, 0.8.1
  location searched: crates.io index
required by package `cookie v0.9.1`
    ... which is depended on by `rocket v0.3.15`
    ... which is depended on by `rocket v0.1.0`
```

This PR updates `rocket` to the latest version and makes the project compile again.