### PR TITLE
Update Swoole to 4.4.7

### DIFF
--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3
 
-ENV SWOOLE_VERSION=4.4.5
+ENV SWOOLE_VERSION=4.4.7
 
 RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
         && cd swoole-src-${SWOOLE_VERSION} \

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -1,11 +1,7 @@
 FROM php:7.3
 
-ENV SWOOLE_VERSION=4.4.7
-
-RUN cd /tmp && curl -sSL "https://github.com/swoole/swoole-src/archive/v${SWOOLE_VERSION}.tar.gz" | tar xzf - \
-        && cd swoole-src-${SWOOLE_VERSION} \
-        && phpize && ./configure > /dev/null && make > /dev/null && make install > /dev/null \
-        && docker-php-ext-enable swoole
+RUN pecl install swoole > /dev/null && \
+    docker-php-ext-enable swoole
 
 RUN docker-php-ext-install pdo_mysql > /dev/null
 


### PR DESCRIPTION
- Update Swoole to 4.4.7
I'm not doing it for Laravel and Lumen, but they're still in 4.3