### PR TITLE
Remove redundant toolset environment flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,4 +130,4 @@ script:
   # run-ci.py runs the diffing to see if travis needs to test this framework. Ideally/eventually,
   # we'd like to try and do the diffing before travis_clean & setup.
   # This will run the tests exactly as you would in your own vm:
-  - if [ "$RUN_TESTS" ]; then docker network create tfb > /dev/null 2>&1 && docker run --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=`pwd`,target=/FrameworkBenchmarks techempower/tfb --mode verify --test-dir $RUN_TESTS --benchmark-env travis; else echo 'Skipping test verification.'; fi
+  - if [ "$RUN_TESTS" ]; then docker network create tfb > /dev/null 2>&1 && docker run --network=tfb -v /var/run/docker.sock:/var/run/docker.sock --mount type=bind,source=`pwd`,target=/FrameworkBenchmarks techempower/tfb --mode verify --test-dir $RUN_TESTS --results-environment Travis; else echo 'Skipping test verification.'; fi

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -182,10 +182,6 @@ def main(argv=None):
         nargs='+',
         default=[1, 10, 20, 50, 100],
         help='List of cached query levels to benchmark')
-    parser.add_argument(
-        '--benchmark-env',
-        default='none',
-        help='Hostname/IP for database server')
 
     # Network options
     parser.add_argument(

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -43,7 +43,6 @@ class BenchmarkConfig:
         self.cached_query_levels = args.cached_query_levels
         self.pipeline_concurrency_levels = args.pipeline_concurrency_levels
         self.query_levels = args.query_levels
-        self.benchmark_env = args.benchmark_env
         self.parse = args.parse
         self.results_environment = args.results_environment
         self.results_name = args.results_name

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -45,7 +45,7 @@ class DockerHelper:
                     timeout=3600,
                     pull=True,
                     buildargs=({
-                      'BENCHMARK_ENV': self.benchmarker.config.benchmark_env
+                      'BENCHMARK_ENV': self.benchmarker.config.results_environment
                     })
                 )
                 buffer = ""


### PR DESCRIPTION
We already have a `--results-environment` flag so I'm going to use that instead of an additional `--benchmark-env` flag to produce the value for the `BENCHMARK_ENV` arg. This value is currently `Citrine` and `Azure` on their respective environments.