### PR TITLE
Java 11 - Update Docker images to the jdk variant

### DIFF
--- a/frameworks/Clojure/compojure/compojure-raw.dockerfile
+++ b/frameworks/Clojure/compojure/compojure-raw.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY project.clj project.clj
 RUN lein ring uberwar
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Clojure/compojure/compojure.dockerfile
+++ b/frameworks/Clojure/compojure/compojure.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY project.clj project.clj
 RUN lein ring uberwar
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/activeweb/activeweb-jackson.dockerfile
+++ b/frameworks/Java/activeweb/activeweb-jackson.dockerfile
@@ -5,7 +5,7 @@ COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/activeweb/activeweb.dockerfile
+++ b/frameworks/Java/activeweb/activeweb.dockerfile
@@ -5,7 +5,7 @@ COPY scripts scripts
 COPY src src
 RUN mvn package -DskipTests -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/armeria/armeria.dockerfile
+++ b/frameworks/Java/armeria/armeria.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /armeria
 COPY --from=maven /armeria/target/hello-1.0-SNAPSHOT-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/baratine/baratine.dockerfile
+++ b/frameworks/Java/baratine/baratine.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /baratine
 COPY --from=maven /baratine/target/testTechempowerBaratine-0.0.1-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar", "tfb-database"]

--- a/frameworks/Java/bayou/bayou.dockerfile
+++ b/frameworks/Java/bayou/bayou.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /bayou
 COPY --from=maven /bayou/target/bayou_TFB-0.1-jar-with-dependencies.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/blade/blade.dockerfile
+++ b/frameworks/Java/blade/blade.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /blade
 COPY --from=maven /blade/target/hello-blade-latest.jar app.jar
 

--- a/frameworks/Java/curacao/curacao.dockerfile
+++ b/frameworks/Java/curacao/curacao.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile war:war -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/dropwizard/dropwizard-jdbi-postgres.dockerfile
+++ b/frameworks/Java/dropwizard/dropwizard-jdbi-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q -P postgres,jdbi
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /dropwizard
 COPY --from=maven /dropwizard/target/hello-world-0.0.1-SNAPSHOT.jar app.jar
 COPY hello-world-jdbi-postgres.yml hello-world-jdbi-postgres.yml

--- a/frameworks/Java/dropwizard/dropwizard-mongodb.dockerfile
+++ b/frameworks/Java/dropwizard/dropwizard-mongodb.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q -P mongo
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /dropwizard
 COPY --from=maven /dropwizard/target/hello-world-0.0.1-SNAPSHOT.jar app.jar
 COPY hello-world-mongo.yml hello-world-mongo.yml

--- a/frameworks/Java/dropwizard/dropwizard-postgres.dockerfile
+++ b/frameworks/Java/dropwizard/dropwizard-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q -P postgres
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /dropwizard
 COPY --from=maven /dropwizard/target/hello-world-0.0.1-SNAPSHOT.jar app.jar
 COPY hello-world-postgres.yml hello-world-postgres.yml

--- a/frameworks/Java/dropwizard/dropwizard.dockerfile
+++ b/frameworks/Java/dropwizard/dropwizard.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q -P mysql
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /dropwizard
 COPY --from=maven /dropwizard/target/hello-world-0.0.1-SNAPSHOT.jar app.jar
 COPY hello-world-mysql.yml hello-world-mysql.yml

--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-mysql.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-postgres.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1

--- a/frameworks/Java/grizzly/grizzly-jersey.dockerfile
+++ b/frameworks/Java/grizzly/grizzly-jersey.dockerfile
@@ -4,7 +4,7 @@ COPY pom-jersey.xml pom.xml
 COPY src-jersey src
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /grizzly-jersey
 COPY --from=maven /grizzly-jersey/target/grizzly-jersey-example.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/grizzly/grizzly.dockerfile
+++ b/frameworks/Java/grizzly/grizzly.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /grizzly
 COPY --from=maven /grizzly/target/grizzly-bm-0.1-jar-with-dependencies.jar app.jar
 CMD ["java", "-Dorg.glassfish.grizzly.nio.transport.TCPNIOTransport.max-receive-buffer-size=16384", "-Dorg.glassfish.grizzly.http.io.OutputBuffer.default-buffer-size=1024", "-Dorg.glassfish.grizzly.memory.BuffersBuffer.bb-cache-size=32", "-jar", "app.jar"]

--- a/frameworks/Java/helidon/helidon.dockerfile
+++ b/frameworks/Java/helidon/helidon.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /helidon
 COPY --from=maven /helidon/target/libs libs
 COPY --from=maven /helidon/target/benchmark.jar app.jar

