### PR TITLE
Build toolset dockerfile instead of pulling from dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ before_script:
   # to determine if the suite should be installed and the current $TESTDIR test should run.
   - export RUN_TESTS=`./toolset/travis/travis_diff.py | tee /dev/tty | grep -oP "travis-run-tests \K(.*)"`
 
-  - if [ "$RUN_TESTS" ]; then docker pull techempower/tfb; fi
+  - if [ "$RUN_TESTS" ]; then docker build -t techempower/tfb - < ./Dockerfile; fi
 
   # Stop services that would claim ports we may need
   - sudo service mysql stop


### PR DESCRIPTION
For local development we've switched to building the toolset docker image but forgot to update travis to do the same.