### PR TITLE
Java/tapestry update dependencies

### DIFF
--- a/frameworks/Java/tapestry/pom.xml
+++ b/frameworks/Java/tapestry/pom.xml
@@ -9,16 +9,17 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <tapestry-release-version>5.4.3</tapestry-release-version>
-        <servlet-api-release-version>2.5</servlet-api-release-version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <tapestry-release-version>5.5.0-beta-2</tapestry-release-version>
+        <servlet-api-release-version>3.1.0</servlet-api-release-version>
+        <jaxb.version>2.4.0-b180830.0438</jaxb.version>
         <testng-release-version>5.14.10</testng-release-version>
         <easymock-release-version>3.0</easymock-release-version>
     </properties>
 
         <dependencies>
-        <!-- Too set up an application with a database, change the artifactId below to
+        <!-- To set up an application with a database, change the artifactId below to
              tapestry-hibernate, and add a dependency on your JDBC driver. You'll also
              need to add Hibernate configuration files, such as hibernate.cfg.xml. -->
         <dependency>
@@ -45,13 +46,11 @@
         -->
 
         <!-- Uncomment this to add support for file uploads:
-
          <dependency>
             <groupId>org.apache.tapestry</groupId>
             <artifactId>tapestry-upload</artifactId>
             <version>${tapestry-release-version}</version>
         </dependency>
-
         -->
 
         <!-- A dependency on either JUnit or TestNG is required, or the surefire plugin (which runs the tests)
@@ -78,11 +77,10 @@ of testing facilities designed for use with TestNG (http://testng.org/), so it's
             <scope>test</scope>
         </dependency>
 
-        <!-- Provided by the servlet container, but sometimes referenced in the application
-       code. -->
+        <!-- Provided by the servlet container, but sometimes referenced in the application code. -->
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet-api-release-version}</version>
             <scope>provided</scope>
         </dependency>
@@ -97,9 +95,13 @@ of testing facilities designed for use with TestNG (http://testng.org/), so it's
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>tapestry</finalName>
@@ -151,9 +153,9 @@ of testing facilities designed for use with TestNG (http://testng.org/), so it's
         </repository>
         <!-- This repository is only needed when the Tapestry version is a preview release, rather
              than a final release. -->
-<!--         <repository> -->
-<!--             <id>apache-staging</id> -->
-<!--             <url>https://repository.apache.org/content/groups/staging/</url> -->
-<!--         </repository> -->
+<!--  --><repository>
+            <id>apache-staging</id>
+            <url>https://repository.apache.org/content/groups/staging/</url>
+        </repository>
     </repositories>
 </project>

--- a/frameworks/Java/tapestry/src/main/resources/hibernate.cfg.xml
+++ b/frameworks/Java/tapestry/src/main/resources/hibernate.cfg.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE hibernate-configuration PUBLIC
         "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-        "http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+        "http://www.hibernate.org/dtd/hibernate-configuration">
 <hibernate-configuration>
     <session-factory>
         <!-- Database connection settings -->

--- a/frameworks/Java/tapestry/tapestry.dockerfile
+++ b/frameworks/Java/tapestry/tapestry.dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /tapestry
 COPY src src
 COPY pom.xml pom.xml
-RUN mvn compile war:war
+RUN mvn compile war:war -q
 
 FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin

--- a/frameworks/Java/tapestry/tapestry.dockerfile
+++ b/frameworks/Java/tapestry/tapestry.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /tapestry
 COPY src src
 COPY pom.xml pom.xml
-RUN mvn compile war:war -q
+RUN mvn compile war:war
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /tapestry/target/tapestry.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml


### PR DESCRIPTION
The changes are:
- Updated Maven image to 3.6.1/Java 11;
- Updated to Java 11 compilation using `openjdk:11.0.3-jre-stretch` because `curl` is not included in **`-slim`**;
- Use **beta** version of Apache Tapestry;
- Update to Servlet 3.1 API;
- Use    JAXB from org.glassfish;
- Update hibernate.cfg.xml DTD definition to fix warning when starting;
- Update Resin to 4.0.61 - get rid of some exceptions when starting.

Unable to update to latest (5.4.2Final) Hibernate - there are exceptions about the way Tapestry is accessing Hibernate.

Update for the other projects with Resin - coming soon...