### PR TITLE
Clean dockerfile in Swoole

### DIFF
--- a/frameworks/PHP/swoole/swoole-no-async.dockerfile
+++ b/frameworks/PHP/swoole/swoole-no-async.dockerfile
@@ -9,5 +9,4 @@ WORKDIR /swoole
 COPY swoole-server-noasync.php swoole-server-noasync.php
 COPY php.ini /usr/local/etc/php/
 
-CMD sed -i 's|NUMCORES|'"$(nproc)"'|g' swoole-server-noasync.php && \
-    php swoole-server-noasync.php
+CMD php swoole-server-noasync.php

--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -5,7 +5,7 @@ use Swoole\Http\Response;
 
 $server = new swoole_http_server('0.0.0.0', 8080, SWOOLE_BASE);
 $server->set([
-    'worker_num' => NUMCORES
+    'worker_num' => swoole_cpu_num()
 ]);
 
 $pdo = new PDO("mysql:host=tfb-database;dbname=hello_world", "benchmarkdbuser", "benchmarkdbpass", [

--- a/frameworks/PHP/swoole/swoole-server.php
+++ b/frameworks/PHP/swoole/swoole-server.php
@@ -5,7 +5,7 @@ use Swoole\Http\Response;
 
 $server = new swoole_http_server('0.0.0.0', 8080, SWOOLE_BASE);
 $server->set([
-    'worker_num' => NUMCORES
+    'worker_num' => swoole_cpu_num()
 ]);
 
 $pool = new DatabasePool();

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -9,5 +9,4 @@ WORKDIR /swoole
 COPY swoole-server.php swoole-server.php
 COPY php.ini /usr/local/etc/php/
 
-CMD sed -i 's|NUMCORES|'"$(nproc)"'|g' swoole-server.php && \
-    php swoole-server.php
+CMD php swoole-server.php


### PR DESCRIPTION
Now use `swoole_cpu_num()` in the code.
That function is available from swoole v1.9.0, we are using v4.4.7
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
