### PR TITLE
H2O: Switch back to a global shared cache

### DIFF
--- a/frameworks/C/h2o/src/event_loop.c
+++ b/frameworks/C/h2o/src/event_loop.c
@@ -63,7 +63,7 @@ static void accept_connection(h2o_socket_t *listener, const char *err)
 		                                                      event_loop,
 		                                                      listener->data);
 
-		if (!ctx->global_data->shutdown) {
+		if (!ctx->shutdown) {
 			size_t accepted = ctx->config->max_accept;
 
 			do {
@@ -170,25 +170,39 @@ static void on_close_connection(void *data)
 
 static void process_messages(h2o_multithread_receiver_t *receiver, h2o_linklist_t *messages)
 {
-	IGNORE_FUNCTION_PARAMETER(messages);
-
 	global_thread_data_t * const global_thread_data = H2O_STRUCT_FROM_MEMBER(global_thread_data_t,
 	                                                                         h2o_receiver,
 	                                                                         receiver);
 
-	// Close the listening sockets immediately, so that if another instance of
-	// the application is started before the current one exits (e.g. when doing
-	// an update), it will accept all incoming connections.
-	if (global_thread_data->ctx->event_loop.h2o_https_socket) {
-		h2o_socket_read_stop(global_thread_data->ctx->event_loop.h2o_https_socket);
-		h2o_socket_close(global_thread_data->ctx->event_loop.h2o_https_socket);
-		global_thread_data->ctx->event_loop.h2o_https_socket = NULL;
-	}
+	while (!h2o_linklist_is_empty(messages)) {
+		message_t * const msg = H2O_STRUCT_FROM_MEMBER(message_t, super, messages->next);
 
-	if (global_thread_data->ctx->event_loop.h2o_socket) {
-		h2o_socket_read_stop(global_thread_data->ctx->event_loop.h2o_socket);
-		h2o_socket_close(global_thread_data->ctx->event_loop.h2o_socket);
-		global_thread_data->ctx->event_loop.h2o_socket = NULL;
+		h2o_linklist_unlink(&msg->super.link);
+
+		switch (msg->type) {
+			case SHUTDOWN:
+				// Close the listening sockets immediately, so that if another instance of
+				// the application is started before the current one exits (e.g. when doing
+				// an update), it will accept all incoming connections.
+				if (global_thread_data->ctx->event_loop.h2o_https_socket) {
+					h2o_socket_read_stop(global_thread_data->ctx->event_loop.h2o_https_socket);
+					h2o_socket_close(global_thread_data->ctx->event_loop.h2o_https_socket);
+					global_thread_data->ctx->event_loop.h2o_https_socket = NULL;
+				}
+
+				if (global_thread_data->ctx->event_loop.h2o_socket) {
+					h2o_socket_read_stop(global_thread_data->ctx->event_loop.h2o_socket);
+					h2o_socket_close(global_thread_data->ctx->event_loop.h2o_socket);
+					global_thread_data->ctx->event_loop.h2o_socket = NULL;
+				}
+
+				global_thread_data->ctx->shutdown = true;
+				break;
+			default:
+				break;
+		}
+
+		free(msg);
 	}
 }
 
@@ -201,7 +215,7 @@ static void shutdown_server(h2o_socket_t *listener, const char *err)
 		                                                      event_loop,
 		                                                      listener->data);
 
-		ctx->global_data->shutdown = true;
+		ctx->shutdown = true;
 
 		// Close the listening sockets immediately, so that if another instance
 		// of the application is started before the current one exits (e.g. when
@@ -218,8 +232,15 @@ static void shutdown_server(h2o_socket_t *listener, const char *err)
 			ctx->event_loop.h2o_socket = NULL;
 		}
 
-		for (size_t i = ctx->config->thread_num - 1; i > 0; i--)
-			h2o_multithread_send_message(&ctx->global_thread_data[i].h2o_receiver, NULL);
+		for (size_t i = ctx->config->thread_num - 1; i > 0; i--) {
+			message_t * const msg = calloc(1, sizeof(*msg));
+
+			if (!msg)
+				abort();
+
+			msg->type = SHUTDOWN;
+			h2o_multithread_send_message(&ctx->global_thread_data[i].h2o_receiver, &msg->super);
+		}
 	}
 }
 
