### PR TITLE
Jackson with MySQL connector CVE - partial update

### DIFF
--- a/frameworks/Java/activeweb/pom.xml
+++ b/frameworks/Java/activeweb/pom.xml
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
     </dependencies>
 

--- a/frameworks/Java/bayou/pom.xml
+++ b/frameworks/Java/bayou/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
 
     </dependencies>

--- a/frameworks/Java/comsat/build.gradle
+++ b/frameworks/Java/comsat/build.gradle
@@ -10,7 +10,7 @@ targetCompatibility = 1.8
 
 version = '0.3'
 
-ext.jacksonVer  = '2.9.7'
+ext.jacksonVer  = '2.9.9'
 ext.quasarVer   = '0.7.5'
 ext.comsatVer   = '0.7.0'
 ext.capsuleVer  = '1.0.2'

--- a/frameworks/Java/dropwizard/pom.xml
+++ b/frameworks/Java/dropwizard/pom.xml
@@ -14,7 +14,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
-		<dropwizard.version>1.3.10</dropwizard.version>
+		<dropwizard.version>1.3.12</dropwizard.version>
 		<javax-activation.version>1.1.1</javax-activation.version>
 		<jaxb.version>2.3.0</jaxb.version>
 		<mysql-connector-java.version>5.1.47</mysql-connector-java.version>

--- a/frameworks/Java/grizzly/pom-jersey.xml
+++ b/frameworks/Java/grizzly/pom-jersey.xml
@@ -22,10 +22,10 @@
 		<grizzly.version>2.4.4</grizzly.version>
 		<hibernate.version>5.4.2.Final</hibernate.version>
 		<hibernate-jpa-api.version>1.0.0.Final</hibernate-jpa-api.version>
-		<jackson.version>2.9.8</jackson.version>
+		<jackson.version>2.9.9</jackson.version>
 		<jaxb.version>2.3.0</jaxb.version>
 		<jersey.version>2.28</jersey.version>
-		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
 		<maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
 		<mustache.version>0.9.6</mustache.version>
 		<mysql-connector.version>5.1.47</mysql-connector.version>
@@ -180,7 +180,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin.version}</version>
 				<configuration>
-					<optimize>true</optimize>
 					<debug>false</debug>
 				</configuration>
 			</plugin>

--- a/frameworks/Java/grizzly/pom.xml
+++ b/frameworks/Java/grizzly/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <build>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
     </dependencies>
 </project>

--- a/frameworks/Java/httpserver/pom.xml
+++ b/frameworks/Java/httpserver/pom.xml
@@ -10,20 +10,20 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.9</version>
         </dependency>
 
         <dependency>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.1</version>
         </dependency>
 
         <dependency>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>1.8.0-beta4</version>
         </dependency>
     </dependencies>
 

--- a/frameworks/Java/javalin/build.gradle
+++ b/frameworks/Java/javalin/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     compile 'io.javalin:javalin:2.8.0'
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.8"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
     compile "org.slf4j:slf4j-simple:1.8.0-beta4"
 }
 

--- a/frameworks/Java/jlhttp/pom.xml
+++ b/frameworks/Java/jlhttp/pom.xml
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
 
         <dependency>

--- a/frameworks/Java/jooby/pom.xml
+++ b/frameworks/Java/jooby/pom.xml
@@ -17,7 +17,7 @@
   <name>jooby</name>
 
   <properties>
-    <jooby.version>1.6.0</jooby.version>
+    <jooby.version>1.6.2</jooby.version>
     <postgresql.version>42.2.5</postgresql.version>
     <rocker.touchFile>/dev/null</rocker.touchFile>
     <maven.compiler.source>11</maven.compiler.source>

--- a/frameworks/Java/light-java/pom.xml
+++ b/frameworks/Java/light-java/pom.xml
@@ -23,14 +23,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.light-4j>2.0.0-BETA2</version.light-4j>
+        <version.light-4j>2.0.1</version.light-4j>
         <version.logback>1.2.3</version.logback>
-        <version.undertow>2.0.16.Final</version.undertow>
-        <version.hikaricp>3.2.0</version.hikaricp>
+        <version.undertow>2.0.21.Final</version.undertow>
+        <version.hikaricp>3.3.1</version.hikaricp>
         <version.mysql>5.1.47</version.mysql>
         <version.postgres>42.2.5</version.postgres>
         <version.dsl-json>1.8.4</version.dsl-json>
-        <version.mustache>0.9.5</version.mustache>
+        <version.mustache>0.9.6</version.mustache>
         <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
         <version.maven-jar-plugin>3.0.2</version.maven-jar-plugin>
         <version.maven-shade-plugin>3.1.0</version.maven-shade-plugin>

--- a/frameworks/Java/nanohttpd/pom.xml
+++ b/frameworks/Java/nanohttpd/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-afterburner</artifactId>
-        <version>2.9.8</version>
+        <version>2.9.9</version>
     </dependency>
     </dependencies>
 

