### PR TITLE
Revert "Suggestion: Improve ENDTIME accuracy"

### DIFF
--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -153,11 +153,11 @@ class Results:
                             if m != None:
                                 rawData['5xx'] = int(m.group(1))
                         if "STARTTIME" in line:
-                            m = re.search("[0-9]+\.*[0-9]*", line)
-                            rawData["startTime"] = float(m.group(0))
+                            m = re.search("[0-9]+", line)
+                            rawData["startTime"] = int(m.group(0))
                         if "ENDTIME" in line:
-                            m = re.search("[0-9]+\.*[0-9]*", line)
-                            rawData["endTime"] = float(m.group(0))
+                            m = re.search("[0-9]+", line)
+                            rawData["endTime"] = int(m.group(0))
                             test_stats = self.__parse_stats(
                                 framework_test, test_type,
                                 rawData["startTime"], rawData["endTime"], 1)

--- a/toolset/wrk/concurrency.sh
+++ b/toolset/wrk/concurrency.sh
@@ -28,10 +28,8 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-/usr/bin/time -o elapsed --format="%e" wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url
-ENDTIME=$(cat elapsed)
-ENDTIME=$(echo "$ENDTIME + $STARTTIME" | bc)
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url
 echo "STARTTIME $STARTTIME"
-echo "ENDTIME $ENDTIME"
+echo "ENDTIME $(date +"%s")"
 sleep 2
 done

--- a/toolset/wrk/pipeline.sh
+++ b/toolset/wrk/pipeline.sh
@@ -28,10 +28,8 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-/usr/bin/time -o elapsed --format="%e" wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s pipeline.lua -- $pipeline
-ENDTIME=$(cat elapsed)
-ENDTIME=$(echo "$ENDTIME + $STARTTIME" | bc)
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $c --timeout 8 -t "$(($c>$max_threads?$max_threads:$c))" $url -s pipeline.lua -- $pipeline
 echo "STARTTIME $STARTTIME"
-echo "ENDTIME $ENDTIME"
+echo "ENDTIME $(date +"%s")"
 sleep 2
 done

--- a/toolset/wrk/query.sh
+++ b/toolset/wrk/query.sh
@@ -28,10 +28,8 @@ echo " wrk -H 'Host: $server_host' -H 'Accept: $accept' -H 'Connection: keep-ali
 echo "---------------------------------------------------------"
 echo ""
 STARTTIME=$(date +"%s")
-/usr/bin/time -o elapsed --format="STARTTIME 0\nENDTIME %e" wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "$url$c"
-ENDTIME=$(cat elapsed)
-ENDTIME=$(echo "$ENDTIME + $STARTTIME" | bc)
+wrk -H "Host: $server_host" -H "Accept: $accept" -H "Connection: keep-alive" --latency -d $duration -c $max_concurrency --timeout 8 -t $max_threads "$url$c"
 echo "STARTTIME $STARTTIME"
-echo "ENDTIME $ENDTIME"
+echo "ENDTIME $(date +"%s")"
 sleep 2
 done


### PR DESCRIPTION
Reverts TechEmpower/FrameworkBenchmarks#4430

This broke the actual benchmarking - seems to be a parsing bug (or something), but for the sake of getting the benchmarking back online, I'm reverting this.

cc @benaadams 