### PR TITLE
Update Go version for fasthttp benchmark

### DIFF
--- a/frameworks/Go/fasthttp/fasthttp.dockerfile
+++ b/frameworks/Go/fasthttp/fasthttp.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.1
+FROM golang:1.11.5
 
 ADD ./ /fasthttp
 WORKDIR /fasthttp


### PR DESCRIPTION
It's still using an almost year old version. Newer versions of Go have many performance improvements.