### PR TITLE
Upgrade PostgreSQL to version 11 

### DIFF
--- a/toolset/databases/postgres/pgdg.list
+++ b/toolset/databases/postgres/pgdg.list
@@ -1,0 +1,2 @@
+deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+deb-src http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -14,11 +14,15 @@ ADD 60-postgresql-shm.conf 60-postgresql-shm.conf
 ADD create-postgres-database.sql create-postgres-database.sql
 ADD create-postgres.sql create-postgres.sql
 
+# prepare PostgreSQL APT repository
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+
 # install postgresql on database machine
 RUN apt-get -y update > /dev/null
 RUN apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" postgresql > /dev/null
 
-ENV PG_VERSION 9.5
+ENV PG_VERSION 11.2
 
 # Make sure all the configuration files in main belong to postgres
 RUN mv postgresql.conf /etc/postgresql/${PG_VERSION}/main/postgresql.conf

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -23,7 +23,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCC4CF8
 RUN apt-get -y update > /dev/null
 RUN apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" postgresql > /dev/null
 
-ENV PG_VERSION 11.2
+ENV PG_VERSION 11
 
 # Make sure all the configuration files in main belong to postgres
 RUN mv postgresql.conf /etc/postgresql/${PG_VERSION}/main/postgresql.conf

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -13,10 +13,11 @@ ADD pg_hba.conf pg_hba.conf
 ADD 60-postgresql-shm.conf 60-postgresql-shm.conf
 ADD create-postgres-database.sql create-postgres-database.sql
 ADD create-postgres.sql create-postgres.sql
+ADD pgdg.list pgdg.list
 
 # prepare PostgreSQL APT repository
-RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+RUN cp pgdg.list /etc/apt/sources.list.d/
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ACCC4CF8
 
 # install postgresql on database machine
 RUN apt-get -y update > /dev/null

--- a/toolset/databases/postgres/postgresql.conf
+++ b/toolset/databases/postgres/postgresql.conf
@@ -40,13 +40,13 @@
 
 data_directory = '/ssd/postgresql'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/11/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/11/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.5-main.pid'		# write an extra PID file
+external_pid_file = '/var/run/postgresql/11-main.pid'		# write an extra PID file
 					# (change requires restart)
 
 

--- a/toolset/databases/postgres/postgresql.conf
+++ b/toolset/databases/postgres/postgresql.conf
@@ -211,7 +211,7 @@ synchronous_commit = off
 
 # These settings are ignored on a standby server
 
-#max_wal_senders = 0		# max number of walsender processes
+max_wal_senders = 0		# max number of walsender processes
 				# (change requires restart)
 #wal_sender_delay = 1s		# walsender cycle time, 1-10000 milliseconds
 #wal_keep_segments = 0		# in logfile segments, 16MB each; 0 disables

--- a/toolset/databases/postgres/postgresql.conf
+++ b/toolset/databases/postgres/postgresql.conf
@@ -163,7 +163,7 @@ random_page_cost = 2
 
 # - Settings -
 
-#wal_level = minimal			# minimal, archive, or hot_standby
+wal_level = minimal			# minimal, archive, or hot_standby
 					# (change requires restart)
 #fsync = on				# turns forced synchronization on or off
 


### PR DESCRIPTION
This is adding [PostgreSQL official APT repository](https://wiki.postgresql.org/wiki/Apt).
Two important settings are introduced:

- `wal_level = minimal`
- `max_wal_senders = 0`

The run in TravisCI is showing `Rust/actix`, `Rust/actix-diesel`, `Rust/actix-pg`, `Rust/actix-platform` as failing due to this change. The build is taking too long and can't finish checking of the rest of the Rust frameworks. Maybe there will be other errors.

The other problems which seems not to be related are:

- C#: [revenj](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338520#L6799-L6802), [servicestack](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338520#L6824-L6826), [evhttp-sharp](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338520#L6592-L6594) - problems with Debian jessie dependencies. Very recently they rotated the supported versions and removed some directories from their mirrors.
- C#: [aspnet-mono-ngx-my](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338520#L6248-L6256), [aspnet-mono-ngx-my-ef](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338520#L6345-L6352) - failing `query` test validation.
- C++: [cpoll_cppsp-postgres-raw](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338521#L2470-L2481), [cpoll_cppsp-postgres-raw-threadpool](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338521#L2580-L2591), [cpoll_cppsp-raw](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338521#L2692-L2703) - failing `query` test validation.
- D: the same failures about dependencies as before this change.
- Dart: [start](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338533#L2835-L2836), [stream](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338533#L2859-L2860) - Debian jessie.
- Go: all [revel](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338538#L2210-L2225) variants are failing in the same way.
- Go: [falcore](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338538#L1884-L1898) - failing `update` test validation.
- Haskell: [snap](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338541#L1593-L1595), [yesod](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338542#L1693-L1694), [yesod-mongodb-raw](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338542#L1716-L1724), [spock](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338544#L1704-L1705) - Debian jessie.
- JavaScript: [hapi-nginx](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338600#L4326-L4327) - Debian jessie.
- JavaScript: [nodejs-mongodb](Ghttps://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338600#L4326-L4327), [nodejs-mongodb-raw](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338600#L5316), [nodejs-postgres](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338600#L5497) - Problem with the DB connections. They tried to access the MySQL server port, not the corresponding MongoDB or PostgreSQL port. Manually setting the port doesn't help.
- PHP: [hhvm](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338608#L2358-L2360) - seems configuration problem. Can't access a socket file.
- Rubi: [hanami](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338612#L5054-L5058) - failing `date header` verification on all endpoints. `hanami-unicorn` is [passing all checks.](https://travis-ci.org/zloster/FrameworkBenchmarks/jobs/518338612#L7241-L7247) 