### PR TITLE
Optimize nginx config

### DIFF
--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
     keepalive_requests 300000; #default 100
 
     server {
-        listen      8080 default_server reuseport;
+        listen      8080 default_server reuseport fastopen=4096;
                     #8080 default_server reuseport deferred backlog=65535 fastopen=4096;
         root /;
         

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -1,7 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
-worker_rlimit_nofile 200000;
+#worker_rlimit_nofile 100000;
 
 events {
     worker_connections 16384;
@@ -40,6 +40,7 @@ http {
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;
         keepalive 20;
+        
     }
 
     server {

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -1,7 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
-worker_rlimit_nofile 200000;
+#worker_rlimit_nofile 100000;
 pcre_jit on;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -1,7 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
-worker_rlimit_nofile 200000;
+#worker_rlimit_nofile 100000;
 pcre_jit on;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -1,7 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
-worker_rlimit_nofile 200000;
+#worker_rlimit_nofile 100000;
 daemon off;
 
 events {


### PR DESCRIPTION
## Nginx tcp fast open
Change to 4096 like the default in h2o. 
Nginx default 511.

## Nginx delete worker_rlimit_nofile from config
The nginx documentation don't explain clearly what it is the defatult and if it is for any worker or for all workers.
But **200,000 file descriptors** and supposing that it is for all workers, in citrine it is a limiting factor.

24 Cores = 24 workers in nginx
24 workers x 16384 processes = **393,216 file descriptors**.
Without counting the fcgi file descriptors.
We need to have a higher number in the php frameworks.

But first try without configuration and using the default, and check if nginx can adjust correctly. 
In nginx without php, after this change disappeared the sockets timeouts.
