### PR TITLE
Unused import

### DIFF
--- a/toolset/benchmark/test_types/framework_test_type.py
+++ b/toolset/benchmark/test_types/framework_test_type.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 import json
 import requests
 import MySQLdb


### PR DESCRIPTION
Import is not required as it is not used

A module is imported (using the import statement) but that module is never used. This creates a dependency that does not need to exist and makes the code more difficult to read.