### PR TITLE
Update  to Java 11 and dependencies

### DIFF
--- a/frameworks/Java/javalin/build.gradle
+++ b/frameworks/Java/javalin/build.gradle
@@ -6,16 +6,17 @@ version '1.0-SNAPSHOT'
 
 mainClassName = 'com.lostsys.test.javalin.Bench'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile 'io.javalin:javalin:2.3.0'
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.6"
-    compile "org.slf4j:slf4j-simple:1.7.25"
+    compile 'io.javalin:javalin:2.8.0'
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    compile "org.slf4j:slf4j-simple:1.8.0-beta4"
 }
 
 //create a single Jar with all dependencies

--- a/frameworks/Java/javalin/javalin.dockerfile
+++ b/frameworks/Java/javalin/javalin.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.7.0-jdk8
+FROM gradle:5.4.1-jdk11 as gradle
 USER root
 WORKDIR /javalin
 COPY build.gradle build.gradle

--- a/frameworks/Java/jawn/build.gradle
+++ b/frameworks/Java/jawn/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 // compiler options
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 mainClassName = 'app.BenchmarkMain'
 
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
     // Framework
-    def framework_version = '0.9.12'
+    def framework_version = '0.9.14'
     compile "net.javapla.jawn:jawn:${framework_version}"
 
 
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.postgresql:postgresql:42.2.5'
 
     //Logging
-    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3' exclude group: 'org.slf4j'
+    runtime group: 'ch.qos.logback', name: 'logback-classic', version: '1.3.0-alpha4' exclude group: 'org.slf4j'
 }
 
 /* ****************** */

--- a/frameworks/Java/jawn/jawn.dockerfile
+++ b/frameworks/Java/jawn/jawn.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.7.0-jdk8
+FROM gradle:5.4.1-jdk11 as gradle
 USER root
 WORKDIR /jawn
 COPY build.gradle build.gradle

--- a/frameworks/Java/jawn/src/main/java/app/BenchmarkMain.java
+++ b/frameworks/Java/jawn/src/main/java/app/BenchmarkMain.java
@@ -30,8 +30,8 @@ public class BenchmarkMain extends Jawn {
         get("/queries",DbController.class, DbController::getQueries);
         get("/updates",DbController.class, DbController::getUpdates);
         
-        get("/json", (context) -> Results.json(new Message(message)).addHeader("Server", "jawn"));
-        get("/plaintext", (context) -> Results.text(bytemessage).addHeader("Server", "jawn"));
+        get("/json", Results.json(new Message(message)).addHeader("Server", "jawn"));
+        get("/plaintext", Results.text(bytemessage).addHeader("Server", "jawn"));
         
         use(new AbstractModule() {
             @Override

--- a/frameworks/Java/ratpack/build.gradle
+++ b/frameworks/Java/ratpack/build.gradle
@@ -3,8 +3,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "io.ratpack:ratpack-gradle:1.5.4"
-        classpath "com.github.jengelman.gradle.plugins:shadow:1.2.4"
+        classpath "io.ratpack:ratpack-gradle:1.6.1"
+        classpath "com.github.jengelman.gradle.plugins:shadow:5.0.0"
     }
 }
 
@@ -18,16 +18,16 @@ repositories {
 }
 
 dependencies {
-    compile 'io.ratpack:ratpack-guice:1.6.0'
-    compile 'io.ratpack:ratpack-hikari:1.6.0'
-    compile 'io.ratpack:ratpack-handlebars:1.6.0'
-    compile 'io.ratpack:ratpack-rx2:1.6.0'
-    compile 'io.reactiverse:reactive-pg-client:0.10.9'
-    compile 'io.vertx:vertx-rx-java2:3.5.4'
+    compile 'io.ratpack:ratpack-guice:1.6.1'
+    compile 'io.ratpack:ratpack-hikari:1.6.1'
+    compile 'io.ratpack:ratpack-handlebars:1.6.1'
+    compile 'io.ratpack:ratpack-rx2:1.6.1'
+    compile 'io.reactiverse:reactive-pg-client:0.11.3'
+    compile 'io.vertx:vertx-rx-java2:3.7.0'
 
     // Default SLF4J binding.  Note that this is a blocking implementation.
     // See here for a non blocking appender http://logging.apache.org/log4j/2.x/manual/async.html
-    runtime 'org.slf4j:slf4j-simple:1.7.25'
+    runtime 'org.slf4j:slf4j-simple:1.8.0-beta4'
     runtime 'org.postgresql:postgresql:42.2.5'
 
 }

--- a/frameworks/Java/ratpack/ratpack-jdbc.dockerfile
+++ b/frameworks/Java/ratpack/ratpack-jdbc.dockerfile
@@ -1,11 +1,11 @@
-FROM gradle:4.7.0-jdk8 as gradle
+FROM gradle:5.4.1-jdk11 as gradle
 USER root
 WORKDIR /ratpack
 COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar", "profile.name=jdbc"]

--- a/frameworks/Java/ratpack/ratpack-pgclient.dockerfile
+++ b/frameworks/Java/ratpack/ratpack-pgclient.dockerfile
@@ -1,11 +1,11 @@
-FROM gradle:4.7.0-jdk8 as gradle
+FROM gradle:5.4.1-jdk11 as gradle
 USER root
 WORKDIR /ratpack
 COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD export DBIP=`getent hosts tfb-database | awk '{ print $1 }'` && \

--- a/frameworks/Java/ratpack/ratpack.dockerfile
+++ b/frameworks/Java/ratpack/ratpack.dockerfile
@@ -1,11 +1,11 @@
-FROM gradle:4.7.0-jdk8 as gradle
+FROM gradle:5.4.1-jdk11 as gradle
 USER root
 WORKDIR /ratpack
 COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:8-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar"]

--- a/frameworks/Java/wizzardo-http/build.gradle
+++ b/frameworks/Java/wizzardo-http/build.gradle
@@ -4,7 +4,8 @@ version '1.0-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'application'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 mainClassName = "com.wizzardo.techempower.App"
 

--- a/frameworks/Java/wizzardo-http/wizzardo-http.dockerfile
+++ b/frameworks/Java/wizzardo-http/wizzardo-http.dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:4.7.0-jdk8
+FROM gradle:5.4.1-jdk11 as gradle
 
 USER root
 WORKDIR /wizzardo-http
@@ -8,11 +8,7 @@ COPY src src
 
 RUN gradle --refresh-dependencies clean fatJar
 
-CMD java \
-    -Xmx2G \
-    -Xms2G \
-    -server \
-    -XX:+UseNUMA \
-    -XX:+UseParallelGC \
-    -XX:+AggressiveOpts \
-    -jar build/libs/wizzardo-http-all-1.0-SNAPSHOT.jar env=prod
+FROM openjdk:11.0.3-jre-slim
+WORKDIR /wizzardo-http
+COPY --from=gradle /wizzardo-http/build/libs/wizzardo-http-all-1.0-SNAPSHOT.jar app.jar
+CMD ["java", "-Xmx2G", "-Xms2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "env=prod"]


### PR DESCRIPTION
Update `javelin`, `jawn`, `ratpack`, `wizzardo-http` to Java 11. Also most of their dependencies. These builds are `gradle`-based.