### PR TITLE
Do not depend on .NET Core 2.2 deps in Giraffe

### DIFF
--- a/frameworks/FSharp/giraffe/src/App/App.fsproj
+++ b/frameworks/FSharp/giraffe/src/App/App.fsproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="Giraffe" Version="4.0.0" />
+    <PackageReference Include="Giraffe" Version="4.0.1" />
     <PackageReference Include="Npgsql" Version="4.1.0" />
     <PackageReference Update="FSharp.Core" Version="4.7" />
   </ItemGroup>


### PR DESCRIPTION
This fixes dependency inconsistencies in ASP.NET Core 3