### PR TITLE
PHP PDO use prepared statements in db server

### DIFF
--- a/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
@@ -6,7 +6,7 @@ return ['default' => [
             'password' => 'benchmarkdbpass',
             'params' => [
                 PDO::ATTR_PERSISTENT => true, //conexión persistente
-                PDO::ATTR_EMULATE_PREPARES => false
+                PDO::ATTR_EMULATE_PREPARES => false,
             ]
         ],
     ];

--- a/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
@@ -6,7 +6,7 @@ return ['default' => [
             'password' => 'benchmarkdbpass',
             'params' => [
                 PDO::ATTR_PERSISTENT => true, //conexión persistente
-                PDO::ATTR_EMULATE_PREPARES => false,
+                PDO::ATTR_EMULATE_PREPARES => false
             ]
         ],
     ];

--- a/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
@@ -6,6 +6,7 @@ return ['default' => [
             'password' => 'benchmarkdbpass',
             'params' => [
                 PDO::ATTR_PERSISTENT => true, //conexión persistente
+                PDO::ATTR_EMULATE_PREPARES => false
             ]
         ],
     ];

--- a/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/config/databases.php
@@ -6,7 +6,6 @@ return ['default' => [
             'password' => 'benchmarkdbpass',
             'params' => [
                 PDO::ATTR_PERSISTENT => true, //conexión persistente
-                PDO::ATTR_EMULATE_PREPARES => false
             ]
         ],
     ];

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
@@ -9,10 +9,10 @@ class RawController extends AppController
         View::select(null, null);
         header('Content-type: application/json');
 
-        $this->pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+        $this->pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
             PDO::ATTR_PERSISTENT => true,
             PDO::ATTR_EMULATE_PREPARES => false
-        ));
+        ]);
     }
 
     public function index()
@@ -45,7 +45,7 @@ class RawController extends AppController
             $id = mt_rand(1, 10000);
             $randomNumber = mt_rand(1, 10000);
 
-            $sth->execute(array($id));
+            $sth->execute([$id]);
             $row = ['id' => $id, 'randomNumber' => $updateSth->fetchColumn()];
             $row['randomNumber'] = $randomNumber;
             $updateSth->execute([$randomNumber, $id]);

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
@@ -10,7 +10,8 @@ class RawController extends AppController
         header('Content-type: application/json');
 
         $this->pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
-            PDO::ATTR_PERSISTENT => true
+            PDO::ATTR_PERSISTENT => true,
+            PDO::ATTR_EMULATE_PREPARES => false
         ));
     }
 

--- a/frameworks/PHP/php/dbquery.php
+++ b/frameworks/PHP/php/dbquery.php
@@ -3,10 +3,10 @@ header('Content-type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
-$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
     PDO::ATTR_PERSISTENT => true,
     PDO::ATTR_EMULATE_PREPARES => false
-));
+]);
 
 // Read number of queries to run from URL parameter
 $query_count = 1;
@@ -15,14 +15,14 @@ if ($_GET['queries'] > 1) {
 }
 
 // Create an array with the response string.
-$arr = array();
+$arr = [];
 
 // Define query
 $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
 
 // For each query, store the result set values in the response array
 while (0 < $query_count--) {
-  $statement->execute(array( mt_rand(1, 10000)) );
+  $statement->execute( [mt_rand(1, 10000)] );
   
   // Store result in array.
   $arr[] = $statement->fetch(PDO::FETCH_ASSOC);

--- a/frameworks/PHP/php/dbquery.php
+++ b/frameworks/PHP/php/dbquery.php
@@ -4,7 +4,8 @@ header('Content-type: application/json');
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
 $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
-    PDO::ATTR_PERSISTENT => true
+    PDO::ATTR_PERSISTENT => true,
+    PDO::ATTR_EMULATE_PREPARES => false
 ));
 
 // Read number of queries to run from URL parameter

--- a/frameworks/PHP/php/dbraw.php
+++ b/frameworks/PHP/php/dbraw.php
@@ -3,9 +3,9 @@ header('Content-type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
-$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
     PDO::ATTR_PERSISTENT => true
-));
+]);
 
 // Define query
 $statement = $pdo->query( 'SELECT id,randomNumber FROM World WHERE id = '. mt_rand(1, 10000) );

--- a/frameworks/PHP/php/fortune.php
+++ b/frameworks/PHP/php/fortune.php
@@ -5,9 +5,9 @@
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
-$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
     PDO::ATTR_PERSISTENT => true
-));
+]);
   
 // Define query and store result in array.
 $arr = $pdo->query( 'SELECT id, message FROM Fortune' )->fetchAll(PDO::FETCH_KEY_PAIR); 

--- a/frameworks/PHP/php/json.php
+++ b/frameworks/PHP/php/json.php
@@ -4,4 +4,4 @@ header('Content-type: application/json');
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-echo json_encode(array('message' => 'Hello, World!'));
+echo json_encode(['message' => 'Hello, World!']);

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -3,10 +3,10 @@ header('Content-type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
-$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
+$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
   PDO::ATTR_PERSISTENT => true,
   PDO::ATTR_EMULATE_PREPARES => false
-));
+]);
 
 // Read number of queries to run from URL parameter
 $query_count = 1;
@@ -15,7 +15,7 @@ if ($_GET['queries'] > 1) {
 }
 
 // Create an array with the response string.
-$arr = array();
+$arr = [];
 
 // Define query
 $statement = $pdo->prepare('SELECT randomNumber FROM World WHERE id = ?');
@@ -26,12 +26,12 @@ while (0 < $query_count--) {
   $id = mt_rand(1, 10000);
   $randomNumber = mt_rand(1, 10000);
 
-  $statement->execute(array($id));
+  $statement->execute( [$id] );
   
   // Store result in array.
-  $world = array('id' => $id, 'randomNumber' => $statement->fetchColumn());
+  $world = ['id' => $id, 'randomNumber' => $statement->fetchColumn()];
   $world['randomNumber'] = $randomNumber;
-  $updateStatement->execute(array($randomNumber, $id));
+  $updateStatement->execute([$randomNumber, $id]);
   
   $arr[] = $world;
 }

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -4,7 +4,8 @@ header('Content-type: application/json');
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
 $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', array(
-    PDO::ATTR_PERSISTENT => true
+  PDO::ATTR_PERSISTENT => true,
+  PDO::ATTR_EMULATE_PREPARES => false
 ));
 
 // Read number of queries to run from URL parameter


### PR DESCRIPTION
By default PDO uses emulated prepared statements in the app server, and not the native db server.

In the multiquery and update tests will be beneficial to use the prepared stm in the db server.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
