### PR TITLE
Update Resin to 4.0.61 and OpenJDK 11

### DIFF
--- a/frameworks/Clojure/compojure/compojure-raw.dockerfile
+++ b/frameworks/Clojure/compojure/compojure-raw.dockerfile
@@ -1,12 +1,12 @@
-FROM clojure:lein-2.8.1 as lein
+FROM clojure:openjdk-11-lein-2.9.1 as lein
 WORKDIR /compojure
 COPY src src
 COPY project.clj project.clj
 RUN lein ring uberwar
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=lein /compojure/target/hello-compojure-standalone.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Clojure/compojure/compojure.dockerfile
+++ b/frameworks/Clojure/compojure/compojure.dockerfile
@@ -1,12 +1,12 @@
-FROM clojure:lein-2.8.1 as lein
+FROM clojure:openjdk-11-lein-2.9.1 as lein
 WORKDIR /compojure
 COPY src src
 COPY project.clj project.clj
 RUN lein ring uberwar
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=lein /compojure/target/hello-compojure-standalone.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -10,7 +10,7 @@
                  [mysql/mysql-connector-java "5.1.47"]
                  [com.mchange/c3p0 "0.9.5.4"]
                  [org.clojure/java.jdbc "0.7.9"]
-                 [com.zaxxer/HikariCP "3.3.1"]
+                 [hikari-cp "2.7.1"]
                  [hiccup "1.0.5"]]
   :repositories {"Sonatype releases" "https://oss.sonatype.org/content/repositories/releases/"}
   :plugins [[lein-ring "0.12.5"]

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -5,7 +5,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [compojure "1.4.0"]
                  [ring/ring-json "0.4.0"]
-                 [korma "0.4.2"]
+                 [korma "0.5.0-RC1"]
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  [mysql/mysql-connector-java "5.1.47"]
                  [com.mchange/c3p0 "0.9.5.4"]

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -13,7 +13,9 @@
                  [hikari-cp "3.3.1"]
                  [hiccup "1.0.5"]]
   :repositories {"Sonatype releases" "https://oss.sonatype.org/content/repositories/releases/"}
-  :plugins [[lein-ring "0.9.7"]]
+  :plugins [[lein-ring "0.12.5"]
+            [org.clojure/core.unify "0.5.7"]
+            [nightlight/lein-nightlight "RELEASE"]]
   :ring {:handler hello.handler/app}
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -8,9 +8,9 @@
                  [korma "0.4.2"]
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
                  [mysql/mysql-connector-java "5.1.47"]
-                 [com.mchange/c3p0 "0.9.5.2"]
-                 [org.clojure/java.jdbc "0.3.7"]
-                 [hikari-cp "1.5.0"]
+                 [com.mchange/c3p0 "0.9.5.4"]
+                 [org.clojure/java.jdbc "0.7.9"]
+                 [hikari-cp "3.3.1"]
                  [hiccup "1.0.5"]]
   :repositories {"Sonatype releases" "https://oss.sonatype.org/content/repositories/releases/"}
   :plugins [[lein-ring "0.9.7"]]

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -10,7 +10,7 @@
                  [mysql/mysql-connector-java "5.1.47"]
                  [com.mchange/c3p0 "0.9.5.4"]
                  [org.clojure/java.jdbc "0.7.9"]
-                 [hikari-cp "3.3.1"]
+                 [com.zaxxer/HikariCP "3.3.1"]
                  [hiccup "1.0.5"]]
   :repositories {"Sonatype releases" "https://oss.sonatype.org/content/repositories/releases/"}
   :plugins [[lein-ring "0.12.5"]

--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -10,7 +10,7 @@
                  [mysql/mysql-connector-java "5.1.47"]
                  [com.mchange/c3p0 "0.9.5.4"]
                  [org.clojure/java.jdbc "0.7.9"]
-                 [hikari-cp "2.7.1"]
+                 [hikari-cp "1.8.3"]
                  [hiccup "1.0.5"]]
   :repositories {"Sonatype releases" "https://oss.sonatype.org/content/repositories/releases/"}
   :plugins [[lein-ring "0.12.5"]

--- a/frameworks/Clojure/compojure/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/src/hello/handler.clj
@@ -48,7 +48,7 @@
                     :minimum-idle       10
                     :maximum-pool-size  512
                     :pool-name          "db-pool"
-                    :jdbc-url           "//tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
+                    :jdbc-url           "jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
                     :username           "benchmarkdbuser"
                     :password           "benchmarkdbpass"
                     :register-mbeans    false}))

