### PR TITLE
Fix reitit db-test not to run in an io-pool thread

### DIFF
--- a/frameworks/Clojure/reitit/src/hello/handler.clj
+++ b/frameworks/Clojure/reitit/src/hello/handler.clj
@@ -2,6 +2,7 @@
   (:require [immutant.web :as web]
             [hikari-cp.core :as hikari]
             [reitit.ring :as ring]
+            [immutant.web.internal.ring :as immutant]
             [porsas.core :as p]
             [jsonista.core :as j])
   (:gen-class)
@@ -10,8 +11,13 @@
 
 (defn blocking [handler]
   (fn [req]
-    (.startBlocking ^HttpServerExchange (:server-exchange req))
-    (handler req)))
+    (let [exchange ^HttpServerExchange (:server-exchange req)]
+      (if (.isInIoThread exchange)
+        (.dispatch exchange ^Runnable ^:once (fn []
+                                               (.startBlocking exchange)
+                                               (immutant/write-response exchange (handler req))
+                                               (.endExchange exchange)))
+        (handler req)))))
 
 (defn random []
   (unchecked-inc (.nextInt (ThreadLocalRandom/current) 10000)))
@@ -41,7 +47,7 @@
 (defn -main [& _]
   (let [ds (hikari/make-datasource
              {:read-only true
-              :maximum-pool-size 64
+              :maximum-pool-size 48
               :pool-name "db-pool"
               :adapter "postgresql"
               :username "benchmarkdbuser"
@@ -57,11 +63,13 @@
            ["/json" json-handler]
            ["/db" (blocking (db-handler ds))]])
         (ring/create-default-handler)
-        {:inject-match? false, :inject-router? false})
+        {:inject-match? false
+         :inject-router? false})
       {:port 8080
        :host "0.0.0.0"
+       :io-threads (* 2 (.availableProcessors (Runtime/getRuntime)))
        :dispatch? false
-       :worker-threads 64
+       :worker-threads 48
        :server {:always-set-keep-alive false}})))
 
 (comment


### PR DESCRIPTION
Fix reitit db-test not to run in an io-pool thread