### PR TITLE
Lock versions instead of wildcards

### DIFF
--- a/frameworks/JavaScript/es4x/package.json
+++ b/frameworks/JavaScript/es4x/package.json
@@ -4,14 +4,14 @@
   "private": true,
   "main": "index.js",
   "devDependencies": {
-    "@vertx/unit": "^3.6.3",
-    "es4x-pm": "^0.7.2"
+    "@vertx/unit": "3.7.0",
+    "es4x-pm": "0.7.3"
   },
   "dependencies": {
-    "@vertx/core": "^3.6.3",
-    "@vertx/web": "^3.6.3",
-    "@vertx/web-templ-handlebars": "^3.6.3",
-    "@reactiverse/reactive-pg-client": "^0.11.2"
+    "@vertx/core": "3.7.0",
+    "@vertx/web": "3.7.0",
+    "@vertx/web-templ-handlebars": "3.7.0",
+    "@reactiverse/reactive-pg-client": "0.11.2"
   },
   "mvnDependencies": [
     "io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.30.Final"


### PR DESCRIPTION
Currently wildcards are used, this makes it hard to troubleshoot or ensure tests are reproducible