### PR TITLE
log number of processors on startup

### DIFF
--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/resources/logback.xml
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/resources/logback.xml
@@ -29,6 +29,8 @@
 
   <logger name="slick" level="ERROR"/>
 
+  <logger name="net.benchmark.akka.http.Main" level="INFO"/>
+
   <logger name="net.benchmark" level="ERROR"/>
 
   <root level="ERROR">

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
@@ -19,6 +19,11 @@ object Main {
     implicit val system: ActorSystem = ActorSystem("AkkaSlickBenchmarkApp")
     implicit val mat: ActorMaterializer = ActorMaterializer()
 
+    val pus = Runtime.getRuntime.availableProcessors()
+    val pusMessage = s"Runtime.getRuntime.availableProcessors says $pus"
+    log.info(pusMessage)
+    println(pusMessage)
+
     val config: Config = system.settings.config
 
     val dbConfig: DatabaseConfig[PostgresProfile] = DatabaseConfiguration.getDefaultDatabaseConfiguration(config)


### PR DESCRIPTION
Hi,

please merge this, it verifies. I just added log statements on startup to debug whether the JVM correctly determines the number of processors. This is part of a troubleshooting effort.

Thanks,
Sven


