### PR TITLE
add r2dbc-pool to avoid lack of connections

### DIFF
--- a/frameworks/Java/spring-webflux/pom.xml
+++ b/frameworks/Java/spring-webflux/pom.xml
@@ -25,6 +25,7 @@
         <pgclient.version>0.11.4</pgclient.version>
         <rxjava2-jdbc.version>0.2.4</rxjava2-jdbc.version>
         <r2dbc-postgresql.version>1.0.0.M7</r2dbc-postgresql.version>
+        <r2dbc-pool.version>1.0.0.BUILD-SNAPSHOT</r2dbc-pool.version>
     </properties>
 
     <dependencies>
@@ -64,6 +65,11 @@
             <groupId>io.r2dbc</groupId>
             <artifactId>r2dbc-postgresql</artifactId>
             <version>${r2dbc-postgresql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-pool</artifactId>
+            <version>${r2dbc-pool.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
@@ -117,6 +123,14 @@
             <id>spring-libs-snapshot</id>
             <name>Spring Snapshots</name>
             <url>https://repo.spring.io/libs-snapshot</url>
+        </repository>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/config/R2dbcConfig.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/config/R2dbcConfig.java
@@ -1,14 +1,17 @@
 package benchmark.config;
 
-import io.r2dbc.postgresql.PostgresqlConnectionConfiguration;
-import io.r2dbc.postgresql.PostgresqlConnectionFactory;
+
+import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
 
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.r2dbc.core.DatabaseClient;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.*;
 
 @Configuration
 @Profile("r2dbc")
@@ -41,16 +44,16 @@ public class R2dbcConfig {
     }
 
     @Bean
-    public PostgresqlConnectionFactory connectionFactory() {
-        PostgresqlConnectionConfiguration configuration = PostgresqlConnectionConfiguration
-                .builder()
-                .host(host)
-                .port(port)
-                .database(name)
-                .username(username)
-                .password(password)
-                .build();
-        return new PostgresqlConnectionFactory(configuration);
+    public ConnectionFactory connectionFactory() {
+        return ConnectionFactories.get(ConnectionFactoryOptions.builder()
+                .option(DRIVER,"pool")
+                .option(PROTOCOL,"postgresql")
+                .option(HOST, host)
+                .option(PORT, port)
+                .option(USER, username)
+                .option(PASSWORD, password)
+                .option(DATABASE, name)
+                .build());
     }
 
     @Bean


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
