### PR TITLE
Remove logging to the console, use pooled connections in 'nodejs-postgres --type update'

### DIFF
--- a/frameworks/JavaScript/nodejs/handlers/sequelize-postgres.js
+++ b/frameworks/JavaScript/nodejs/handlers/sequelize-postgres.js
@@ -4,7 +4,10 @@ const Sequelize = require('sequelize');
 const sequelize = new Sequelize('hello_world', 'benchmarkdbuser', 'benchmarkdbpass', {
   host: 'tfb-database',
   dialect: 'postgres',
-  logging: false
+  logging: false,
+  pool: {
+    min: 20, max: 20
+  }
 });
 
 const Worlds = sequelize.define('world', {
@@ -74,7 +77,6 @@ module.exports = {
   Updates: (queries, req, res) => {
     const worldPromises = [];
 
-    console.log('queries: ', queries);
     for (let i = 0; i < queries; i++) {
       worldPromises.push(randomWorldPromise());
     }


### PR DESCRIPTION
Running `tfb --test nodejs-postgres --type update` logs to the console a lot, which is annoying. It also seems to be slowing down the test significantly (at least on my computer). This commit

* Removes console.log call
* Uses a fixed pool of 20 database connections for further speeding up the test (because the database configuration is shared, all node.js + postgres + sequelize tests should run slightly faster)

To get an idea, here are the "before" and "after" results (hoping that my understanding of the test results is correct):

**Before:**

```
Benchmark results:
{'results': [{'endTime': 1550596503,
              'latencyAvg': '1.32s',
              'latencyMax': '3.65s',
              'latencyStdev': '361.21ms',
              'startTime': 1550596488,
              'totalRequests': 5520},
             {'endTime': 1550596521,
              'latencyAvg': '2.80s',
              'latencyMax': '5.25s',
              'latencyStdev': '949.25ms',
              'startTime': 1550596505,
              'totalRequests': 2437},
             {'endTime': 1550596538,
              'latencyAvg': '4.87s',
              'latencyMax': '7.05s',
              'latencyStdev': '882.99ms',
              'startTime': 1550596523,
              'totalRequests': 1300},
             {'connect': 0,
              'endTime': 1550596555,
              'latencyAvg': '6.13s',
              'latencyMax': '7.98s',
              'latencyStdev': '891.51ms',
              'read': 0,
              'startTime': 1550596540,
              'timeout': 22,
              'totalRequests': 1024,
              'write': 0},
             {'connect': 0,
              'endTime': 1550596572,
              'latencyAvg': '7.05s',
              'latencyMax': '8.00s',
              'latencyStdev': '926.37ms',
              'read': 0,
              'startTime': 1550596557,
              'timeout': 312,
              'totalRequests': 674,
              'write': 0}]}
Complete
```

**After:**

```
Benchmark results:
{'results': [{'endTime': 1550596301,
              'latencyAvg': '288.24ms',
              'latencyMax': '1.53s',
              'latencyStdev': '92.44ms',
              'startTime': 1550596286,
              'totalRequests': 26623},
             {'endTime': 1550596318,
              'latencyAvg': '1.33s',
              'latencyMax': '3.46s',
              'latencyStdev': '353.93ms',
              'startTime': 1550596303,
              'totalRequests': 5500},
             {'endTime': 1550596335,
              'latencyAvg': '2.49s',
              'latencyMax': '4.97s',
              'latencyStdev': '616.70ms',
              'startTime': 1550596320,
              'totalRequests': 2806},
             {'endTime': 1550596352,
              'latencyAvg': '3.88s',
              'latencyMax': '5.64s',
              'latencyStdev': '923.27ms',
              'startTime': 1550596337,
              'totalRequests': 1749},
             {'endTime': 1550596369,
              'latencyAvg': '4.62s',
              'latencyMax': '7.56s',
              'latencyStdev': '1.11s',
              'startTime': 1550596354,
              'totalRequests': 1409}]}
Complete
```


