### PR TITLE
Double workers in workerman

### DIFF
--- a/frameworks/PHP/workerman/server-async.php
+++ b/frameworks/PHP/workerman/server-async.php
@@ -5,7 +5,7 @@ use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = shell_exec('nproc');
+$http_worker->count         = shell_exec('nproc') * 2;
 $http_worker->onWorkerStart = static function() {
     global $mysql;
 

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -7,7 +7,7 @@ use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = shell_exec('nproc');
+$http_worker->count         = shell_exec('nproc') * 2;
 $http_worker->onWorkerStart = function () {
     global $pdo, $fortune, $statement;
     $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
