### PR TITLE
Join update and install

### DIFF
--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -23,7 +23,7 @@ http {
     keepalive_requests 300000; #default 100
 
     server {
-        listen       8080 bind reuseport;
+        listen       8080 default_server bind reuseport;
 
         root /;
         

--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq git unzip php7.2 php7.2-common php7.2-cli php7.2-dev php7.2-mbstring composer curl build-essential > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq git unzip php7.2 php7.2-common php7.2-cli php7.2-dev php7.2-mbstring composer curl build-essential > /dev/null
 
 # An extension is required!
 # We deal with concurrencies over 1k, which stream_select doesn't support.

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/clancats/clancats.dockerfile
+++ b/frameworks/PHP/clancats/clancats.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter-hhvm.dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-t
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/cygnite/cygnite.dockerfile
+++ b/frameworks/PHP/cygnite/cygnite.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.0-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq > /dev/null
-RUN apt-get install -yqq nginx git unzip curl php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-opcache > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip curl php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-opcache > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/hhvm/hhvm.dockerfile
+++ b/frameworks/PHP/hhvm/hhvm.dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-t
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.3-mongodb  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.3-mongodb  > /dev/null
 
 ADD ./ /hhvm_app
 WORKDIR /hhvm_app

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/laravel/laravel-swoole.dockerfile
+++ b/frameworks/PHP/laravel/laravel-swoole.dockerfile
@@ -28,8 +28,8 @@ RUN echo "APP_SWOOLE=true" >> .env
 # An additional benefit of this method is that the correct version of composer will be used for the environment and version of the php system in the docker image
 RUN deploy/swoole/install-composer.sh
 
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq git unzip > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq git unzip > /dev/null
 COPY deploy/swoole/composer* ./
 RUN php composer.phar install -a --no-dev --quiet
 

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 RUN apt-get install -yqq php7.3-mbstring php7.3-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null

--- a/frameworks/PHP/limonade/limonade.dockerfile
+++ b/frameworks/PHP/limonade/limonade.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/lithium/lithium.dockerfile
+++ b/frameworks/PHP/lithium/lithium.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/lumen/lumen-swoole.dockerfile
+++ b/frameworks/PHP/lumen/lumen-swoole.dockerfile
@@ -25,8 +25,8 @@ RUN chmod -R 777 /lumen
 # An additional benefit of this method is that the correct version of composer will be used for the environment and version of the php system in the docker image
 RUN deploy/swoole/install-composer.sh
 
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq git unzip > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq git unzip > /dev/null
 COPY deploy/swoole/composer* ./
 RUN php composer.phar install -a --no-dev --quiet
 

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 RUN apt-get install -yqq php7.3-mbstring php7.3-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.2/fpm/
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.2 php7.2-common php7.2-cli php7.2-fpm php7.2-mysql php7.2-mongodb  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
 ### Install php
 
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/php/php-ngx.dockerfile
+++ b/frameworks/PHP/php/php-ngx.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq wget git unzip libxml2-dev cmake make \
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq wget git unzip libxml2-dev cmake make \
                     zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
                     php7.3 php7.3-common php7.3-dev libphp7.3-embed php7.3-mysql nginx > /dev/null
 

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt update -yqq
-RUN apt install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-pgsql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-pgsql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/5.6/fpm/
 RUN sed -i "s|listen = /run/php/php7.3-fpm.sock|listen = /run/php/php5.6-fpm.sock|g" /etc/php/5.6/fpm/php-fpm.conf

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 COPY deploy/conf/* /etc/php/7.3/fpm/
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/phreeze/phreeze.dockerfile
+++ b/frameworks/PHP/phreeze/phreeze.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/silex/silex-raw.dockerfile
+++ b/frameworks/PHP/silex/silex-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/silex/silex.dockerfile
+++ b/frameworks/PHP/silex/silex.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/slim/slim-hhvm.dockerfile
+++ b/frameworks/PHP/slim/slim-hhvm.dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-t
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq hhvm nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/slim/slim-php5.dockerfile
+++ b/frameworks/PHP/slim/slim-php5.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php5.6 php5.6-common php5.6-cli php5.6-fpm php5.6-mysql php5.6-xml php5.6-mbstring php5.6-mcrypt  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 RUN apt-get install php7.3-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 RUN apt-get install php7.3-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/yii2/yii2-hhvm.dockerfile
+++ b/frameworks/PHP/yii2/yii2-hhvm.dockerfile
@@ -6,8 +6,8 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common apt-t
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xB4112585D386EB94
 RUN add-apt-repository https://dl.hhvm.com/ubuntu
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.3-mongodb  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq hhvm nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-xml php7.3-mbstring php7.3-mongodb  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-mbstring  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-mbstring  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -4,8 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq  > /dev/null
-RUN apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 RUN apt-get install -yqq php7.3-xml php7.3-mbstring  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null


### PR DESCRIPTION
To solve docker cache problems.
Now each time we change the install will force an update.

Example problem:
We changed to install php 7.3 in php-ngx, but the update was cached.
https://tfb-status.techempower.com/unzip/results.2019-01-18-12-54-08-988.zip/results/20190115140632/php-ngx/build/php-ngx.log
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
