### PR TITLE
Fix debug mode

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -202,12 +202,18 @@ class DockerHelper:
             if hasattr(test, 'docker_cmd'):
                 docker_cmd = test.docker_cmd
 
+            # Expose ports in debugging mode
+            ports = {}
+            if self.benchmarker.config.mode == "debug":
+                ports = {test.port: test.port}
+
             container = self.server.containers.run(
                 "techempower/tfb.test.%s" % test.name,
                 name=name,
                 command=docker_cmd,
                 network=self.benchmarker.config.network,
                 network_mode=self.benchmarker.config.network_mode,
+                ports=ports,
                 stderr=True,
                 detach=True,
                 init=True,


### PR DESCRIPTION
This problem was introduced when we switched to docker.  This exposes the test port to vagrant or whatever host is running docker but only in `--mode debug`

Sorry this took so long to get to @joanhey !

resolves #4284 