### PR TITLE
H2O: Make the start-servers.sh script reusable

### DIFF
--- a/frameworks/C/h2o/h2o.dockerfile
+++ b/frameworks/C/h2o/h2o.dockerfile
@@ -9,27 +9,25 @@ RUN apt update && \
 ### Install mustache-c
 
 ENV MUSTACHE_C_BUILD_DIR=mustache-c
-ENV MUSTACHE_C_HOME=/mustache-c
+ENV MUSTACHE_C_PREFIX=/opt/mustache-c
 
 RUN git clone "https://github.com/x86-64/mustache-c.git" "$MUSTACHE_C_BUILD_DIR" && \
     cd "$MUSTACHE_C_BUILD_DIR" && \
     git checkout 01f1e4732c4862071bbf07242128abf1e28cc105 && \
-    CFLAGS="-O3 -flto -march=native" ./autogen.sh --prefix="$MUSTACHE_C_HOME" && \
+    CFLAGS="-O3 -flto -march=native" ./autogen.sh --prefix="$MUSTACHE_C_PREFIX" && \
     make -j "$(nproc)" install
-
-ENV LD_LIBRARY_PATH="${MUSTACHE_C_HOME}/lib:$LD_LIBRARY_PATH"
 
 ### Install h2o
 
 ENV H2O_VERSION=2.2.5
 ENV H2O_ARCHIVE="v${H2O_VERSION}.tar.gz"
-ENV H2O_HOME=/h2o
+ENV H2O_PREFIX=/opt/h2o
 
 RUN wget -qO "$H2O_ARCHIVE" "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" && \
     tar xf "$H2O_ARCHIVE" && \
     cd "h2o-$H2O_VERSION" && \
-    cmake -DCMAKE_INSTALL_PREFIX="$H2O_HOME" -DCMAKE_C_FLAGS="-flto -march=native" \
-          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib && \
+    cmake -DCMAKE_INSTALL_PREFIX="$H2O_PREFIX" -DCMAKE_C_FLAGS="-flto -march=native" \
+          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib . && \
     make -j "$(nproc)" install
 
 CMD ["./start-servers.sh"]

--- a/frameworks/C/h2o/src/tls.c
+++ b/frameworks/C/h2o/src/tls.c
@@ -128,7 +128,6 @@ void cleanup_openssl(global_data_t *global_data)
 	CRYPTO_set_dynlock_create_callback(NULL);
 	CRYPTO_set_dynlock_destroy_callback(NULL);
 	CRYPTO_set_dynlock_lock_callback(NULL);
-	ERR_remove_state(0);
 	ERR_free_strings();
 	CONF_modules_unload(1);
 	EVP_cleanup();

--- a/frameworks/C/h2o/start-servers.sh
+++ b/frameworks/C/h2o/start-servers.sh
@@ -2,13 +2,29 @@
 
 set -e
 
-CPU_COUNT="$(nproc)"
-H2O_APP_HOME=/h2o_app
-H2O_APP_BUILD_DIR="${H2O_APP_HOME}_build"
+CPU_COUNT=$(nproc)
 H2O_APP_PROFILE_PORT=54321
 H2O_APP_PROFILE_URL="http://127.0.0.1:$H2O_APP_PROFILE_PORT"
+SCRIPT_PATH=$(realpath "$0")
+H2O_APP_SRC_ROOT=$(dirname "$SCRIPT_PATH")
+H2O_APP_BUILD_DIR="${H2O_APP_SRC_ROOT}/build"
 NUM_WORKERS="$CPU_COUNT"
-TROOT=/
+
+if [[ -z "$DBHOST" ]]; then
+	DBHOST=tfb-database
+fi
+
+if [[ -z "$H2O_APP_PREFIX" ]]; then
+	H2O_APP_PREFIX=/opt/h2o_app
+fi
+
+if [[ -z "$H2O_PREFIX" ]]; then
+	H2O_PREFIX=/usr
+fi
+
+if [[ -z "$MUSTACHE_C_PREFIX" ]]; then
+	MUSTACHE_C_PREFIX=/opt/mustache-c
+fi
 
 # A hacky way to detect whether we are running in the physical hardware or the cloud environment.
 if [[ "$CPU_COUNT" -gt 16 ]]; then
