### PR TITLE
Correct small typo in header

### DIFF
--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
@@ -5,7 +5,7 @@ class DbController extends AppController
     protected function before_filter()
     {
         View::select(null, null);
-        header('Content-type: application/json');
+        header('Content-Type: application/json');
     }
 
     public function index()

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/index_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/index_controller.php
@@ -10,7 +10,7 @@ class IndexController extends AppController
     public function index()
     {
         View::select(null, null);
-        header('Content-type: text/plain');
+        header('Content-Type: text/plain');
         echo 'Hello, World!';
     }
 }

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/json_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/json_controller.php
@@ -6,7 +6,7 @@ class JsonController extends AppController
     public function index()
     {
         View::select(null, null);
-        header('Content-type: application/json');
+        header('Content-Type: application/json');
         echo json_encode(['message' => 'Hello, World!']);
     }
 }

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/raw_controller.php
@@ -7,7 +7,7 @@ class RawController extends AppController
     protected function before_filter()
     {
         View::select(null, null);
-        header('Content-type: application/json');
+        header('Content-Type: application/json');
 
         $this->pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass', [
             PDO::ATTR_PERSISTENT => true

--- a/frameworks/PHP/kumbiaphp/bench/app/views/_shared/templates/hello.phtml
+++ b/frameworks/PHP/kumbiaphp/bench/app/views/_shared/templates/hello.phtml
@@ -1,2 +1,0 @@
-<?php header('Content-type: text/plain') ?>
-Hello, World!

--- a/frameworks/PHP/kumbiaphp/bench/app/views/_shared/templates/json.phtml
+++ b/frameworks/PHP/kumbiaphp/bench/app/views/_shared/templates/json.phtml
@@ -1,4 +1,0 @@
-<?php
-/*mime type para el contenido*/
-header('Content-type: application/json');
-echo json_encode($data);

--- a/frameworks/PHP/php/dborm.php
+++ b/frameworks/PHP/php/dborm.php
@@ -1,6 +1,6 @@
 <?php
 // Set content type
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php

--- a/frameworks/PHP/php/dbquery.php
+++ b/frameworks/PHP/php/dbquery.php
@@ -1,5 +1,5 @@
 <?php
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php

--- a/frameworks/PHP/php/dbraw.php
+++ b/frameworks/PHP/php/dbraw.php
@@ -1,5 +1,5 @@
 <?php
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php

--- a/frameworks/PHP/php/eloquent/db-eloquent.php
+++ b/frameworks/PHP/php/eloquent/db-eloquent.php
@@ -1,6 +1,6 @@
 <?php
 // Set content type
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 require __DIR__.'/boot-eloquent.php';
 

--- a/frameworks/PHP/php/eloquent/db-laravel-query-builder.php
+++ b/frameworks/PHP/php/eloquent/db-laravel-query-builder.php
@@ -1,6 +1,6 @@
 <?php
 // Set content type
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 require __DIR__.'/init-capsule.php';
 

--- a/frameworks/PHP/php/eloquent/update-eloquent.php
+++ b/frameworks/PHP/php/eloquent/update-eloquent.php
@@ -25,5 +25,5 @@ while ($query_count--) {
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php
-header('Content-type: application/json');
+header('Content-Type: application/json');
 echo json_encode($arr);

--- a/frameworks/PHP/php/json.php
+++ b/frameworks/PHP/php/json.php
@@ -1,6 +1,6 @@
 <?php
 // Set content type
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 // Use the PHP standard JSON encoder.
 // http://www.php.net/manual/en/function.json-encode.php

--- a/frameworks/PHP/php/plaintext.php
+++ b/frameworks/PHP/php/plaintext.php
@@ -2,6 +2,6 @@
 // Plaintext Test
 
 // Set content type
-header('Content-type: text/plain');
+header('Content-Type: text/plain');
 
 echo 'Hello, World!';

--- a/frameworks/PHP/php/updateraw.php
+++ b/frameworks/PHP/php/updateraw.php
@@ -1,5 +1,5 @@
 <?php
-header('Content-type: application/json');
+header('Content-Type: application/json');
 
 // Database connection
 // http://www.php.net/manual/en/ref.pdo-mysql.php

--- a/frameworks/PHP/ubiquity/app/controllers/Db.php
+++ b/frameworks/PHP/ubiquity/app/controllers/Db.php
@@ -10,7 +10,7 @@ use models\World;
 class Db extends \Ubiquity\controllers\Controller {
 
 	public function initialize() {
-		\header('Content-type: application/json');
+		\header('Content-Type: application/json');
 		\Ubiquity\cache\CacheManager::startProd(\Ubiquity\controllers\Startup::$config);
 		DAO::setModelDatabase(World::class);
 	}


### PR DESCRIPTION
from 7 years ago.

All people use the raw php as reference and copy the header with the typo.
It is not important in most situations, but in some platforms can cause a duplicated header.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
