### PR TITLE
Change json to check int

### DIFF
--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
@@ -10,29 +10,29 @@ class DbController extends AppController
 
     public function index()
     {
-        echo json_encode(World::byId(mt_rand(1, 10000)));
+        echo json_encode(World::byId(mt_rand(1, 10000)), JSON_NUMERIC_CHECK);
     }
 
     public function query($count = 1)
     {
         $count = min(max($count, 1), 500);
-        $worlds = [];
+
         while ($count--) {
             $worlds[] = World::byId(mt_rand(1, 10000));
         }
-        echo json_encode($worlds);
+        echo json_encode($worlds, JSON_NUMERIC_CHECK);
     }
 
     public function update($count = 1)
     {
         $count = min(max($count, 1), 500);
-        $worlds = [];
+
         while ($count--) {
             $row = World::byId(mt_rand(1, 10000));
             $row->randomNumber = mt_rand(1, 10000);
             $row->update();
             $worlds[] = $row;
         }
-        echo json_encode($worlds);
+        echo json_encode($worlds, JSON_NUMERIC_CHECK);
     }
 }

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
@@ -16,29 +16,28 @@ class RawController extends AppController
 
     public function index()
     {
-        $statement = $this->pdo->query( 'SELECT id,randomNumber FROM World WHERE id = '. mt_rand(1, 10000) );
-        echo json_encode($statement->fetch(PDO::FETCH_ASSOC));
+        $statement = $this->pdo->query( 'SELECT id,randomNumber FROM World WHERE id='. mt_rand(1, 10000) );
+        echo json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
     }
 
     public function query($count = 1)
     {
         $count = min(max($count, 1), 500);
-        $res = $this->pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
-        $worlds = [];
+        $res = $this->pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
+
         while ($count--) {
             $res->execute([mt_rand(1, 10000)]);
             $worlds[] = $res->fetch(PDO::FETCH_ASSOC);
         }
-        echo json_encode($worlds);
+        echo json_encode($worlds, JSON_NUMERIC_CHECK);
     }
 
     public function update($count = 1)
     {
         $count = min(max($count, 1), 500);
-        $worlds = [];
         
-        $sth = $this->pdo->prepare('SELECT * FROM World WHERE id = ?');
-        $updateSth = $this->pdo->prepare('UPDATE World SET randomNumber = ? WHERE id = ?');
+        $sth = $this->pdo->prepare('SELECT randomNumber FROM World WHERE id=?');
+        $updateSth = $this->pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         
         while ($count--) {
             $id = mt_rand(1, 10000);
@@ -50,6 +49,6 @@ class RawController extends AppController
             );
             $worlds[] = $row;
         }
-        echo json_encode($worlds);
+        echo json_encode($worlds, JSON_NUMERIC_CHECK);
     }
 }

--- a/frameworks/PHP/php/dborm.php
+++ b/frameworks/PHP/php/dborm.php
@@ -17,7 +17,7 @@ ActiveRecord\Config::initialize(function ($cfg) {
 });
 
 if (! isset($_GET['queries'])) {
-    echo json_encode(World::find_by_id(mt_rand(1, 10000))->to_array());
+    echo json_encode(World::find_by_id(mt_rand(1, 10000))->to_array(), JSON_NUMERIC_CHECK);
     return;
 }
 

--- a/frameworks/PHP/php/dborm.php
+++ b/frameworks/PHP/php/dborm.php
@@ -17,7 +17,7 @@ ActiveRecord\Config::initialize(function ($cfg) {
 });
 
 if (! isset($_GET['queries'])) {
-    echo json_encode(World::find_by_id(mt_rand(1, 10000))->to_array(), JSON_NUMERIC_CHECK);
+    echo json_encode( World::find_by_id(mt_rand(1, 10000))->to_array(), JSON_NUMERIC_CHECK);
     return;
 }
 

--- a/frameworks/PHP/php/dborm.php
+++ b/frameworks/PHP/php/dborm.php
@@ -36,4 +36,4 @@ while ($query_count--) {
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-echo json_encode($arr);
+echo json_encode($arr, JSON_NUMERIC_CHECK);

--- a/frameworks/PHP/php/dbquery.php
+++ b/frameworks/PHP/php/dbquery.php
@@ -13,9 +13,6 @@ if ($_GET['queries'] > 1) {
   $query_count = min($_GET['queries'], 500);
 }
 
-// Create an array with the response string.
-$arr = [];
-
 // Define query
 $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
 
@@ -29,4 +26,4 @@ while ($query_count--) {
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-echo json_encode($arr);
+echo json_encode($arr, JSON_NUMERIC_CHECK);

--- a/frameworks/PHP/php/dbraw.php
+++ b/frameworks/PHP/php/dbraw.php
@@ -12,4 +12,4 @@ $statement = $pdo->query( 'SELECT id,randomNumber FROM World WHERE id = '. mt_ra
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-echo json_encode($statement->fetch(PDO::FETCH_ASSOC));
+echo json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -14,8 +14,8 @@ if ($_GET['queries'] > 1) {
 }
 
 // Define query
-$statement = $pdo->prepare('SELECT randomNumber FROM World WHERE id = ?');
-$updateStatement = $pdo->prepare('UPDATE World SET randomNumber = ? WHERE id = ?');
+$statement = $pdo->prepare('SELECT randomNumber FROM World WHERE id=?');
+$updateStatement = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
 
 // For each query, store the result set values in the response array
 while ($query_count--) {

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -13,9 +13,6 @@ if ($_GET['queries'] > 1) {
   $query_count = min($_GET['queries'], 500);
 }
 
-// Create an array with the response string.
-$arr = [];
-
 // Define query
 $statement = $pdo->prepare('SELECT randomNumber FROM World WHERE id = ?');
 $updateStatement = $pdo->prepare('UPDATE World SET randomNumber = ? WHERE id = ?');
@@ -36,4 +33,4 @@ while ($query_count--) {
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-echo json_encode($arr);
+echo json_encode($arr, JSON_NUMERIC_CHECK);

--- a/frameworks/PHP/workerman/dbraw.php
+++ b/frameworks/PHP/workerman/dbraw.php
@@ -7,7 +7,7 @@ function dbraw()
 
     if ( ! isset($_GET['queries'])) {
         $statement->execute([mt_rand(1, 10000)]);
-        return json_encode($statement->fetch());
+        return json_encode($statement->fetch(), JSON_NUMERIC_CHECK);
     }
 
     $query_count = 1;
@@ -20,5 +20,5 @@ function dbraw()
         $arr[] = $statement->fetch();
     }
 
-    return json_encode($arr);
+    return json_encode($arr, JSON_NUMERIC_CHECK);
 }

--- a/frameworks/PHP/workerman/updateraw.php
+++ b/frameworks/PHP/workerman/updateraw.php
@@ -22,5 +22,5 @@ function updateraw()
         $arr[] = $world;
     }
 
-    return json_encode($arr);
+    return json_encode($arr, JSON_NUMERIC_CHECK);
 }


### PR DESCRIPTION
so they don't get wrapped with quotes.

Test: vanilla php, kumbiaphp and workerman.

If there is any gain, we will change the rest of php frameworks.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