@@ -23,9 +39,9 @@ fi
 
 build_h2o_app()
 {
-	cmake -DCMAKE_INSTALL_PREFIX="$H2O_APP_HOME" -DCMAKE_BUILD_TYPE=Release \
-	      -DCMAKE_PREFIX_PATH="${H2O_HOME};${MUSTACHE_C_HOME}" \
-	      -DCMAKE_C_FLAGS="-march=native $1" "$TROOT"
+	cmake -DCMAKE_INSTALL_PREFIX="$H2O_APP_PREFIX" -DCMAKE_BUILD_TYPE=Release \
+	      -DCMAKE_PREFIX_PATH="${H2O_PREFIX};${MUSTACHE_C_PREFIX}" \
+	      -DCMAKE_C_FLAGS="-march=native $1" "$H2O_APP_SRC_ROOT"
 	make -j "$CPU_COUNT"
 }
 
@@ -39,13 +55,13 @@ run_curl()
 run_h2o_app()
 {
 	taskset -c "$1" "$2/h2o_app" -a20 -f "$3/template" -m "$DB_CONN" "$4" "$5" \
-	        -d "host=tfb-database dbname=hello_world user=benchmarkdbuser sslmode=disable \
+	        -d "host=$DBHOST dbname=hello_world user=benchmarkdbuser sslmode=disable \
 	            password=benchmarkdbpass" &
 }
 
 generate_profile_data()
 {
-	run_h2o_app 0 . "$TROOT" "-p$H2O_APP_PROFILE_PORT" -t1
+	run_h2o_app 0 . "$H2O_APP_SRC_ROOT" "-p$H2O_APP_PROFILE_PORT" -t1
 	local -r H2O_APP_PROFILE_PID=$!
 	while ! curl "$H2O_APP_PROFILE_URL" > /dev/null 2>&1; do sleep 1; done
 	run_curl json
@@ -70,16 +86,17 @@ make -j "$CPU_COUNT" install
 popd
 rm -rf "$H2O_APP_BUILD_DIR"
 echo "Maximum database connections per thread: $DB_CONN"
+export LD_LIBRARY_PATH="${MUSTACHE_C_PREFIX}/lib:$LD_LIBRARY_PATH"
 
 if "$USE_PROCESSES"; then
 	echo "h2o_app processes: $NUM_WORKERS"
 
 	for ((i = 0; i < NUM_WORKERS; i++)); do
-		run_h2o_app "$i" "${H2O_APP_HOME}/bin" "${H2O_APP_HOME}/share/h2o_app" -t1
+		run_h2o_app "$i" "${H2O_APP_PREFIX}/bin" "${H2O_APP_PREFIX}/share/h2o_app" -t1
 	done
 else
 	echo "Running h2o_app multithreaded."
-	run_h2o_app 0 "${H2O_APP_HOME}/bin" "${H2O_APP_HOME}/share/h2o_app"
+	run_h2o_app 0 "${H2O_APP_PREFIX}/bin" "${H2O_APP_PREFIX}/share/h2o_app"
 fi
 
 wait

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -26,7 +26,7 @@ RUN wget -qO "$H2O_ARCHIVE" "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" &&
     tar xf "$H2O_ARCHIVE" && \
     cd "h2o-$H2O_VERSION" && \
     cmake -DCMAKE_INSTALL_PREFIX="$H2O_HOME" -DCMAKE_C_FLAGS="-flto -march=native" \
-          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=off && \
+          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=off . && \
     make -j "$(nproc)" install  > /dev/null
 
 CMD service php7.3-fpm start && \

--- a/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
+++ b/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
@@ -12,7 +12,7 @@ RUN wget -q "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" && \
     tar xf "$H2O_ARCHIVE" && \
     cd "h2o-$H2O_VERSION" && \
     cmake -DCMAKE_INSTALL_PREFIX="$H2O_HOME" -DCMAKE_C_FLAGS="-flto -march=native" \
-          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=on && \
+          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=on . && \
     make -j "$(nproc)" install
 
 CMD "${H2O_HOME}/bin/h2o" -c h2o.conf


### PR DESCRIPTION
Now it is possible to run the script directly (outside of the Docker environment). It may be necessary to set one or more of the following environment variables:
* `DBHOST` - database server address (default: `tfb-database`)
* `H2O_APP_PREFIX` - Web application installation path (default: `/opt/h2o_app`)
* `H2O_PREFIX` - libh2o installation path (default: `/usr`)
* `MUSTACHE_C_PREFIX` - mustache-c installation path (default: `/opt/mustache-c`)

Do a small clean-up as well.