### PR TITLE
 Revert to 1024 children

### DIFF
--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
     keepalive_requests 300000; #default 100
 
     server {
-        listen      8080 default_server reuseport fastopen=4096;
+        listen      8080 default_server reuseport deferred fastopen=4096;
                     #8080 default_server reuseport deferred backlog=65535 fastopen=4096;
         root /;
         

--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 512
+pm.max_children = 1024
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'

--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -39,7 +39,7 @@ http {
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;
-        keepalive 20;
+        keepalive 40;
         
     }
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -14,7 +14,7 @@ WORKDIR /kumbiaphp
 
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 -q https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 CMD service php7.3-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kumbiaphp
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 RUN git clone -b v0.4.0 --single-branch --depth 1 https://github.com/KumbiaPHP/ActiveRecord.git vendor/Kumbia/ActiveRecord
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 CMD service php7.3-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 512
+pm.max_children = 1024
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -40,7 +40,7 @@ http {
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php5.6-fpm.sock;
-        keepalive 20;
+        keepalive 40;
     }
 
     server {

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -40,7 +40,7 @@ http {
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;
-        keepalive 20;
+        keepalive 40;
     }
 
     server {

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -16,7 +16,7 @@ RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" dbraw.php
 RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" fortune.php
 RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" updateraw.php
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-php5-raw.dockerfile
+++ b/frameworks/PHP/php/php-php5-raw.dockerfile
@@ -13,7 +13,7 @@ RUN sed -i "s|listen = /run/php/php7.3-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /php
 WORKDIR /php
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-php5.dockerfile
+++ b/frameworks/PHP/php/php-php5.dockerfile
@@ -15,7 +15,7 @@ RUN sed -i "s|listen = /run/php/php7.3-fpm.sock|listen = /run/php/php5.6-fpm.soc
 ADD ./ /php
 WORKDIR /php
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/5.6/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /php
 RUN sed -i "s|listen = /run/php/php7.3-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.3/fpm/php-fpm.conf
 RUN sed -i "s|server unix:/var/run/php/php7.3-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-raw7.dockerfile
+++ b/frameworks/PHP/php/php-raw7.dockerfile
@@ -12,7 +12,7 @@ COPY deploy/conf/* /etc/php/7.3/fpm/
 ADD ./ /php
 WORKDIR /php
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -14,7 +14,7 @@ COPY deploy/conf/* /etc/php/7.3/fpm/
 ADD ./ /php
 WORKDIR /php
 
-#RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 


### PR DESCRIPTION
Better results with 1024.

Tried for the update problem, but it is a bug in php 7.3.
It's solved, in 2-3 weeks arrive in PHP 7.3.2. 
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
