### PR TITLE
Using fastcgi_socket_keepalive

### DIFF
--- a/frameworks/PHP/php/deploy/nginx7.conf
+++ b/frameworks/PHP/php/deploy/nginx7.conf
@@ -41,6 +41,7 @@ http {
     fastcgi_temp_file_write_size 256k;
     reset_timedout_connection on;
     server_names_hash_bucket_size 100;
+    fastcgi_socket_keepalive on;
 
     upstream fastcgi_backend {
         server unix:/var/run/php/php7.3-fpm.sock;


### PR DESCRIPTION
new in nginx 1.15.6

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
