### PR TITLE
Change docker containers to shut down gracefully

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -250,7 +250,7 @@ class DockerHelper:
     @staticmethod
     def __stop_container(container):
         try:
-            container.kill()
+            container.stop(timeout=2)
             time.sleep(2)
         except:
             # container has already been killed


### PR DESCRIPTION
This gives containers up to a couple of seconds to shut down gracefully before killing it as it did before.

This allows collecting and logging statistics at the end of the tests, closing logs and other files that need to be persisted, maybe do cleanup, and in theory might prevent some other issues caused by killing the containers violently. Although it adds up to 2 seconds per framework to the test, I think this is negligible overall compared to the test times or to adding a new framework.

I chose the 2 second timeout since it's enough for the frameworks I tested and doesn't add much, though you might want to tweak it in the future if necessary (the default for this parameter is 10 seconds which I thought might be too much in the worst case).