### PR TITLE
Update h2o.conf in php and mruby

### DIFF
--- a/frameworks/PHP/php/deploy/h2o.conf
+++ b/frameworks/PHP/php/deploy/h2o.conf
@@ -1,7 +1,6 @@
 server-name: "h2o"
 user: www-data
 max-connections: 65536
-access-log: /dev/null
 error-log: /dev/stderr
 
 listen:

--- a/frameworks/Ruby/h2o_mruby/h2o.conf
+++ b/frameworks/Ruby/h2o_mruby/h2o.conf
@@ -1,5 +1,5 @@
 listen: 8080
-max-connections: 32768
+max-connections: 65536
 error-log: /proc/self/fd/2
 hosts:
   "0.0.0.0":


### PR DESCRIPTION
Mruby update `max-connections` to 65536. This change in PHP had ~20% gain.

The h2o manual don't show a default value for the `access-log`.
Perhaps it is none (no access log). 
But if we add the value `/dev/null`, will be created and send it, for each request.


<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
