### PR TITLE
Add Workerman with Mysqli

### DIFF
--- a/frameworks/PHP/workerman/benchmark_config.json
+++ b/frameworks/PHP/workerman/benchmark_config.json
@@ -63,6 +63,27 @@
       "display_name": "workerman-async-db",
       "notes": "",
       "versus": "php"
+    },
+    "mysqli": {
+      "db_url": "/db",
+      "query_url": "/db?queries=",
+      "update_url": "/update?queries=",
+      "fortune_url": "/fortune",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "MySQL",
+      "framework": "None",
+      "language": "PHP",
+      "flavor": "PHP7",
+      "orm": "Raw",
+      "platform": "workerman",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "workerman-mysqli",
+      "notes": "Using Mysqli",
+      "versus": "php"
     }
   }]
 }

--- a/frameworks/PHP/workerman/composer.json
+++ b/frameworks/PHP/workerman/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
-		"workerman/workerman": "^3.5",
+		"workerman/workerman": "dev-master",
 		"react/mysql": "^0.3.3"
 	}
 }

--- a/frameworks/PHP/workerman/db-mysqli.php
+++ b/frameworks/PHP/workerman/db-mysqli.php
@@ -1,0 +1,80 @@
+<?php
+
+//$db = new mysqli('p:tfb-database', 'benchmarkdbuser', 'benchmarkdbpass', 'hello_world');
+
+
+function db()
+{
+    global $db;
+
+    $statement = $db->prepare('SELECT id,randomNumber FROM World WHERE id=?');
+
+    if ( ! isset($_GET['queries'])) {
+        $id = mt_rand(1, 10000);
+        $statement->bind_param('i', $id);
+        $statement->execute();
+        return json_encode($statement->get_result()->fetch_assoc(), JSON_NUMERIC_CHECK);
+    }
+
+    $query_count = 1;
+    if ($_GET['queries'] > 1) {
+        $query_count = min($_GET['queries'], 500);
+    }
+
+    while ($query_count--) {
+        $id = mt_rand(1, 10000);
+        $statement->bind_param('i', $id);
+        $statement->execute();
+        $arr[] = $statement->get_result()->fetch_assoc();
+    }
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+}
+
+function fortune()
+{
+    global $db;
+
+    $arr    = $db->query('SELECT id,message FROM Fortune')->fetch_all(MYSQLI_NUM);
+    $arr[] = [0 => 0, 1 => 'Additional fortune added at request time.'];
+    usort($arr, function($a, $b){return strcmp($a[1], $b[1]);});
+
+    $html = '';
+    foreach ($arr as $item) {
+        $message = htmlspecialchars($item[1], ENT_QUOTES, 'UTF-8');
+        $html .= "<tr><td>$item[0]</td><td>$message</td></tr>";
+    }
+
+    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'
+            .$html.
+            '</table></body></html>';
+}
+
+function update()
+{
+    global $db;
+
+    $query_count = 1;
+    if ($_GET['queries'] > 1) {
+        $query_count = min($_GET['queries'], 500);
+    }
+
+    $statement       = $db->prepare('SELECT randomNumber FROM World WHERE id=?');
+    $updateStatement = $db->prepare('UPDATE World SET randomNumber=? WHERE id=?');
+
+    while ($query_count--) {
+        $id = mt_rand(1, 10000);
+        $statement->bind_param('i', $id);
+        $statement->execute();
+
+        $world = ['id' => $id, 'randomNumber' => $statement->get_result()->fetch_row()];
+        
+        $update = mt_rand(1, 10000);
+        $updateStatement->bind_param('ii',$update, $id);
+        $updateStatement->execute();
+
+        $arr[] = ['id' => $id, 'randomNumber' => $update];
+    }
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+}

--- a/frameworks/PHP/workerman/php.ini
+++ b/frameworks/PHP/workerman/php.ini
@@ -6,3 +6,5 @@ opcache.enable_file_override=1
 opcache.huge_code_pages=1
 
 mysqlnd.collect_statistics = Off
+
+memory_limit = 512M

--- a/frameworks/PHP/workerman/server-mysqli.php
+++ b/frameworks/PHP/workerman/server-mysqli.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__.'/vendor/autoload.php';
+require_once __DIR__.'/db-mysqli.php';
+
+use Workerman\Protocols\Http;
+use Workerman\Worker;
+
+$http_worker                = new Worker('http://0.0.0.0:8080');
+$http_worker->count         = shell_exec('nproc');
+$http_worker->onWorkerStart = function () {
+    global $db;
+    $db = new mysqli('p:tfb-database', 'benchmarkdbuser', 'benchmarkdbpass', 'hello_world');
+};
+
+$http_worker->onMessage = static function ($connection) {
+
+    Http::header('Date: '.gmdate('D, d M Y H:i:s').' GMT');
+
+    switch (parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)) {
+
+        case '/db':
+            Http::header('Content-Type: application/json');
+            return $connection->send(db());
+
+        case '/fortune':
+            Http::header('Content-Type: text/html; charset=utf-8');
+            return $connection->send(fortune());
+
+        case '/update':
+            Http::header('Content-Type: application/json');
+            return $connection->send(update());
+
+            //case '/info':
+            //   Http::header('Content-Type: text/plain');
+            //   ob_start();
+            //   phpinfo();
+            //   $connection->send(ob_get_clean());
+
+            //default:
+            //   Http::header('HTTP', true, 404);
+            //   $connection->send('Error 404');
+    }
+};
+
+Worker::runAll();

--- a/frameworks/PHP/workerman/workerman-mysqli.dockerfile
+++ b/frameworks/PHP/workerman/workerman-mysqli.dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:19.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-mysql  > /dev/null
+
+RUN apt-get install -yqq composer > /dev/null
+
+RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
+
+COPY php.ini /etc/php/7.3/cli/php.ini
+
+ADD ./ /workerman
+WORKDIR /workerman
+
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+
+CMD php /workerman/server-mysqli.php start


### PR DESCRIPTION
To check if Mysqli is really much faster than PDO.

For now use a worker per core.
And raise memory limit to 512Mb as Mysqli looks like use more memory. 
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
