### PR TITLE
Java/dropwizard - Replace usage of Hibernate's Criteria API

### DIFF
--- a/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/db/hibernate/FortuneHibernateImpl.java
+++ b/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/db/hibernate/FortuneHibernateImpl.java
@@ -1,11 +1,14 @@
 package com.example.helloworld.db.hibernate;
 
-import com.example.helloworld.db.FortuneDAO;
-import com.example.helloworld.db.model.Fortune;
 import io.dropwizard.hibernate.AbstractDAO;
-import org.hibernate.SessionFactory;
 
 import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+
+import com.example.helloworld.db.FortuneDAO;
+import com.example.helloworld.db.model.Fortune;
 
 public class FortuneHibernateImpl extends AbstractDAO<Fortune> implements FortuneDAO {
 
@@ -14,6 +17,6 @@ public class FortuneHibernateImpl extends AbstractDAO<Fortune> implements Fortun
     }
 
     public List<Fortune> list() {
-        return list(criteria());
+        return list((Query<Fortune>) query("SELECT f FROM Fortune f"));
     }
 }

--- a/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/db/model/Fortune.java
+++ b/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/db/model/Fortune.java
@@ -16,7 +16,6 @@ public class Fortune implements Comparable<Fortune> {
     @Column(name = "message", nullable = false)
     private String message;
 
-    @SuppressWarnings("unused")
     public Fortune() {}
     
     public Fortune(String message) {


### PR DESCRIPTION
Replace the usage of Hibernate's `Criteria API` with the `Query API` in the `Fortune` test. The result is no more warnings about deprecations.