### PR TITLE
Bigger Mysqlnd mempool size

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php.ini
@@ -1010,9 +1010,6 @@ date.timezone = UTC
 ;pdo_odbc.db2_instance_name
 
 [Pdo_mysql]
-; If mysqlnd is used: Number of cache slots for the internal result set cache
-; http://php.net/pdo_mysql.cache_size
-pdo_mysql.cache_size = 2000
 
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
 ; MySQL defaults.
@@ -1206,11 +1203,11 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Default size of the mysqlnd memory pool, which is used by result sets.
 ; http://php.net/mysqlnd.mempool_default_size
-;mysqlnd.mempool_default_size = 16000
+mysqlnd.mempool_default_size = 32768
 
 ; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
 ; http://php.net/mysqlnd.net_cmd_buffer_size
-;mysqlnd.net_cmd_buffer_size = 2048
+;mysqlnd.net_cmd_buffer_size = 4096
 
 ; Size of a pre-allocated buffer used for reading data sent by the server in
 ; bytes.

--- a/frameworks/PHP/php/deploy/conf/php.ini
+++ b/frameworks/PHP/php/deploy/conf/php.ini
@@ -1010,9 +1010,6 @@ date.timezone = UTC
 ;pdo_odbc.db2_instance_name
 
 [Pdo_mysql]
-; If mysqlnd is used: Number of cache slots for the internal result set cache
-; http://php.net/pdo_mysql.cache_size
-pdo_mysql.cache_size = 2000
 
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
 ; MySQL defaults.
@@ -1206,7 +1203,7 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Default size of the mysqlnd memory pool, which is used by result sets.
 ; http://php.net/mysqlnd.mempool_default_size
-;mysqlnd.mempool_default_size = 16000
+mysqlnd.mempool_default_size = 32768
 
 ; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
 ; http://php.net/mysqlnd.net_cmd_buffer_size


### PR DESCRIPTION
and delete  pdo_mysql.cache_size (deprecated)

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
