### PR TITLE
Create a travis Swoole job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,8 @@ env:
     - "TESTLANG=Perl"
     - 'TESTDIR="PHP/php"'
     - 'TESTDIR="PHP/cakephp PHP/codeigniter PHP/fat-free PHP/fuel PHP/kumbiaphp PHP/phpixie PHP/slim PHP/symfony PHP/yii2 PHP/zend PHP/spiral"'
-    - 'TESTDIR="PHP/amp PHP/hamlet PHP/laravel PHP/lumen PHP/hhvm PHP/peachpie PHP/php-ngx PHP/swoole PHP/workerman PHP/phalcon PHP/ubiquity PHP/hyperf PHP/sw-fw-less PHP/imi"'
+    - 'TESTDIR="PHP/amp PHP/hhvm PHP/peachpie PHP/php-ngx PHP/workerman PHP/phalcon"'
+    - 'TESTDIR="PHP/hamlet PHP/laravel PHP/lumen PHP/swoole PHP/ubiquity PHP/hyperf PHP/sw-fw-less PHP/imi"'
     - 'TESTDIR="Python/aiohttp Python/api_hour Python/apidaora Python/blacksheep Python/bottle Python/cherrypy Python/django Python/eve Python/falcon Python/fastapi Python/flask"'
     - 'TESTDIR="Python/hug Python/japronto Python/klein Python/morepath Python/pyramid Python/quart Python/responder Python/sanic Python/spyne Python/starlette"'
     - 'TESTDIR="Python/tornado Python/turbogears Python/uvicorn Python/uwsgi Python/vibora Python/web2py Python/webware Python/weppy Python/wsgi"'

--- a/frameworks/PHP/hamlet/hamlet-swoole.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet-swoole.dockerfile
@@ -15,8 +15,8 @@ ADD ./ /php
 WORKDIR /php
 RUN chmod -R 777 /php
 
-RUN composer require hamlet-framework/http-swoole:dev-master
-RUN composer require hamlet-framework/db-mysql-swoole:dev-master
-RUN composer update --no-dev
+RUN composer require hamlet-framework/http-swoole:dev-master --quiet
+RUN composer require hamlet-framework/db-mysql-swoole:dev-master --quiet
+RUN composer update --no-dev --quiet
 
 CMD php /php/swoole.php

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:19.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update -y \
-    && apt install -y gnupg ca-certificates apt-transport-https wget curl \
-    && wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add - \
-    && echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list \
-    && apt-get update -y \
-    && apt-get install -y nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+
+RUN apt-get install -yqq composer > /dev/null
 
 COPY deploy/fpm/php-fpm.conf /etc/php/7.3/fpm/php-fpm.conf
 COPY deploy/fpm/php.ini /etc/php/7.3/fpm/php.ini
@@ -17,8 +17,7 @@ WORKDIR /app
 
 RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer update --no-dev
+RUN composer update --no-dev --quiet
 
 CMD service php7.3-fpm start \
     && nginx -c /app/deploy/fpm/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/imi/imi.dockerfile
+++ b/frameworks/PHP/imi/imi.dockerfile
@@ -1,12 +1,12 @@
 FROM php:7.3
 
-RUN apt -yqq update
-RUN apt -yqq install git
+RUN pecl install swoole > /dev/null && \
+    docker-php-ext-enable swoole
 
 RUN docker-php-ext-install pdo_mysql > /dev/null
 
-RUN pecl install swoole-4.4.6
-RUN docker-php-ext-enable swoole
+RUN apt -yqq update > /dev/null && \
+    apt -yqq install git zip > /dev/null
 
 WORKDIR /imi
 
@@ -15,7 +15,7 @@ COPY . /imi
 RUN chmod -R ug+rwx /imi/.runtime
 
 RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN composer install --no-dev --classmap-authoritative
+RUN composer install --no-dev --classmap-authoritative --quiet > /dev/null
 RUN composer dumpautoload -o
 
 CMD php vendor/bin/imi server/start -name main

--- a/frameworks/PHP/imi/imi.dockerfile
+++ b/frameworks/PHP/imi/imi.dockerfile
@@ -6,7 +6,7 @@ RUN pecl install swoole > /dev/null && \
 RUN docker-php-ext-install pdo_mysql > /dev/null
 
 RUN apt -yqq update > /dev/null && \
-    apt -yqq install git zip > /dev/null
+    apt -yqq install git unzip > /dev/null
 
 WORKDIR /imi
 

--- a/frameworks/PHP/sw-fw-less/sw-fw-less.dockerfile
+++ b/frameworks/PHP/sw-fw-less/sw-fw-less.dockerfile
@@ -6,7 +6,7 @@ RUN pecl install swoole > /dev/null && \
 RUN docker-php-ext-install pdo_mysql > /dev/null
 
 RUN apt -yqq update > /dev/null && \
-    apt -yqq install git zip > /dev/null
+    apt -yqq install git unzip > /dev/null
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php \


### PR DESCRIPTION
Every time there are more frameworks using swoole, and exceed the maximum job time.

Change dockerfiles to use the docker cache.

Update php and swoole.

The `maintainer` line in dockerfile, also break the cache, so move it at the bottom.

Now all frameworks are using the same versions of php and swoole.

Use quiet mode, to remove verbosity noise.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
