### PR TITLE
Rollback graaljs as it seems to not run on citrine but passes on CI

### DIFF
--- a/frameworks/JavaScript/es4x/es4x.dockerfile
+++ b/frameworks/JavaScript/es4x/es4x.dockerfile
@@ -1,4 +1,4 @@
-FROM oracle/graalvm-ce:19.1.0
+FROM oracle/graalvm-ce:19.0.2
 # Set working dir
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
