### PR TITLE
Use the CoreRT compiler from the new blob feed

### DIFF
--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/NuGet.Config
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/NuGet.Config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -5,6 +5,11 @@
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Opt out of the "easy mode" of the CoreRT compiler (http://aka.ms/OptimizeCoreRT) -->
+    <RootAllApplicationAssemblies>false</RootAllApplicationAssemblies>
+    <IlcGenerateCompleteTypeMetadata>false</IlcGenerateCompleteTypeMetadata>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
* Use CoreRT compiler from the new blob feed. See dotnet/corert#7268
* Opt out of compiler defaults. These options became the defaults in the past months, but the benchmark doesn't need them. This removes almost 10 MB of cruft from the produced executable (which likely helps working set and code locality).