### PR TITLE
Fix reading dstat results

### DIFF
--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -462,7 +462,7 @@ class Results:
         with open(stats_file) as stats:
             # dstat doesn't output a completely compliant CSV file - we need to strip the header
             for _ in range(4):
-                print(stats.next())
+                stats.next()
             stats_reader = csv.reader(stats)
             main_header = stats_reader.next()
             sub_header = stats_reader.next()

--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -461,8 +461,8 @@ class Results:
         stats_file = self.get_stats_file(framework_test.name, test_type)
         with open(stats_file) as stats:
             # dstat doesn't output a completely compliant CSV file - we need to strip the header
-            while stats.next() != "\n":
-                pass
+            for _ in range(4):
+                print(stats.next())
             stats_reader = csv.reader(stats)
             main_header = stats_reader.next()
             sub_header = stats_reader.next()


### PR DESCRIPTION
In dstat 0.7.2 the header information was separated by a newline. In 0.7.3 that newline is removed causing the toolset to iterate over the whole file without parsing anything. Since we know the header is only 4 lines, we'll skip those lines.