### PR TITLE
Rust Actix Readme correct fortune url

### DIFF
--- a/frameworks/Rust/actix/README.md
+++ b/frameworks/Rust/actix/README.md
@@ -43,7 +43,7 @@ PostgreSQL.
 
 ### Test 4: Fortunes (Template rendering)
 
-    http://localhost:8080/fortunes
+    http://localhost:8080/fortune
 
 ### Test 5: Update Query
 


### PR DESCRIPTION
Correction of a typo in fortune url in the readme of Actix.