### PR TITLE
Update php-ngx to v0.20

### DIFF
--- a/frameworks/PHP/php-ngx/app-async.php
+++ b/frameworks/PHP/php-ngx/app-async.php
@@ -1,35 +1,89 @@
 <?php
-// Future app to use Mysql async pool 
+require_once '/ngx_php7/t/lib/mysql.php';
+define('DBIP', gethostbyname('localhost'));
+define('DB_HOST', gethostbyname('tfb-database'));
+define('DB_PORT', '3306');
+define('DB_USER', 'benchmarkdbuser');
+define('DB_PASS', 'benchmarkdbpass');
+define('DB_NAME', 'hello_world');
 
-require_once "/ngx_php7/t/lib/mysql.php";
-define("DB_HOST", gethostbyname("tfb-database"));
-define("DB_PORT", "3306");
-define("DB_USER", "benchmarkdbuser");
-define("DB_PASS", "benchmarkdbpass");
-define("DB_NAME", "hello_world");
 
 function fortune()
 {
+    ngx_header_set('Content-Type', 'text/html;charset=UTF-8');
     $my = new php\ngx\mysql();
     yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
-    $ret = yield from $my->query("SELECT id, message FROM Fortune");
-    
+    $ret = yield from $my->query('SELECT id, message FROM Fortune');
+
     $arr = [];
     foreach ($ret as $row) {
-            $arr[$row["id"]] = $row["message"];
+        $arr[$row['id']] = $row['message'];
     }
-    $arr[0] = "Additional fortune added at request time.";
+    $arr[0] = 'Additional fortune added at request time.';
     asort($arr);
-    
-    $html = "";
+
+    $html = '';
     foreach ($arr as $id => $message) {
-        $message = htmlspecialchars($message, ENT_QUOTES, "UTF-8");
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
         $html .= "<tr><td>$id</td><td>$message</td></tr>";
     }
+    echo '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>',
+        $html,
+        '</table></body></html>';
 
-    echo    "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>",
-            $html,
-            "</table></body></html>";
+    unset($my);
+}
 
-    yield from $my->close();
+function query()
+{
+    ngx_header_set('Content-Type', 'application/json');
+    $my = new php\ngx\mysql();
+    yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
+    $query_count = 1;
+    $params      = ngx_query_args();
+    if ($params['queries'] > 1) {
+        $query_count = $params['queries'] > 500 ? 500 : $params['queries'];
+    }
+    $arr = [];
+    while ($query_count--) {
+        $rand  = mt_rand(1, 10000);
+        $arr[] = (yield from $my->query("SELECT id,randomNumber FROM World WHERE id = {$rand}"))[0];
+    }
+    unset($my);
+    echo json_encode($arr);
+}
+
+function db()
+{
+    ngx_header_set('Content-Type', 'application/json');
+
+    $my = new php\ngx\mysql();
+    yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
+    $data = (yield from $my->query('SELECT id,randomNumber FROM World WHERE id = '.mt_rand(1, 10000)))[0];
+
+    unset($my);
+    echo json_encode($data);
+}
+
+function update()
+{
+    ngx_header_set('Content-Type', 'application/json');
+    $my = new php\ngx\mysql();
+    yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
+    $query_count = 1;
+    $params      = ngx_query_args();
+    if ($params['queries'] > 1) {
+        $query_count = $params['queries'] > 500 ? 500 : $params['queries'];
+    }
+    $arr = [];
+    while ($query_count--) {
+        $id                    = mt_rand(1, 10000);
+        $world                 = (yield from $my->query("SELECT id, randomNumber FROM World WHERE id = {$id}"))[0];
+        $world['id']           = $id;
+        $world['randomNumber'] = mt_rand(1, 10000);
+        yield from $my->query("UPDATE World SET randomNumber = {$world['randomNumber']} WHERE id = {$world['id']}");
+        $arr[] = $world;
+    }
+    unset($my);
+    echo json_encode($arr);
 }

--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -1,6 +1,5 @@
 <?php
 
-global $pdo;
 $pdo = new PDO("mysql:host=tfb-database;dbname=hello_world", "benchmarkdbuser", "benchmarkdbpass");
 
 

--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -1,13 +1,13 @@
 <?php
 
