### PR TITLE
Fix hunt test and use same base dockers for all D tests

### DIFF
--- a/frameworks/D/collie/collie-ldc.dockerfile
+++ b/frameworks/D/collie/collie-ldc.dockerfile
@@ -4,6 +4,6 @@ ADD ./ /collie
 WORKDIR /collie
 
 RUN dub upgrade --verbose
-RUN dub build -f -b release-nobounds --compiler=ldc2
+RUN dub build -f -b release --compiler=ldc2
 
 CMD ["./http"]

--- a/frameworks/D/collie/collie-ldc.dockerfile
+++ b/frameworks/D/collie/collie-ldc.dockerfile
@@ -4,6 +4,6 @@ ADD ./ /collie
 WORKDIR /collie
 
 RUN dub upgrade --verbose
-RUN dub build -f -b release --compiler=ldc2
+RUN dub build -f -b release-nobounds --compiler=ldc2
 
 CMD ["./http"]

--- a/frameworks/D/collie/collie-ldc.dockerfile
+++ b/frameworks/D/collie/collie-ldc.dockerfile
@@ -1,4 +1,4 @@
-FROM dlanguage/ldc:1.7.0
+FROM dlang2/ldc-ubuntu:1.15.0
 
 ADD ./ /collie
 WORKDIR /collie

--- a/frameworks/D/collie/collie.dockerfile
+++ b/frameworks/D/collie/collie.dockerfile
@@ -1,4 +1,4 @@
-FROM dlanguage/ldc:1.7.0
+FROM dlang2/dmd-ubuntu:2.085.1
 
 ADD ./ /collie
 WORKDIR /collie

--- a/frameworks/D/collie/collie.dockerfile
+++ b/frameworks/D/collie/collie.dockerfile
@@ -4,6 +4,6 @@ ADD ./ /collie
 WORKDIR /collie
 
 RUN dub upgrade --verbose
-RUN dub build -f -b release
+RUN dub build -f -b release-nobounds
 
 CMD ["./http"]

--- a/frameworks/D/collie/collie.dockerfile
+++ b/frameworks/D/collie/collie.dockerfile
@@ -4,6 +4,6 @@ ADD ./ /collie
 WORKDIR /collie
 
 RUN dub upgrade --verbose
-RUN dub build -f -b release-nobounds
+RUN dub build -f -b release
 
 CMD ["./http"]

--- a/frameworks/D/collie/dub.json
+++ b/frameworks/D/collie/dub.json
@@ -5,6 +5,6 @@
 	"authors": ["dsby"],
 	"targetType": "executable",
 	"dependencies": {
-            "collie" : "~>0.10.3"
+            "collie" : "~>0.10.16"
 	}
 }

--- a/frameworks/D/collie/source/request.d
+++ b/frameworks/D/collie/source/request.d
@@ -43,7 +43,7 @@ protected:
 
 	final @property bool isVaild(){return _erroCode == HTTPErrorCode.NO_ERROR;}
 
-	pragma(inline,true)
+	pragma(inline)
 	final string printDate() {
 		DateTime date = cast(DateTime)Clock.currTime;
 		return format(

--- a/frameworks/D/hunt/dub.json
+++ b/frameworks/D/hunt/dub.json
@@ -11,9 +11,9 @@
 	"libs-posix": [ "http_parser" ],
 	"lflags-posix": ["-Lhttp-parser/"],
 	"dependencies": {
-		"hunt": "~>1.2.0-rc.1",
-		"hunt-database": "~>1.2.0-beta.1",
-		"std_data_json": "~>0.18.2"
+		"hunt": "~>1.2.0-rc.6",
+		"hunt-database": "~>1.2.0-beta.5",
+		"std_data_json": "~>0.18.3"
 	},
 	"configurations": [
 		{

--- a/frameworks/D/hunt/dub.json
+++ b/frameworks/D/hunt/dub.json
@@ -5,8 +5,8 @@
 		"Putao"
 	],
 	"description": "A mini http server powered by Hunt.",
-    "copyright": "Copyright (C) 2017-2019, HuntLabs",
-    "homepage": "https://www.huntlabs.net/",
+	"copyright": "Copyright (C) 2017-2019, HuntLabs",
+	"homepage": "https://www.huntlabs.net/",
 	"license": "Apache-2.0",
 	"libs-posix": [ "http_parser" ],
 	"lflags-posix": ["-Lhttp-parser/"],
@@ -26,5 +26,15 @@
 				"hunt-database": "postgresql"
 			}
 		}
-	]
+	],
+	"buildTypes": {
+		"debug": {
+			"buildOptions": ["debugMode", "optimize"]
+		},
+		"release": {
+			"buildOptions": ["releaseMode", "optimize", "inline"],
+			"dflags": ["-boundscheck=off"],
+			"dflags-ldc": ["-flto=thin"]
+		}
+	}
 }