--- a/frameworks/Clojure/compojure/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/src/hello/handler.clj
@@ -34,7 +34,7 @@
           :password "benchmarkdbpass"
           ;;OPTIONAL KEYS
           :delimiters "" ;; remove delimiters
-          :maximum-pool-size 256}))
+          :maximum-pool-size 512}))
 
 ;; Create HikariCP-pooled "raw" jdbc data source
 (defn make-hikari-data-source
@@ -46,14 +46,11 @@
                     :idle-timeout       600000
                     :max-lifetime       1800000
                     :minimum-idle       10
-                    :maximum-pool-size  256
+                    :maximum-pool-size  512
                     :pool-name          "db-pool"
-                    :adapter            "mysql"
+                    :jdbc-url           "//tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
                     :username           "benchmarkdbuser"
                     :password           "benchmarkdbpass"
-                    :database-name      "hello_world"
-                    :server-name        "tfb-database"
-                    :port-number        3306
                     :register-mbeans    false}))
 
 ;; Reuse a single HikariCP-pooled data source

--- a/frameworks/Groovy/grails/grails-app/conf/BuildConfig.groovy
+++ b/frameworks/Groovy/grails/grails-app/conf/BuildConfig.groovy
@@ -3,8 +3,8 @@ grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"
 grails.project.work.dir = "target/work"
-grails.project.target.level = 1.8
-grails.project.source.level = 1.8
+grails.project.target.level = 1.7
+grails.project.source.level = 1.7
 //grails.project.war.file = "target/${appName}-${appVersion}.war"
 
 grails.project.fork = [

--- a/frameworks/Groovy/grails/grails-app/conf/BuildConfig.groovy
+++ b/frameworks/Groovy/grails/grails-app/conf/BuildConfig.groovy
@@ -3,8 +3,8 @@ grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"
 grails.project.work.dir = "target/work"
-grails.project.target.level = 1.7
-grails.project.source.level = 1.7
+grails.project.target.level = 1.8
+grails.project.source.level = 1.8
 //grails.project.war.file = "target/${appName}-${appVersion}.war"
 
 grails.project.fork = [

--- a/frameworks/Groovy/grails/grails.dockerfile
+++ b/frameworks/Groovy/grails/grails.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:8-jdk
 
 WORKDIR /grails
 COPY grails-app grails-app
@@ -19,7 +19,7 @@ RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output c
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} prod -non-interactive -plain-output war
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 RUN cp /grails/target/hello-0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Groovy/grails/grails.dockerfile
+++ b/frameworks/Groovy/grails/grails.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 
 WORKDIR /grails
 COPY grails-app grails-app
@@ -19,7 +19,7 @@ RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output c
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} prod -non-interactive -plain-output war
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 RUN cp /grails/target/hello-0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Groovy/grails/grails.dockerfile
+++ b/frameworks/Groovy/grails/grails.dockerfile
@@ -19,7 +19,7 @@ RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} -non-interactive -plain-output c
 RUN grails -Dgrails.work.dir=${GRAILS_WORK_DIR} prod -non-interactive -plain-output war
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 RUN cp /grails/target/hello-0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/activeweb/activeweb-jackson.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-jackson.dockerfile
@@ -1,13 +1,13 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /activeweb
 COPY pom.xml pom.xml
 COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /activeweb/target/activeweb.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/activeweb/activeweb.dockerfile
+++ b/frameworks/Java/activeweb/activeweb.dockerfile
@@ -1,13 +1,13 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /activeweb
 COPY pom.xml pom.xml
 COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /activeweb/target/activeweb.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/activeweb/pom.xml
