### PR TITLE
Java/comsat - Add JVM option for more MaxDirectMemorySize

### DIFF
--- a/frameworks/Java/comsat/comsat-servlet-undertow.dockerfile
+++ b/frameworks/Java/comsat/comsat-servlet-undertow.dockerfile
@@ -8,4 +8,4 @@ RUN gradle capsule -q
 FROM openjdk:8-jre-slim
 WORKDIR /comsat
 COPY --from=gradle /comsat/build/libs/comsat-0.3-capsule.jar app.jar
-CMD ["java", "-Dcapsule.mode=servlet-undertow", "-jar", "app.jar"]
+CMD ["java", "-Dcapsule.mode=servlet-undertow", "-XX:MaxDirectMemorySize=128M", "-jar", "app.jar"]


### PR DESCRIPTION
Let's see if this helps the benchmark [not to die](https://tfb-status.techempower.com/unzip/results.2019-05-04-11-56-15-224.zip/results/20190430202646/comsat-servlet-undertow/run/comsat-servlet-undertow.log). Look at the very bottom of the log.