### PR TITLE
docker add COMPlus_ReadyToRun variable

### DIFF
--- a/frameworks/CSharp/beetlex/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/beetlex/Benchmarks/Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeetleX.FastHttpApi" Version="1.5.0" />
+    <PackageReference Include="BeetleX.FastHttpApi" Version="1.5.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageReference Include="SpanJson" Version="2.0.10" />
   </ItemGroup>

--- a/frameworks/CSharp/beetlex/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/beetlex/Benchmarks/Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeetleX.FastHttpApi" Version="1.5.0.8" />
+    <PackageReference Include="BeetleX.FastHttpApi" Version="1.5.2.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageReference Include="SpanJson" Version="2.0.10" />
   </ItemGroup>

--- a/frameworks/CSharp/beetlex/Benchmarks/Program.cs
+++ b/frameworks/CSharp/beetlex/Benchmarks/Program.cs
@@ -64,6 +64,7 @@ namespace Benchmarks
             mApiServer.Options.LogLevel = BeetleX.EventArgs.LogType.Off;
             mApiServer.Options.LogToConsole = true;
             mApiServer.Options.PrivateBufferPool = true;
+            mApiServer.Options.IOQueueEnabled = true;
             mApiServer.Register(typeof(Program).Assembly);
             mApiServer.HttpRequesting += OnRequesting;
             mApiServer.Open();

--- a/frameworks/CSharp/beetlex/beetlex.dockerfile
+++ b/frameworks/CSharp/beetlex/beetlex.dockerfile
@@ -4,6 +4,7 @@ COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
 FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
+ENV COMPlus_ReadyToRun 0
 WORKDIR /app
 COPY --from=build /app/out ./
 ENTRYPOINT ["dotnet", "Benchmarks.dll"]


### PR DESCRIPTION
update beetlex

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