+++ b/frameworks/Java/activeweb/pom.xml
@@ -9,6 +9,9 @@
     <name>ActiveWeb Benchmark App</name>
 
     <properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
         <activeweb.version>1.11</activeweb.version>
         <activejdbc.version>1.4.10</activejdbc.version>
     </properties>
@@ -33,10 +36,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+					<debug>false</debug>
                 </configuration>
             </plugin>
 
@@ -108,17 +110,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>1.8.0-beta4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
     </dependencies>
 

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /curacao
 COPY pom.xml pom.xml
 COPY src src
-RUN mvn compile war:war
+RUN mvn compile war:war -q
 
 FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /curacao
 COPY pom.xml pom.xml
 COPY src src
-RUN mvn compile war:war -q
+RUN mvn compile war:war
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /curacao/target/curacao.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/curacao/pom.xml
+++ b/frameworks/Java/curacao/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -22,23 +22,23 @@
         <dependency>
             <groupId>curacao</groupId>
             <artifactId>curacao</artifactId>
-            <version>4.2.0</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>curacao</groupId>
             <artifactId>curacao-gson</artifactId>
-            <version>4.2.0</version>
+            <version>6.0.0</version>
         </dependency>
 
-        <!-- Servlet -->
+        <!-- Servlet
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Logback -->
+        -->
+        <!-- Logback 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
@@ -49,6 +49,7 @@
             <artifactId>logback-classic</artifactId>
             <version>1.1.7</version>
         </dependency>
+        -->
 
     </dependencies>
 

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 
 WORKDIR /gemini
 
@@ -9,11 +9,10 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-mysql.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk
-RUN apt update -qqy && apt install -yqq curl > /dev/null
+FROM openjdk:11.0.3-jre-stretch
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /gemini/target/HelloWorld-0.0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 
 WORKDIR /gemini
 
@@ -9,11 +9,10 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-postgres.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk
-RUN apt update -qqy && apt install -yqq curl > /dev/null
+FROM openjdk:11.0.3-jre-stretch
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /gemini/target/HelloWorld-0.0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 
 WORKDIR /gemini
 
@@ -9,11 +9,10 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:10-jdk
-RUN apt update -qqy && apt install -yqq curl > /dev/null
+FROM openjdk:11.0.3-jre-stretch
 
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /gemini/target/HelloWorld-0.0.1.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/gemini/pom.xml
+++ b/frameworks/Java/gemini/pom.xml
@@ -9,8 +9,8 @@
     <version>0.0.1</version>
 
     <properties>
-        <maven.compiler.source>10</maven.compiler.source>
-        <maven.compiler.target>10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/frameworks/Java/revenj-jvm/pom.xml
+++ b/frameworks/Java/revenj-jvm/pom.xml
@@ -9,8 +9,8 @@
 	<version>1.1.0</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/frameworks/Java/revenj-jvm/pom.xml
