### PR TITLE
Syntax error

### DIFF
--- a/toolset/databases/mongodb/create.js
+++ b/toolset/databases/mongodb/create.js
@@ -1,4 +1,3 @@
-use hello_world
 db.world.drop()
 for (var i = 1; i <= 10000; i++) {
   db.world.save( { _id: i, id: i, randomNumber: (Math.floor(Math.random() * 10000) + 1) })


### PR DESCRIPTION
A piece of code could not be parsed due to syntax errors.

Syntax errors prevent code from executing correctly. If a piece of code contains syntax errors, this most likely indicates that it is never run and thus is dead code that should be removed.