### PR TITLE
Improve akka-http fortunes

### DIFF
--- a/frameworks/Scala/akka-http/akka-http/build.sbt
+++ b/frameworks/Scala/akka-http/akka-http/build.sbt
@@ -6,7 +6,7 @@ name := "akka-http-benchmark"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.8"
 
 resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "de.heikoseeberger" %% "akka-http-jsoniter-scala" % "1.23.0",
   "mysql" % "mysql-connector-java" % "5.1.47",
   "com.zaxxer" % "HikariCP" % "3.3.0",
-  "org.scalatra.scalate" %% "scalate-core" % "1.8.0",
+  "org.scalatra.scalate" %% "scalate-core" % "1.9.1",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 

--- a/frameworks/Scala/akka-http/akka-http/src/main/resources/application.conf
+++ b/frameworks/Scala/akka-http/akka-http/src/main/resources/application.conf
@@ -19,8 +19,8 @@ akka {
         dbuser: "benchmarkdbuser"
         dbpass: "benchmarkdbpass"
         jdbc-url: "jdbc:mysql://"${akka.http.benchmark.mysql.dbhost}":"${akka.http.benchmark.mysql.dbport}"/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
-        connection-pool-size: 128
-        thread-pool-size: 128
+        connection-pool-size: 512
+        thread-pool-size: 512
       }
     }
     server {

--- a/frameworks/Scala/akka-http/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/datastore/DataStore.scala
+++ b/frameworks/Scala/akka-http/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/datastore/DataStore.scala
@@ -12,5 +12,5 @@ trait DataStore {
 
   def updateWorld(world: World): Future[Boolean]
 
-  def getFortunes: Future[immutable.Seq[Fortune]]
+  def getFortunes: Future[Seq[Fortune]]
 }

--- a/frameworks/Scala/akka-http/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/handlers/FortunesHandler.scala
+++ b/frameworks/Scala/akka-http/akka-http/src/main/scala/com/typesafe/akka/http/benchmark/handlers/FortunesHandler.scala
@@ -1,6 +1,6 @@
 package com.typesafe.akka.http.benchmark.handlers
 
-import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.HttpCharsets._
 import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.model._
@@ -16,7 +16,7 @@ trait FortunesHandler { _: Infrastructure with DataStore with Templating =>
   def fortunesEndpoint: Route =
     get {
       path("fortunes") {
-        onSuccess(getFortunes)(complete(_))
+        complete(getFortunes)
       }
     }
 


### PR DESCRIPTION
- Upgrade to scalate 1.9.1 (sanitization performance improvement https://github.com/scalate/scalate/pull/204) and Scala 2.12.8
- avoid allocations when adding a fortune and sorting fortunes
- use column indices instead of names to avoid expensive building of columns index
- increase thread and connection pool to match the maximum concurrency of the fortunes benchmark: 512