### PR TITLE
Phoenix performance

### DIFF
--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -14,7 +14,7 @@ config :hello, Hello.Repo,
   password: "benchmarkdbpass",
   database: "hello_world",
   hostname: "tfb-database",
-  pool_size: 256
+  pool_size: 14
 
 config :logger,
   compile_time_purge_matching: [

--- a/frameworks/Elixir/phoenix/mix.exs
+++ b/frameworks/Elixir/phoenix/mix.exs
@@ -5,7 +5,7 @@ defmodule Hello.Mixfile do
     [
       app: :hello,
       version: "0.1.0",
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,

--- a/frameworks/Elixir/phoenix/phoenix.dockerfile
+++ b/frameworks/Elixir/phoenix/phoenix.dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.8.1
+FROM elixir:1.9.1
 
 ADD ./ /phoenix
 WORKDIR /phoenix

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -1,41 +1,40 @@
 defmodule Hello.PageController do
+  alias Hello.{Fortune, World}
+
   use Hello.Web, :controller
-  alias Hello.World
-  alias Hello.Fortune
+
+  @json "application/json"
+  @plain "text/plain"
 
   def index(conn, _params) do
     conn
-    |> put_resp_content_type("application/json", nil)
+    |> put_resp_content_type(@json, nil)
     |> send_resp(200, Jason.encode_to_iodata!(%{"TE Benchmarks\n" => "Started"}))
   end
 
   # avoid namespace collision
   def _json(conn, _params) do
     conn
-    |> put_resp_content_type("application/json", nil)
+    |> put_resp_content_type(@json, nil)
     |> send_resp(200, Jason.encode_to_iodata!(%{"message" => "Hello, world!"}))
   end
 
   def db(conn, _params) do
     conn
-    |> put_resp_content_type("application/json", nil)
+    |> put_resp_content_type(@json, nil)
     |> send_resp(200, Jason.encode_to_iodata!(Repo.get(World, :rand.uniform(10000))))
   end
 
   def queries(conn, params) do
-    q = try do
-      case String.to_integer(params["queries"]) do
-        x when x < 1    -> 1
-        x when x > 500  -> 500
-        x               -> x
-      end
-    rescue
-      ArgumentError -> 1
-    end
+    json =
+      params["queries"]
+      |> query_range()
+      |> parallel(fn _ -> Repo.get(World, :rand.uniform(10000)) end)
+      |> Jason.encode_to_iodata!()
 
     conn
-    |> put_resp_content_type("application/json", nil)
-    |> send_resp(200, Jason.encode_to_iodata!(for _ <- 1..q, do: Repo.get(World, :rand.uniform(10000))))
+    |> put_resp_content_type(@json, nil)
+    |> send_resp(200, json)
   end
 
   def fortunes(conn, _params) do
@@ -50,32 +49,45 @@ defmodule Hello.PageController do
   end
 
   def updates(conn, params) do
-    q = try do
-      case String.to_integer(params["queries"]) do
-        x when x < 1    -> 1
-        x when x > 500  -> 500
-        x               -> x
-      end
-    rescue
-      ArgumentError -> 1
-    end
-
-    data = for _ <- 1..q do
-      id = :rand.uniform(10000)
-      num = :rand.uniform(10000)
-      w = Repo.get(World, id)
-      changeset = Ecto.Changeset.change(w, randomnumber: num)
-      Repo.update!(changeset)
-    end
+    json =
+      params["queries"]
+      |> query_range()
+      |> parallel(fn _ ->
+          Repo.checkout(fn ->
+            World
+            |> Repo.get(:rand.uniform(10000))
+            |> Ecto.Changeset.change(randomnumber: :rand.uniform(10000))
+            |> Repo.update!()
+          end)
+        end)
+      |> Jason.encode_to_iodata!()
 
     conn
-    |> put_resp_content_type("application/json", nil)
-    |> send_resp(200, Jason.encode_to_iodata!(data))
+    |> put_resp_content_type(@json, nil)
+    |> send_resp(200, json)
   end
 
   def plaintext(conn, _params) do
     conn
-    |> put_resp_content_type("text/plain", nil)
+    |> put_resp_content_type(@plain, nil)
     |> send_resp(200, "Hello, world!")
+  end
+
+  defp parallel(collection, func) do
+    collection
+    |> Enum.map(&Task.async(fn -> func.(&1) end))
+    |> Enum.map(&Task.await(&1))
+  end
+
+  defp query_range(queries) do
+    try do
+      case String.to_integer(queries) do
+        x when x < 1    -> 1..1
+        x when x > 500  -> 1..500
+        x               -> 1..x
+      end
+    rescue
+      ArgumentError -> 1..1
+    end
   end
 end


### PR DESCRIPTION
@michalmuskala @josevalim Tested these changes on my local machine and saw a small bump in performance. 

Updated elixir to v1.9.1 which is self explanatory. Changed the SQL queries so that they can be run in parallel to show off the concurrency features of elixir.

We reduce the pool_size, since our storage is an SSD and we are running on 14 cores. More threads only perform better when there is blocking which is common with HDDs due to seeking with the spindle/platter, this doesn't exist with an SSD. Since we aren't blocking on I/O, we can't get more work done unless we add more cores to the processor. Therefore any open connections above the number of cores only adds to overhead and diminished performance. So we tune it to 14 which is what the TechEmpower people are using with their hardware. 