### PR TITLE
update facil.io version

### DIFF
--- a/frameworks/C/facil.io/facil.io.dockerfile
+++ b/frameworks/C/facil.io/facil.io.dockerfile
@@ -5,8 +5,9 @@ COPY ./ ./
 # using a common installation script will allow implementation variations (in future updates)
 RUN ./setup-common.sh
 
-# we don't need more than 32K concurrent connections
-ENV CFLAGS="-DFIO_MAX_SOCK_CAPACITY=65536"
+# 1. we don't need more than 32K concurrent connections
+# 2. facil.io hash maps are resistant to hash flooding, we can use a faster hashing function.
+ENV CFLAGS="-DFIO_MAX_SOCK_CAPACITY=65536 -DFIO_USE_RISKY_HASH=1"
 
 # compile test
 RUN cp -f bench_app.c facil_app/src/app.c

--- a/frameworks/C/facil.io/setup-common.sh
+++ b/frameworks/C/facil.io/setup-common.sh
@@ -17,8 +17,8 @@ if [[ (! -d facil_app) ||  (-n "${FIO_EDGE}") ]] ; then
 	# Setting FIO_EDGE will test against the master branch on the development machine. i.e.:
 	#     $ FIO_EDGE=1 tfb --mode verify --test facil.io
 	if [[ -z "${FIO_EDGE}" ]]; then
-		echo "INFO: loading facil.io version 0.7.0.beta3"
-	  FIO_URL="https://api.github.com/repos/boazsegev/facil.io/tarball/0.7.0.beta3"
+		echo "INFO: loading facil.io version 0.7.0.beta7"
+	  FIO_URL="https://api.github.com/repos/boazsegev/facil.io/tarball/0.7.0.beta7"
 	else
 		echo "INFO: development mode detected, loading facil.io from master."
 		FIO_URL="https://github.com/boazsegev/facil.io/archive/master.tar.gz"


### PR DESCRIPTION
facil.io version 0.7.0.beta7 is probably the last beta version before an 0.7.0 version release.

It includes changes to the hash map data structure, added security features, and numerous fixes, such as unaligned memory access fix for SipHash.

These changes could effect performance (some for the better and some might negatively impact performance in favor of security or memory consumption).

Thanks!
   Bo.