### PR TITLE
Upgrade play2-scala-reactivemongo to Play 2.7 as well

### DIFF
--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/build.sbt
@@ -7,8 +7,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, PlayNettyServer)
 scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "org.reactivemongo" %% "play2-reactivemongo" % "0.16.0-play26",
-  "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.0-play26",
+  "org.reactivemongo" %% "play2-reactivemongo" % "0.16.2-play27",
+  "org.reactivemongo" %% "reactivemongo-play-json" % "0.16.2-play27",
   "com.softwaremill.macwire" %% "macros" % "2.3.0",
   "com.softwaremill.macwire" %% "util" % "2.3.0"
 )

--- a/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-reactivemongo/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.0")


### PR DESCRIPTION
`play2-reactivemongo` with Play 2.7 support was published yesterday:
https://mvnrepository.com/artifact/org.reactivemongo/play2-reactivemongo_2.12/0.16.2-play27

Finally, this is the last Play 2 application which gets upgraded to latest version 2.7 :tada: 