### PR TITLE
Use the prepared statement directly

### DIFF
--- a/frameworks/PHP/workerman/dbraw.php
+++ b/frameworks/PHP/workerman/dbraw.php
@@ -1,14 +1,13 @@
 <?php
 function dbraw()
 {
-    global $pdo;
-    static $statement;
+    global $statement;
 
-    $statement = $statement ?? $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+    //$statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 
     if ( ! isset($_GET['queries'])) {
         $statement->execute([mt_rand(1, 10000)]);
-        return json_encode($statement->fetch(PDO::FETCH_ASSOC));
+        return json_encode($statement->fetch());
     }
 
     $query_count = 1;
@@ -18,7 +17,7 @@ function dbraw()
 
     while ($query_count--) {
         $statement->execute([mt_rand(1, 10000)]);
-        $arr[] = $statement->fetch(PDO::FETCH_ASSOC);
+        $arr[] = $statement->fetch();
     }
 
     return json_encode($arr);

--- a/frameworks/PHP/workerman/fortune.php
+++ b/frameworks/PHP/workerman/fortune.php
@@ -1,13 +1,13 @@
 <?php
 function fortune()
 {
-    global $pdo;
-    static $statement;
-    $statement = $statement ?? $pdo->prepare('SELECT id,message FROM Fortune');
-    $statement->execute();
+    global $fortune;
 
-    $arr       = $statement->fetchAll(PDO::FETCH_KEY_PAIR);
-    $arr[0]    = 'Additional fortune added at request time.';
+    //$fortune = $pdo->prepare('SELECT id,message FROM Fortune');
+    $fortune->execute();
+
+    $arr    = $fortune->fetchAll(PDO::FETCH_KEY_PAIR);
+    $arr[0] = 'Additional fortune added at request time.';
     asort($arr);
 
     $html = '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>';
@@ -15,5 +15,6 @@ function fortune()
         $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
         $html .= "<tr><td>{$id}</td><td>{$message}</td></tr>";
     }
-    return $html . '</table></body></html>';
+
+    return $html.'</table></body></html>';
 }

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -10,7 +10,7 @@ $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = shell_exec('nproc');
 $http_worker->onWorkerStart = function () {
     global $pdo, $fortune, $statement;
-    $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world;charset=utf8',
+    $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',
         'benchmarkdbuser', 'benchmarkdbpass',
         [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
     $fortune   = $pdo->prepare('SELECT id,message FROM Fortune');

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -7,12 +7,16 @@ use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = (int) shell_exec('nproc') ?? 64;
+$http_worker->count         = shell_exec('nproc');
 $http_worker->onWorkerStart = function () {
-    global $pdo;
-    $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',
-        'benchmarkdbuser', 'benchmarkdbpass');
+    global $pdo, $fortune, $statement;
+    $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world;charset=utf8',
+        'benchmarkdbuser', 'benchmarkdbpass',
+        [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+    $fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
+    $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 };
+
 $http_worker->onMessage = static function ($connection) {
 
     Http::header('Date: '.gmdate('D, d M Y H:i:s').' GMT');
@@ -45,7 +49,8 @@ $http_worker->onMessage = static function ($connection) {
             //   $connection->send(ob_get_clean());
 
             //default:
-            //   $connection->send('error');
+            //   Http::header('HTTP', true, 404);
+            //   $connection->send('Error 404');
     }
 };
 

--- a/frameworks/PHP/workerman/updateraw.php
+++ b/frameworks/PHP/workerman/updateraw.php
@@ -1,25 +1,26 @@
 <?php
-function updateraw() {
-  global $pdo;
-  $query_count = 1;
-  if ($_GET['queries'] > 1) {
-    $query_count = min($_GET['queries'], 500);
-  }
+function updateraw()
+{
+    global $pdo;
+    $query_count = 1;
+    if ($_GET['queries'] > 1) {
+        $query_count = min($_GET['queries'], 500);
+    }
 
-  $statement = $pdo->prepare('SELECT randomNumber FROM World WHERE id = ?');
-  $updateStatement = $pdo->prepare('UPDATE World SET randomNumber = ? WHERE id = ?');
+    $statement       = $pdo->prepare('SELECT randomNumber FROM World WHERE id=?');
+    $updateStatement = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
 
-  while ($query_count--) {
-    $id = mt_rand(1, 10000);
-    $statement->execute([$id]);
-    
-    $world = ['id' => $id, 'randomNumber' => $statement->fetchColumn()];
-    $updateStatement->execute(
-      [$world['randomNumber'] = mt_rand(1, 10000), $id]
-    );
- 
-    $arr[] = $world;
-  }
+    while ($query_count--) {
+        $id = mt_rand(1, 10000);
+        $statement->execute([$id]);
 
-  return json_encode($arr);
+        $world = ['id' => $id, 'randomNumber' => $statement->fetchColumn()];
+        $updateStatement->execute(
+            [$world['randomNumber'] = mt_rand(1, 10000), $id]
+        );
+
+        $arr[] = $world;
+    }
+
+    return json_encode($arr);
 }


### PR DESCRIPTION
For now only for db, queries and fortune.
I don't expect any gain, almost using emulated prepares. But we will try it.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
