### PR TITLE
Fixed set 'timer_resolution'

### DIFF
--- a/frameworks/PHP/php/deploy/nginx_php.conf
+++ b/frameworks/PHP/php/deploy/nginx_php.conf
@@ -2,7 +2,7 @@ user www-data;
 worker_processes  auto;
 error_log stderr error;
 #worker_rlimit_nofile 100000;
-timer_resolution 1000ms;
+#timer_resolution 1000ms;
 daemon off;
 
 events {


### PR DESCRIPTION
causing fortune problems

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
