### PR TITLE
Nginx disable msie_padding

### DIFF
--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -5,6 +5,7 @@ error_log stderr error;
 #worker_rlimit_nofile 1000000;
 timer_resolution 1000ms;
 daemon off;
+msie_padding off;
 
 events {
     worker_connections 32768;

--- a/frameworks/C/nginx/nginx.conf
+++ b/frameworks/C/nginx/nginx.conf
@@ -5,7 +5,6 @@ error_log stderr error;
 #worker_rlimit_nofile 1000000;
 timer_resolution 1000ms;
 daemon off;
-msie_padding off;
 
 events {
     worker_connections 32768;
@@ -16,6 +15,7 @@ http {
     include       /etc/nginx/mime.types;
     access_log off;
     server_tokens off;
+    msie_padding off;
 
     sendfile off; #default
     tcp_nopush off; #default


### PR DESCRIPTION
Disables adding comments to responses for MSIE clients with status greater than 400
to increase the response size to 512 bytes.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
