### PR TITLE
H2O: Do not connect to the database in advance

### DIFF
--- a/frameworks/C/h2o/src/database.c
+++ b/frameworks/C/h2o/src/database.c
@@ -461,12 +461,6 @@ error:
 	error_notification(ctx, false, DB_ERROR);
 }
 
-void connect_to_database(thread_context_t *ctx)
-{
-	for (size_t i = ctx->config->max_db_conn_num - ctx->db_state.db_conn_num; i > 0; i--)
-		start_database_connect(ctx, NULL);
-}
-
 int execute_query(thread_context_t *ctx, db_query_param_t *param)
 {
 	int ret = EXIT_FAILURE;

--- a/frameworks/C/h2o/src/database.h
+++ b/frameworks/C/h2o/src/database.h
@@ -90,7 +90,6 @@ typedef struct {
 	h2o_timeout_t h2o_timeout;
 } db_state_t;
 
-void connect_to_database(thread_context_t *ctx);
 int execute_query(thread_context_t *ctx, db_query_param_t *param);
 void free_database_state(h2o_loop_t *loop, db_state_t *db_state);
 void initialize_database_state(h2o_loop_t *loop, db_state_t *db_state);

--- a/frameworks/C/h2o/src/main.c
+++ b/frameworks/C/h2o/src/main.c
@@ -332,9 +332,6 @@ int main(int argc, char *argv[])
 			setup_process();
 			start_threads(global_data.global_thread_data);
 			initialize_thread_context(global_data.global_thread_data, true, &ctx);
-			// This is just an optimization, so that the application does not try to
-			// establish database connections in the middle of servicing requests.
-			connect_to_database(&ctx);
 			event_loop(&ctx);
 			// Even though this is global data, we need to close
 			// it before the associated event loop is cleaned up.

--- a/frameworks/C/h2o/src/thread.c
+++ b/frameworks/C/h2o/src/thread.c
@@ -46,9 +46,6 @@ static void *run_thread(void *arg)
 
 	initialize_thread_context(arg, false, &ctx);
 	set_thread_memory_allocation_policy(ctx.config->thread_num);
-	// This is just an optimization, so that the application does not try to
-	// establish database connections in the middle of servicing requests.
-	connect_to_database(&ctx);
 	event_loop(&ctx);
 	free_thread_context(&ctx);
 	pthread_exit(NULL);


### PR DESCRIPTION
All tests do a warm-up, so that optimization should not be necessary.