### PR TITLE
updating 0http framework version

### DIFF
--- a/frameworks/JavaScript/0http/0http.dockerfile
+++ b/frameworks/JavaScript/0http/0http.dockerfile
@@ -1,11 +1,8 @@
-FROM node:10-alpine
+FROM node:10
 
 WORKDIR /usr/src/app
 
 COPY app.js package.json ./
-
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh
 
 RUN npm install
 

--- a/frameworks/JavaScript/0http/0http.dockerfile
+++ b/frameworks/JavaScript/0http/0http.dockerfile
@@ -5,5 +5,6 @@ WORKDIR /usr/src/app
 COPY app.js package.json ./
 
 RUN npm install
+RUN npm install uNetworking/uWebSockets.js#v15.11.0
 
 CMD ["node", "app.js"]

--- a/frameworks/JavaScript/0http/0http.dockerfile
+++ b/frameworks/JavaScript/0http/0http.dockerfile
@@ -4,7 +4,9 @@ WORKDIR /usr/src/app
 
 COPY app.js package.json ./
 
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
 RUN npm install
-RUN npm install uNetworking/uWebSockets.js#v15.11.0
 
 CMD ["node", "app.js"]

--- a/frameworks/JavaScript/0http/app.js
+++ b/frameworks/JavaScript/0http/app.js
@@ -1,8 +1,9 @@
-const cluster = require('cluster')
-const cpus = require('os').cpus()
-
 const cero = require('0http')
-const { router, server } = cero()
+const low = require('0http/lib/server/low')
+
+const { router, server } = cero({
+  server: low()
+})
 
 router.on('GET', '/json', (req, res) => {
   res.setHeader('server', '0http')
@@ -18,8 +19,4 @@ router.on('GET', '/plaintext', (req, res) => {
   res.end('Hello, World!')
 })
 
-if (cluster.isMaster) {
-  cpus.forEach(() => cluster.fork())
-} else {
-  server.listen(8080)
-}
+server.listen(8080, socket => {})

--- a/frameworks/JavaScript/0http/app.js
+++ b/frameworks/JavaScript/0http/app.js
@@ -5,11 +5,8 @@ const { router, server } = cero({
   server: low()
 })
 
-const date = new Date().toUTCString()
-
 router.on('GET', '/json', (req, res) => {
   res.setHeader('server', '0http')
-  res.setHeader('date', date)
   res.setHeader('content-type', 'application/json')
 
   res.end(JSON.stringify({ message: 'Hello, World!' }))
@@ -17,10 +14,9 @@ router.on('GET', '/json', (req, res) => {
 
 router.on('GET', '/plaintext', (req, res) => {
   res.setHeader('server', '0http')
-  res.setHeader('date', date)
   res.setHeader('content-type', 'text/plain')
 
   res.end('Hello, World!')
 })
 
-server.listen(8080, socket => {})
+server.start(8080, socket => {})

--- a/frameworks/JavaScript/0http/app.js
+++ b/frameworks/JavaScript/0http/app.js
@@ -5,8 +5,11 @@ const { router, server } = cero({
   server: low()
 })
 
+const date = new Date().toUTCString()
+
 router.on('GET', '/json', (req, res) => {
   res.setHeader('server', '0http')
+  res.setHeader('date', date)
   res.setHeader('content-type', 'application/json')
 
   res.end(JSON.stringify({ message: 'Hello, World!' }))
@@ -14,6 +17,7 @@ router.on('GET', '/json', (req, res) => {
 
 router.on('GET', '/plaintext', (req, res) => {
   res.setHeader('server', '0http')
+  res.setHeader('date', date)
   res.setHeader('content-type', 'text/plain')
 
   res.end('Hello, World!')

--- a/frameworks/JavaScript/0http/package.json
+++ b/frameworks/JavaScript/0http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "0http",
   "dependencies": {
-    "0http": "1.2.0",
+    "0http": "1.2.1",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.11.0"
   },
   "main": "app.js"

--- a/frameworks/JavaScript/0http/package.json
+++ b/frameworks/JavaScript/0http/package.json
@@ -1,7 +1,8 @@
 {
   "name": "0http",
   "dependencies": {
-    "0http": "1.2.0"
+    "0http": "1.2.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.11.0"
   },
   "main": "app.js"
 }

--- a/frameworks/JavaScript/0http/package.json
+++ b/frameworks/JavaScript/0http/package.json
@@ -1,8 +1,7 @@
 {
   "name": "0http",
   "dependencies": {
-    "0http": "1.2.0",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.11.0"
+    "0http": "1.2.0"
   },
   "main": "app.js"
 }

--- a/frameworks/JavaScript/0http/package.json
+++ b/frameworks/JavaScript/0http/package.json
@@ -1,7 +1,8 @@
 {
   "name": "0http",
   "dependencies": {
-    "0http": "1.0.0"
+    "0http": "1.2.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v15.11.0"
   },
   "main": "app.js"
 }


### PR DESCRIPTION
Updating `0http` to version `1.2.0` in order to use the newly created `low` http server: https://github.com/jkyberneees/0http#low-server