### PR TITLE
Fix nodejs-mysql dockerfile

### DIFF
--- a/frameworks/JavaScript/nodejs/nodejs-mysql.dockerfile
+++ b/frameworks/JavaScript/nodejs/nodejs-mysql.dockerfile
@@ -4,6 +4,6 @@ COPY ./ ./
 
 RUN npm install
 
-ENV NODE_HANDLER mysql-raw
+ENV NODE_HANDLER sequelize 
 
 CMD ["node", "app.js"]


### PR DESCRIPTION
If you look at the round 17 results, "nodejs" and "nodejs-mysql" have almost identical results in every single test. This is because, due to a bug in `nodejs-mysql.dockerfile`, they execute exactly the same code. And that's because `nodejs-mysql.dockerfile` and `nodejs.dockerfile` are identical. In the end, in both cases, the "mysql-raw" flavor gets executed, but the results for "nodejs-mysql" are incorrectly labeled as "orm: full". This trivial commit fixes this and makes this test run the (already existing) Sequelize-backed database access code.

Please note that this fix will result in somewhat lower scores for the "nodejs-mysql" test. This is expected because it will start actually using a "full" ORM (which is always slower).