### PR TITLE
[ci fw-only Java/play1] Play1 to conform to #4622

### DIFF
--- a/frameworks/Java/play1/README.md
+++ b/frameworks/Java/play1/README.md
@@ -1,2 +1,31 @@
-FrameworkBenchmarks-play1.2.5
-=============================
+# Play framework Benchmarking Test
+
+[Play framework](https://www.playframework.com/) - the high velocity web framework for Java and Scala.
+
+### Test sources
+
+This is the list:
+
+ * [Plaintext](app/controllers/Application.java#L24)
+ * [JSON](app/controllers/Application.java#L28)
+ * [DB](app/controllers/Application.java#L39)
+ * [Queries](app/controllers/Application.java#L45)
+
+## Software Versions
+
+The tests were run with:
+
+ * [Oracle Java 10](https://www.oracle.com/java/)
+ * [MySQL 5.7](http://www.mysql.com/)
+
+Please check the versions in the install and build scripts of TFB project.
+
+## Test URLs
+
+All implementations use the same URLs.
+
+ * Plaintext - `http://localhost:8080/plaintext`
+ * JSON - `http://localhost:8080/json`
+ * DB - `http://localhost:8080/db`
+ * Queries - `http://localhost:8080/query?queries=`
+

--- a/frameworks/Java/play1/README.md
+++ b/frameworks/Java/play1/README.md
@@ -1,6 +1,6 @@
-# Play framework Benchmarking Test
+# Play 1 framework Benchmarking Test
 
-[Play framework](https://www.playframework.com/) - the high velocity web framework for Java and Scala.
+[Play 1 framework](https://www.playframework.com/) - the high velocity web framework for Java and Scala. This is the old version - it's not Play 2.
 
 ### Test sources
 

--- a/frameworks/Java/play1/app/controllers/Application.java
+++ b/frameworks/Java/play1/app/controllers/Application.java
@@ -22,7 +22,7 @@ public class Application extends Controller {
 	}
 
 	public static void hello() {
-		renderText("hello world");
+		renderText("Hello, world!");
 	}
 
 	public static void json() {
@@ -36,9 +36,18 @@ public class Application extends Controller {
 	 * 
 	 * @param queries
 	 */
-	public static void dbSync(int queries) {
-		if (queries == 0)
+	public static void dbSync() {
+		Long id = Long.valueOf(ThreadLocalRandom.current().nextInt(TEST_DATABASE_ROWS) + 1);
+		World result = World.findById(id);
+		renderJSON(result);
+	}
+
+    public static void dbQueries(int queries) {
+		if (queries == 0) {
 			queries = 1;
+		} else if (queries > 500) {
+			queries = 500;
+        }
 		final List<World> worlds = new ArrayList<World>();
 		for (int i = 0; i < queries; ++i) {
 			Long id = Long.valueOf(ThreadLocalRandom.current().nextInt(TEST_DATABASE_ROWS) + 1);
@@ -46,7 +55,7 @@ public class Application extends Controller {
 			worlds.add(result);
 		}
 		renderJSON(worlds);
-	}
+    }
 
 	@play.db.jpa.NoTransaction
 	public static void setup() {

--- a/frameworks/Java/play1/benchmark_config.json
+++ b/frameworks/Java/play1/benchmark_config.json
@@ -3,8 +3,9 @@
   "tests": [{
     "default": {
       "json_url": "/json",
+      "plaintext_url": "/plaintext",
       "db_url": "/db",
-      "query_url": "/db?queries=",
+      "query_url": "/query?queries=",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Fullstack",

--- a/frameworks/Java/play1/conf/routes
+++ b/frameworks/Java/play1/conf/routes
@@ -6,9 +6,10 @@
 # Home page
 GET     /json                           Application.json
 GET     /db                             Application.dbSync
+GET     /query                          Application.dbQueries
+GET     /plaintext                      Application.hello
 GET     /db2                            Application.dbAsyncAllQueries
 GET     /db3                            Application.dbAsyncEachQuery
 GET     /setup                          Application.setup
 GET     /                               Application.index
-GET     /hello                          Application.hello
 

--- a/frameworks/Java/play1/notes.txt
+++ b/frameworks/Java/play1/notes.txt
@@ -1,3 +1,0 @@
-json.tosjon jackson ?
-
-jackson version ?

--- a/frameworks/Java/play1/play1.dockerfile
+++ b/frameworks/Java/play1/play1.dockerfile
@@ -4,7 +4,7 @@ COPY app app
 COPY conf conf
 COPY public public
 COPY test test
-RUN wget -nv https://downloads.typesafe.com/play/1.5.0/play-1.5.0.zip
-RUN unzip -q play-1.5.0.zip
+RUN wget -nv https://downloads.typesafe.com/play/1.5.2/play-1.5.2.zip
+RUN unzip -q play-1.5.2.zip
 RUN apt install -yqq python
 CMD ["play-1.5.0/play", "run", "--%prod"]

--- a/frameworks/Java/play1/play1.dockerfile
+++ b/frameworks/Java/play1/play1.dockerfile
@@ -7,4 +7,4 @@ COPY test test
 RUN wget -nv https://downloads.typesafe.com/play/1.5.2/play-1.5.2.zip
 RUN unzip -q play-1.5.2.zip
 RUN apt install -yqq python
-CMD ["play-1.5.0/play", "run", "--%prod"]
+CMD ["play-1.5.2/play", "run", "--%prod"]


### PR DESCRIPTION
- bump Play 1 version to 1.5.2 - there are almost no references to this old version of the framework. I've checked some combinations of numbers to see if there is something "newer";
- add/update separate `db` and `query` endpoints (#4622);
- add the check for more than 500 requested queries (#4622);
- add `plaintext` implementation;
- updated README.md to contain the basic information;
- remove `notes.txt`