+++ b/frameworks/Java/revenj-jvm/pom.xml
@@ -11,6 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<jaxb.version>2.4.0-b180830.0438</jaxb.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -28,6 +29,11 @@
 			<groupId>com.fizzed</groupId>
 			<artifactId>rocker-runtime</artifactId>
 			<version>1.2.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>${jaxb.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/frameworks/Java/revenj-jvm/pom.xml
+++ b/frameworks/Java/revenj-jvm/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.fizzed</groupId>
 			<artifactId>rocker-runtime</artifactId>
-			<version>0.20.0</version>
+			<version>1.2.1</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -70,7 +70,7 @@
 			<plugin>
 				<groupId>com.fizzed</groupId>
 				<artifactId>rocker-maven-plugin</artifactId>
-				<version>0.20.0</version>
+				<version>1.2.1</version>
 				<executions>
 					<execution>
 						<id>generate-rocker-templates</id>

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-8 as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /revenj-jvm
 COPY src src
 COPY pom.xml pom.xml
@@ -11,11 +11,11 @@ RUN apt install -yqq mono-complete mono-fastcgi-server
 RUN wget -q https://github.com/ngs-doo/revenj/releases/download/1.4.2/dsl-compiler.zip
 RUN unzip -o dsl-compiler.zip
 RUN rm dsl-compiler.zip
-RUN mvn compile war:war -q
+RUN mvn compile war:war
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /revenj-jvm/target/revenj.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -3,6 +3,8 @@ WORKDIR /revenj-jvm
 COPY src src
 COPY pom.xml pom.xml
 
+# no GPG by default in the base image
+RUN apt update -qqy && apt install -yqq gnupg wget > /dev/null
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list
 RUN apt update

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -13,7 +13,7 @@ RUN apt install -yqq mono-complete mono-fastcgi-server
 RUN wget -q https://github.com/ngs-doo/revenj/releases/download/1.4.2/dsl-compiler.zip
 RUN unzip -o dsl-compiler.zip
 RUN rm dsl-compiler.zip
-RUN mvn compile war:war
+RUN mvn compile war:war -q
 
 FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -10,10 +10,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<cache2k-version>1.2.0.Final</cache2k-version>
-		<jackson-version>2.9.7</jackson-version>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<cache2k-version>1.2.1.Final</cache2k-version>
+		<jackson-version>2.9.8</jackson-version>
 		<!-- This is the default web.xml for plaintext and json only -->
 		<maven.war.xml>src/main/webapp/WEB-INF/web.xml</maven.war.xml>
 	</properties>
@@ -44,6 +44,12 @@
 			<groupId>javax.inject</groupId>
 			<artifactId>javax.inject</artifactId>
 			<version>1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.3.2</version>
 		</dependency>
 
 		<!-- Servlet -->

--- a/frameworks/Java/servlet/servlet-afterburner.dockerfile
+++ b/frameworks/Java/servlet/servlet-afterburner.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P afterburner
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/servlet/servlet-cjs.dockerfile
+++ b/frameworks/Java/servlet/servlet-cjs.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P cjs
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -4,9 +4,9 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P mysql
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/servlet/servlet-postgresql.dockerfile
+++ b/frameworks/Java/servlet/servlet-postgresql.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P postgresql
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/servlet/servlet.dockerfile
+++ b/frameworks/Java/servlet/servlet.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /servlet
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /servlet/target/servlet.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -20,10 +20,10 @@
 	</licenses>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<wicket.version>8.3.0</wicket.version>
-		<slf4j.version>1.7.25</slf4j.version>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<wicket.version>8.4.0</wicket.version>
+		<slf4j.version>1.8.0-beta4</slf4j.version>
 	</properties>
 	<dependencies>
 		<!-- WICKET DEPENDENCIES -->
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
-			<version>2.6.0</version>
+			<version>3.3.1</version>
 			<scope>compile</scope>
 		</dependency>
 
@@ -64,13 +64,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-afterburner</artifactId>
-			<version>2.9.7</version>
+			<version>2.9.8</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.7</version>
+			<version>2.9.8</version>
 		</dependency>
 
 		<dependency>

--- a/frameworks/Java/wicket/wicket.dockerfile
+++ b/frameworks/Java/wicket/wicket.dockerfile
@@ -1,12 +1,12 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /wicket
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:10-jdk
+FROM openjdk:11.0.3-jre-stretch
 WORKDIR /resin
-RUN curl -sL http://caucho.com/download/resin-4.0.56.tar.gz | tar xz --strip-components=1
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*
 COPY --from=maven /wicket/target/hellowicket-1.0.war webapps/ROOT.war
 COPY resin.xml conf/resin.xml

--- a/frameworks/Kotlin/hexagon/gradle.properties
+++ b/frameworks/Kotlin/hexagon/gradle.properties
@@ -7,5 +7,5 @@ kotlinCoroutinesVersion=1.1.1
 kotlinVersion=1.3.30
 logbackVersion=1.2.3
 name=hexagon
-postgresqlVersion=42.2.5.jre7
+postgresqlVersion=42.2.5
 testngVersion=6.14.3

--- a/frameworks/Kotlin/hexagon/hexagon-jetty-postgresql.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-jetty-postgresql.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11
+FROM openjdk:11.0.3-jre-stretch
 ENV DBSTORE postgresql
 ENV POSTGRESQL_DB_HOST tfb-database
 ENV WEBENGINE jetty

--- a/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
@@ -1,4 +1,3 @@
-
 #
 # BUILD
 #
@@ -14,7 +13,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11
+FROM openjdk:11.0.3-jre-stretch
 ENV DBSTORE mongodb
 ENV MONGODB_DB_HOST tfb-database
 ENV RESIN 4.0.58

--- a/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
@@ -16,8 +16,10 @@ RUN gradle --quiet --exclude-task test
 FROM openjdk:11.0.3-jre-stretch
 ENV DBSTORE mongodb
 ENV MONGODB_DB_HOST tfb-database
-ENV RESIN 4.0.58
 
-RUN curl http://caucho.com/download/resin-$RESIN.tar.gz | tar xvz -C /opt
-COPY --from=gradle_build /hexagon/build/libs/ROOT.war /opt/resin-$RESIN/webapps
-ENTRYPOINT /opt/resin-$RESIN/bin/resin.sh console
+WORKDIR /resin
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
+RUN rm -rf webapps/*
+COPY --from=gradle_build /hexagon/build/libs/ROOT.war webapps/ROOT.war
+COPY resin.xml conf/resin.xml
+CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Kotlin/hexagon/hexagon-resin-postgresql.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-resin-postgresql.dockerfile
@@ -1,4 +1,3 @@
-
 #
 # BUILD
 #
@@ -14,11 +13,13 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11
+FROM openjdk:11.0.3-jre-stretch
 ENV DBSTORE postgresql
 ENV POSTGRESQL_DB_HOST tfb-database
-ENV RESIN 4.0.58
 
-RUN curl http://caucho.com/download/resin-$RESIN.tar.gz | tar xvz -C /opt
-COPY --from=gradle_build /hexagon/build/libs/ROOT.war /opt/resin-$RESIN/webapps
-ENTRYPOINT /opt/resin-$RESIN/bin/resin.sh console
+WORKDIR /resin
+RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
+RUN rm -rf webapps/*
+COPY --from=gradle_build /hexagon/build/libs/ROOT.war webapps/ROOT.war
+COPY resin.xml conf/resin.xml
+CMD ["java", "-jar", "lib/resin.jar", "console"]

--- a/frameworks/Kotlin/hexagon/hexagon.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11
+FROM openjdk:11.0.3-jre-stretch
 ENV DBSTORE mongodb
 ENV MONGODB_DB_HOST tfb-database
 ENV WEBENGINE jetty

--- a/frameworks/Kotlin/hexagon/resin.xml
+++ b/frameworks/Kotlin/hexagon/resin.xml
@@ -1,0 +1,18 @@
+<resin xmlns="http://caucho.com/ns/resin"
+       xmlns:resin="http://caucho.com/ns/resin/core">
+
+    <cluster id="">
+        <resin:import path="/resin/conf/app-default.xml" />
+        
+        <log name="" level="config" path="stdout:" timestamp="[%H:%M:%S.%s] " />
+
+        <server id="">
+            <http port="8080" />
+        </server>
+
+        <host>
+            <web-app-deploy path="/resin/webapps"
+                            expand-preserve-fileset="WEB-INF/work/**"/>
+        </host>
+    </cluster>
+</resin>


### PR DESCRIPTION
Resin and Java 11, the dependencies are also updated (maybe there are omissions):
- [x] Servlet
- [x] Gemini
- [x] wicket
- [x] revenj-jvm
- [x] activeweb
- [x] curacao
- [x] Kotlin/hexagon
- [x] Clojure/compojure

Only `Resin` updated. Stays on `Java 8`. `Grails` code is very old and the update will require effort.
- [x] Groovy/grails - too much effort will be required. Very old version currently.