### PR TITLE
Update Express-mongodb query to pass the test

### DIFF
--- a/frameworks/JavaScript/express/benchmark_config.json
+++ b/frameworks/JavaScript/express/benchmark_config.json
@@ -31,7 +31,7 @@
     },
     "mongodb": {
       "db_url": "/mongoose",
-      "query_url": "/mongoose?queries=",
+      "query_url": "/mongooseq?queries=",
       "update_url": "/mongoose-update?queries=",
       "fortune_url": "/mongoose-fortune",
       "port": 8080,

--- a/frameworks/JavaScript/express/mongodb-app.js
+++ b/frameworks/JavaScript/express/mongodb-app.js
@@ -55,7 +55,7 @@ if (cluster.isMaster) {
   app.set('views', __dirname + '/views');
 
   // Routes
-  app.get('/mongoose', async (req, res) => {
+  app.get('/mongooseq', async (req, res) => {
     const queries = Math.min(parseInt(req.query.queries) || 1, 500),
       results = [];
 
@@ -63,7 +63,13 @@ if (cluster.isMaster) {
       results.push(await MWorld.findOne({ id: (Math.floor(Math.random() * 10000) + 1) }));
     }
 
-    res.send(queries > 1 ? results : results[0]);
+    res.send(results);
+  });
+
+  app.get('/mongoose', async (req, res) => {
+    let results = await MWorld.findOne({ id: (Math.floor(Math.random() * 10000) + 1) });
+
+    res.send(results);
   });
 
   app.get('/mongoose-fortune', (req, res) => {


### PR DESCRIPTION
Fix for the change in tests #4622

Ready javascript frameworks for multiple queries test

But there are more with `Invalid Date header`
~and it's **only a warning, and would be a fail**, or nobody will change the code.
Use the same date in all requests is a big advantage.~
Only use a different date format.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
