### PR TITLE
Enable Arm64 testing with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 #
 #
 
+arch: arm64
 sudo: required
 dist: xenial
 language: generic

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -1,3 +1,4 @@
+#
 from toolset.utils.output_helper import log, FNULL
 from toolset.utils.docker_helper import DockerHelper
 from toolset.utils.time_logger import TimeLogger

--- a/toolset/databases/mysql/my.cnf
+++ b/toolset/databases/mysql/my.cnf
@@ -23,7 +23,6 @@ socket          = /var/run/mysqld/mysqld.sock
 port            = 3306
 skip-external-locking
 skip-name-resolve
-lower_case_table_names = 1
 
 character-set-server=utf8
 collation-server=utf8_general_ci

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,11 +1,7 @@
-FROM buildpack-deps:bionic
+FROM buildpack-deps:eoan
 
 ADD create.sql create.sql
 ADD my.cnf my.cnf
-ADD mysql.list mysql.list
-
-RUN cp mysql.list /etc/apt/sources.list.d/
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8C718D3B5072E1F5
 
 RUN apt-get update > /dev/null
 RUN apt-get install -yqq locales > /dev/null
@@ -29,6 +25,7 @@ RUN rm -rf /ssd/mysql
 RUN rm -rf /ssd/log/mysql
 RUN cp -R -p /var/lib/mysql /ssd/
 RUN cp -R -p /var/log/mysql /ssd/log
+RUN install -dm755 /var/run/mysqld
 
 # It may seem weird that we call `service mysql start` several times, but the RUN
 # directive is a 1-time operation for building this image. Subsequent RUN calls

--- a/toolset/databases/mysql/mysql.list
+++ b/toolset/databases/mysql/mysql.list
@@ -1,7 +1,0 @@
-# You may comment out entries below, but any other modifications may be lost.
-# Use command 'dpkg-reconfigure mysql-apt-config' as root for modifications.
-deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-apt-config
-deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-8.0
-deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-tools
-#deb http://repo.mysql.com/apt/ubuntu/ bionic mysql-tools-preview
-deb-src http://repo.mysql.com/apt/ubuntu/ bionic mysql-8.0

--- a/toolset/databases/postgres/pgdg.list
+++ b/toolset/databases/postgres/pgdg.list
@@ -1,2 +1,0 @@
-deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
-deb-src http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -1,20 +1,15 @@
-FROM buildpack-deps:bionic
+FROM buildpack-deps:eoan
 
 ADD postgresql.conf postgresql.conf
 ADD pg_hba.conf pg_hba.conf
 ADD 60-postgresql-shm.conf 60-postgresql-shm.conf
 ADD create-postgres-database.sql create-postgres-database.sql
 ADD create-postgres.sql create-postgres.sql
-ADD pgdg.list pgdg.list
-
-# prepare PostgreSQL APT repository
-RUN cp pgdg.list /etc/apt/sources.list.d/
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN apt-get -yqq update > /dev/null
 RUN apt-get -yqq install locales
 
-ENV PG_VERSION 12
+ENV PG_VERSION 11
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/toolset/databases/postgres/postgresql.conf
+++ b/toolset/databases/postgres/postgresql.conf
@@ -40,13 +40,13 @@
 
 data_directory = '/ssd/postgresql'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/12/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/11/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/12/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/11/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/12-main.pid'		# write an extra PID file
+external_pid_file = '/var/run/postgresql/11-main.pid'		# write an extra PID file
 					# (change requires restart)
 
 


### PR DESCRIPTION
Now that Travis CI [supports](https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support) testing in an Arm64 environment, I thought that it would be an interesting experiment to see how much the Web frameworks actually worked in that case. My expectation is that anything using C/C++ or OpenJDK will pass, but I don't have any confidence in the rest. That's why I advise against merging this change - a, frankly speaking, minor platform should not be an impediment to testing in general.