### PR TITLE
Faster FCGI config

### DIFF
--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -28,14 +28,12 @@ http {
     index index.php;
 
     location / {
-      try_files $uri $uri/ /index.php?$uri&$args;
+      try_files $uri /index.php?$uri&$args;
     }
 
-    location ~ \.php$ {
-       
+    location = /index.php {
       fastcgi_pass fastcgi_backend;
       fastcgi_keep_conn on;
-      fastcgi_index index.php;
       fastcgi_param SCRIPT_FILENAME  $document_root$fastcgi_script_name;
       include /etc/nginx/fastcgi_params;
     }

--- a/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-hhvm.conf
@@ -28,14 +28,12 @@ http {
     index index.php;
 
     location / {
-      try_files $uri $uri/ /index.php?$uri&$args;
+      try_files $uri /index.php?$uri&$args;
     }
 
-    location ~ \.php$ {
-       
+    location = /index.php {
       fastcgi_pass fastcgi_backend;
       fastcgi_keep_conn on;
-      fastcgi_index index.php;
       fastcgi_param SCRIPT_FILENAME  $document_root$fastcgi_script_name;
       include /etc/nginx/fastcgi_params;
     }

--- a/frameworks/PHP/cygnite/deploy/nginx.conf
+++ b/frameworks/PHP/cygnite/deploy/nginx.conf
@@ -50,14 +50,12 @@ http {
         index  index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?$uri&$args;
+            try_files $uri /index.php?$uri&$args;
         }
 
-        location ~ \.php$ {
-             
+        location = /index.php {
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /etc/nginx/fastcgi_params;
         }

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -50,14 +50,12 @@ http {
         index  index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?$uri&$args;
+            try_files $uri /index.php?$uri&$args;
         }
 
-        location ~ \.php$ {
-             
+        location = /index.php {
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /etc/nginx/fastcgi_params;
         }

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -50,14 +50,12 @@ http {
         index  index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?$uri&$args;
+            try_files $uri /index.php?$uri&$args;
         }
 
-        location ~ \.php$ {
-             
+        location = /index.php {
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /etc/nginx/fastcgi_params;
         }

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -50,14 +50,12 @@ http {
         index  index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?$uri&$args;
+            try_files $uri /index.php?$uri&$args;
         }
 
-        location ~ \.php$ {
-             
+        location = /index.php {
             fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        /etc/nginx/fastcgi_params;
         }

--- a/frameworks/PHP/slim/deploy/nginx-hhvm.conf
+++ b/frameworks/PHP/slim/deploy/nginx-hhvm.conf
@@ -49,16 +49,14 @@ http {
         index index.php;
 
         location / {
-            try_files $uri $uri/ /index.php?$uri&$args;
+            try_files $uri /index.php?$uri&$args;
         }
 
-        location ~ \.php$ {
-             
-            fastcgi_pass fastcgi_backend;
+        location = /index.php {
+            fastcgi_pass   fastcgi_backend;
             fastcgi_keep_conn on;
-            fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME  $document_root$fastcgi_script_name;
-            include /etc/nginx/fastcgi_params;
+            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+            include        /etc/nginx/fastcgi_params;
         }
     }
 }


### PR DESCRIPTION
Fat-free, slim, cygnite and codeigniter fail with the fastest one.
So using another not so fast #4341, still using one stat() in each request.

Anyone that know more about these frameworks, can change it to the fastest.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
