### PR TITLE
[ci fw-only C/octane] Attempt to fix JSON test implementation

### DIFF
--- a/frameworks/C/octane/src/responders/sds_responder.cpp
+++ b/frameworks/C/octane/src/responders/sds_responder.cpp
@@ -29,14 +29,14 @@ void create_json_response_sds(write_batch* batch) {
     // volatile is used to ensure that the object is instantiated every time
 	// the function is called.
 	const volatile struct {
-		const unsigned char *message;
+		const char *message;
     } object = {PLAINTEXT_CONTENT};
 
     StringBuffer s;
     Writer<StringBuffer> writer(s);
     writer.StartObject();
     writer.Key("message");
-    writer.String((const unsigned char *)object.message, strlen(object.message));
+    writer.String((const char *)object.message, strlen(object.message));
     writer.EndObject();
 
     sds response_buffer = sdsnew("HTTP/1.1 200 OK\r\n");

--- a/frameworks/C/octane/src/responders/sds_responder.cpp
+++ b/frameworks/C/octane/src/responders/sds_responder.cpp
@@ -27,9 +27,9 @@ void create_plaintext_response_sds(write_batch* batch) {
 void create_json_response_sds(write_batch* batch) {
     // Taken from H20 implementation.
     // volatile is used to ensure that the object is instantiated every time
-	// the function is called.
-	const volatile struct {
-		const char *message;
+    // the function is called.
+    const volatile struct {
+        const char *message;
     } object = {PLAINTEXT_CONTENT};
 
     StringBuffer s;

--- a/frameworks/C/octane/src/responders/sds_responder.cpp
+++ b/frameworks/C/octane/src/responders/sds_responder.cpp
@@ -25,11 +25,18 @@ void create_plaintext_response_sds(write_batch* batch) {
 }
 
 void create_json_response_sds(write_batch* batch) {
+    // Taken from H20 implementation.
+    // volatile is used to ensure that the object is instantiated every time
+	// the function is called.
+	const volatile struct {
+		const unsigned char *message;
+    } object = {PLAINTEXT_CONTENT};
+
     StringBuffer s;
     Writer<StringBuffer> writer(s);
     writer.StartObject();
     writer.Key("message");
-    writer.String("Hello, World!");
+    writer.String((const unsigned char *)object.message, strlen(object.message));
     writer.EndObject();
 
     sds response_buffer = sdsnew("HTTP/1.1 200 OK\r\n");


### PR DESCRIPTION
My take on #4094. The code is copied/adapted from the C/h2o implementation:
https://github.com/TechEmpower/FrameworkBenchmarks/blob/42e68c26198497aa03f27b5ab7be6aad16cc43df/frameworks/C/h2o/src/json_serializer.c#L41-L45

Other problems:

- This is a C code and the files are named after the C++ convention (`.cpp` vs `.c`, `.hpp` vs `.h`);
- The date header handling. The validation is giving a warning about the date formatting.

The last one is not exactly easy fix. Here is the h2o implementation:
https://github.com/h2o/h2o/blob/526c69ed7e705917c701cc4d3be1551c9d39aaf0/lib/common/time.c#L52-L76

