### PR TITLE
Update php-fpm.conf

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -84,12 +84,12 @@ error_log = /dev/stderr
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 1000000
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -99,7 +99,7 @@ error_log = /dev/stderr
 ; - /dev/poll  (Solaris >= 7)
 ; - port       (Solaris >= 10)
 ; Default Value: not set (auto detection)
-;events.mechanism = epoll
+events.mechanism = epoll
 
 ; When FPM is built with systemd integration, specify the interval,
 ; in seconds, between health report notification to systemd.
@@ -165,7 +165,7 @@ listen = /run/php/php7.3-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+;listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many
@@ -469,12 +469,12 @@ pm.max_spare_servers = 512
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 65535
 
 ; Set max core size rlimit.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Chroot to this directory at the start. This value must be defined as an
 ; absolute path. When this value is not set, chroot is not used.

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -84,12 +84,12 @@ error_log = /dev/stderr
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 1000000
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -99,7 +99,7 @@ error_log = /dev/stderr
 ; - /dev/poll  (Solaris >= 7)
 ; - port       (Solaris >= 10)
 ; Default Value: not set (auto detection)
-;events.mechanism = epoll
+events.mechanism = epoll
 
 ; When FPM is built with systemd integration, specify the interval,
 ; in seconds, between health report notification to systemd.
@@ -165,7 +165,7 @@ listen = /run/php/php7.3-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+;listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many
@@ -469,12 +469,12 @@ pm.max_spare_servers = 512
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 65535
 
 ; Set max core size rlimit.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Chroot to this directory at the start. This value must be defined as an
 ; absolute path. When this value is not set, chroot is not used.


### PR DESCRIPTION
rlimit_files, rlimit_core, epoll,...

Still searching where is the bottleneck.
In the fortune test php-raw7 have only an avg latency of 0.9ms and max of 25.2ms. Less than other frameworks with a lot more req/s.
And at 128 concurrent it's the peek, and later degrade.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
