### PR TITLE
Stop docker containers on run_test failure/error

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -92,9 +92,6 @@ class Benchmarker:
                 file=file,
                 color=Fore.RED if success else '')
         self.time_logger.log_test_end(log_prefix=prefix, file=file)
-        # Stop all the containers if the test failed / errored
-        if not success:
-            self.docker_helper.stop()
         return success
 
     def __run_test(self, test, benchmark_log):
@@ -139,7 +136,6 @@ class Benchmarker:
             container = test.start()
             self.time_logger.mark_test_starting()
             if container is None:
-                self.docker_helper.stop([container, database_container])
                 message = "ERROR: Problem starting {name}".format(
                     name=test.name)
                 self.results.write_intermediate(test.name, message)
@@ -162,7 +158,6 @@ class Benchmarker:
                 time.sleep(test.wait_before_sending_requests)
 
             if not accepting_requests:
-                self.docker_helper.stop([container, database_container])
                 message = "ERROR: Framework is not accepting requests from client machine"
                 self.results.write_intermediate(test.name, message)
                 return self.__exit_test(
@@ -205,9 +200,6 @@ class Benchmarker:
                 log_prefix, benchmark_log)
             self.time_logger.log_verify_end(log_prefix, benchmark_log)
 
-            # Stop this test
-            self.docker_helper.stop([container, database_container])
-
             # Save results thus far into the latest results directory
             self.results.write_intermediate(test.name,
                                             time.strftime(
@@ -233,6 +225,8 @@ class Benchmarker:
                 message="Error during test: %s" % test.name,
                 prefix=log_prefix,
                 file=benchmark_log)
+        finally:
+            self.docker_helper.stop()
 
         return self.__exit_test(
             success=True, prefix=log_prefix, file=benchmark_log)

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -92,6 +92,9 @@ class Benchmarker:
                 file=file,
                 color=Fore.RED if success else '')
         self.time_logger.log_test_end(log_prefix=prefix, file=file)
+        # Stop all the containers if the test failed / errored
+        if not success:
+            self.docker_helper.stop()
         return success
 
     def __run_test(self, test, benchmark_log):

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -272,9 +272,10 @@ class DockerHelper:
             for container in containers:
                 DockerHelper.__stop_container(container)
         else:
-            self.__stop_all(self.server)
+            DockerHelper.__stop_all(self.server)
             if is_multi_setup:
-                self.__stop_all(self.database)
+                DockerHelper.__stop_all(self.database)
+                DockerHelper.__stop_all(self.client)
 
         self.database.containers.prune()
         if is_multi_setup:


### PR DESCRIPTION
Make sure all server and database containers are stopped when a test fails; whether it's a normal failure or an error that bubbled up from the toolset.