### PR TITLE
Swoole send error

### DIFF
--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -151,7 +151,8 @@ $server->on('request', function (Request $req, Response $res) use ($db, $fortune
         }
 
     } catch (\Throwable $e) {
-        $response->status(500);
+        $res->status(500);
+        $res->end('code ' . $e->getCode(). 'msg: '. $e->getMessage());
     }
 });
 

--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -117,39 +117,42 @@ $updates = function (int $queries) use ($pdo): string {
  * On every request to the (web)server, execute the following code
  */
 $server->on('request', function (Request $req, Response $res) use ($db, $fortunes, $updates) {
+    try {
+        switch ($req->server['request_uri']) {
+            case '/json':
+                $res->header('Content-Type', 'application/json');
+                $res->end(json_encode(['message' => 'Hello, World!']));
+                break;
 
-    switch ($req->server['request_uri']) {
-        case '/json':
-            $res->header('Content-Type', 'application/json');
-            $res->end(json_encode(['message' => 'Hello, World!']));
-            break;
+            case '/plaintext':
+                $res->header('Content-Type', 'text/plain; charset=utf-8');
+                $res->end('Hello, World!');
+                break;
 
-        case '/plaintext':
-            $res->header('Content-Type', 'text/plain; charset=utf-8');
-            $res->end('Hello, World!');
-            break;
+            case '/db':
+                $res->header('Content-Type', 'application/json');
 
-        case '/db':
-            $res->header('Content-Type', 'application/json');
+                if (isset($req->get['queries'])) {
+                    $res->end($db((int) $req->get['queries']));
+                } else {
+                    $res->end($db(-1));
+                }
+                break; 
 
-            if (isset($req->get['queries'])) {
-                $res->end($db((int) $req->get['queries']));
-            } else {
-                $res->end($db(-1));
-            }
-            break; 
+            case '/fortunes':
+                $res->header('Content-Type', 'text/html; charset=utf-8');
+                $res->end($fortunes());
+                break;
 
-        case '/fortunes':
-            $res->header('Content-Type', 'text/html; charset=utf-8');
-            $res->end($fortunes());
-            break;
+            case '/updates':
+                $res->header('Content-Type', 'application/json');
+                $res->end($updates((int) $req->get['queries'] ?? 1));
+                break;
+        }
 
-        case '/updates':
-            $res->header('Content-Type', 'application/json');
-            $res->end($updates((int) $req->get['queries'] ?? 1));
-            break;
+    } catch (\Throwable $e) {
+        $response->status(500);
     }
-
 });
 
 $server->start();

--- a/frameworks/PHP/swoole/swoole-server.php
+++ b/frameworks/PHP/swoole/swoole-server.php
@@ -133,69 +133,72 @@ $server->on('workerStart', function () use ($pool) {
  * On every request to the (web)server, execute the following code
  */
 $server->on('request', function (Request $req, Response $res) use ($db, $fortunes, $updates) {
+    try {
+        switch ($req->server['request_uri']) {
+            case '/json':
+                $res->header('Content-Type', 'application/json');
+                $res->end(json_encode(['message' => 'Hello, World!']));
+                break;
 
-    switch ($req->server['request_uri']) {
-        case '/json':
-            $res->header('Content-Type', 'application/json');
-            $res->end(json_encode(['message' => 'Hello, World!']));
-            break;
+            case '/plaintext':
+                $res->header('Content-Type', 'text/plain; charset=utf-8');
+                $res->end('Hello, World!');
+                break;
 
-        case '/plaintext':
-            $res->header('Content-Type', 'text/plain; charset=utf-8');
-            $res->end('Hello, World!');
-            break;
+            case '/db':
+                $res->header('Content-Type', 'application/json');
 
-        case '/db':
-            $res->header('Content-Type', 'application/json');
+                if (isset($req->get['queries'])) {
+                    $res->end($db('mysql', (int)$req->get['queries']));
+                } else {
+                    $res->end($db('mysql', -1));
+                }
+                break;
 
-            if (isset($req->get['queries'])) {
-                $res->end($db('mysql', (int)$req->get['queries']));
-            } else {
-                $res->end($db('mysql', -1));
-            }
-            break;
+            case '/fortunes':
+                $res->header('Content-Type', 'text/html; charset=utf-8');
+                $res->end($fortunes('mysql'));
+                break;
 
-        case '/fortunes':
-            $res->header('Content-Type', 'text/html; charset=utf-8');
-            $res->end($fortunes('mysql'));
-            break;
+            case '/updates':
+                $res->header('Content-Type', 'application/json');
 
-        case '/updates':
-            $res->header('Content-Type', 'application/json');
+                if (isset($req->get['queries'])) {
+                    $res->end($updates('mysql', (int)$req->get['queries']));
+                } else {
+                    $res->end($updates('mysql', -1));
+                }
+                break;
 
-            if (isset($req->get['queries'])) {
-                $res->end($updates('mysql', (int)$req->get['queries']));
-            } else {
-                $res->end($updates('mysql', -1));
-            }
-            break;
+            case '/db_postgres':
+                $res->header('Content-Type', 'application/json');
 
-        case '/db_postgres':
-            $res->header('Content-Type', 'application/json');
+                if (isset($req->get['queries'])) {
+                    $res->end($db('postgres', (int)$req->get['queries']));
+                } else {
+                    $res->end($db('postgres', -1));
+                }
+                break;
 
-            if (isset($req->get['queries'])) {
-                $res->end($db('postgres', (int)$req->get['queries']));
-            } else {
-                $res->end($db('postgres', -1));
-            }
-            break;
+            case '/fortunes_postgres':
+                $res->header('Content-Type', 'text/html; charset=utf-8');
+                $res->end($fortunes('postgres'));
+                break;
 
-        case '/fortunes_postgres':
-            $res->header('Content-Type', 'text/html; charset=utf-8');
-            $res->end($fortunes('postgres'));
-            break;
+            case '/updates_postgres':
+                $res->header('Content-Type', 'application/json');
 
-        case '/updates_postgres':
-            $res->header('Content-Type', 'application/json');
+                if (isset($req->get['queries'])) {
+                    $res->end($updates('postgres', (int)$req->get['queries']));
+                } else {
+                    $res->end($updates('postgres', -1));
+                }
+                break;
+        }
 
-            if (isset($req->get['queries'])) {
-                $res->end($updates('postgres', (int)$req->get['queries']));
-            } else {
-                $res->end($updates('postgres', -1));
-            }
-            break;
+    } catch (\Throwable $e) {
+        $response->status(500);
     }
-
 });
 
 $server->start();

--- a/frameworks/PHP/swoole/swoole-server.php
+++ b/frameworks/PHP/swoole/swoole-server.php
@@ -197,7 +197,8 @@ $server->on('request', function (Request $req, Response $res) use ($db, $fortune
         }
 
     } catch (\Throwable $e) {
-        $response->status(500);
+        $res->status(500);
+        $res->end('code ' . $e->getCode(). 'msg: '. $e->getMessage());
     }
 });
 


### PR DESCRIPTION
Actually Swoole don't send any error, so we think that all is correct.
But the log is full of errors:
https://tfb-status.techempower.com/unzip/results.2019-10-05-23-14-37-606.zip/results/20191002030153/swoole/run/swoole.log

This change try to return the errors.
If the errors don't appear in the log, later we will investigate how to show it in the log too.

Unfortunately almost all frameworks using Swoole have the same behavior.
https://tfb-status.techempower.com/unzip/results.2019-10-05-23-14-37-606.zip/results/20191002030153/hamlet-swoole/run/hamlet-swoole.log

https://tfb-status.techempower.com/unzip/results.2019-10-05-23-14-37-606.zip/results/20191002030153/laravel-swoole/run/laravel-swoole.log

https://tfb-status.techempower.com/unzip/results.2019-10-05-23-14-37-606.zip/results/20191002030153/sw-fw-less/run/sw-fw-less.log
....
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