-$pdo = new PDO("mysql:host=tfb-database;dbname=hello_world", "benchmarkdbuser", "benchmarkdbpass");
+$pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass');
 
 
 function db()
 {
     global $pdo;
 
-    $statement = $pdo->prepare("SELECT id,randomNumber FROM World WHERE id=?");
+    $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 
     $statement->execute([mt_rand(1, 10000)]);
     echo json_encode($statement->fetch(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
@@ -17,11 +17,11 @@ function query()
 {
     global $pdo;
 
-    $statement = $pdo->prepare("SELECT id,randomNumber FROM World WHERE id=?");
+    $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 
     $query_count = 1;
-    if ($_GET["queries"] > 1) {
-        $query_count = min($_GET["queries"], 500);
+    if ($_GET['queries'] > 1) {
+        $query_count = min($_GET['queries'], 500);
     }
 
     while ($query_count--) {
@@ -36,20 +36,20 @@ function update()
 {
     global $pdo;
     $query_count = 1;
-    if ($_GET["queries"] > 1) {
-        $query_count = min($_GET["queries"], 500);
+    if ($_GET['queries'] > 1) {
+        $query_count = min($_GET['queries'], 500);
     }
 
-    $statement       = $pdo->prepare("SELECT randomNumber FROM World WHERE id=?");
-    $updateStatement = $pdo->prepare("UPDATE World SET randomNumber=? WHERE id=?");
+    $statement       = $pdo->prepare('SELECT randomNumber FROM World WHERE id=?');
+    $updateStatement = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
 
     while ($query_count--) {
         $id = mt_rand(1, 10000);
         $statement->execute([$id]);
 
-        $world = ["id" => $id, "randomNumber" => $statement->fetchColumn()];
+        $world = ['id' => $id, 'randomNumber' => $statement->fetchColumn()];
         $updateStatement->execute(
-            [$world["randomNumber"] = mt_rand(1, 10000), $id]
+            [$world['randomNumber'] = mt_rand(1, 10000), $id]
         );
 
         $arr[] = $world;
@@ -62,20 +62,20 @@ function fortune()
 {
     global $pdo;
 
-    $fortune = $pdo->prepare("SELECT id,message FROM Fortune");
+    $fortune = $pdo->prepare('SELECT id,message FROM Fortune');
     $fortune->execute();
 
     $arr    = $fortune->fetchAll(PDO::FETCH_KEY_PAIR);
-    $arr[0] = "Additional fortune added at request time.";
+    $arr[0] = 'Additional fortune added at request time.';
     asort($arr);
 
-    $html = "";
+    $html = '';
     foreach ($arr as $id => $message) {
-        $message = htmlspecialchars($message, ENT_QUOTES, "UTF-8");
+        $message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
         $html .= "<tr><td>$id</td><td>$message</td></tr>";
     }
 
-    echo    "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>",
+    echo    '<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>',
             $html,
-            "</table></body></html>";
+            '</table></body></html>';
 }

--- a/frameworks/PHP/php-ngx/benchmark_config.json
+++ b/frameworks/PHP/php-ngx/benchmark_config.json
@@ -46,7 +46,10 @@
       "versus": "php"
     },
     "async": {
+      "db_url": "/db",
+      "query_url": "/query?queries=",
       "fortune_url": "/fortune",
+      "update_url": "/update?queries=",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Platform",

--- a/frameworks/PHP/php-ngx/deploy/nginx_async.conf
+++ b/frameworks/PHP/php-ngx/deploy/nginx_async.conf
@@ -36,24 +36,27 @@ http {
 
         php_keepalive 200;
 
-        location = /hello {
-            add_header Content-Type text/plain;
-            content_by_php '
-                echo "Hello, World!";
+        location = /fortune {
+	        content_by_php '
+                yield from fortune();
             ';
         }
 
-        location = /json {
-            add_header Content-Type application/json;
+        location = /db {
             content_by_php '
-                echo json_encode(["message" => "Hello, World!"]);
+                yield from db();
             ';
         }
-        
-        location = /fortune {
-            add_header Content-Type "text/html; charset=UTF-8";
+
+        location /query {
 	        content_by_php '
-                yield from fortune();
+                yield from query();
+            ';
+        }
+
+        location /update {
+            content_by_php '
+                yield from update();
             ';
         }
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -13,7 +13,7 @@ ADD ./ ./
 
 ENV NGINX_VERSION=1.17.4
 
-RUN git clone -b v0.0.19 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.20 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -13,7 +13,7 @@ ADD ./ ./
 
 ENV NGINX_VERSION=1.17.4
 
-RUN git clone -b v0.0.19 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.20 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -13,7 +13,7 @@ ADD ./ ./
 
 ENV NGINX_VERSION=1.17.4
 
-RUN git clone -b v0.0.19 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.20 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \


### PR DESCRIPTION
Update php-ngx.
Now we can use single quotes ' versus only double " in the init. 
So we can include any library in the `init_worker`.

Add all tests to the async variant.

@rryqszq4 :+1: 

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
