### PR TITLE
Java/comsat - remove JVM option for more MaxDirectMemorySize

### DIFF
--- a/frameworks/Java/comsat/comsat-servlet-undertow.dockerfile
+++ b/frameworks/Java/comsat/comsat-servlet-undertow.dockerfile
@@ -8,4 +8,4 @@ RUN gradle capsule -q
 FROM openjdk:8-jre-slim
 WORKDIR /comsat
 COPY --from=gradle /comsat/build/libs/comsat-0.3-capsule.jar app.jar
-CMD ["java", "-Dcapsule.mode=servlet-undertow", "-XX:MaxDirectMemorySize=128M", "-jar", "app.jar"]
+CMD ["java", "-Dcapsule.mode=servlet-undertow", "-jar", "app.jar"]


### PR DESCRIPTION
This commit reverts #4739. This change caused [`plaintext` and `json` to fail](https://tfb-status.techempower.com/unzip/results.2019-05-12-08-02-48-672.zip/comsat-servlet-undertow). Before it only `plaintext` was failing.