### PR TITLE
Delete set header in fortunes

### DIFF
--- a/frameworks/PHP/workerman/server-async.php
+++ b/frameworks/PHP/workerman/server-async.php
@@ -42,7 +42,7 @@ $http_worker->onMessage = static function ($connection) {
             return;
 
         case '/fortune':
-            Http::header('Content-Type: text/html; charset=utf-8');
+            //Http::header('Content-Type: text/html; charset=utf-8');
             $mysql->query('SELECT id,message FROM Fortune', 
                 static function ($command) use ($connection) {
                     $arr = $command->resultRows;

--- a/frameworks/PHP/workerman/server-mysqli.php
+++ b/frameworks/PHP/workerman/server-mysqli.php
@@ -23,7 +23,7 @@ $http_worker->onMessage = static function ($connection) {
             return $connection->send(db());
 
         case '/fortune':
-            Http::header('Content-Type: text/html; charset=utf-8');
+            //Http::header('Content-Type: text/html; charset=utf-8');
             return $connection->send(fortune());
 
         case '/update':

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -35,7 +35,7 @@ $http_worker->onMessage = static function ($connection) {
             return $connection->send(dbraw());
 
         case '/fortune':
-            Http::header('Content-Type: text/html; charset=utf-8');
+            //Http::header('Content-Type: text/html; charset=utf-8');
             return $connection->send(fortune());
 
         case '/update':


### PR DESCRIPTION
by default Workerman send  `Content-Type: text/html; charset=utf-8`

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
