### PR TITLE
Ubiquity: update React to PHP-PM

### DIFF
--- a/frameworks/PHP/ubiquity/.ubiquity/react-config.php
+++ b/frameworks/PHP/ubiquity/.ubiquity/react-config.php
@@ -1,2 +1,5 @@
 <?php
-return array("host"=>"0.0.0.0","port"=>8085);
+return array(
+	"host" => "0.0.0.0",
+	"port" => 8090
+);

--- a/frameworks/PHP/ubiquity/README.md
+++ b/frameworks/PHP/ubiquity/README.md
@@ -5,7 +5,7 @@ Ubiquity is a full-stack php framework, These tests involve:
 - the ORM part (Full)
 - the JSON serialization (native php)
 
-Tests are available with NginX and Ubiquity-React servers.
+Tests are available with NginX and PHP-PM servers.
 
 ## Test Type Implementation Source Code
 The tests are separated into 4 controllers:
@@ -27,7 +27,9 @@ The tests were run with:
 * [Ubiquity 2.1.*](https://ubiquity.kobject.net/)
 * [PHP Version 7.3.*](http://www.php.net/) with FPM and APC
 * [nginx 1.14](http://nginx.org/)
+* [PHP-PM](https://github.com/php-pm/php-pm)
 * [Ubiquity-reactphp server](https://github.com/phpMv/ubiquity-reactphp)
+* [Ubiquity-php-pm bridge](https://github.com/phpMv/ubiquity-php-pm)
 * [MySQL 5.7](https://dev.mysql.com/)
 
 ## Test URLs

--- a/frameworks/PHP/ubiquity/benchmark_config.json
+++ b/frameworks/PHP/ubiquity/benchmark_config.json
@@ -32,7 +32,7 @@
         "update_url": "/Db/update/",
         "query_url": "/Db/query/",
         "fortune_url": "/Fortunes",
-        "port": 8085,
+        "port": 8090,
         "approach": "Realistic",
         "classification": "Fullstack",
         "database": "MySQL",
@@ -41,10 +41,10 @@
         "flavor": "PHP7",
         "orm": "Full",
         "platform": "None",
-        "webserver": "react",
+        "webserver": "php-pm",
         "os": "Linux",
         "database_os": "Linux",
-        "display_name": "ubiquity-react",
+        "display_name": "ubiquity-php-pm",
         "notes": "",
         "versus": "php"
       }

--- a/frameworks/PHP/ubiquity/ubiquity-react.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-react.dockerfile
@@ -5,16 +5,18 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip php7.3 php7.3-common php7.3-cli php7.3-mysql php7.3-mbstring > /dev/null
+    apt-get install -yqq git unzip php7.3 php7.3-common php7.3-cli php7.3-mysql php7.3-mbstring php7.3-cgi > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/php-cli.ini /etc/php/7.3/cli/conf.d/php.ini
+RUN ln -s /usr/lib/cgi-bin/php /usr/bin/php7.3-cgi
+
+COPY deploy/conf/php.ini /etc/php/7.3/cgi/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
 
-RUN composer require phpmv/ubiquity-devtools:dev-master phpmv/ubiquity-reactphp:dev-master --quiet
+RUN composer require phpmv/ubiquity-php-pm:dev-master --quiet
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
@@ -22,4 +24,6 @@ RUN chmod 777 -R /ubiquity/app/cache/*
 
 RUN chmod 777 -R /ubiquity/.ubiquity/*
 
-CMD /ubiquity/vendor/bin/Ubiquity serve -t=react -p=8085 -h=0.0.0.0
+RUN chmod 777 /ubiquity/vendor/bin/ppm
+
+CMD /ubiquity/vendor/bin/ppm --bridge='\PHPPM\Ubiquity' --bootstrap='\PHPPM\Ubiquity' start --debug 0 --workers 16 --host=0.0.0.0 --port=8090


### PR DESCRIPTION
I switched to [php-pm](https://github.com/php-pm/php-pm) as a React server, considering the poor results I got in the previous version.

I haven't forgotten your request for the vanilla React test, I'm just waiting to get more convincing results with Ubiquity and to be up to the job.
