### PR TITLE
Update projects to use nuget ref assemblies for .NET Framework targets

### DIFF
--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <LangVersion>7.3</LangVersion>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
-    <!-- Add the myget feed, without altering any other configurations. -->
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,19 +27,6 @@
     <PackageReference Include="MySqlConnector" Version="0.56.0" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2"/>
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <!-- Make .NET 4.7.1 reference assemblies available even on Linux -->
-    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.7.1" Version="1.0.0" ExcludeAssets="All" PrivateAssets="All" />
-    <Reference Include="netstandard" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <!-- Make sure the reference assemblies are available -->
-    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.1\1.0.0\lib\net471\</FrameworkPathOverride>
-  </PropertyGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -6,8 +6,6 @@
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
-    <!-- Add the myget feed, without altering any other configurations. -->
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,19 +17,7 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="MySqlConnector" Version="0.56.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2"/>
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <!-- Make .NET 4.7.1 reference assemblies available even on Linux -->
-    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.7.1" Version="1.0.0" ExcludeAssets="All" PrivateAssets="All" />
-    <Reference Include="netstandard" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-  </ItemGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <!-- Make sure the reference assemblies are available -->
-    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.1\1.0.0\lib\net471\</FrameworkPathOverride>
-  </PropertyGroup>
 </Project>

--- a/frameworks/CSharp/nancy/src/NancyBenchmark.csproj
+++ b/frameworks/CSharp/nancy/src/NancyBenchmark.csproj
@@ -9,9 +9,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
     <!-- Add the myget feed, without altering any other configurations. -->
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreAdditionalProjectSources>
-    <!-- Make sure the reference assemblies are available -->
-    <FrameworkPathOverride>$(NuGetPackageRoot)microsoft.targetingpack.netframework.v4.7.1\1.0.0\lib\net471\</FrameworkPathOverride>
   </PropertyGroup>
   
   <ItemGroup>
@@ -42,12 +39,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.1.0" />
-    <!-- Make .NET 4.7.1 reference assemblies available even on Linux -->
-    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.7.1" Version="1.0.0" ExcludeAssets="All" PrivateAssets="All" />
-    <Reference Include="netstandard" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2"/>
   </ItemGroup>
 
 </Project>

--- a/frameworks/CSharp/nancy/src/NuGet.config
+++ b/frameworks/CSharp/nancy/src/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="aspnetcore" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="Nancy" value="https://www.myget.org/F/nancyfx/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
These projects are currently using:

- Package: Microsoft.TargetingPack.NETFramework.v4.7.1
- Feed: https://dotnet.myget.org/F/dotnet-core/api/v3/index.json

We published an official alternative on nuget.org recently that aligns with this use case. It supports all . NET Framework versions from 2.0 onward.

- Package: [Microsoft.NETFramework.ReferenceAssemblies](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies)
- Feed: default nuget.org feed

All projects that use sdk-style projects and target .NET Framework should move to using this package. The reduction in lines and complexity in the project files demonstrates the win.