### PR TITLE
Play 2 (Java): Disable (unused) JPA ThreadLocal

### DIFF
--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/conf/application.conf
@@ -16,6 +16,7 @@ play.filters.enabled = [ ]
 # Disable thread local, it's not used by this application
 # ~~~~~
 play.allowHttpContext = false
+play.jpa.allowJPAEntityManagerContext = false
 
 play.modules {
   enabled += "startup.StartupModule"

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/conf/application.conf
@@ -16,6 +16,7 @@ play.filters.enabled = [ ]
 # Disable thread local, it's not used by this application
 # ~~~~~
 play.allowHttpContext = false
+play.jpa.allowJPAEntityManagerContext = false
 
 play.modules {
   enabled += "startup.StartupModule"

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/conf/application.conf
@@ -16,6 +16,7 @@ play.filters.enabled = [ ]
 # Disable thread local, it's not used by this application
 # ~~~~~
 play.allowHttpContext = false
+play.jpa.allowJPAEntityManagerContext = false
 
 play.modules {
   enabled += "startup.StartupModule"

--- a/frameworks/Java/play2-java/play2-java/conf/application.conf
+++ b/frameworks/Java/play2-java/play2-java/conf/application.conf
@@ -16,6 +16,7 @@ play.filters.enabled = [ ]
 # Disable thread local, it's not used by this application
 # ~~~~~
 play.allowHttpContext = false
+play.jpa.allowJPAEntityManagerContext = false
 
 play.modules {
   enabled += "startup.StartupModule"


### PR DESCRIPTION
Play 2 Java apps don't use that thread-local. Let's see if disabling it improves performance.

The setting is documented here: https://www.playframework.com/documentation/2.7.x/JavaHttpContextMigration27#Disabling-the-Http.Context-and-JPA-thread-local

Play 2 Scala applications are not effected by this.