### PR TITLE
Update Nginx Rlimit

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/nginx.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/nginx.conf
@@ -1,7 +1,7 @@
 user www-data;
 worker_processes  auto;
 error_log stderr error;
-#worker_rlimit_nofile 100000;
+worker_rlimit_nofile 2000000;
 timer_resolution 1000ms;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx-pools.conf
+++ b/frameworks/PHP/php/deploy/nginx-pools.conf
@@ -2,7 +2,7 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 timer_resolution 1000ms;
-#worker_rlimit_nofile 100000;
+worker_rlimit_nofile 2000000;
 pcre_jit on;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx5.conf
+++ b/frameworks/PHP/php/deploy/nginx5.conf
@@ -2,7 +2,7 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 timer_resolution 1000ms;
-#worker_rlimit_nofile 100000;
+worker_rlimit_nofile 2000000;
 pcre_jit on;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -2,7 +2,7 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 timer_resolution 1000ms;
-#worker_rlimit_nofile 100000;
+worker_rlimit_nofile 2000000;
 pcre_jit on;
 
 events {

--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -25,7 +25,7 @@ http {
     php_ini_path /deploy/conf/php.ini;
 
     server {
-        listen       8080 reuseport;
+        listen       8080 default_server reuseport;
 
         root /;
         index  index.html;

--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65s;
     keepalive_disable none;
-    keepalive_requests 1000;
+    keepalive_requests 10000;
 
     php_ini_path /deploy/conf/php.ini;
 

--- a/frameworks/PHP/ubiquity/README.md
+++ b/frameworks/PHP/ubiquity/README.md
@@ -4,7 +4,6 @@
 Ubiquity is a full-stack php framework, These tests involve:
 - the ORM part (Full)
 - the JSON serialization (native php)
-- the Twig template engine
 
 ## Test Type Implementation Source Code
 The tests are separated into 4 controllers:


### PR DESCRIPTION
Bigger nginx rlimit for file descriptors
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
