### PR TITLE
More updates to Java11

### DIFF
--- a/frameworks/Java/blade/blade.dockerfile
+++ b/frameworks/Java/blade/blade.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /blade
 COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:8-jdk
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /blade
 COPY --from=maven /blade/target/hello-blade-latest.jar app.jar
 

--- a/frameworks/Java/blade/pom.xml
+++ b/frameworks/Java/blade/pom.xml
@@ -12,13 +12,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
-        <java.version>1.8</java.version>
-        <blade.version>2.0.12.ALPHA</blade.version>
-        <netty.version>4.1.30.Final</netty.version>
-        <anima.version>0.2.4</anima.version>
-        <hikaricp.version>3.2.0</hikaricp.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <blade.version>2.0.15.ALPHA</blade.version>
+        <netty.version>4.1.36.Final</netty.version>
+        <anima.version>0.2.6</anima.version>
+        <hikaricp.version>3.3.1</hikaricp.version>
         <mysql-conn.version>5.1.47</mysql-conn.version>
         <blade-jetbrick.version>0.1.3</blade-jetbrick.version>
+        <jetbrick-version>2.1.10</jetbrick-version>
     </properties>
 
     <dependencies>
@@ -38,6 +40,18 @@
             <groupId>com.bladejava</groupId>
             <artifactId>blade-template-jetbrick</artifactId>
             <version>${blade-jetbrick.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.subchen</groupId>
+                    <artifactId>jetbrick-template</artifactId>
+                </exclusion>
+			</exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.subchen</groupId>
+            <artifactId>jetbrick-template</artifactId>
+            <version>${jetbrick-version}</version>
         </dependency>
 
         <dependency>
@@ -84,9 +98,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <encoding>UTF-8</encoding>
+                    <debug>false</debug>
                 </configuration>
             </plugin>
             <plugin>

--- a/frameworks/Java/helidon/helidon.dockerfile
+++ b/frameworks/Java/helidon/helidon.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /helidon
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /helidon
 COPY --from=maven /helidon/target/libs libs
 COPY --from=maven /helidon/target/benchmark.jar app.jar

--- a/frameworks/Java/helidon/pom.xml
+++ b/frameworks/Java/helidon/pom.xml
@@ -26,11 +26,11 @@
     <name>${project.artifactId}</name>
 
     <properties>
-        <helidon.version>1.0.0</helidon.version>
+        <helidon.version>1.0.3</helidon.version>
         <!-- Default package. Will be overriden by Maven archetype -->
         <package>io.helidon.examples.quickstart.se</package>
         <mainClass>io.helidon.benchmark.Main</mainClass>
-        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <libs.classpath.prefix>libs</libs.classpath.prefix>
         <copied.libs.dir>${project.build.directory}/${libs.classpath.prefix}</copied.libs.dir>
@@ -46,22 +46,25 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <debug>false</debug>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.1</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -113,12 +116,12 @@
             <dependency>
                 <groupId>io.reactivex.rxjava2</groupId>
                 <artifactId>rxjava</artifactId>
-                <version>2.2.7</version>
+                <version>2.2.8</version>
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
-                <version>2.7.8</version>
+                <version>3.3.1</version>
             </dependency>
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>

--- a/frameworks/Java/jooby/jooby.dockerfile
+++ b/frameworks/Java/jooby/jooby.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src
 COPY public public
 RUN mvn package -q
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /jooby
 COPY --from=maven /jooby/target/jooby-1.0.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby/pom.xml
+++ b/frameworks/Java/jooby/pom.xml
@@ -17,10 +17,11 @@
   <name>jooby</name>
 
   <properties>
-    <jooby.version>1.4.0</jooby.version>
+    <jooby.version>1.6.0</jooby.version>
     <postgresql.version>42.2.5</postgresql.version>
     <rocker.touchFile>/dev/null</rocker.touchFile>
-
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <!-- Startup class -->
     <application.class>com.techempower.App</application.class>
   </properties>

--- a/frameworks/Java/jooby/pom.xml
+++ b/frameworks/Java/jooby/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jooby</groupId>
     <artifactId>jooby-project</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
   </parent>
 
   <artifactId>jooby</artifactId>

--- a/frameworks/Java/jooby2/jooby2-jetty.dockerfile
+++ b/frameworks/Java/jooby2/jooby2-jetty.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jooby2
 COPY pom.xml pom.xml
 COPY src src
 COPY public public
 RUN mvn package -q -P jetty
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/jooby2-undertow.dockerfile
+++ b/frameworks/Java/jooby2/jooby2-undertow.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jooby2
 COPY pom.xml pom.xml
 COPY src src
 COPY public public
 RUN mvn package -q -P undertow
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/jooby2.dockerfile
+++ b/frameworks/Java/jooby2/jooby2.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jooby2
 COPY pom.xml pom.xml
 COPY src src
 COPY public public
 RUN mvn package -q -P netty
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/pom.xml
+++ b/frameworks/Java/jooby2/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.jooby</groupId>
     <artifactId>jooby-project</artifactId>
-    <version>2.0.0.RC1</version>
+    <version>2.0.0.RC2</version>
   </parent>
 
   <artifactId>jooby2</artifactId>
@@ -17,8 +17,11 @@
   <name>jooby 2.x</name>
 
   <properties>
-    <jooby.version>2.0.0.RC1</jooby.version>
+    <jooby.version>2.0.0.RC2</jooby.version>
     <postgresql.version>42.2.5</postgresql.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
 
     <!-- Startup class -->
     <application.class>com.techempower.App</application.class>
@@ -61,6 +64,13 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
+
+    <!-- ASM library -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>7.1</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -85,7 +95,14 @@
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-compiler-plugin</artifactId>
+         <version>3.8.0</version>
+         <configuration>
+           <debug>false</debug>
+         </configuration>
+       </plugin>
       <!-- Build fat jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/frameworks/Java/t-io/pom.xml
+++ b/frameworks/Java/t-io/pom.xml
@@ -8,11 +8,13 @@
 	<parent>
 		<groupId>org.t-io</groupId>
 		<artifactId>tio-http-parent</artifactId>
-		<version>3.2.4.v20181218-RELEASE</version>
+		<version>3.2.9.v20190401-RELEASE</version>
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<main.class>org.tio.http.server.benchmark.TioBenchmarkStarter</main.class>
 	</properties>
 
@@ -45,6 +47,14 @@
 		</resources>
 
 		<plugins>
+			<plugin>
+ 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<debug>false</debug>
+				</configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/frameworks/Java/t-io/tio-mvc.dockerfile
+++ b/frameworks/Java/t-io/tio-mvc.dockerfile
@@ -1,8 +1,10 @@
-FROM maven:3.5.3-jdk-8
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /t-io
 COPY pom.xml pom.xml
 COPY src src
 COPY script script
 RUN mvn package -q
+
+#TODO use separate JDK/JRE for the RUN (as the other builds)
 WORKDIR /t-io/target/tio-http-server-benchmark
 CMD ["java", "-server", "-Xms1G", "-Xmx1G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dpacket.handler.mode=queue1", "-cp", "/t-io/target/tio-http-server-benchmark/config:/t-io/target/tio-http-server-benchmark/lib/*", "org.tio.http.server.benchmark.TioBenchmarkStarter"]

--- a/frameworks/Java/voovan/pom.xml
+++ b/frameworks/Java/voovan/pom.xml
@@ -8,8 +8,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <main.class>org.voovan.VoovanTFB</main.class>
     </properties>
 

--- a/frameworks/Java/voovan/voovan.dockerfile
+++ b/frameworks/Java/voovan/voovan.dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.5.3-jdk-8-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /voovan
 COPY pom.xml pom.xml
 COPY src src
 COPY config/framework.properties config/framework.properties
 RUN mvn package -q
 
-FROM openjdk:8-jdk-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /voovan
 COPY --from=maven /voovan/target/voovan-bench-0.1-jar-with-dependencies.jar app.jar
 COPY --from=maven /voovan/config/framework.properties config/framework.properties


### PR DESCRIPTION
Update to Maven 3.6.1, Java JDK/JRE 11 runtime and compilation.
 - blade
 - helidon
 - jooby
 - jooby2
 - t-io
 - voovan