### PR TITLE
Php pools

### DIFF
--- a/frameworks/PHP/php/deploy/conf/php-fpm-pools.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm-pools.conf
@@ -68,7 +68,7 @@ error_log = /dev/stderr
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
-; process.max = 128
+ process.max = 0
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lowest priority)
@@ -84,12 +84,12 @@ error_log = /dev/stderr
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 2000000
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = unlimited
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -165,7 +165,7 @@ listen = /run/php/php7.3-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+;listen.backlog = 65535
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 512
+pm.max_children = 256
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
@@ -560,11 +560,48 @@ listen = /run/php/php7.3-fpm-2.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+;listen.backlog = 65535
 
 listen.owner = www-data
 listen.group = www-data
 ;listen.mode = 0660
 
 pm = static
-pm.max_children = 512
+pm.max_children = 256
+
+[www3]
+
+user = www-data
+group = www-data
+
+listen = /run/php/php7.3-fpm-3.sock
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 65535
+
+listen.owner = www-data
+listen.group = www-data
+;listen.mode = 0660
+
+pm = static
+pm.max_children = 256
+
+
+[www4]
+
+user = www-data
+group = www-data
+
+listen = /run/php/php7.3-fpm-4.sock
+
+; Set listen(2) backlog.
+; Default Value: 511 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = 65535
+
+listen.owner = www-data
+listen.group = www-data
+;listen.mode = 0660
+
+pm = static
+pm.max_children = 256

--- a/frameworks/PHP/php/deploy/nginx-pools.conf
+++ b/frameworks/PHP/php/deploy/nginx-pools.conf
@@ -41,6 +41,8 @@ http {
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;
         server unix:/var/run/php/php7.3-fpm-2.sock;
+        server unix:/var/run/php/php7.3-fpm-3.sock;
+        server unix:/var/run/php/php7.3-fpm-4.sock;
         keepalive 40;
     }
 

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -13,7 +13,7 @@ ADD ./ /php
 WORKDIR /php
 
 COPY deploy/conf/php-fpm-pools.conf /etc/php/7.3/fpm/php-fpm.conf
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 512|pm.max_children = 256|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 256|pm.max_children = 128|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 


### PR DESCRIPTION
Now will use 4 php-fpm pools

**Don't merge.**

Only for check that the update test problem it's solved. And other connections problems.

Now it's working perfect. But will be necesary to clean the docker cache in citrine.
PHP don't have for select minor versions, like this one 7.3.2.
Only php 7.3, and the docker cache will never update to that version.

And this error create a lot of 52Mb logs.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
