### PR TITLE
Easier debugging

### DIFF
--- a/deployment/vagrant/Vagrantfile
+++ b/deployment/vagrant/Vagrantfile
@@ -13,7 +13,12 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.network "private_network", ip: "172.16.0.16"
-  config.vm.network :forwarded_port, guest: 8080, host: 28080
+
+  TCP_PORTS = [2001, 3000, 8000, 8080, 8081, 8082, 8085, 9000]
+
+  TCP_PORTS.each do |port|
+      config.vm.network :forwarded_port, guest: port, host: 20000 + port
+  end
 
   provision_bootstrap(config)
   provider_virtualbox(config)
@@ -24,5 +29,5 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ]
   end
-  
+
 end

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -175,7 +175,9 @@ class Benchmarker:
 
             # Debug mode blocks execution here until ctrl+c
             if self.config.mode == "debug":
-                log("Entering debug mode. Server has started. CTRL-c to stop.",
+                msg = "Entering debug mode. Server http://localhost:%s has started. CTRL-c to stop.\r\n" % test.port
+                msg = msg + "From outside vagrant: http://localhost:%s" % (int(test.port) + 20000)
+                log(msg,
                     prefix=log_prefix,
                     file=benchmark_log,
                     color=Fore.YELLOW)


### PR DESCRIPTION
Replaces #4646 

Mapped a few more ports that tests are using in vagrant to 20000 + port and updated debug messages to include this information.