### PR TITLE
Access $pdo when is necessary

### DIFF
--- a/frameworks/PHP/workerman/dbraw.php
+++ b/frameworks/PHP/workerman/dbraw.php
@@ -1,6 +1,7 @@
 <?php
-function dbraw($pdo)
+function dbraw()
 {
+    global $pdo;
     static $statement;
 
     $statement = $statement ?? $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');

--- a/frameworks/PHP/workerman/fortune.php
+++ b/frameworks/PHP/workerman/fortune.php
@@ -1,6 +1,7 @@
 <?php
-function fortune($pdo)
+function fortune()
 {
+    global $pdo;
     static $statement;
     $statement = $statement ?? $pdo->prepare('SELECT id,message FROM Fortune');
     $statement->execute();

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -14,7 +14,6 @@ $http_worker->onWorkerStart = function () {
         'benchmarkdbuser', 'benchmarkdbpass');
 };
 $http_worker->onMessage = static function ($connection) {
-    global $pdo;
 
     Http::header('Date: '.gmdate('D, d M Y H:i:s').' GMT');
 
@@ -29,15 +28,15 @@ $http_worker->onMessage = static function ($connection) {
 
         case '/db':
             Http::header('Content-Type: application/json');
-            return $connection->send(dbraw($pdo));
+            return $connection->send(dbraw());
 
         case '/fortune':
             Http::header('Content-Type: text/html; charset=utf-8');
-            return $connection->send(fortune($pdo));
+            return $connection->send(fortune());
 
         case '/update':
             Http::header('Content-Type: application/json');
-            return $connection->send(updateraw($pdo));
+            return $connection->send(updateraw());
 
             //case '/info':
             //   Http::header('Content-Type: text/plain');

--- a/frameworks/PHP/workerman/updateraw.php
+++ b/frameworks/PHP/workerman/updateraw.php
@@ -1,5 +1,6 @@
 <?php
-function updateraw($pdo) {
+function updateraw() {
+  global $pdo;
   $query_count = 1;
   if ($_GET['queries'] > 1) {
     $query_count = min($_GET['queries'], 500);


### PR DESCRIPTION
And not always

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
