### PR TITLE
Update travis differ

### DIFF
--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -52,20 +52,13 @@ def quit_diffing():
         print("No tests to run.")
     exit(0)
 
-
-is_PR = (os.getenv("TRAVIS_PULL_REQUEST") != "false")
-last_commit  = ""
-
-if is_PR:
-    print('I am testing a pull request')
-    last_commit = subprocess.check_output(
-        "git rev-list -n 1 FETCH_HEAD^2", shell=True).rstrip('\n')
-
+last_commit = os.getenv("TRAVIS_COMMIT")
 # https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
 changes = clean_output(
     subprocess.check_output([
         'bash', '-c',
-        'git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master)'
+        'git --no-pager diff --name-only {0} $(git merge-base {0} master)'
+            .format(last_commit)
     ]))
 print("Determining what to run based on the following file changes: \n{!s}"
     .format('\n'.join(changes.split('\n')[0:10])))
@@ -76,10 +69,7 @@ if len(changes.split('\n')) > 10:
 # COMMIT MESSAGES:
 # Before any complicated diffing, check for forced runs from the commit message
 # Use -2 because travis now inserts a merge commit as the last commit
-last_commit_msg = subprocess.check_output(
-    ["bash", "-c", "git log --format=%B -n 1 {!s}".format(last_commit)])
-print("Parsing commit message for travis commands: {!s}"
-    .format(last_commit_msg))
+last_commit_msg = os.getenv("TRAVIS_COMMIT_MESSAGE")
 
 test_dirs = []
 run_tests = []

--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -57,8 +57,10 @@ def quit_diffing():
 
 
 curr_branch = ""
-is_master = os.getenv("TRAVIS_BRANCH") == "master"
 is_PR = (os.getenv("TRAVIS_PULL_REQUEST") != "false")
+# TRAVIS_BRANCH is the target branch when it's a pull request or the name
+# of the branch when it isn't
+is_master = not is_PR and os.getenv("TRAVIS_BRANCH") == "master"
 
 if is_PR:
     curr_branch = "FETCH_HEAD"

--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -59,7 +59,7 @@ if is_PR:
 else:
     curr_branch = os.getenv("TRAVIS_COMMIT")
     # Also fetch master to compare against
-    subprocess.check_output(['bash', '-c', 'git fetch origin master'])
+    subprocess.check_output(['bash', '-c', 'git fetch origin master:master'])
 
 # https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
 changes = clean_output(

--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -52,13 +52,21 @@ def quit_diffing():
         print("No tests to run.")
     exit(0)
 
-last_commit = os.getenv("TRAVIS_COMMIT")
+curr_branch = ""
+is_PR = (os.getenv("TRAVIS_PULL_REQUEST") != "false")
+if is_PR:
+    curr_branch = "FETCH_HEAD"
+else:
+    curr_branch = os.getenv("TRAVIS_COMMIT")
+    # Also fetch master to compare against
+    subprocess.check_output(['bash', '-c', 'git fetch origin master'])
+
 # https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
 changes = clean_output(
     subprocess.check_output([
         'bash', '-c',
         'git --no-pager diff --name-only {0} $(git merge-base {0} master)'
-            .format(last_commit)
+            .format(curr_branch)
     ]))
 print("Determining what to run based on the following file changes: \n{!s}"
     .format('\n'.join(changes.split('\n')[0:10])))

--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -129,11 +129,8 @@ if re.search(r'\[ci lang .+\]', last_commit_msg, re.M):
                 run_tests.append(test)
 
 
-# Ignore travis and docker directory changes
-# Also for now, ignore the old linux setup folders, as we don't want to
-# trigger a full run as we remove old fw_depends scripts. [ci run-all] will
-# still work if it's needed.
-if re.search(r'^toolset\/(?!(travis\/|continuous\/|scaffolding\/))|^tfb|^Dockerfile', changes, re.M) is not None:
+# Ignore travis, continuous and scaffolding changes
+if re.search(r'^toolset\/(?!(travis\/|continuous\/|scaffolding\/))', changes, re.M) is not None:
     print("Found changes to core toolset. Running all tests.")
     run_tests = test_dirs
     quit_diffing()

--- a/toolset/travis/travis_diff.py
+++ b/toolset/travis/travis_diff.py
@@ -5,13 +5,14 @@
 #
 # @description: This script is only for use within Travis-CI. It is meant to
 # look through the commit history and determine whether or not the current
-# framework test directory needs to be run. It compares the state of the PR branch
-# against the target branch.
+# framework test directory needs to be run. It compares the state of the PR
+# branch against the target branch.
 #
-# Any changes found in the toolset/* directory other than continuous/*, travis/* and
-# scaffolding/* will cause all tests to be run.
+# Any changes found in the toolset/* directory other than continuous/*, travis/*
+# and scaffolding/* will cause all tests to be run.
 #
-# The following commands can be put in commit messages to affect which tests will run:
+# The following commands can be put in commit messages to affect which tests
+# will run:
 #
 # [ci skip] - Provided by Travis. Travis won't trigger any builds.
 # [ci run-all] - This will force all tests to run.
@@ -21,12 +22,14 @@
 # [ci lang-only Java C++] - Ensures that only Java and C++ run despite detected changes.
 # [ci lang Java C++] - Forces Java and C++ tests to run in addition to detected changes.
 #
-# If only a single test within a language group is forced to run, none of the other tests
-# in that language group will run.
+# If only a single test within a language group is forced to run, none of the
+# other tests in that language group will run.
 #
-# IMPORTANT: the [ci *] commands must be added to every commit message. We do not look at
-#  previous commit messages. Make sure to keep your PR branch up-to-date with the target
-#  branch to avoid running unwanted tests.
+# The master branch will run the full suite of tests.
+#
+# IMPORTANT: the [ci *] commands must be added to every commit message. We do
+# not look at previous commit messages. Make sure to keep your PR branch
+# up-to-date with the target branch to avoid running unwanted tests.
 
 
 import subprocess
@@ -52,11 +55,14 @@ def quit_diffing():
         print("No tests to run.")
     exit(0)
 
+
 curr_branch = ""
+is_master = os.getenv("TRAVIS_BRANCH") == "master"
 is_PR = (os.getenv("TRAVIS_PULL_REQUEST") != "false")
+
 if is_PR:
     curr_branch = "FETCH_HEAD"
-else:
+elif not is_master:
     curr_branch = os.getenv("TRAVIS_COMMIT")
     # Also fetch master to compare against
     subprocess.check_output(['bash', '-c', 'git fetch origin master:master'])
@@ -91,7 +97,7 @@ elif os.getenv("TESTDIR"):
     test_dirs = os.getenv("TESTDIR").split(' ')
 
 # Forced full run
-if re.search(r'\[ci run-all\]', last_commit_msg, re.M):
+if is_master or re.search(r'\[ci run-all\]', last_commit_msg, re.M):
     print("All tests have been forced to run from the commit message.")
     run_tests = test_dirs
     quit_diffing()


### PR DESCRIPTION
The `FETCH_HEAD` trick was cool, but it turns out travis only checksout `FETCH_HEAD` during pull requests. We need the last  commit for other branches. Travis provides this in the `TRAVIS_COMMIT` env var. Travis also now provides a `TRAVIS_COMMIT_MESSAGE`  which allows us to clean up even more code.

resolves #4655 