### PR TITLE
Revert emulate prepares

### DIFF
--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
@@ -10,8 +10,7 @@ class RawController extends AppController
         header('Content-type: application/json');
 
         $this->pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
-            PDO::ATTR_PERSISTENT => true,
-            PDO::ATTR_EMULATE_PREPARES => false
+            PDO::ATTR_PERSISTENT => true
         ]);
     }
 

--- a/frameworks/PHP/php/dbquery.php
+++ b/frameworks/PHP/php/dbquery.php
@@ -4,8 +4,7 @@ header('Content-type: application/json');
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
 $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
-    PDO::ATTR_PERSISTENT => true,
-    PDO::ATTR_EMULATE_PREPARES => false
+    PDO::ATTR_PERSISTENT => true
 ]);
 
 // Read number of queries to run from URL parameter

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -4,8 +4,7 @@ header('Content-type: application/json');
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php
 $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
-  PDO::ATTR_PERSISTENT => true,
-  PDO::ATTR_EMULATE_PREPARES => false
+  PDO::ATTR_PERSISTENT => true
 ]);
 
 // Read number of queries to run from URL parameter


### PR DESCRIPTION
This change #4862 was made at the same time that the CVE-2019-1147x patches.
So we could not see the differences.
Apparently it is slower with that change.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
