### PR TITLE
frameworks: Update Finagle and Finatra versions

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,4 +1,4 @@
-lazy val finagleVersion = "19.9.0"
+lazy val finagleVersion = "19.10.0"
 
 name := "finagle-benchmark"
 scalaVersion := "2.12.8"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,4 +1,4 @@
-lazy val finatraVersion = "19.9.0"
+lazy val finatraVersion = "19.10.0"
 
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"


### PR DESCRIPTION
Problem

We have released our next monthly release of both [Finagle](https://github.com/twitter/finagle) and [Finatra](https://github.com/twitter/finatra) and would like to update the associated benchmarks.

Solution

Update the versions of each framework used in the benchmarks to the latest October release.