### PR TITLE
Create the Contet-type header from php

### DIFF
--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -6,6 +6,7 @@ $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 
 function db()
 {
     global $pdo;
+    ngx_header_set('Content-Type', 'application/json');
 
     $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 
@@ -16,6 +17,7 @@ function db()
 function query()
 {
     global $pdo;
+    ngx_header_set('Content-Type', 'application/json');
 
     $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 
@@ -36,6 +38,8 @@ function query()
 function update()
 {
     global $pdo;
+    ngx_header_set('Content-Type', 'application/json');
+
     $query_count = 1;
     $params      = ngx::query_args()['queries'];
     if ($params > 1) {
@@ -63,6 +67,7 @@ function update()
 function fortune()
 {
     global $pdo;
+    ngx_header_set('Content-Type', 'text/html;charset=UTF-8');
 
     $fortune = $pdo->prepare('SELECT id,message FROM Fortune');
     $fortune->execute();

--- a/frameworks/PHP/php-ngx/deploy/nginx.conf
+++ b/frameworks/PHP/php-ngx/deploy/nginx.conf
@@ -37,42 +37,38 @@ http {
         php_keepalive 200;
 
         location = /hello {
-            add_header Content-Type text/plain;
             content_by_php '
+                ngx_header_set("Content-Type", "text/plain");
                 echo "Hello, World!";
             ';
         }
 
         location = /json {
-            add_header Content-Type application/json;
             content_by_php '
+                ngx_header_set("Content-Type", "application/json");
                 echo json_encode(["message" => "Hello, World!"]);
             ';
         }
         
         location = /fortune {
-            add_header Content-Type "text/html; charset=UTF-8";
 	        content_by_php '
                 fortune();
             ';
         }
 
         location = /db {
-            add_header Content-Type application/json;
             content_by_php '
                 db();
             ';
         }
 
         location /query {
-            add_header Content-Type application/json;
             content_by_php '
                 query();
             ';
         }
 
         location /update {
-            add_header Content-Type application/json;
             content_by_php '
                 update();
             ';


### PR DESCRIPTION
So nginx don't need to check the headers to add the Content-Type, for each req.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
