### PR TITLE
H2O: Various changes again

### DIFF
--- a/frameworks/C/h2o/src/database.c
+++ b/frameworks/C/h2o/src/database.c
@@ -390,12 +390,8 @@ static void start_database_connect(thread_context_t *ctx, db_conn_t *db_conn)
 	}
 	else {
 		ctx->db_state.db_conn_num++;
-		db_conn = calloc(1, sizeof(*db_conn));
-
-		if (!db_conn) {
-			STANDARD_ERROR("calloc");
-			goto error;
-		}
+		db_conn = h2o_mem_alloc(sizeof(*db_conn));
+		memset(db_conn, 0, sizeof(*db_conn));
 
 		const char * const conninfo = ctx->config->db_host ? ctx->config->db_host : "";
 
@@ -451,17 +447,14 @@ error_dup:
 	PQfinish(db_conn->conn);
 error_connect:
 	free(db_conn);
-error:
 	error_notification(ctx, false, DB_ERROR);
 }
 
 void add_prepared_statement(const char *name, const char *query, list_t **prepared_statements)
 {
-	prepared_statement_t * const p = calloc(1, sizeof(*p));
+	prepared_statement_t * const p = h2o_mem_alloc(sizeof(*p));
 
-	if (!p)
-		abort();
-
+	memset(p, 0, sizeof(*p));
 	p->l.next = *prepared_statements;
 	p->name = name;
 	p->query = query;

--- a/frameworks/C/h2o/src/event_loop.c
+++ b/frameworks/C/h2o/src/event_loop.c
@@ -233,11 +233,9 @@ static void shutdown_server(h2o_socket_t *listener, const char *err)
 		}
 
 		for (size_t i = ctx->config->thread_num - 1; i > 0; i--) {
-			message_t * const msg = calloc(1, sizeof(*msg));
+			message_t * const msg = h2o_mem_alloc(sizeof(*msg));
 
-			if (!msg)
-				abort();
-
+			memset(msg, 0, sizeof(*msg));
 			msg->type = SHUTDOWN;
 			h2o_multithread_send_message(&ctx->global_thread_data[i].h2o_receiver, &msg->super);
 		}

--- a/frameworks/C/h2o/src/handlers/fortune.c
+++ b/frameworks/C/h2o/src/handlers/fortune.c
@@ -194,35 +194,31 @@ static int fortunes(struct st_h2o_handler_t *self, h2o_req_t *req)
 	thread_context_t * const ctx = H2O_STRUCT_FROM_MEMBER(thread_context_t,
 	                                                      event_loop.h2o_ctx,
 	                                                      req->conn->ctx);
-	fortune_ctx_t * const fortune_ctx = calloc(1, sizeof(*fortune_ctx));
+	fortune_ctx_t * const fortune_ctx = h2o_mem_alloc(sizeof(*fortune_ctx));
+	fortune_t * const fortune = h2o_mem_alloc_pool(&req->pool, sizeof(*fortune));
+	fortune_ctx_t ** const p = h2o_mem_alloc_shared(&req->pool, sizeof(*p), cleanup_request);
 
-	if (fortune_ctx) {
-		fortune_t * const fortune = h2o_mem_alloc_pool(&req->pool, sizeof(*fortune));
-		fortune_ctx_t ** const p = h2o_mem_alloc_shared(&req->pool, sizeof(*p), cleanup_request);
+	*p = fortune_ctx;
+	memset(fortune, 0, sizeof(*fortune));
+	fortune->id.base = NEW_FORTUNE_ID;
+	fortune->id.len = sizeof(NEW_FORTUNE_ID) - 1;
+	fortune->message.base = NEW_FORTUNE_MESSAGE;
+	fortune->message.len = sizeof(NEW_FORTUNE_MESSAGE) - 1;
+	memset(fortune_ctx, 0, sizeof(*fortune_ctx));
+	fortune_ctx->generator.proceed = complete_fortunes;
+	fortune_ctx->num_result = 1;
+	fortune_ctx->param.command = FORTUNE_TABLE_NAME;
+	fortune_ctx->param.on_error = on_fortune_error;
+	fortune_ctx->param.on_result = on_fortune_result;
+	fortune_ctx->param.on_timeout = on_fortune_timeout;
+	fortune_ctx->param.flags = IS_PREPARED;
+	fortune_ctx->req = req;
+	fortune_ctx->result = &fortune->l;
 
-		*p = fortune_ctx;
-		memset(fortune, 0, sizeof(*fortune));
-		fortune->id.base = NEW_FORTUNE_ID;
-		fortune->id.len = sizeof(NEW_FORTUNE_ID) - 1;
-		fortune->message.base = NEW_FORTUNE_MESSAGE;
-		fortune->message.len = sizeof(NEW_FORTUNE_MESSAGE) - 1;
-		fortune_ctx->generator.proceed = complete_fortunes;
-		fortune_ctx->num_result = 1;
-		fortune_ctx->param.command = FORTUNE_TABLE_NAME;
-		fortune_ctx->param.on_error = on_fortune_error;
-		fortune_ctx->param.on_result = on_fortune_result;
-		fortune_ctx->param.on_timeout = on_fortune_timeout;
-		fortune_ctx->param.flags = IS_PREPARED;
-		fortune_ctx->req = req;
-		fortune_ctx->result = &fortune->l;
-
-		if (execute_query(ctx, &fortune_ctx->param)) {
-			fortune_ctx->cleanup = true;
-			send_service_unavailable_error(DB_REQ_ERROR, req);
-		}
+	if (execute_query(ctx, &fortune_ctx->param)) {
+		fortune_ctx->cleanup = true;
+		send_service_unavailable_error(DB_REQ_ERROR, req);
 	}
-	else
-		send_error(INTERNAL_SERVER_ERROR, REQ_ERROR, req);
 
 	return 0;
 }

