### PR TITLE
add postgresql to rails

### DIFF
--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -1,6 +1,5 @@
 source 'http://rubygems.org'
 
-gem 'mysql2', '0.5.2'
 gem 'unicorn', '5.4.1'
 gem 'puma', '3.12.0'
 gem 'activerecord-import', '0.27.0'
@@ -8,3 +7,11 @@ gem 'activerecord', '5.2.2', :require => 'active_record'
 gem 'rails', '5.2.2'
 gem 'tzinfo-data', '1.2018.7'
 gem 'oj', '3.7.9'
+
+group :mysql do
+  gem 'mysql2', '0.5.2'
+end
+
+group :postgresql do
+  gem 'pg', '1.1.4'
+end

--- a/frameworks/Ruby/rails/README.md
+++ b/frameworks/Ruby/rails/README.md
@@ -17,6 +17,7 @@ The tests were run with:
 - [Unicorn 5.4.1](http://unicorn.bogomips.org/)
 - [Puma 3.12](http://puma.io/)
 - [MySQL 5.5](https://dev.mysql.com/)
+- [PostgreSQL 11](https://www.postgresql.org/)
 
 ## Paths & Source for Tests
 

--- a/frameworks/Ruby/rails/app/models/world.rb
+++ b/frameworks/Ruby/rails/app/models/world.rb
@@ -1,3 +1,6 @@
 class World < ApplicationRecord
   self.table_name = "World"
+
+  alias_attribute(:randomNumber, :randomnumber) \
+    if connection.adapter_name.downcase.start_with?('postgres')
 end

--- a/frameworks/Ruby/rails/benchmark_config.json
+++ b/frameworks/Ruby/rails/benchmark_config.json
@@ -23,6 +23,28 @@
       "notes": "",
       "versus": "rack-puma-mri"
     },
+    "postgresql": {
+      "json_url": "/hello_world/json",
+      "db_url": "/hello_world/db",
+      "query_url": "/hello_world/query?queries=",
+      "fortune_url": "/fortune",
+      "update_url": "/update?queries=",
+      "plaintext_url": "/plaintext",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Fullstack",
+      "database": "Postgres",
+      "framework": "rails",
+      "language": "Ruby",
+      "orm": "Full",
+      "platform": "Rack",
+      "webserver": "Puma",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "rails-postgresql",
+      "notes": "",
+      "versus": ""
+    },
     "unicorn": {
       "json_url": "/hello_world/json",
       "db_url": "/hello_world/db",

--- a/frameworks/Ruby/rails/benchmark_config.json
+++ b/frameworks/Ruby/rails/benchmark_config.json
@@ -24,12 +24,10 @@
       "versus": "rack-puma-mri"
     },
     "postgresql": {
-      "json_url": "/hello_world/json",
       "db_url": "/hello_world/db",
       "query_url": "/hello_world/query?queries=",
       "fortune_url": "/fortune",
       "update_url": "/update?queries=",
-      "plaintext_url": "/plaintext",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Fullstack",

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -1,6 +1,5 @@
 ---
 _: &common
-  adapter: mysql2
   database: hello_world
   username: benchmarkdbuser
   password: benchmarkdbpass
@@ -15,6 +14,12 @@ test:
   <<: *common
   pool: 64
 
-production:
+production_mysql:
   <<: *common
+  adapter: mysql2
+  pool: 256
+
+production_postgresql:
+  <<: *common
+  adapter: postgresql
   pool: 256

--- a/frameworks/Ruby/rails/config/environments/production_mysql.rb
+++ b/frameworks/Ruby/rails/config/environments/production_mysql.rb
@@ -1,0 +1,2 @@
+# builds on production's configuration.
+require Rails.root.join('config', 'environments', 'production')

--- a/frameworks/Ruby/rails/config/environments/production_postgresql.rb
+++ b/frameworks/Ruby/rails/config/environments/production_postgresql.rb
@@ -1,0 +1,2 @@
+# builds on production's configuration.
+require Rails.root.join('config', 'environments', 'production')

--- a/frameworks/Ruby/rails/rails-postgresql.dockerfile
+++ b/frameworks/Ruby/rails/rails-postgresql.dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.6
+
+ADD ./ /rails
+
+WORKDIR /rails
+
+RUN bundle install --jobs=4 --gemfile=/rails/Gemfile --path=/rails/rails/bundle --without mysql
+
+ENV DBTYPE=postgresql
+CMD DB_HOST=tfb-database bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production_postgresql

--- a/frameworks/Ruby/rails/rails-unicorn.dockerfile
+++ b/frameworks/Ruby/rails/rails-unicorn.dockerfile
@@ -6,7 +6,7 @@ ADD ./ /rails
 
 WORKDIR /rails
 
-RUN bundle install --jobs=4 --gemfile=/rails/Gemfile --path=/rails/rails/bundle
+RUN bundle install --jobs=4 --gemfile=/rails/Gemfile --path=/rails/rails/bundle --without=postgresql
 
 CMD nginx -c /rails/config/nginx.conf && \
-  DB_HOST=tfb-database bundle exec unicorn_rails -E production -c config/unicorn.rb
+  DB_HOST=tfb-database bundle exec unicorn_rails -E production_mysql -c config/unicorn.rb

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -4,6 +4,6 @@ ADD ./ /rails
 
 WORKDIR /rails
 
-RUN bundle install --jobs=4 --gemfile=/rails/Gemfile --path=/rails/rails/bundle
+RUN bundle install --jobs=4 --gemfile=/rails/Gemfile --path=/rails/rails/bundle --without postgresql
 
-CMD DB_HOST=tfb-database bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD DB_HOST=tfb-database bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production_mysql


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Having done quite a few Rails related contracts over the last 5 years I've seen a lot more Postgres than Mysql. I also suggest that most new projects are using Postgres. 

I've added Postgres to the test suite. With the recent release of Rails 6 I'd  like to update a few things in here but this seems to be the most glaring omission. I followed the paradigm that I saw in the Sinatra Mysql vs Postgres project.
