### PR TITLE
Revert "Updated unit to 128 processes"

### DIFF
--- a/frameworks/PHP/php/deploy/nginx-unit.json
+++ b/frameworks/PHP/php/deploy/nginx-unit.json
@@ -8,7 +8,7 @@
     "applications": {
         "benchmark": {
             "type": "php 7",
-            "processes": 128,
+            "processes": 64,
             "user": "www-data",
             "group": "www-data",
             "root": "/php/",


### PR DESCRIPTION
Reverts TechEmpower/FrameworkBenchmarks#4988

Worst results than with 64 processes. Also we need to compare php7.0 & php7.3 with the same processes number.
Later we will try with other numbers.