### PR TITLE
Add swoole without async db pool

### DIFF
--- a/frameworks/PHP/swoole/benchmark_config.json
+++ b/frameworks/PHP/swoole/benchmark_config.json
@@ -23,6 +23,27 @@
       "display_name": "Swoole",
       "notes": "",
       "versus": "php"
+    },
+    "no-async": {
+      "db_url": "/db",
+      "query_url": "/db?queries=",
+      "fortune_url": "/fortunes",
+      "update_url": "/updates?queries=",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
+      "framework": "None",
+      "language": "PHP",
+      "flavor": "PHP7",
+      "orm": "Raw",
+      "platform": "swoole",
+      "webserver": "none",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "Swoole-postgres",
+      "notes": "Without async db pool connection",
+      "versus": "php"
     }
   }]
 }

--- a/frameworks/PHP/swoole/swoole-no-async.dockerfile
+++ b/frameworks/PHP/swoole/swoole-no-async.dockerfile
@@ -1,0 +1,13 @@
+FROM php:7.3
+
+RUN pecl install swoole > /dev/null && \
+    docker-php-ext-enable swoole
+
+RUN docker-php-ext-install pdo_mysql > /dev/null
+
+WORKDIR /swoole
+COPY swoole-server-noasync.php swoole-server-noasync.php
+COPY php.ini /usr/local/etc/php/
+
+CMD sed -i 's|NUMCORES|'"$(nproc)"'|g' swoole-server-noasync.php && \
+    php swoole-server-noasync.php

--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -1,0 +1,155 @@
+<?php
+
+use Swoole\Http\Request;
+use Swoole\Http\Response;
+
+$server = new swoole_http_server('0.0.0.0', 8080, SWOOLE_BASE);
+$server->set([
+    'worker_num' => NUMCORES
+]);
+
+$pdo = new PDO("mysql:host=tfb-database;dbname=hello_world", "benchmarkdbuser", "benchmarkdbpass", [
+    PDO::ATTR_PERSISTENT => true
+]);
+
+/**
+ * The DB test
+ *
+ * @param int $queries
+ *
+ * @return string
+ */
+$db = function (int $queries = 1) use ($pdo): string {
+    if ( $queries === -1) {
+        $statement = $pdo->prepare("SELECT id,randomNumber FROM World WHERE id=?");
+        $statement->execute([mt_rand(1, 10000)]);
+        return json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
+    }
+    
+    // Read number of queries to run from URL parameter
+    $query_count = 1;
+    if ($queries > 1) {
+        $query_count = $queries > 500 ? 500 : $queries;
+    }
+
+    // Create an array with the response string.
+    $arr = [];
+    // Define query
+    $db = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+
+    // For each query, store the result set values in the response array
+    while ($query_count--) {
+        $db->execute([mt_rand(1, 10000)]);
+        $arr[] = $db->fetch(PDO::FETCH_ASSOC);
+    }
+
+    // Use the PHP standard JSON encoder.
+    // http://www.php.net/manual/en/function.json-encode.php
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+};
+
+/**
+ * The Fortunes test
+ *
+ * @return string
+ */
+$fortunes = function () use ($pdo): string {
+
+    $fortune = [];
+    $db = $pdo->prepare('SELECT id, message FROM Fortune');
+    $db->execute();
+    $fortune = $db->fetchAll(PDO::FETCH_KEY_PAIR);
+
+    $fortune[0] = 'Additional fortune added at request time.';
+    asort($fortune);
+
+    $html = '';
+    foreach ($fortune as $id => $message) {
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+        $html .= "<tr><td>$id</td><td>$message</td></tr>";
+    }
+
+    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'. 
+            $html.
+            '</table></body></html>';
+};
+
+/**
+ * The Updates test
+ *
+ * @param int $queries
+ *
+ * @return string
+ */
+$updates = function (int $queries) use ($pdo): string {
+    $query_count = 1;
+    if ($queries > 1) {
+        $query_count = $queries > 500 ? 500 : $queries;
+    }
+
+    $statement       = $pdo->prepare("SELECT randomNumber FROM World WHERE id=?");
+    $updateStatement = $pdo->prepare("UPDATE World SET randomNumber=? WHERE id=?");
+
+    while ($query_count--) {
+        $id = mt_rand(1, 10000);
+        $statement->execute([$id]);
+
+        $world = ["id" => $id, "randomNumber" => $statement->fetchColumn()];
+        $updateStatement->execute(
+            [$world["randomNumber"] = mt_rand(1, 10000), $id]
+        );
+
+        $arr[] = $world;
+    }
+
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+};
+
+/**
+ * On start of the PHP worker. One worker per server process is started.
+ */
+//$server->on('workerStart', function () use ($pool) {
+//});
+
+/**
+ * On every request to the (web)server, execute the following code
+ */
+$server->on('request', function (Request $req, Response $res) use ($db, $fortunes, $updates) {
+
+    switch ($req->server['request_uri']) {
+        case '/json':
+            $res->header('Content-Type', 'application/json');
+            $res->end(json_encode(['message' => 'Hello, World!']));
+            break;
+
+        case '/plaintext':
+            $res->header('Content-Type', 'text/plain; charset=utf-8');
+            $res->end('Hello, World!');
+            break;
+
+        case '/db':
+            $res->header('Content-Type', 'application/json');
+
+            if (isset($req->get['queries'])) {
+                $res->end($db((int) $req->get['queries']));
+            } else {
+                $res->end($db(-1));
+            }
+            break; 
+
+        case '/fortunes':
+            $res->header('Content-Type', 'text/html; charset=utf-8');
+            $res->end($fortunes());
+            break;
+
+        case '/updates':
+            $res->header('Content-Type', 'application/json');
+            $res->end($updates((int) $req->get['queries'] ?? 1));
+            break;
+    }
+
+});
+
+$server->start();


### PR DESCRIPTION
The actual swoole test is using async db pool connection.

So we can compare without it. Using the normal PDO from PHP.

The rest of frameworks can compare and learn.
Also we will know the envent loop performance.

A benchmark it is NOT a competition. It is a tool that help to create better and faster code.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
