### PR TITLE
[ci skip] Remove --benchmark-env argument from the continuous scripts

### DIFF
--- a/toolset/continuous/tfb-startup.sh
+++ b/toolset/continuous/tfb-startup.sh
@@ -35,7 +35,6 @@ docker run \
   --results-name "$TFB_RUN_NAME" \
   --results-environment "$TFB_ENVIRONMENT" \
   --results-upload-uri "$TFB_UPLOAD_URI" \
-  --benchmark-env "$TFB_ENVIRONMENT" \
   --quiet
 
 echo "zipping the results"


### PR DESCRIPTION
This option was removed from the tfb toolset, so including it is an error.