### PR TITLE
Update Gotham to v0.4

### DIFF
--- a/frameworks/Rust/gotham/Cargo.toml
+++ b/frameworks/Rust/gotham/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Isaac Whitfield <iw@whitfin.io>"]
 
 [dependencies]
-gotham = "0.3"
+gotham = "0.4"
 hyper = "0.12"
 mime = "0.3"
 serde = "1.0"

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.29.1
+FROM rust:1.36.0
 
 WORKDIR /gotham
 COPY ./src ./src


### PR DESCRIPTION
This PR updates the Rust Gotham framework to the latest version, and updates the Rust version in the Docker image. No changes to the actual files are required :)