### PR TITLE
Swoole using normal functions in no-async

### DIFF
--- a/frameworks/PHP/swoole/db-no-async.php
+++ b/frameworks/PHP/swoole/db-no-async.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * The DB test
+ *
+ * @param int $queries
+ *
+ * @return string
+ */
+function db(int $queries = 1) : string {
+    global $pdo;
+    if ( $queries === -1) {
+        $statement = $pdo->prepare("SELECT id,randomNumber FROM World WHERE id=?");
+        $statement->execute([mt_rand(1, 10000)]);
+        return json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
+    }
+    
+    // Read number of queries to run from URL parameter
+    $query_count = 1;
+    if ($queries > 1) {
+        $query_count = $queries > 500 ? 500 : $queries;
+    }
+
+    // Create an array with the response string.
+    $arr = [];
+    // Define query
+    $db = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+
+    // For each query, store the result set values in the response array
+    while ($query_count--) {
+        $db->execute([mt_rand(1, 10000)]);
+        $arr[] = $db->fetch(PDO::FETCH_ASSOC);
+    }
+
+    // Use the PHP standard JSON encoder.
+    // http://www.php.net/manual/en/function.json-encode.php
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+}
+
+/**
+ * The Fortunes test
+ *
+ * @return string
+ */
+function fortunes() : string {
+    global $pdo;
+    $fortune = [];
+    $db = $pdo->prepare('SELECT id, message FROM Fortune');
+    $db->execute();
+    $fortune = $db->fetchAll(PDO::FETCH_KEY_PAIR);
+
+    $fortune[0] = 'Additional fortune added at request time.';
+    asort($fortune);
+
+    $html = '';
+    foreach ($fortune as $id => $message) {
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+        $html .= "<tr><td>$id</td><td>$message</td></tr>";
+    }
+
+    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'
+            .$html.
+            '</table></body></html>';
+}
+
+/**
+ * The Updates test
+ *
+ * @param int $queries
+ *
+ * @return string
+ */
+function updates(int $queries) : string {
+    global $pdo;
+    $query_count = 1;
+    if ($queries > 1) {
+        $query_count = $queries > 500 ? 500 : $queries;
+    }
+
+    $statement       = $pdo->prepare("SELECT randomNumber FROM World WHERE id=?");
+    $updateStatement = $pdo->prepare("UPDATE World SET randomNumber=? WHERE id=?");
+
+    while ($query_count--) {
+        $id = mt_rand(1, 10000);
+        $statement->execute([$id]);
+
+        $world = ["id" => $id, "randomNumber" => $statement->fetchColumn()];
+        $updateStatement->execute(
+            [$world["randomNumber"] = mt_rand(1, 10000), $id]
+        );
+
+        $arr[] = $world;
+    }
+
+
+    return json_encode($arr, JSON_NUMERIC_CHECK);
+}

--- a/frameworks/PHP/swoole/swoole-no-async.dockerfile
+++ b/frameworks/PHP/swoole/swoole-no-async.dockerfile
@@ -5,8 +5,9 @@ RUN pecl install swoole > /dev/null && \
 
 RUN docker-php-ext-install pdo_mysql > /dev/null
 
+ADD ./ /swoole
 WORKDIR /swoole
-COPY swoole-server-noasync.php swoole-server-noasync.php
+
 COPY php.ini /usr/local/etc/php/
 
 CMD php swoole-server-noasync.php

--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -44,7 +44,7 @@ function db(int $queries = 1) : string {
     // http://www.php.net/manual/en/function.json-encode.php
 
     return json_encode($arr, JSON_NUMERIC_CHECK);
-};
+}
 
 /**
  * The Fortunes test
@@ -70,7 +70,7 @@ function fortunes() : string {
     return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'. 
             $html.
             '</table></body></html>';
-};
+}
 
 /**
  * The Updates test
@@ -103,7 +103,7 @@ function updates(int $queries) : string {
 
 
     return json_encode($arr, JSON_NUMERIC_CHECK);
-};
+}
 
 /**
  * On start of the PHP worker. One worker per server process is started.

--- a/frameworks/PHP/swoole/swoole-server-noasync.php
+++ b/frameworks/PHP/swoole/swoole-server-noasync.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__.'/db-no-async.php';
 
 use Swoole\Http\Request;
 use Swoole\Http\Response;
@@ -7,103 +8,6 @@ $server = new swoole_http_server('0.0.0.0', 8080, SWOOLE_BASE);
 $server->set([
     'worker_num' => swoole_cpu_num()
 ]);
-
-/**
- * The DB test
- *
- * @param int $queries
- *
- * @return string
- */
-function db(int $queries = 1) : string {
-    global $pdo;
-    if ( $queries === -1) {
-        $statement = $pdo->prepare("SELECT id,randomNumber FROM World WHERE id=?");
-        $statement->execute([mt_rand(1, 10000)]);
-        return json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
-    }
-    
-    // Read number of queries to run from URL parameter
-    $query_count = 1;
-    if ($queries > 1) {
-        $query_count = $queries > 500 ? 500 : $queries;
-    }
-
-    // Create an array with the response string.
-    $arr = [];
-    // Define query
-    $db = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
-
-    // For each query, store the result set values in the response array
-    while ($query_count--) {
-        $db->execute([mt_rand(1, 10000)]);
-        $arr[] = $db->fetch(PDO::FETCH_ASSOC);
-    }
-
-    // Use the PHP standard JSON encoder.
-    // http://www.php.net/manual/en/function.json-encode.php
-
-    return json_encode($arr, JSON_NUMERIC_CHECK);
-}
-
-/**
- * The Fortunes test
- *
- * @return string
- */
-function fortunes() : string {
-    global $pdo;
-    $fortune = [];
-    $db = $pdo->prepare('SELECT id, message FROM Fortune');
-    $db->execute();
-    $fortune = $db->fetchAll(PDO::FETCH_KEY_PAIR);
-
-    $fortune[0] = 'Additional fortune added at request time.';
-    asort($fortune);
-
-    $html = '';
-    foreach ($fortune as $id => $message) {
-        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
-        $html .= "<tr><td>$id</td><td>$message</td></tr>";
-    }
-
-    return '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>'. 
-            $html.
-            '</table></body></html>';
-}
-
-/**
- * The Updates test
- *
- * @param int $queries
- *
- * @return string
- */
-function updates(int $queries) : string {
-    global $pdo;
-    $query_count = 1;
-    if ($queries > 1) {
-        $query_count = $queries > 500 ? 500 : $queries;
-    }
-
-    $statement       = $pdo->prepare("SELECT randomNumber FROM World WHERE id=?");
-    $updateStatement = $pdo->prepare("UPDATE World SET randomNumber=? WHERE id=?");
-
-    while ($query_count--) {
-        $id = mt_rand(1, 10000);
-        $statement->execute([$id]);
-
-        $world = ["id" => $id, "randomNumber" => $statement->fetchColumn()];
-        $updateStatement->execute(
-            [$world["randomNumber"] = mt_rand(1, 10000), $id]
-        );
-
-        $arr[] = $world;
-    }
-
-
-    return json_encode($arr, JSON_NUMERIC_CHECK);
-}
 
 /**
  * On start of the PHP worker. One worker per server process is started.


### PR DESCRIPTION
Now don't use anonymous functions, so we can create the PDO instance in the workerStart.

Use PDO exeption in errors too. See #5157 and https://github.com/TechEmpower/FrameworkBenchmarks/pull/5157#pullrequestreview-302440407

This configuration is similar to the rest of event driven php platforms.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
