### PR TITLE
adding restana and 0http frameworks

### DIFF
--- a/frameworks/JavaScript/0http/0http.dockerfile
+++ b/frameworks/JavaScript/0http/0http.dockerfile
@@ -1,0 +1,9 @@
+FROM node:10-alpine
+
+WORKDIR /usr/src/app
+
+COPY app.js package.json ./
+
+RUN npm install
+
+CMD ["node", "app.js"]

--- a/frameworks/JavaScript/0http/README.md
+++ b/frameworks/JavaScript/0http/README.md
@@ -1,0 +1,24 @@
+# 0http Benchmarking Test
+
+From https://www.npmjs.com/package/0http:
+
+> Cero friction HTTP request router. The need for speed!
+
+### Test Type Implementation Source Code
+
+* [JSON](app.js)
+* [PLAINTEXT](app.js)
+
+## Important Libraries
+The tests were run with:
+* [0http](https://www.npmjs.com/package/0http)
+* [NodeJS](https://nodejs.org/en/)
+
+## Test URLs
+### JSON
+
+http://localhost:8080/json
+
+### PLAINTEXT
+
+http://localhost:8080/plaintext

--- a/frameworks/JavaScript/0http/app.js
+++ b/frameworks/JavaScript/0http/app.js
@@ -1,0 +1,19 @@
+const cluster = require('cluster')
+const cpus = require('os').cpus()
+
+const cero = require('0http')
+const { router, server } = cero()
+
+router.on('GET', '/json', (req, res) => {
+  res.end(JSON.stringify({ message: 'Hello, World!' }))
+})
+
+router.on('GET', '/plaintext', (req, res) => {
+  res.end('Hello, World!')
+})
+
+if (cluster.isMaster) {
+  cpus.forEach(() => cluster.fork())
+} else {
+  server.listen(8080)
+}

--- a/frameworks/JavaScript/0http/app.js
+++ b/frameworks/JavaScript/0http/app.js
@@ -5,10 +5,16 @@ const cero = require('0http')
 const { router, server } = cero()
 
 router.on('GET', '/json', (req, res) => {
+  res.setHeader('server', '0http')
+  res.setHeader('content-type', 'application/json')
+
   res.end(JSON.stringify({ message: 'Hello, World!' }))
 })
 
 router.on('GET', '/plaintext', (req, res) => {
+  res.setHeader('server', '0http')
+  res.setHeader('content-type', 'text/plain')
+
   res.end('Hello, World!')
 })
 

--- a/frameworks/JavaScript/0http/benchmark_config.json
+++ b/frameworks/JavaScript/0http/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework": "0http",
+  "tests": [{
+    "default": {
+      "plaintext_url": "/plaintext",
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "0http",
+      "language": "JavaScript",
+      "flavor": "NodeJS",
+      "orm": "Raw",
+      "platform": "nodejs",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "0http",
+      "notes": "",
+      "versus": "nodejs"
+    }
+  }]
+}

--- a/frameworks/JavaScript/0http/package.json
+++ b/frameworks/JavaScript/0http/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "0http",
+  "dependencies": {
+    "0http": "1.0.0"
+  },
+  "main": "app.js"
+}

--- a/frameworks/JavaScript/restana/README.md
+++ b/frameworks/JavaScript/restana/README.md
@@ -1,0 +1,24 @@
+# Restana Benchmarking Test
+
+From https://www.npmjs.com/package/restana:
+
+> Blazing fast, tiny and minimalist connect-like web framework for building REST micro-services.
+
+### Test Type Implementation Source Code
+
+* [JSON](app.js)
+* [PLAINTEXT](app.js)
+
+## Important Libraries
+The tests were run with:
+* [restana](https://www.npmjs.com/package/restana)
+* [NodeJS](https://nodejs.org/en/)
+
+## Test URLs
+### JSON
+
+http://localhost:8080/json
+
+### PLAINTEXT
+
+http://localhost:8080/plaintext

--- a/frameworks/JavaScript/restana/app.js
+++ b/frameworks/JavaScript/restana/app.js
@@ -4,10 +4,16 @@ const cpus = require('os').cpus()
 const service = require('restana')()
 
 service.get('/json', (req, res) => {
+  res.setHeader('server', 'restana')
+  res.setHeader('content-type', 'application/json')
+  
   res.end(JSON.stringify({ message: 'Hello, World!' }))
 })
 
 service.get('/plaintext', (req, res) => {
+  res.setHeader('server', 'restana')
+  res.setHeader('content-type', 'text/plain')
+
   res.end('Hello, World!')
 })
 

--- a/frameworks/JavaScript/restana/app.js
+++ b/frameworks/JavaScript/restana/app.js
@@ -1,0 +1,18 @@
+const cluster = require('cluster')
+const cpus = require('os').cpus()
+
+const service = require('restana')()
+
+service.get('/json', (req, res) => {
+  res.end(JSON.stringify({ message: 'Hello, World!' }))
+})
+
+service.get('/plaintext', (req, res) => {
+  res.end('Hello, World!')
+})
+
+if (cluster.isMaster) {
+  cpus.forEach(() => cluster.fork())
+} else {
+  service.start(8080)
+}

--- a/frameworks/JavaScript/restana/benchmark_config.json
+++ b/frameworks/JavaScript/restana/benchmark_config.json
@@ -1,0 +1,24 @@
+{
+  "framework": "restana",
+  "tests": [{
+    "default": {
+      "plaintext_url": "/plaintext",
+      "json_url": "/json",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "None",
+      "framework": "restana",
+      "language": "JavaScript",
+      "flavor": "NodeJS",
+      "orm": "Raw",
+      "platform": "nodejs",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "restana",
+      "notes": "",
+      "versus": "nodejs"
+    }
+  }]
+}

--- a/frameworks/JavaScript/restana/package.json
+++ b/frameworks/JavaScript/restana/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "restana",
+  "dependencies": {
+    "restana": "^3.3.0"
+  },
+  "main": "app.js"
+}

--- a/frameworks/JavaScript/restana/restana.dockerfile
+++ b/frameworks/JavaScript/restana/restana.dockerfile
@@ -1,0 +1,9 @@
+FROM node:10-alpine
+
+WORKDIR /usr/src/app
+
+COPY app.js package.json ./
+
+RUN npm install
+
+CMD ["node", "app.js"]


### PR DESCRIPTION
In this PR we submit the following JavaScript frameworks:
- 0http
- restana
> Both frameworks are listed as TOP node.js frameworks at: https://github.com/the-benchmarker/web-frameworks

Only the following tests are supported:
- json
- plaintext
