### PR TITLE
Update Java/spring and Java/spring-webflux projects to Java 11

### DIFF
--- a/frameworks/Java/spring-webflux/pom.xml
+++ b/frameworks/Java/spring-webflux/pom.xml
@@ -13,17 +13,18 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.1.5.RELEASE</version>
     </parent>
 
     <properties>
-        <maven.compiler.source>10</maven.compiler.source>
-        <maven.compiler.target>10</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-data-r2dbc.version>1.0.0.M2</spring-data-r2dbc.version>
         <postgresql.version>42.2.5</postgresql.version>
-        <pgclient.version>0.10.6</pgclient.version>
-        <rxjava2-jdbc.version>0.2.0</rxjava2-jdbc.version>
-        <r2dbc-postgresql.version>1.0.0.BUILD-SNAPSHOT</r2dbc-postgresql.version>
+        <pgclient.version>0.11.4</pgclient.version>
+        <rxjava2-jdbc.version>0.2.4</rxjava2-jdbc.version>
+        <r2dbc-postgresql.version>1.0.0.M7</r2dbc-postgresql.version>
     </properties>
 
     <dependencies>
@@ -67,7 +68,7 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-r2dbc</artifactId>
-            <version>1.0.0.BUILD-SNAPSHOT</version>
+            <version>${spring-data-r2dbc.version}</version>
         </dependency>
     </dependencies>
 
@@ -93,7 +94,14 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <debug>false</debug>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/frameworks/Java/spring-webflux/pom.xml
+++ b/frameworks/Java/spring-webflux/pom.xml
@@ -13,12 +13,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.5.RELEASE</version>
+        <version>2.2.0.M2</version>
     </parent>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-data-r2dbc.version>1.0.0.M2</spring-data-r2dbc.version>
         <postgresql.version>42.2.5</postgresql.version>

--- a/frameworks/Java/spring-webflux/spring-webflux-jdbc.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-jdbc.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=jdbc,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux-mongo.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-mongo.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=mongo"]

--- a/frameworks/Java/spring-webflux/spring-webflux-pgclient.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-pgclient.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=pgclient,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux-rxjdbc.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-rxjdbc.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=rxjdbc,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=r2dbc,postgres"]

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/config/R2dbcConfig.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/config/R2dbcConfig.java
@@ -3,11 +3,12 @@ package benchmark.config;
 import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
 import io.r2dbc.postgresql.PostgresqlConnectionFactory;
 import io.r2dbc.spi.ConnectionFactory;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.r2dbc.function.DatabaseClient;
+import org.springframework.data.r2dbc.core.DatabaseClient;
 
 @Configuration
 @Profile("r2dbc")

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/repository/R2dbcDbRepository.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/repository/R2dbcDbRepository.java
@@ -3,7 +3,7 @@ package benchmark.repository;
 import benchmark.model.Fortune;
 import benchmark.model.World;
 import org.springframework.context.annotation.Profile;
-import org.springframework.data.r2dbc.function.DatabaseClient;
+import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
@@ -3,11 +3,13 @@ package benchmark.web;
 import benchmark.model.Fortune;
 import benchmark.model.World;
 import benchmark.repository.DbRepository;
+
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/frameworks/Java/spring/pom.xml
+++ b/frameworks/Java/spring/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.5.RELEASE</version>
+    <version>2.2.0.M2</version>
   </parent>
 
   <properties>
@@ -46,6 +46,21 @@
       <version>${postgresql.version}</version>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>spring-libs-snapshot</id>
+        <name>Spring Snapshots</name>
+        <url>https://repo.spring.io/libs-snapshot</url>
+      </repository>
+    </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>spring-libs-snapshot</id>
+      <name>Spring Snapshots</name>
+      <url>https://repo.spring.io/libs-snapshot</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <plugins>

--- a/frameworks/Java/spring/pom.xml
+++ b/frameworks/Java/spring/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.2.RELEASE</version>
+    <version>2.1.5.RELEASE</version>
   </parent>
 
   <properties>
@@ -52,6 +52,14 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <debug>false</debug>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/frameworks/Java/spring/spring-mongo.dockerfile
+++ b/frameworks/Java/spring/spring-mongo.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.6.0-jdk-11-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/hello-spring-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=mongo"]

--- a/frameworks/Java/spring/spring.dockerfile
+++ b/frameworks/Java/spring/spring.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.6.0-jdk-11-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /spring
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11-jre-slim
+FROM openjdk:11.0.3-jre-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/hello-spring-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=jdbc,postgres"]


### PR DESCRIPTION
Also resolve build failures in the `Java/spring-webflux` project.
Warning: due to https://github.com/spring-projects/spring-data-r2dbc/issues/113 the build for `spring-webflux` variant will fail.