### PR TITLE
Add docker_context benchmark_config property

### DIFF
--- a/frameworks/JavaScript/nodejs/benchmark_config.json
+++ b/frameworks/JavaScript/nodejs/benchmark_config.json
@@ -2,6 +2,7 @@
   "framework": "nodejs",
   "tests": [{
     "default": {
+      "docker_context": "../",
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "db_url": "/db",

--- a/frameworks/JavaScript/nodejs/nodejs.dockerfile
+++ b/frameworks/JavaScript/nodejs/nodejs.dockerfile
@@ -2,7 +2,7 @@ FROM node:10.12.0
 
 ARG TFB_TEST_NAME
 
-COPY ./ ./
+COPY ./nodejs ./
 
 RUN npm install
 


### PR DESCRIPTION
This adds a new property to the `benchmark_config.json` called `docker_context`. This allows you to define a path relative to your test to be available during the build step. The primary use case for this, as asked for by @naushadh, is to share modules, config, etc across multiple frameworks.

In the included nodejs example, I've added:

```
"docker_context": "../",
```

to the default test's benchmark config. This places the root context of our dockerfile in the `frameworks/JavaScript` directory, meaning I can now add any files from any of the other JS frameworks to my dockerfile. This also means that in order to add all the files for my framework, I had to change `COPY ./ ./` to `COPY ./nodejs ./`

Concerns:

 - I'm still not :100: that I want this. For most tests, you can run the Dockerfile without the toolset to spin up a server. This makes it a little less obvious that you'd have to provide a custom context if you were to do that.
 - I did check that this doesn't increase the image size. The extra context is only available at build time.
 - I like the idea of reducing copying/pasting for people that submit and maintain multiple frameworks and use a lot of the same files. However, I don't like that this would tightly couple implementations across framework folders. I'd have to do some serious magic in the travis differ to trigger a framework test because it's using the context of a file that was edited.

Before merge:

- [ ] conversation and approvals
- [ ] remove nodejs example
- [ ] add docs to wiki