### PR TITLE
optimize may-minihttp to enable reuse port

### DIFF
--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -8,5 +8,9 @@ num_cpus = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-may = { git = "https://github.com/Xudong-Huang/may" }
+may = "0.3"
 may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp.git" }
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.32.0
+FROM rust:1.35
 
 ADD ./ /may
 WORKDIR /may

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.35
+FROM rust:1.36
 
 ADD ./ /may
 WORKDIR /may


### PR DESCRIPTION
in this merge
- update the may dependency version from rust crate.io
- enable reuse port for multi thread listening
- update rustc compiler version to 1.35
