### PR TITLE
laravel, lumen, laravel-swoole, lumen-swoole, swoole

### DIFF
--- a/frameworks/PHP/laravel/composer.json
+++ b/frameworks/PHP/laravel/composer.json
@@ -1,60 +1,62 @@
 {
     "name": "laravel/laravel",
-    "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
-    "license": "MIT",
     "type": "project",
+    "description": "The Laravel Framework.",
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
+    "license": "MIT",
     "require": {
-        "php": ">=7.1.3",
-        "fideloper/proxy": "~4.0",
-        "laravel/framework": "5.7.*",
-        "laravel/tinker": "~1.0"
+        "php": "^7.1.3",
+        "fideloper/proxy": "^4.0",
+        "laravel/framework": "5.8.*",
+        "laravel/tinker": "^1.0"
     },
     "require-dev": {
-        "filp/whoops": "~2.0",
-        "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "~1.0",
-        "nunomaduro/collision": "~2.0",
-        "phpunit/phpunit": "~7.0",
-        "symfony/thanks": "^1.0"
+        "beyondcode/laravel-dump-server": "^1.0",
+        "filp/whoops": "^2.0",
+        "fzaninotto/faker": "^1.4",
+        "mockery/mockery": "^1.0",
+        "nunomaduro/collision": "^2.0",
+        "phpunit/phpunit": "^7.5"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
     },
     "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        },
         "classmap": [
             "database/seeds",
             "database/factories"
-        ],
-        "psr-4": {
-            "App\\": "app/"
-        }
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
         }
     },
-    "extra": {
-        "laravel": {
-            "dont-discover": [
-            ]
-        }
-    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi"
+        ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "@php artisan key:generate"
-        ],
-        "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "@php artisan key:generate --ansi"
         ]
-    },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true,
-        "optimize-autoloader": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/frameworks/PHP/laravel/deploy/swoole/composer.json
+++ b/frameworks/PHP/laravel/deploy/swoole/composer.json
@@ -1,61 +1,65 @@
 {
     "name": "laravel/laravel",
-    "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
-    "license": "MIT",
     "type": "project",
+    "description": "The Laravel Framework.",
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
+    "license": "MIT",
     "require": {
-        "php": ">=7.1.3",
-        "fideloper/proxy": "~4.0",
-        "laravel/framework": "5.6.*",
-        "laravel/tinker": "~1.0",
-        "swooletw/laravel-swoole": "v2.5.0"
+        "php": "^7.1.3",
+        "fideloper/proxy": "^4.0",
+        "laravel/framework": "5.8.*",
+        "laravel/tinker": "^1.0",
+        "swooletw/laravel-swoole": "v2.6.5.3"
     },
     "require-dev": {
-        "filp/whoops": "~2.0",
-        "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "~1.0",
-        "nunomaduro/collision": "~2.0",
-        "phpunit/phpunit": "~7.0",
-        "symfony/thanks": "^1.0"
+        "beyondcode/laravel-dump-server": "^1.0",
+        "filp/whoops": "^2.0",
+        "fzaninotto/faker": "^1.4",
+        "mockery/mockery": "^1.0",
+        "nunomaduro/collision": "^2.0",
+        "phpunit/phpunit": "^7.5"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": []
+        }
     },
     "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        },
         "classmap": [
             "database/seeds",
             "database/factories"
-        ],
-        "psr-4": {
-            "App\\": "app/"
-        }
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
         }
     },
-    "extra": {
-        "laravel": {
-            "dont-discover": [
-            ]
-        }
-    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover --ansi"
+        ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ],
         "post-create-project-cmd": [
-            "@php artisan key:generate"
-        ],
-        "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "@php artisan key:generate --ansi"
         ]
-    },
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true,
-        "optimize-autoloader": true
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }
+
+

--- a/frameworks/PHP/laravel/laravel-swoole.dockerfile
+++ b/frameworks/PHP/laravel/laravel-swoole.dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.2
+FROM php:7.3
 
-ENV SWOOLE_VERSION=4.2.1
+ENV SWOOLE_VERSION=4.3.0
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \
@@ -23,7 +23,7 @@ RUN chmod -R 777 /laravel
 RUN echo "APP_SWOOLE=true" >> .env
 
 # Install composer using the installation method documented at https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
-# This method was chosen because composer is not part of the apt repositories that are in the default PHP 7.2 docker image
+# This method was chosen because composer is not part of the apt repositories that are in the default PHP 7.3 docker image
 # Adding alternate apt php repos can potentially cause problems with extension compatibility between the php build from the docker image and the alternate php build
 # An additional benefit of this method is that the correct version of composer will be used for the environment and version of the php system in the docker image
 RUN deploy/swoole/install-composer.sh

--- a/frameworks/PHP/lumen/bootstrap/app.php
+++ b/frameworks/PHP/lumen/bootstrap/app.php
@@ -3,7 +3,7 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 try {
-    (new Dotenv\Dotenv(__DIR__.'/../'))->load();
+    Dotenv\Dotenv::create(__DIR__.'/../')->load();
 } catch (Dotenv\Exception\InvalidPathException $e) {
     //
 }

--- a/frameworks/PHP/lumen/composer.json
+++ b/frameworks/PHP/lumen/composer.json
@@ -6,12 +6,12 @@
     "type": "project",
     "require": {
         "php": ">=7.1.3",
-        "laravel/lumen-framework": "5.6.*",
-        "vlucas/phpdotenv": "~2.2"
+        "laravel/lumen-framework": "5.8.*",
+        "vlucas/phpdotenv": "^3.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~7.5",
         "mockery/mockery": "~1.0"
     },
     "autoload": {

--- a/frameworks/PHP/lumen/deploy/swoole/composer.json
+++ b/frameworks/PHP/lumen/deploy/swoole/composer.json
@@ -6,13 +6,13 @@
     "type": "project",
     "require": {
         "php": ">=7.1.3",
-        "laravel/lumen-framework": "5.6.*",
-        "vlucas/phpdotenv": "~2.2",
-        "swooletw/laravel-swoole": "v2.5.0"
+        "laravel/lumen-framework": "5.8.*",
+        "vlucas/phpdotenv": "^3.0",
+        "swooletw/laravel-swoole": "v2.6.5.3"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~7.5",
         "mockery/mockery": "~1.0"
     },
     "autoload": {

--- a/frameworks/PHP/lumen/lumen-swoole.dockerfile
+++ b/frameworks/PHP/lumen/lumen-swoole.dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.2
+FROM php:7.3
 
-ENV SWOOLE_VERSION=4.2.1
+ENV SWOOLE_VERSION=4.3.0
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.2
+FROM php:7.3
 
-ENV SWOOLE_VERSION=4.2.9
+ENV SWOOLE_VERSION=4.3.0
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \


### PR DESCRIPTION
lumen: update to laravel 5.8 and phpdotenv 3.x

laravel-swoole: update to php 7.3, Swoole 4.3.0, Laravel 5.8, and laravel-swoole 2.6.5.3
lumen-swoole: update to php 7.3, Swoole 4.3.0, Laravel 5.8, and laravel-swoole 2.6.5.3, phpdotenv 3.x

laravel-swoole and lumen-swoole updated to swoole 4.3.0 and perhaps also laravel-swoole 2.6.5.3 resolves an issue where plaintext tests did not return data.  This happened presumably because the swoole server crashed.

swoole: update to php 7.3 and Swoole 4.3.0

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
