### PR TITLE
go-std: re-use a single buffer in plaintext

### DIFF
--- a/frameworks/Go/go-std/src/go.mod
+++ b/frameworks/Go/go-std/src/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 // indirect
-	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/quicktemplate v1.0.2
 	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/frameworks/Go/go-std/src/handlers/handlers.go
+++ b/frameworks/Go/go-std/src/handlers/handlers.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/valyala/bytebufferpool"
-
 	"go-std/src/storage"
 	"go-std/src/templates"
 )
@@ -193,13 +191,15 @@ func UpdateHandler(db storage.DB) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+var helloWorld = []byte("Hello, World!")
+
 // PlaintextHandler . Test 6: Plaintext
 func PlaintextHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "Go")
 	w.Header().Set("Content-Type", "text/plain")
-	b := bytebufferpool.Get()
-	b.SetString("Hello, World!")
-	w.Write(b.Bytes())
-	b.Reset()
-	bytebufferpool.Put(b)
+	// As per 6, iv:
+	//  This test is not intended to exercise the allocation of memory or
+	//  instantiation of objects. Therefore it is acceptable but not required
+	//  to re-use a single buffer for the response text.
+	w.Write(helloWorld)
 }


### PR DESCRIPTION
I've noticed that go std code is using unnecessary memory allocations in plaintext benchmark.

This PR allows plaintext handler to re-use buffer and adds a comment stating that it is not prohibited.