--- a/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
@@ -1,4 +1,4 @@
-FROM dlangchina/dlang-dmd:latest
+FROM dlang2/dmd-ubuntu:2.085.1
 
 ADD ./ /hunt
 WORKDIR /hunt
@@ -8,7 +8,7 @@ RUN apt update -y && apt install -y --no-install-recommends git && rm -rf /var/l
 RUN git clone https://github.com/nodejs/http-parser.git && \
     cd http-parser && \
     make package
-    
+
 RUN dub upgrade --verbose
 RUN dub build --build=release --arch=x86_64 --config=postgresql --compiler=dmd -f
 

--- a/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
@@ -3,13 +3,13 @@ FROM dlang2/dmd-ubuntu:2.085.1
 ADD ./ /hunt
 WORKDIR /hunt
 
-RUN apt update -y && apt install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
+RUN apt update -y && apt install -y --no-install-recommends git && apt install -yqq libpq-dev libsqlite3-dev libmysqlclient-dev zlib1g-dev && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 
 RUN git clone https://github.com/nodejs/http-parser.git && \
     cd http-parser && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build --build=release-nobounds --arch=x86_64 --config=postgresql --compiler=dmd -f
+RUN dub build --build=release --arch=x86_64 --config=postgresql --compiler=dmd -f
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-dmd-postgresql.dockerfile
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build --build=release --arch=x86_64 --config=postgresql --compiler=dmd -f
+RUN dub build --build=release-nobounds --arch=x86_64 --config=postgresql --compiler=dmd -f
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
@@ -1,4 +1,4 @@
-FROM dlangchina/dlang-ldc:latest
+FROM dlang2/ldc-ubuntu:1.15.0
 
 ADD ./ /hunt
 WORKDIR /hunt

--- a/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build --build=release --arch=x86_64 --compiler=ldc2 --config=postgresql -f
+RUN dub build --build=release-nobounds --arch=x86_64 --compiler=ldc2 --config=postgresql -f
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc-postgresql.dockerfile
@@ -3,13 +3,13 @@ FROM dlang2/ldc-ubuntu:1.15.0
 ADD ./ /hunt
 WORKDIR /hunt
 
-RUN apt update -y && apt install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
+RUN apt update -y && apt install -y --no-install-recommends git && apt install -yqq libpq-dev libsqlite3-dev libmysqlclient-dev zlib1g-dev  && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 
 RUN git clone https://github.com/nodejs/http-parser.git && \
     cd http-parser && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build --build=release-nobounds --arch=x86_64 --compiler=ldc2 --config=postgresql -f
+RUN dub build --build=release --arch=x86_64 --compiler=ldc2 --config=postgresql -f
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-ldc.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc.dockerfile
@@ -1,6 +1,6 @@
 FROM dlang2/ldc-ubuntu:1.15.0
 
-RUN apt update -y && apt install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
+RUN apt update -y && apt install -y --no-install-recommends git && apt install -yqq libpq-dev libsqlite3-dev libmysqlclient-dev zlib1g-dev  && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 
 ADD ./ /hunt
 WORKDIR /hunt
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build -f --arch=x86_64 --build=release-nobounds --compiler=ldc2 -c=lite
+RUN dub build -f --arch=x86_64 --build=release --compiler=ldc2 -c=lite
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-ldc.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc.dockerfile
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build -f --arch=x86_64 --build=release --compiler=ldc2 -c=lite
+RUN dub build -f --arch=x86_64 --build=release-nobounds --compiler=ldc2 -c=lite
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt-ldc.dockerfile
+++ b/frameworks/D/hunt/hunt-ldc.dockerfile
@@ -1,4 +1,4 @@
-FROM dlangchina/dlang-ldc:latest
+FROM dlang2/ldc-ubuntu:1.15.0
 
 RUN apt update -y && apt install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 

--- a/frameworks/D/hunt/hunt.dockerfile
+++ b/frameworks/D/hunt/hunt.dockerfile
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build -f --arch=x86_64 --build=release --compiler=dmd -c=lite
+RUN dub build -f --arch=x86_64 --build=release-nobounds --compiler=dmd -c=lite
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/hunt.dockerfile
+++ b/frameworks/D/hunt/hunt.dockerfile
@@ -1,4 +1,4 @@
-FROM dlangchina/dlang-dmd:latest
+FROM dlang2/dmd-ubuntu:2.085.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 
@@ -8,7 +8,7 @@ WORKDIR /hunt
 RUN git clone https://github.com/nodejs/http-parser.git && \
     cd http-parser && \
     make package
