### PR TITLE
PHP-FPM change rlimit file descriptor

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -68,7 +68,7 @@ error_log = /dev/stderr
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
-; process.max = 128
+process.max = 0
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lowest priority)
@@ -84,12 +84,12 @@ error_log = /dev/stderr
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 100000
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -165,7 +165,7 @@ listen = /run/php/php7.3-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+listen.backlog = -1
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many
@@ -469,12 +469,12 @@ pm.max_spare_servers = 512
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 100000
 
 ; Set max core size rlimit.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Chroot to this directory at the start. This value must be defined as an
 ; absolute path. When this value is not set, chroot is not used.

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -68,7 +68,7 @@ error_log = /dev/stderr
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
-; process.max = 128
+process.max = 0
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lowest priority)
@@ -84,12 +84,12 @@ error_log = /dev/stderr
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 100000
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -165,7 +165,7 @@ listen = /run/php/php7.3-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
-listen.backlog = 65535
+listen.backlog = -1
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many
@@ -469,12 +469,12 @@ pm.max_spare_servers = 512
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = 100000
 
 ; Set max core size rlimit.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = 'unlimited'
 
 ; Chroot to this directory at the start. This value must be defined as an
 ; absolute path. When this value is not set, chroot is not used.


### PR DESCRIPTION
After #4683 More keepalive requests, PHP is faster and the latency lower. Later I will send a PR for all the PHP frameworks.

But still don't scale after 128 concurrent connections.
This pattern happens with nginx and h2o, and not with php_ngx and others don't using php-fpm.

So the bottleneck seems to be in the php-fpm.
Changed rlimit to not use defaults.


<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
