### PR TITLE
Config now show the webserver h2o

### DIFF
--- a/frameworks/C/h2o/benchmark_config.json
+++ b/frameworks/C/h2o/benchmark_config.json
@@ -18,7 +18,7 @@
       "flavor": "None",
       "orm": "Raw",
       "platform": "None",
-      "webserver": "None",
+      "webserver": "h2o",
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "H2O",

--- a/frameworks/Crystal/h2o.cr/benchmark_config.json
+++ b/frameworks/Crystal/h2o.cr/benchmark_config.json
@@ -14,7 +14,7 @@
         "flavor": "None",
         "orm": "Raw",
         "platform": "None",
-        "webserver": "None",
+        "webserver": "h2o",
         "os": "Linux",
         "database_os": "Linux",
         "display_name": "crystal-h2o",


### PR DESCRIPTION
Useful when comparing results
Also when used like a lib.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