--- a/frameworks/Java/ninja-standalone/pom.xml
+++ b/frameworks/Java/ninja-standalone/pom.xml
@@ -33,6 +33,46 @@
             <groupId>org.ninjaframework</groupId>
             <artifactId>ninja-servlet</artifactId>
             <version>${ninja.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.core</artifactId>
+                    <groupId>jackson-core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.module</artifactId>
+                    <groupId>jackson-module-afterburner</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.dataformat</artifactId>
+                    <groupId>jackson-dataformat-xml</groupId>
+                </exclusion>
+             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.9.9</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.core</artifactId>
+                    <groupId>jackson-annotations</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.9</version>
         </dependency>
 
         <dependency>

--- a/frameworks/Java/officefloor/src/pom.xml
+++ b/frameworks/Java/officefloor/src/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 	<name>OfficeFloor Benchmarks</name>
 	<properties>
-		<officefloor.version>3.9.2</officefloor.version>
+		<officefloor.version>3.10.2</officefloor.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<jaxb.version>2.3.0</jaxb.version>
@@ -50,6 +50,11 @@
 				<groupId>net.officefloor.benchmarks</groupId>
 				<artifactId>woof_benchmark_micro</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>2.9.9</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/frameworks/Java/restexpress/pom.xml
+++ b/frameworks/Java/restexpress/pom.xml
@@ -27,6 +27,17 @@
 			<groupId>com.strategicgains</groupId>
 			<artifactId>RestExpress</artifactId>
 			<version>0.12.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>com.fasterxml.jackson.core</artifactId>
+					<groupId>jackson-databind</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.strategicgains.repoexpress</groupId>

--- a/frameworks/Java/restexpress/pom.xml
+++ b/frameworks/Java/restexpress/pom.xml
@@ -38,6 +38,17 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.9.9</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>com.fasterxml.jackson.core</artifactId>
+					<groupId>jackson-annotations</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+			<version>2.9.9</version>
 		</dependency>
 		<dependency>
 			<groupId>com.strategicgains.repoexpress</groupId>

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<cache2k-version>1.2.1.Final</cache2k-version>
-		<jackson-version>2.9.8</jackson-version>
+		<jackson-version>2.9.9</jackson-version>
 		<!-- This is the default web.xml for plaintext and json only -->
 		<maven.war.xml>src/main/webapp/WEB-INF/web.xml</maven.war.xml>
 	</properties>

--- a/frameworks/Java/servlet3/pom.xml
+++ b/frameworks/Java/servlet3/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
+			<version>2.9.9</version>
 		</dependency>
 
 		<dependency>

--- a/frameworks/Java/tapestry/pom.xml
+++ b/frameworks/Java/tapestry/pom.xml
@@ -95,7 +95,7 @@ of testing facilities designed for use with TestNG (http://testng.org/), so it's
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/frameworks/Java/undertow-jersey/pom.xml
+++ b/frameworks/Java/undertow-jersey/pom.xml
@@ -121,6 +121,36 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>com.fasterxml.jackson.core</artifactId>
+          <groupId>jackson-annotations</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>com.fasterxml.jackson.core</artifactId>
+          <groupId>jackson-databind</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>com.fasterxml.jackson.module</artifactId>
+          <groupId>jackson-module-jaxb-annotations</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.9.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>2.9.9</version>
     </dependency>
 
     <dependency>

--- a/frameworks/Java/undertow-jersey/pom.xml
+++ b/frameworks/Java/undertow-jersey/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
-      <version>2.0.20.Final</version>
+      <version>2.0.21.Final</version>
     </dependency>
 
     <dependency>

--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -14,12 +14,12 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <hikaricp.version>3.2.0</hikaricp.version>
-    <jackson.version>2.9.7</jackson.version>
+    <hikaricp.version>3.3.1</hikaricp.version>
+    <jackson.version>2.9.9</jackson.version>
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
-    <mustache.version>0.9.5</mustache.version>
+    <mustache.version>0.9.6</mustache.version>
     <postgresql.version>42.2.5</postgresql.version>
-    <undertow.version>2.0.15.Final</undertow.version>
+    <undertow.version>2.0.21.Final</undertow.version>
   </properties>
 
   <prerequisites>

--- a/frameworks/Java/vertx-web/pom.xml
+++ b/frameworks/Java/vertx-web/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-afterburner</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
     </dependency>
 
     <dependency>

--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -64,13 +64,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-afterburner</artifactId>
-			<version>2.9.8</version>
+			<version>2.9.9</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.9.8</version>
+			<version>2.9.9</version>
 		</dependency>
 
 		<dependency>

--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -6,7 +6,7 @@ version := finagleVersion
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-http" % finagleVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.8"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9"
 )
 
 assemblyJarName in assembly := "finagle-benchmark.jar"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -20,7 +20,7 @@ assemblyMergeStrategy in assembly := {
 libraryDependencies ++= Seq(
   "com.twitter" %% "finatra-http" % finatraVersion,
   "org.slf4j" % "slf4j-nop" % "1.7.25",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.8",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.9",
   "javax.activation" % "activation" % "1.1.1"
 )
 


### PR DESCRIPTION
More information here: https://github.com/FasterXML/jackson-databind/issues/2326

I've changed the easy ones. Also some of the projects where a little more exclusion/inclusion was needed. What is left are the ones with the most effort required.

- Java/jooby2 - even RC3 doesn't have Jackson 2.9.9. Probably the declaration as child POM should be removed. Than exclude and import the correct version of the dependencies;
- Java/ratpack - Gradle build;
- Java/proteus - around 6 `Jackson` dependencies;
- Java/spring;
- Java/spring-webflux;
- Clojure/http-kit;
- Clojure/compojure;
- Clojure/aleph;
- probably I've missed some.

I don't plan to work on them. It will be too much effort for me.