### PR TITLE
Update postgres to v12

### DIFF
--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -14,7 +14,7 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
 RUN apt-get -yqq update > /dev/null
 RUN apt-get -yqq install locales
 
-ENV PG_VERSION 11
+ENV PG_VERSION 12
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/toolset/databases/postgres/postgresql.conf
+++ b/toolset/databases/postgres/postgresql.conf
@@ -40,13 +40,13 @@
 
 data_directory = '/ssd/postgresql'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/11/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/12/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/11/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/12/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/11-main.pid'		# write an extra PID file
+external_pid_file = '/var/run/postgresql/12-main.pid'		# write an extra PID file
 					# (change requires restart)
 
 


### PR DESCRIPTION
Now it's downloading posgres v12, but still harcoded to v11.
So my last PRs are failing.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
