### PR TITLE
Cached queries test using wrong query levels

### DIFF
--- a/toolset/benchmark/test_types/cached_query_type.py
+++ b/toolset/benchmark/test_types/cached_query_type.py
@@ -49,7 +49,7 @@ class CachedQueryTestType(FrameworkTestType):
             self.config.duration,
             'levels':
             " ".join(
-                "{}".format(item) for item in self.config.concurrency_levels),
+                "{}".format(item) for item in self.config.cached_query_levels),
             'server_host':
             self.config.server_host,
             'url':


### PR DESCRIPTION
We were accidentally using the concurrency levels `[16, 32, 64, 128, 256, 512]` for the cached query levels, which should be `[1, 10, 20, 50, 100]`

resolves #3804 and now lines up with the documentation at https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview#requirements-6