### PR TITLE
Php-ngx update

### DIFF
--- a/frameworks/PHP/php/php-ngx.dockerfile
+++ b/frameworks/PHP/php/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-ngx.dockerfile
+++ b/frameworks/PHP/php/php-ngx.dockerfile
@@ -13,7 +13,7 @@ ADD ./ ./
 
 ENV NGINX_VERSION=1.17.0
 
-RUN git clone -b v0.0.17 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.18 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php/php-ngx.dockerfile
+++ b/frameworks/PHP/php/php-ngx.dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update -yqq > /dev/null && \
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.15.8
+ENV NGINX_VERSION=1.17.0
 
-RUN git clone -b v0.0.16 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.17 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php/php-ngx.dockerfile
+++ b/frameworks/PHP/php/php-ngx.dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq wget git unzip libxml2-dev cmake make \
+    apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
                     zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
                     php7.3 php7.3-common php7.3-dev libphp7.3-embed php7.3-mysql nginx > /dev/null
 


### PR DESCRIPTION
Nginx 1.17.0 and Ubuntu 19.04.

Php-ngx to 0.0.18, fix a problem with php 7.3.6
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