-    
+
 RUN dub upgrade --verbose
 RUN dub build -f --arch=x86_64 --build=release --compiler=dmd -c=lite
 

--- a/frameworks/D/hunt/hunt.dockerfile
+++ b/frameworks/D/hunt/hunt.dockerfile
@@ -1,6 +1,6 @@
 FROM dlang2/dmd-ubuntu:2.085.1
 
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
+RUN apt-get update && apt-get install -y --no-install-recommends git && apt install -yqq libpq-dev libsqlite3-dev libmysqlclient-dev zlib1g-dev && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*
 
 ADD ./ /hunt
 WORKDIR /hunt
@@ -10,6 +10,6 @@ RUN git clone https://github.com/nodejs/http-parser.git && \
     make package
 
 RUN dub upgrade --verbose
-RUN dub build -f --arch=x86_64 --build=release-nobounds --compiler=dmd -c=lite
+RUN dub build -f --arch=x86_64 --build=release --compiler=dmd -c=lite
 
 CMD ["./hunt-minihttp"]

--- a/frameworks/D/hunt/source/http/Processor.d
+++ b/frameworks/D/hunt/source/http/Processor.d
@@ -46,7 +46,7 @@ private:
 	HttpRequest request;
 	State state;
 	bool serving;
-	
+
 public:
 	TcpStream client;
 
@@ -59,7 +59,7 @@ public:
 	}
 
 	void run() {
-		client.onDataReceived((ByteBuffer buffer) { 
+		client.onReceived((ByteBuffer buffer) {
 			version(NO_HTTPPARSER) {
 				client.write(cast(ubyte[])ResponseData);
 			} else {
@@ -70,8 +70,8 @@ public:
 		.onClosed(() {
 			// notifyClientClosed();
 		})
-		.onError((string msg) { 
-			debug warning("Error: ", msg); 
+		.onError((string msg) {
+			debug warning("Error: ", msg);
 		})
 		.start();
 	}

--- a/frameworks/D/vibed/dub.json
+++ b/frameworks/D/vibed/dub.json
@@ -32,5 +32,15 @@
         "vibe-d-postgresql": "2.0.2"
       }
     }
-  ]
+  ],
+  "buildTypes": {
+      "debug": {
+          "buildOptions": ["debugMode", "optimize"]
+      },
+      "release": {
+          "buildOptions": ["releaseMode", "optimize", "inline"],
+          "dflags": ["-boundscheck=off"],
+          "dflags-ldc": ["-flto=thin"]
+      }
+  }
 }

--- a/frameworks/D/vibed/vibed-dmd-pgsql.dockerfile
+++ b/frameworks/D/vibed/vibed-dmd-pgsql.dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN apt update -yqq && apt install -yqq libpq-dev zlib1g-dev
 
-RUN dub build -b release-nobounds --config=postgresql
+RUN dub build -b release --config=postgresql
 
 CMD ["/dlang/app/fwb"]

--- a/frameworks/D/vibed/vibed-ldc-pgsql.dockerfile
+++ b/frameworks/D/vibed/vibed-ldc-pgsql.dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN apt update -yqq && apt install -yqq libpq-dev zlib1g-dev
 
-RUN dub build -b release-nobounds --compiler=ldc2 --config=postgresql
+RUN dub build -b release --compiler=ldc2 --config=postgresql
 
 CMD ["/dlang/app/fwb"]

--- a/frameworks/D/vibed/vibed-ldc.dockerfile
+++ b/frameworks/D/vibed/vibed-ldc.dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN apt update -yqq && apt install -yqq zlib1g-dev
 
-RUN dub build -b release-nobounds --compiler=ldc2 --verbose
+RUN dub build -b release --compiler=ldc2 --verbose
 
 CMD ["/dlang/app/fwb"]

--- a/frameworks/D/vibed/vibed.dockerfile
+++ b/frameworks/D/vibed/vibed.dockerfile
@@ -5,6 +5,6 @@ COPY . .
 
 RUN apt update -yqq && apt install -yqq libpq-dev zlib1g-dev
 
-RUN dub build -b release-nobounds --verbose
+RUN dub build -b release --verbose
 
 CMD ["/dlang/app/fwb"]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
