### PR TITLE
Update es4x.dockerfile

### DIFF
--- a/frameworks/JavaScript/es4x/es4x.dockerfile
+++ b/frameworks/JavaScript/es4x/es4x.dockerfile
@@ -1,4 +1,4 @@
-FROM oracle/graalvm-ce:1.0.0-rc16
+FROM oracle/graalvm-ce:19.0.0
 # Set working dir
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
GraalVM is a GA release, this upgrades the benchmark to run on stable docker image instead of RC release.
