### PR TITLE
Update nginx keepalive

### DIFF
--- a/frameworks/PHP/cakephp/deploy/nginx.conf
+++ b/frameworks/PHP/cakephp/deploy/nginx.conf
@@ -18,7 +18,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -18,7 +18,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/fat-free/deploy/nginx.conf
+++ b/frameworks/PHP/fat-free/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/fuel/deploy/nginx.conf
+++ b/frameworks/PHP/fuel/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/laravel/deploy/nginx.conf
+++ b/frameworks/PHP/laravel/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/limonade/deploy/nginx.conf
+++ b/frameworks/PHP/limonade/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/lithium/deploy/nginx.conf
+++ b/frameworks/PHP/lithium/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/lumen/deploy/nginx.conf
+++ b/frameworks/PHP/lumen/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
     
 
     open_file_cache max=2000 inactive=20s;

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/phpixie/deploy/nginx.conf
+++ b/frameworks/PHP/phpixie/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-5.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
+++ b/frameworks/PHP/slim/deploy/nginx-fpm-7.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/symfony/deploy/nginx.conf
+++ b/frameworks/PHP/symfony/deploy/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     open_file_cache max=2000 inactive=20s;
     open_file_cache_valid 60s;

--- a/frameworks/PHP/yii2/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-fpm.conf
@@ -15,7 +15,7 @@ http {
     sendfile on;
     keepalive_timeout  65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;

--- a/frameworks/PHP/zend/deploy/nginx.conf
+++ b/frameworks/PHP/zend/deploy/nginx.conf
@@ -18,7 +18,7 @@ http {
 
     keepalive_timeout  65;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;


### PR DESCRIPTION
In #4698 by mistake updated to 1000 and needed to be 10000
So all frameworks have the same config.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
