### PR TITLE
Update revenj-jvm.dockerfile to explicitly install unzip command

### DIFF
--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 
 # no GPG by default in the base image
-RUN apt update -qqy && apt install -yqq gnupg wget > /dev/null
+RUN apt update -qqy && apt install -yqq gnupg unzip wget > /dev/null
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /etc/apt/sources.list.d/mono-xamarin.list
 RUN apt update


### PR DESCRIPTION
It failed in the latest `Citrine` run because of this.