### PR TITLE
Install ext-event for better performance

### DIFF
--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update -yqq > /dev/null && \
 
 RUN apt-get install -yqq composer > /dev/null
 
+RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
+
 COPY deploy/conf/* /etc/php/7.3/fpm/
 
 ADD ./ /workerman


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Workerman suggests to install ext-event for better performance but it wasn't installed.
https://github.com/walkor/Workerman/blob/master/composer.json#L29
In centos it could be installed by `yum install -y php-pecl-event` but in ubuntu it could be installed a little bit harder:
```bash
apt-get install -y php-pear php-dev libevent-dev
printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event
echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
```