### PR TITLE
Update aspnetcore-corert-rhtx to use Microsoft Container Registry

### DIFF
--- a/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.9 main" | tee /etc/apt/sources.list.d/llvm.list
 RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-get update
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out -r linux-x64
 
-FROM microsoft/dotnet:2.2-aspnetcore-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 


### PR DESCRIPTION
Pull request #4919 that updated this for all .NET Core benchmarks happened around the same time as this new configuration was added. This pull request mops up after that.