### PR TITLE
Use postgres connection pooling for lisp frameworks

### DIFF
--- a/frameworks/Lisp/ningle/ningle.ros
+++ b/frameworks/Lisp/ningle/ningle.ros
@@ -166,7 +166,7 @@ exec ros -Q -- $0 "$@"
     (apply #'woo:run
       (lambda (env)
         ;; preprocessing
-        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database")
+        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database" :pooled-p t)
                      (ningle.app::call *app* env))))
           ;; postprocessing
           res))

--- a/frameworks/Lisp/ninglex/ninglex.ros
+++ b/frameworks/Lisp/ninglex/ninglex.ros
@@ -147,7 +147,7 @@ exec ros -Q -- $0 "$@"
     (apply #'woo:run
       (lambda (env)
         ;; preprocessing
-        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database")
+        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database" :pooled-p t)
                      (ningle.app::call *app* env))))
           ;; postprocessing
           res))

--- a/frameworks/Lisp/woo/woo.ros
+++ b/frameworks/Lisp/woo/woo.ros
@@ -159,7 +159,7 @@ exec ros -Q -- $0 "$@"
     (apply #'woo:run
       (lambda (env)
         ;; preprocessing
-        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database")
+        (let ((res (postmodern:with-connection '("hello_world" "benchmarkdbuser" "benchmarkdbpass" "tfb-database" :pooled-p t)
                      (funcall 'handler env))))
           ;; postprocessing
           res))


### PR DESCRIPTION
The Lisp frameworks (woo, Ningle, and ninglex) do not currently use postmodern's built-in connection pooling, which leads to benchmark performance well below what can be achieved by the frameworks themselves.  This commit changes the test applications to use connection pooling.