--- a/frameworks/Java/httpserver/httpserver-postgres.dockerfile
+++ b/frameworks/Java/httpserver/httpserver-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "postgres"]

--- a/frameworks/Java/httpserver/httpserver.dockerfile
+++ b/frameworks/Java/httpserver/httpserver.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/jetty/jetty-servlet.dockerfile
+++ b/frameworks/Java/jetty/jetty-servlet.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jetty
 COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q -P servlet
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jetty
 COPY --from=maven /jetty/target/jetty-example-0.1-jar-with-dependencies.jar app.jar
 CMD ["java", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar"]

--- a/frameworks/Java/jetty/jetty.dockerfile
+++ b/frameworks/Java/jetty/jetty.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.3-jdk-10-slim as maven
+FROM maven:3.6.1-jdk-11-slim as maven
 WORKDIR /jetty
 COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jetty
 COPY --from=maven /jetty/target/jetty-example-0.1-jar-with-dependencies.jar app.jar
 CMD ["java", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar"]

--- a/frameworks/Java/jetty/pom.xml
+++ b/frameworks/Java/jetty/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <jetty.version>9.4.12.v20180830</jetty.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <jetty.version>9.4.19.v20190610</jetty.version>
         <main.class>hello.handler.HelloWebServer</main.class>
     </properties>
 
@@ -55,6 +55,11 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-servlet</artifactId>
                     <version>${jetty.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
+                    <version>1.2.1</version>
                 </dependency>
             </dependencies>
             <build>

--- a/frameworks/Java/jlhttp/jlhttp-postgres.dockerfile
+++ b/frameworks/Java/jlhttp/jlhttp-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jlhttp
 COPY --from=maven /jlhttp/target/jlhttp-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "postgres"]

--- a/frameworks/Java/jlhttp/jlhttp.dockerfile
+++ b/frameworks/Java/jlhttp/jlhttp.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jlhttp
 COPY --from=maven /jlhttp/target/jlhttp-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/jooby/jooby.dockerfile
+++ b/frameworks/Java/jooby/jooby.dockerfile
@@ -5,7 +5,7 @@ COPY src src
 COPY public public
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jooby
 COPY --from=maven /jooby/target/jooby-1.0.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/jooby2-jetty.dockerfile
+++ b/frameworks/Java/jooby2/jooby2-jetty.dockerfile
@@ -5,7 +5,7 @@ COPY src src
 COPY public public
 RUN mvn package -q -P jetty
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/jooby2-undertow.dockerfile
+++ b/frameworks/Java/jooby2/jooby2-undertow.dockerfile
@@ -5,7 +5,7 @@ COPY src src
 COPY public public
 RUN mvn package -q -P undertow
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/jooby2/jooby2.dockerfile
+++ b/frameworks/Java/jooby2/jooby2.dockerfile
@@ -5,7 +5,7 @@ COPY src src
 COPY public public
 RUN mvn package -q -P netty
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /jooby2
 COPY --from=maven /jooby2/target/jooby-2x.jar app.jar
 COPY conf conf

--- a/frameworks/Java/minijax/minijax.dockerfile
+++ b/frameworks/Java/minijax/minijax.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /minijax
 COPY --from=maven /minijax/target/minijax-techempower-0.0.1.jar app.jar
 COPY minijax.properties minijax.properties

--- a/frameworks/Java/nanohttpd/nanohttpd.dockerfile
+++ b/frameworks/Java/nanohttpd/nanohttpd.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /nanohttpd
 COPY --from=maven /nanohttpd/target/nanohttpd-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/netty/netty.dockerfile
+++ b/frameworks/Java/netty/netty.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /netty
 COPY --from=maven /netty/target/netty-example-0.1-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/ninja-standalone/ninja-standalone.dockerfile
+++ b/frameworks/Java/ninja-standalone/ninja-standalone.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /ninja-standalone
 COPY --from=maven /ninja-standalone/target/ninja-standalone-0.0.1-SNAPSHOT-jar-with-dependencies.jar app.jar
 CMD ["java", "-Dninja.port=8080", "-jar", "app.jar"]

--- a/frameworks/Java/officefloor/officefloor-micro.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-micro.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 WORKDIR /officefloor/src/woof_benchmark_micro
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_micro/target/woof_benchmark_micro-1.0.0.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/officefloor/officefloor-netty.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-netty.dockerfile
@@ -8,7 +8,7 @@ RUN mvn -q clean install
 WORKDIR /officefloor/src/woof_benchmark_netty
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_netty/target/woof_benchmark_netty-1.0.0.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/officefloor/officefloor-rapidoid.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-rapidoid.dockerfile
@@ -8,7 +8,7 @@ RUN mvn -q clean install
 WORKDIR /officefloor/src/woof_benchmark_rapidoid
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_rapidoid/target/woof_benchmark_rapidoid-1.0.0.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/officefloor/officefloor-raw.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-raw.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 WORKDIR /officefloor/src/woof_benchmark_raw
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 RUN apt-get update && apt-get install -y libjna-java
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_raw/target/woof_benchmark_raw-1.0.0.jar server.jar

--- a/frameworks/Java/officefloor/officefloor-spring_data.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-spring_data.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 WORKDIR /officefloor/src/woof_benchmark_spring
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_spring/target/woof_benchmark_spring-1.0.0-exec.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/officefloor/officefloor-thread_affinity.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-thread_affinity.dockerfile
@@ -8,7 +8,7 @@ RUN mvn -q clean install
 WORKDIR /officefloor/src/woof_benchmark_thread_affinity
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 RUN apt-get update && apt-get install -y libjna-java
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_thread_affinity/target/woof_benchmark_thread_affinity-1.0.0.jar server.jar

--- a/frameworks/Java/officefloor/officefloor-tpr.dockerfile
+++ b/frameworks/Java/officefloor/officefloor-tpr.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 WORKDIR /officefloor/src/woof_benchmark_tpr
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark_tpr/target/woof_benchmark_tpr-1.0.0.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/officefloor/officefloor.dockerfile
+++ b/frameworks/Java/officefloor/officefloor.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 WORKDIR /officefloor/src/woof_benchmark
 RUN mvn -q clean package
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /officefloor
 COPY --from=maven /officefloor/src/woof_benchmark/target/woof_benchmark-1.0.0.jar server.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseNUMA", "-Dhttp.port=8080", "-Dhttp.server.name=OF", "-Dhttp.date.header=true", "-jar", "server.jar"]

--- a/frameworks/Java/proteus/proteus-mysql.dockerfile
+++ b/frameworks/Java/proteus/proteus-mysql.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q --update-snapshots
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /proteus
 COPY --from=maven /proteus/target/proteus-techempower-1.0.0.jar app.jar
 COPY --from=maven /proteus/target/lib lib

--- a/frameworks/Java/proteus/proteus.dockerfile
+++ b/frameworks/Java/proteus/proteus.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn package -q --update-snapshots
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /proteus
 COPY --from=maven /proteus/target/proteus-techempower-1.0.0.jar app.jar
 COPY --from=maven /proteus/target/lib lib

--- a/frameworks/Java/quarkus/quarkus.dockerfile
+++ b/frameworks/Java/quarkus/quarkus.dockerfile
@@ -5,7 +5,7 @@ RUN mvn dependency:go-offline -q
 COPY src src
 RUN mvn package -q
 
-FROM openjdk:11-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /quarkus
 COPY --from=maven /quarkus/target/lib lib
 COPY --from=maven /quarkus/target/benchmark-1.0-SNAPSHOT-runner.jar app.jar

--- a/frameworks/Java/rapidoid/rapidoid-http-fast.dockerfile
+++ b/frameworks/Java/rapidoid/rapidoid-http-fast.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /rapidoid
 COPY --from=maven /rapidoid/target/rapidoid-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-cp", "app.jar", "lowlevel.Main", "profiles=production"]

--- a/frameworks/Java/rapidoid/rapidoid-mysql.dockerfile
+++ b/frameworks/Java/rapidoid/rapidoid-mysql.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /rapidoid
 COPY --from=maven /rapidoid/target/rapidoid-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-cp", "app.jar", "highlevel.Main", "profiles=mysql,production"]

--- a/frameworks/Java/rapidoid/rapidoid-postgres.dockerfile
+++ b/frameworks/Java/rapidoid/rapidoid-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /rapidoid
 COPY --from=maven /rapidoid/target/rapidoid-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-cp", "app.jar", "highlevel.Main", "profiles=postgres,production"]

--- a/frameworks/Java/rapidoid/rapidoid.dockerfile
+++ b/frameworks/Java/rapidoid/rapidoid.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /rapidoid
 COPY --from=maven /rapidoid/target/rapidoid-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-cp", "app.jar", "highlevel.Main", "profiles=production"]

--- a/frameworks/Java/ratpack/ratpack-jdbc.dockerfile
+++ b/frameworks/Java/ratpack/ratpack-jdbc.dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar", "profile.name=jdbc"]

--- a/frameworks/Java/ratpack/ratpack-pgclient.dockerfile
+++ b/frameworks/Java/ratpack/ratpack-pgclient.dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD export DBIP=`getent hosts tfb-database | awk '{ print $1 }'` && \

--- a/frameworks/Java/ratpack/ratpack.dockerfile
+++ b/frameworks/Java/ratpack/ratpack.dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle build.gradle
 COPY src src
 RUN gradle shadowJar
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /ratpack
 COPY --from=gradle /ratpack/build/libs/ratpack-all.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar"]

--- a/frameworks/Java/restexpress/restexpress-mysql-raw.dockerfile
+++ b/frameworks/Java/restexpress/restexpress-mysql-raw.dockerfile
@@ -5,7 +5,7 @@ COPY src/main/resources/config/dev/mysql-environment.properties src/main/resourc
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /restexpress
 COPY --from=maven /restexpress/target/world-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/restexpress/restexpress.dockerfile
+++ b/frameworks/Java/restexpress/restexpress.dockerfile
@@ -5,7 +5,7 @@ COPY src/main/resources/config/dev/mongodb-environment.properties src/main/resou
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /restexpress
 COPY --from=maven /restexpress/target/world-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
+++ b/frameworks/Java/revenj-jvm/revenj-jvm.dockerfile
@@ -15,7 +15,7 @@ RUN unzip -o dsl-compiler.zip
 RUN rm dsl-compiler.zip
 RUN mvn compile war:war -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-afterburner.dockerfile
+++ b/frameworks/Java/servlet/servlet-afterburner.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P afterburner
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-cjs.dockerfile
+++ b/frameworks/Java/servlet/servlet-cjs.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P cjs
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-mysql.dockerfile
+++ b/frameworks/Java/servlet/servlet-mysql.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P mysql
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet-postgresql.dockerfile
+++ b/frameworks/Java/servlet/servlet-postgresql.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q -P postgresql
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/servlet/servlet.dockerfile
+++ b/frameworks/Java/servlet/servlet.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/smart-socket/smart-socket.dockerfile
+++ b/frameworks/Java/smart-socket/smart-socket.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /smart-socket
 COPY --from=maven /smart-socket/target/smart-socket-benchmark-1.0-jar-with-dependencies.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-cp", "app.jar", "org.smartboot.http.Bootstrap"]

--- a/frameworks/Java/spark/spark.dockerfile
+++ b/frameworks/Java/spark/spark.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spark
 COPY --from=maven /spark/target/hello-spark-1.0.0-BUILD-SNAPSHOT.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "app.jar"]

--- a/frameworks/Java/spring-webflux/spring-webflux-jdbc.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-jdbc.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=jdbc,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux-mongo.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-mongo.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=mongo"]

--- a/frameworks/Java/spring-webflux/spring-webflux-pgclient.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-pgclient.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=pgclient,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux-rxjdbc.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux-rxjdbc.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=rxjdbc,postgres"]

--- a/frameworks/Java/spring-webflux/spring-webflux.dockerfile
+++ b/frameworks/Java/spring-webflux/spring-webflux.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/spring-webflux-benchmark.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=r2dbc,postgres"]

--- a/frameworks/Java/spring/spring-mongo.dockerfile
+++ b/frameworks/Java/spring/spring-mongo.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/hello-spring-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=mongo"]

--- a/frameworks/Java/spring/spring.dockerfile
+++ b/frameworks/Java/spring/spring.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /spring
 COPY --from=maven /spring/target/hello-spring-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dlogging.level.root=OFF", "-jar", "app.jar", "--spring.profiles.active=jdbc,postgres"]

--- a/frameworks/Java/tapestry/tapestry.dockerfile
+++ b/frameworks/Java/tapestry/tapestry.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/undertow-jersey/undertow-jersey-hikaricp.dockerfile
+++ b/frameworks/Java/undertow-jersey/undertow-jersey-hikaricp.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q -P hikaricp
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /undertow-jersey
 COPY --from=maven /undertow-jersey/target/undertow-jersey.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/undertow-jersey/undertow-jersey.dockerfile
+++ b/frameworks/Java/undertow-jersey/undertow-jersey.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /undertow-jersey
 COPY --from=maven /undertow-jersey/target/undertow-jersey.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Java/voovan/voovan.dockerfile
+++ b/frameworks/Java/voovan/voovan.dockerfile
@@ -5,7 +5,7 @@ COPY src src
 COPY config/framework.properties config/framework.properties
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /voovan
 COPY --from=maven /voovan/target/voovan-bench-0.1-jar-with-dependencies.jar app.jar
 COPY --from=maven /voovan/config/framework.properties config/framework.properties

--- a/frameworks/Java/wicket/wicket.dockerfile
+++ b/frameworks/Java/wicket/wicket.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY pom.xml pom.xml
 RUN mvn compile war:war -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /resin
 RUN curl -sL http://caucho.com/download/resin-4.0.61.tar.gz | tar xz --strip-components=1
 RUN rm -rf webapps/*

--- a/frameworks/Java/wizzardo-http/wizzardo-http.dockerfile
+++ b/frameworks/Java/wizzardo-http/wizzardo-http.dockerfile
@@ -8,7 +8,7 @@ COPY src src
 
 RUN gradle --refresh-dependencies clean fatJar
 
-FROM openjdk:11.0.3-jre-slim
+FROM openjdk:11.0.3-jdk-slim
 WORKDIR /wizzardo-http
 COPY --from=gradle /wizzardo-http/build/libs/wizzardo-http-all-1.0-SNAPSHOT.jar app.jar
 CMD ["java", "-Xmx2G", "-Xms2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "env=prod"]

--- a/frameworks/Kotlin/hexagon/hexagon-jetty-postgresql.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-jetty-postgresql.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 ENV DBSTORE postgresql
 ENV POSTGRESQL_DB_HOST tfb-database
 ENV WEBENGINE jetty

--- a/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-resin-mongodb.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 ENV DBSTORE mongodb
 ENV MONGODB_DB_HOST tfb-database
 

--- a/frameworks/Kotlin/hexagon/hexagon-resin-postgresql.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon-resin-postgresql.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 ENV DBSTORE postgresql
 ENV POSTGRESQL_DB_HOST tfb-database
 

--- a/frameworks/Kotlin/hexagon/hexagon.dockerfile
+++ b/frameworks/Kotlin/hexagon/hexagon.dockerfile
@@ -14,7 +14,7 @@ RUN gradle --quiet --exclude-task test
 #
 # RUNTIME
 #
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 ENV DBSTORE mongodb
 ENV MONGODB_DB_HOST tfb-database
 ENV WEBENGINE jetty

--- a/frameworks/Kotlin/ktor/ktor-cio.dockerfile
+++ b/frameworks/Kotlin/ktor/ktor-cio.dockerfile
@@ -4,7 +4,7 @@ COPY ktor/pom.xml pom.xml
 COPY ktor/src src
 RUN mvn clean package -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /ktor
 COPY --from=maven /ktor/target/tech-empower-framework-benchmark-1.0-SNAPSHOT-cio-bundle.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Kotlin/ktor/ktor-jasync.dockerfile
+++ b/frameworks/Kotlin/ktor/ktor-jasync.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /app
 COPY ktor-asyncdb/gradle gradle
 COPY ktor-asyncdb/build.gradle build.gradle

--- a/frameworks/Kotlin/ktor/ktor-jetty.dockerfile
+++ b/frameworks/Kotlin/ktor/ktor-jetty.dockerfile
@@ -4,7 +4,7 @@ COPY ktor/pom.xml pom.xml
 COPY ktor/src src
 RUN mvn clean package -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /ktor
 COPY --from=maven /ktor/target/tech-empower-framework-benchmark-1.0-SNAPSHOT-jetty-bundle.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/frameworks/Kotlin/ktor/ktor-reactivepg.dockerfile
+++ b/frameworks/Kotlin/ktor/ktor-reactivepg.dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /app
 COPY ktor-asyncdb/gradle gradle
 COPY ktor-asyncdb/build.gradle build.gradle

--- a/frameworks/Kotlin/ktor/ktor.dockerfile
+++ b/frameworks/Kotlin/ktor/ktor.dockerfile
@@ -4,7 +4,7 @@ COPY ktor/pom.xml pom.xml
 COPY ktor/src src
 RUN mvn clean package -q
 
-FROM openjdk:11.0.3-jre-stretch
+FROM openjdk:11.0.3-jdk-stretch
 WORKDIR /ktor
 COPY --from=maven /ktor/target/tech-empower-framework-benchmark-1.0-SNAPSHOT-netty-bundle.jar app.jar
 CMD ["java", "-server","-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-XX:+AlwaysPreTouch", "-jar", "app.jar"]


### PR DESCRIPTION
Java 11 doesn't have JRE variants.
Also update Jetty to Java 11.