### PR TITLE
Decrease the number of max DB connections in the pool

### DIFF
--- a/frameworks/Java/grizzly/pom.xml
+++ b/frameworks/Java/grizzly/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <build>

--- a/frameworks/Java/grizzly/src-jersey/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/grizzly/src-jersey/main/resources/META-INF/persistence.xml
@@ -16,8 +16,8 @@
 			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.jdbc.batch_size" value="30" />
 			<property name="hibernate.jdbc.batch_versioned_data" value="true" />
-			<property name="hibernate.hikari.minimumIdle" value="256" />
-			<property name="hibernate.hikari.maximumPoolSize" value="256" />
+			<property name="hibernate.hikari.minimumIdle" value="192" />
+			<property name="hibernate.hikari.maximumPoolSize" value="192" />
 			<property name="hibernate.hikari.idleTimeout" value="30000" />
 			<property name="hibernate.hikari.dataSourceClassName" value="com.mysql.jdbc.jdbc2.optional.MysqlDataSource" />
 			<property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false" />

--- a/frameworks/Java/undertow-jersey/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/undertow-jersey/src/main/resources/META-INF/persistence.xml
@@ -16,8 +16,8 @@
 			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.jdbc.batch_size" value="30" />
 			<property name="hibernate.jdbc.batch_versioned_data" value="true" />
-			<property name="hibernate.c3p0.min_size" value="256" />
-			<property name="hibernate.c3p0.max_size" value="256" />
+			<property name="hibernate.c3p0.min_size" value="192" />
+			<property name="hibernate.c3p0.max_size" value="192" />
 			<property name="hibernate.c3p0.timeout" value="1800" />
 			<property name="hibernate.c3p0.max_statements" value="2048" />
 			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />

--- a/frameworks/Java/undertow-jersey/src/main/resources/hikarycp/META-INF/persistence.xml
+++ b/frameworks/Java/undertow-jersey/src/main/resources/hikarycp/META-INF/persistence.xml
@@ -16,8 +16,8 @@
 			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.jdbc.batch_size" value="30" />
 			<property name="hibernate.jdbc.batch_versioned_data" value="true" />
-			<property name="hibernate.hikari.minimumIdle" value="256" />
-			<property name="hibernate.hikari.maximumPoolSize" value="256" />
+			<property name="hibernate.hikari.minimumIdle" value="192" />
+			<property name="hibernate.hikari.maximumPoolSize" value="192" />
 			<property name="hibernate.hikari.idleTimeout" value="30000" />
 			<property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
 			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />


### PR DESCRIPTION
Even with the sorting before the update there are still deadlock exceptions.
From the documentation:
> If the LATEST DETECTED DEADLOCK section of InnoDB Monitor output includes a message stating, “TOO DEEP OR LONG SEARCH IN THE LOCK TABLE WAITS-FOR GRAPH, WE WILL ROLL BACK FOLLOWING TRANSACTION,” this indicates that the number of transactions on the wait-for list has reached a limit of **200**. A wait-for list that exceeds 200 transactions **is treated as a deadlock** and the transaction attempting to check the wait-for list is rolled back.

Source: https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlock-detection.html

The existence of this mechanism basically prevents the usage of bigger connection pools  for the `Update` test - above 200 concurrent DB connections. Maybe it should be disabled and the transaction time-out lowered to 5 or 10 seconds. IMO in this way some of the parity will be preserved for MySQL and PostgreSQL configurations.