--- a/frameworks/C/h2o/src/main.c
+++ b/frameworks/C/h2o/src/main.c
@@ -276,11 +276,9 @@ void add_postinitialization_task(void (*task)(struct thread_context_t *, void *)
                                  void *arg,
                                  list_t **postinitialization_tasks)
 {
-	task_t * const t = calloc(1, sizeof(*t));
+	task_t * const t = h2o_mem_alloc(sizeof(*t));
 
-	if (!t)
-		abort();
-
+	memset(t, 0, sizeof(*t));
 	t->l.next = *postinitialization_tasks;
 	t->arg = arg;
 	t->task = task;

--- a/frameworks/C/h2o/src/thread.c
+++ b/frameworks/C/h2o/src/thread.c
@@ -123,6 +123,8 @@ global_thread_data_t *initialize_global_thread_data(const config_t *config,
 			ret[i].global_data = global_data;
 		}
 	}
+	else
+		STANDARD_ERROR("aligned_alloc");
 
 	return ret;
 }
@@ -152,8 +154,10 @@ void start_threads(global_thread_data_t *global_thread_data)
 	const size_t cpusetsize = CPU_ALLOC_SIZE(num_cpus);
 	cpu_set_t * const cpuset = CPU_ALLOC(num_cpus);
 
-	if (!cpuset)
+	if (!cpuset) {
+		STANDARD_ERROR("CPU_ALLOC");
 		abort();
+	}
 
 	CHECK_ERROR(pthread_attr_init, &attr);
 	// The first thread context is used by the main thread.

--- a/frameworks/C/h2o/src/tls.c
+++ b/frameworks/C/h2o/src/tls.c
@@ -150,8 +150,11 @@ void initialize_openssl(const config_t *config, global_data_t *global_data)
 	SSL_library_init();
 	SSL_load_error_strings();
 	openssl_global_data.num_lock = CRYPTO_num_locks();
-	openssl_global_data.lock = calloc(openssl_global_data.num_lock,
-	                                  sizeof(*openssl_global_data.lock));
+	openssl_global_data.lock =
+			h2o_mem_alloc(openssl_global_data.num_lock * sizeof(*openssl_global_data.lock));
+	memset(openssl_global_data.lock,
+	       0,
+	       openssl_global_data.num_lock * sizeof(*openssl_global_data.lock));
 	CHECK_ERROR(pthread_mutexattr_init, &openssl_global_data.lock_attr);
 	CHECK_ERROR(pthread_mutexattr_settype,
 	            &openssl_global_data.lock_attr,

--- a/frameworks/C/h2o/src/utility.c
+++ b/frameworks/C/h2o/src/utility.c
@@ -164,15 +164,13 @@ json_generator_t *get_json_generator(list_t **pool, size_t *gen_num)
 		(*gen_num)--;
 	}
 	else {
-		ret = malloc(sizeof(*ret));
+		ret = h2o_mem_alloc(sizeof(*ret));
+		memset(ret, 0, sizeof(*ret));
+		ret->gen = yajl_gen_alloc(NULL);
 
-		if (ret) {
-			ret->gen = yajl_gen_alloc(NULL);
-
-			if (!ret->gen) {
-				free(ret);
-				ret = NULL;
-			}
+		if (!ret->gen) {
+			free(ret);
+			ret = NULL;
 		}
 	}
 


### PR DESCRIPTION
* Switch most of the calls to memory allocation routines to h2o_mem_alloc() - leads to cleaner code.
* Remove the multi-process functionality from the h2o.sh script - it is no longer necessary.
* Make sure that calls to abort() are preceded by printing an error message