### PR TITLE
Change timer resolution

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -2,6 +2,7 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 #worker_rlimit_nofile 100000;
+timer_resolution 1000ms;
 
 events {
     worker_connections 16384;

--- a/frameworks/PHP/php/deploy/nginx-pools.conf
+++ b/frameworks/PHP/php/deploy/nginx-pools.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+timer_resolution 1000ms;
 #worker_rlimit_nofile 100000;
 pcre_jit on;
 

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+timer_resolution 1000ms;
 #worker_rlimit_nofile 100000;
 pcre_jit on;
 

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
+timer_resolution 1000ms;
 #worker_rlimit_nofile 100000;
 pcre_jit on;
 


### PR DESCRIPTION
Call gettimeofday() once per second.

If we see good results, we will change it in all php fws.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
