### PR TITLE
Add CoreRT with Red Hat Linux transport 

### DIFF
--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -6,7 +6,9 @@ using System.Net;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace PlatformBenchmarks
 {

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -29,6 +29,25 @@ namespace PlatformBenchmarks
                 theadCount = value;
             }
 
+            if (string.Equals(webHost, "LinuxTransport", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.ConfigureServices(services =>
+                {
+                    services.Configure<KestrelServerOptions>(options =>
+                    {
+                        // Run callbacks on the transport thread
+                        options.ApplicationSchedulingMode = SchedulingMode.Inline;
+                    });
+                })
+                .UseLinuxTransport(options =>
+                {
+                    if (theadCount.HasValue)
+                    {
+                        options.ThreadCount = theadCount.Value;
+                    }
+                });
+            }
+
             return builder;
         }
         

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/NuGet.Config
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/NuGet.Config
@@ -4,5 +4,6 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="rh" value="https://www.myget.org/F/redhat-dotnet/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="2.2.0-*" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/Utilities/BufferWriter.cs
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/Utilities/BufferWriter.cs
@@ -72,8 +72,7 @@ namespace PlatformBenchmarks
                 Commit();
             }
 
-            _output.GetMemory(count);
-            _span = _output.GetSpan();
+            _span = _output.GetSpan(count);
         }
 
         private void WriteMultiBuffer(ReadOnlySpan<byte> source)

--- a/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/rd.xml
+++ b/frameworks/CSharp/aspnetcore-corert/PlatformBenchmarks/rd.xml
@@ -44,5 +44,8 @@
         <Assembly Name="Microsoft.Extensions.Configuration.Json">
             <Type Name="Microsoft.Extensions.Configuration.Json.JsonConfigurationSource" Dynamic="Required All" />
         </Assembly>
+        <Assembly Name="RedHat.AspNetCore.Server.Kestrel.Transport.Linux">
+            <Type Name="RedHat.AspNetCore.Server.Kestrel.Transport.Linux.LinuxTransportFactory" Dynamic="Required All" />
+        </Assembly>
     </Application>
 </Directives>

--- a/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
@@ -1,0 +1,14 @@
+FROM microsoft/dotnet:2.2-sdk AS build
+RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
+RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
+RUN apt-get update
+RUN apt-get -yqq install cmake clang-3.9 libicu57 libunwind8 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+WORKDIR /app
+COPY PlatformBenchmarks .
+RUN dotnet publish -c Release -o out -r linux-x64
+
+FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+
+ENTRYPOINT ["./PlatformBenchmarks", "--server.urls=http://+:8080", "KestrelTransport=LinuxTransport"]

--- a/frameworks/CSharp/aspnetcore-corert/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore-corert/benchmark_config.json
@@ -19,6 +19,25 @@
       "display_name": "ASP.NET Core",
       "notes": "",
       "versus": "aspcore"
+    },
+    "rhtx": {
+      "plaintext_url": "/plaintext",
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "ASP.NET Core",
+      "language": "C#",
+      "orm": "Raw",
+      "platform": ".NET",
+      "flavor": "CoreRT",
+      "webserver": "Kestrel",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "ASP.NET Core, Red Hat Linux Transport",
+      "notes": "",
+      "versus": "aspcore"
     }
   }]
 }


### PR DESCRIPTION
Adds an option to run with the [Red Hat Linux transport](https://developers.redhat.com/blog/2018/07/24/improv-net-core-kestrel-performance-linux/) on top of the existing socket-based solution.