### PR TITLE
Use PDO exeption in errors

### DIFF
--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -9,7 +9,7 @@ $server->set([
 ]);
 
 $pdo = new PDO("mysql:host=tfb-database;dbname=hello_world", "benchmarkdbuser", "benchmarkdbpass", [
-    PDO::ATTR_PERSISTENT => true
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
 ]);
 
 /**
@@ -70,8 +70,8 @@ $fortunes = function () use ($pdo): string {
         $html .= "<tr><td>$id</td><td>$message</td></tr>";
     }
 
-    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'. 
-            $html.
+    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'
+            .$html.
             '</table></body></html>';
 };
 
@@ -148,11 +148,15 @@ $server->on('request', function (Request $req, Response $res) use ($db, $fortune
                 $res->header('Content-Type', 'application/json');
                 $res->end($updates((int) $req->get['queries'] ?? 1));
                 break;
+
+            default:
+                $res->status(404);
+                $res->end('Error 404');
         }
 
     } catch (\Throwable $e) {
         $res->status(500);
-        $res->end('code ' . $e->getCode(). 'msg: '. $e->getMessage());
+        $res->end('Error 500');
     }
 });
 


### PR DESCRIPTION
To avoid the anormal results in swoole-no-async db tests.
And disabled persistent db connection.
Hoping that now will show more errors, and lower the results numbers.

PD: possibly will not change anything.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
