### PR TITLE
Add support for specifying multiple test types

### DIFF
--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -131,6 +131,7 @@ def main(argv=None):
             'all', 'json', 'db', 'query', 'cached_query', 'fortune', 'update',
             'plaintext'
         ],
+        nargs='+',
         default='all',
         help='which type of test to run')
     parser.add_argument(

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -21,11 +21,11 @@ class BenchmarkConfig:
         types['plaintext'] = PlaintextTestType(self)
         types['cached_query'] = CachedQueryTestType(self)
 
-        # Turn type into a map instead of a string
-        if args.type == 'all':
+        # Turn type into a map instead of a list of strings
+        if 'all' in args.type:
             self.types = types
         else:
-            self.types = {args.type: types[args.type]}
+            self.types = {t: types[t] for t in args.type}
 
         self.duration = args.duration
         self.exclude = args.exclude


### PR DESCRIPTION
This allows one to specify multiple types on the command line, e.g. '--type db query fortune'. Convenient for comparison, analysis, development, etc. Backwards compatible with default, explicit 'all' and single argument.

