### PR TITLE
Make onyx multi-query and updates test implementations compliant

### DIFF
--- a/frameworks/Crystal/onyx/src/endpoints/worlds/many.cr
+++ b/frameworks/Crystal/onyx/src/endpoints/worlds/many.cr
@@ -2,7 +2,7 @@ struct Endpoints::Worlds::Many
   include Onyx::HTTP::Endpoint
   include RandomID
 
-  QUERY = Models::World.where("id = ANY(?)", 0).build(true)[0]
+  QUERY = Models::World.where(id: 0).build(true)[0]
 
   params do
     query do
@@ -12,13 +12,14 @@ struct Endpoints::Worlds::Many
 
   def call
     queries = params.query.queries.is_a?(String) ? 1 : params.query.queries.as(Int32)
-    ids = queries.clamp(1..500).times.map do
-      random_id
-    end.join(',').try do |s|
-      "{#{s}}"
+
+    worlds = Array(Models::World).new
+
+    queries.clamp(1..500).times.each do
+      world = Onyx.query(Models::World, QUERY, random_id).first
+      worlds << world
     end
 
-    worlds = Onyx.query(Models::World, QUERY, ids)
     return Views::Worlds.new(worlds)
   end
 end

--- a/frameworks/Crystal/onyx/src/endpoints/worlds/update.cr
+++ b/frameworks/Crystal/onyx/src/endpoints/worlds/update.cr
@@ -2,7 +2,8 @@ struct Endpoints::Worlds::Update
   include Onyx::HTTP::Endpoint
   include RandomID
 
-  QUERY = Models::World.update.set(random_number: 0).where(id: 0).build[0]
+  SELECT_QUERY = Models::World.where(id: 0).build(true)[0]
+  UPDATE_QUERY = Models::World.update.set(random_number: 0).where(id: 0).build[0]
 
   params do
     query do
@@ -16,12 +17,10 @@ struct Endpoints::Worlds::Update
     worlds = Array(Models::World).new
 
     queries.clamp(1..500).times.each do
-      id, number = {random_id, random_id}
-
-      world = Models::World.new(id: id, random_number: number)
+      world = Onyx.query(Models::World, SELECT_QUERY, random_id).first
+      world.random_number = random_id
+      Onyx.exec(UPDATE_QUERY, world.random_number, world.id)
       worlds << world
-
-      Onyx.exec(QUERY, world.random_number, world.id)
     end
 
     return Views::Worlds.new(worlds)


### PR DESCRIPTION
Fixes #4842

The updates test implementation was also non-compliant because it was not
selecting worlds from the database.  Instead, it was generating new world
objects in memory with random attributes.