### PR TITLE
Symfony - persistent connections

### DIFF
--- a/frameworks/PHP/symfony/config/packages/doctrine.yaml
+++ b/frameworks/PHP/symfony/config/packages/doctrine.yaml
@@ -2,12 +2,13 @@ doctrine:
     dbal:
         # configure these for your database server
         driver: 'pdo_mysql'
-        server_version: '5.7'
+        server_version: '8.0'
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4
             collate: utf8mb4_unicode_ci
-
+        options:
+            !php/const \PDO::ATTR_PERSISTENT: true
         url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: true

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -36,7 +36,7 @@ class DbController
      */
     public function queries(Request $request): JsonResponse
     {
-        $queries = $request->query->getInt('queries', 1);
+        $queries = (int) $request->query->get('queries', 1);
         $queries = min(max($queries, 1), 500);
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
@@ -54,7 +54,7 @@ class DbController
      */
     public function update(Request $request): JsonResponse
     {
-        $queries = $request->query->getInt('queries', 1);
+        $queries = (int) $request->query->get('queries', 1);
         $queries = min(500, max(1, $queries));
 
         $worlds = [];

--- a/frameworks/PHP/symfony/src/Controller/DbRawController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbRawController.php
@@ -35,7 +35,7 @@ class DbRawController
      */
     public function queries(Request $request): JsonResponse
     {
-        $queries = $request->query->getInt('queries', 1);
+        $queries = (int) $request->query->get('queries', 1);
         $queries = min(max($queries, 1), 500);
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
@@ -55,7 +55,7 @@ class DbRawController
      */
     public function updates(Request $request): JsonResponse
     {
-        $queries = $request->query->getInt('queries', 1);
+        $queries = (int) $request->query->get('queries', 1);
         $queries = min(500, max(1, $queries));
 
         $worlds = [];

--- a/frameworks/PHP/symfony/src/Controller/FortunesController.php
+++ b/frameworks/PHP/symfony/src/Controller/FortunesController.php
@@ -26,7 +26,7 @@ class FortunesController
      */
     public function fortunes(): Response
     {
-        $fortunes = $this->fortuneRepository->findAll();
+        $fortunes = $this->fortuneRepository->findBy([]);
 
         $runtimeFortune = new Fortune();
         $runtimeFortune->setId(0);

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -18,6 +18,11 @@ WORKDIR /symfony
 RUN mkdir -m 777 -p /symfony/var/cache/{dev,prod} /symfony/var/log
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --classmap-authoritative --no-dev
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer dump-env prod
+
+# removes hardcoded option `ATTR_STATEMENT_CLASS` conflicting with `ATTR_PERSISTENT`. Hack not needed when upgrading to Doctrine 3
+# see https://github.com/doctrine/dbal/issues/2315
+RUN sed -i '/PDO::ATTR_STATEMENT_CLASS/d' ./vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php
+
 RUN php bin/console cache:clear
 
 CMD service php7.3-fpm start && \

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -18,6 +18,11 @@ WORKDIR /symfony
 RUN mkdir -m 777 -p /symfony/var/cache/{dev,prod} /symfony/var/log
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --classmap-authoritative --no-dev
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer dump-env prod
+
+# removes hardcoded option `ATTR_STATEMENT_CLASS` conflicting with `ATTR_PERSISTENT`. Hack not needed when upgrading to Doctrine 3
+# see https://github.com/doctrine/dbal/issues/2315
+RUN sed -i '/PDO::ATTR_STATEMENT_CLASS/d' ./vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php
+
 RUN php bin/console cache:clear
 
 CMD service php7.3-fpm start && \


### PR DESCRIPTION
Current TestSuite is failing because of number of connection to the database. 
The solution is to use "persistent connection", but this is not currently supported by Doctrine (see https://github.com/doctrine/dbal/issues/2315) because setting ATTR_PERSISTENT conflict with ATTR_STATEMENT_CLASS.

nb: This issue has been fixed in Doctrine 3 (not yet released nor installable)

This PR patch doctrine to support persistent connection in PHP/symfony

note: Drawback is: caching results won't works anymore. Which not an issue in our case because caching result is not permitted in the benchmark.

This PR also replaces calls to aliases by a call to the original method. Less function calls === more performances. Tell me if you prefer a dedicated PR

ping @raziel057 @kaznovac