@@ -248,7 +269,7 @@ static void start_accept_polling(const config_t *config,
 
 void event_loop(thread_context_t *ctx)
 {
-	while (!ctx->global_data->shutdown || ctx->event_loop.conn_num)
+	while (!ctx->shutdown || ctx->event_loop.conn_num)
 		h2o_evloop_run(ctx->event_loop.h2o_ctx.loop, INT32_MAX);
 }
 

--- a/frameworks/C/h2o/src/event_loop.h
+++ b/frameworks/C/h2o/src/event_loop.h
@@ -26,6 +26,10 @@
 
 #include "global_data.h"
 
+typedef enum {
+	SHUTDOWN
+} message_type_t;
+
 typedef struct thread_context_t thread_context_t;
 
 typedef struct {
@@ -35,6 +39,11 @@ typedef struct {
 	h2o_accept_ctx_t h2o_accept_ctx;
 	h2o_context_t h2o_ctx;
 } event_loop_t;
+
+typedef struct {
+	message_type_t type;
+	h2o_multithread_message_t super;
+} message_t;
 
 void event_loop(thread_context_t *ctx);
 void free_event_loop(event_loop_t *event_loop, h2o_multithread_receiver_t *h2o_receiver);

--- a/frameworks/C/h2o/src/global_data.h
+++ b/frameworks/C/h2o/src/global_data.h
@@ -31,7 +31,8 @@
 #include "list.h"
 #include "handlers/request_handler_data.h"
 
-typedef struct global_thread_data_t global_thread_data_t;
+struct global_thread_data_t;
+struct thread_context_t;
 
 typedef struct {
 	const char *bind_address;
@@ -52,15 +53,19 @@ typedef struct {
 
 typedef struct {
 	h2o_logger_t *file_logger;
-	global_thread_data_t *global_thread_data;
+	struct global_thread_data_t *global_thread_data;
+	list_t *postinitialization_tasks;
 	list_t *prepared_statements;
 	h2o_socket_t *signals;
 	SSL_CTX *ssl_ctx;
 	size_t memory_alignment;
 	int signal_fd;
-	bool shutdown;
 	h2o_globalconf_t h2o_config;
 	request_handler_data_t request_handler_data;
 } global_data_t;
+
+void add_postinitialization_task(void (*task)(struct thread_context_t *, void *),
+                                 void *arg,
+                                 list_t **postinitialization_tasks);
 
 #endif // GLOBAL_DATA_H_

--- a/frameworks/C/h2o/src/handlers/request_handler_data.h
+++ b/frameworks/C/h2o/src/handlers/request_handler_data.h
@@ -21,18 +21,18 @@
 
 #define REQUEST_HANDLER_DATA_H_
 
-#include <h2o.h>
-#include <stdbool.h>
+#include "cache.h"
 
 struct mustache_token_t;
 
 typedef struct {
 	struct mustache_token_t *fortunes_template;
+	cache_t world_cache;
 } request_handler_data_t;
 
 typedef struct {
-	h2o_cache_t *world_cache;
-	bool populate_world_cache;
+	// Replace with any actual fields; structures without members cause compiler warnings.
+	int pad;
 } request_handler_thread_data_t;
 
 #endif // REQUEST_HANDLER_DATA_H_

--- a/frameworks/C/h2o/src/handlers/world.h
+++ b/frameworks/C/h2o/src/handlers/world.h
@@ -25,9 +25,9 @@
 
 #include "global_data.h"
 
-void free_world_handler_thread_data(request_handler_thread_data_t *request_handler_thread_data);
-void initialize_world_handler_thread_data(request_handler_thread_data_t *request_handler_data);
-void initialize_world_handlers(global_data_t *global_data,
+void cleanup_world_handlers(global_data_t *global_data);
+void initialize_world_handlers(const config_t *config,
+                               global_data_t *global_data,
                                h2o_hostconf_t *hostconf,
                                h2o_access_log_filehandle_t *log_handle);
 

--- a/frameworks/C/h2o/src/main.c
+++ b/frameworks/C/h2o/src/main.c
@@ -46,9 +46,16 @@
 	"[-q <max enqueued database queries per thread>] [-r <root directory>] " \
 	"[-s <HTTPS port>] [-t <thread number>]\n"
 
+typedef struct {
+	list_t l;
+	void *arg;
+	void (*task)(thread_context_t *, void *);
+} task_t;
+
 static void free_global_data(global_data_t *global_data);
 static int initialize_global_data(const config_t *config, global_data_t *global_data);
 static int parse_options(int argc, char *argv[], config_t *config);
+static void run_postinitialization_tasks(list_t **tasks, thread_context_t *ctx);
 static void set_default_options(config_t *config);
 static void setup_process(void);
 
@@ -211,6 +218,18 @@ static int parse_options(int argc, char *argv[], config_t *config)
 	return EXIT_SUCCESS;
 }
 
+static void run_postinitialization_tasks(list_t **tasks, thread_context_t *ctx)
+{
+	if (*tasks)
+		do {
+			task_t * const t = H2O_STRUCT_FROM_MEMBER(task_t, l, *tasks);
+
+			*tasks = (*tasks)->next;
+			t->task(ctx, t->arg);
+			free(t);
+		} while (*tasks);
+}
+
 static void set_default_options(config_t *config)
 {
 	if (!config->max_accept)
@@ -253,6 +272,21 @@ static void setup_process(void)
 	CHECK_ERRNO(setrlimit, RLIMIT_NOFILE, &rlim);
 }
 
+void add_postinitialization_task(void (*task)(struct thread_context_t *, void *),
+                                 void *arg,
+                                 list_t **postinitialization_tasks)
+{
+	task_t * const t = calloc(1, sizeof(*t));
+
+	if (!t)
+		abort();
+
+	t->l.next = *postinitialization_tasks;
+	t->arg = arg;
+	t->task = task;
+	*postinitialization_tasks = &t->l;
+}
+
 int main(int argc, char *argv[])
 {
 	config_t config;
@@ -267,6 +301,7 @@ int main(int argc, char *argv[])
 			setup_process();
 			start_threads(global_data.global_thread_data);
 			initialize_thread_context(global_data.global_thread_data, true, &ctx);
+			run_postinitialization_tasks(&global_data.postinitialization_tasks, &ctx);
 			event_loop(&ctx);
 			// Even though this is global data, we need to close
 			// it before the associated event loop is cleaned up.

--- a/frameworks/C/h2o/src/request_handler.c
+++ b/frameworks/C/h2o/src/request_handler.c
@@ -61,11 +61,12 @@ static const char *status_code_to_string(http_status_code_t status_code)
 void cleanup_request_handlers(global_data_t *global_data)
 {
 	cleanup_fortunes_handler(global_data);
+	cleanup_world_handlers(global_data);
 }
 
 void free_request_handler_thread_data(request_handler_thread_data_t *request_handler_thread_data)
 {
-	free_world_handler_thread_data(request_handler_thread_data);
+	IGNORE_FUNCTION_PARAMETER(request_handler_thread_data);
 }
 
 const char *get_query_param(const char *query,
@@ -97,7 +98,7 @@ void initialize_request_handler_thread_data(
 		const config_t *config, request_handler_thread_data_t *request_handler_thread_data)
 {
 	IGNORE_FUNCTION_PARAMETER(config);
-	initialize_world_handler_thread_data(request_handler_thread_data);
+	IGNORE_FUNCTION_PARAMETER(request_handler_thread_data);
 }
 
 void initialize_request_handlers(const config_t *config,
@@ -108,7 +109,7 @@ void initialize_request_handlers(const config_t *config,
 	initialize_fortunes_handler(config, global_data, hostconf, log_handle);
 	initialize_json_serializer_handler(hostconf, log_handle);
 	initialize_plaintext_handler(hostconf, log_handle);
-	initialize_world_handlers(global_data, hostconf, log_handle);
+	initialize_world_handlers(config, global_data, hostconf, log_handle);
 }
 
 void register_request_handler(const char *path,

--- a/frameworks/C/h2o/src/thread.h
+++ b/frameworks/C/h2o/src/thread.h
@@ -51,6 +51,7 @@ struct thread_context_t {
 	list_t *json_generator;
 	size_t json_generator_num;
 	unsigned random_seed;
+	bool shutdown;
 	db_state_t db_state;
 	event_loop_t event_loop;
 	request_handler_thread_data_t request_handler_data;


### PR DESCRIPTION
Thread-local caches have led to a performance regression in the cached queries test (which is counter-intuitive, and currently I don't have a good understanding of the reasons), so let's go back to the original implementation.