### PR TITLE
Optimize keepalive

### DIFF
--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -19,6 +19,8 @@ http {
     tcp_nopush off; #default
     tcp_nodelay on; #default
     keepalive_timeout 65;
+    keepalive_disable none; #default msie6
+    keepalive_requests 300000; #default 100
 
     server {
         listen       8080 bind reuseport;

--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -18,6 +18,8 @@ http {
     tcp_nopush off;
     tcp_nodelay on;
     keepalive_timeout 65s;
+    keepalive_disable none;
+    keepalive_requests 300000;
 
     php_ini_path /deploy/conf/php.ini;
 


### PR DESCRIPTION
Most keepalive libs use only the timeout and unlimited requests.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
