### PR TITLE
Fix verification procedure freezing on Citrine

### DIFF
--- a/toolset/databases/abstract_database.py
+++ b/toolset/databases/abstract_database.py
@@ -90,8 +90,8 @@ class AbstractDatabase:
         cls.reset_cache(config)
         #Start siege requests
         path = config.db_root
-        process = PopenTimeout(shlex.split("siege -c %s -r %s %s -R %s/.siegerc" % (concurrency, count, url, path)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
-        output, _ = process.communicate(timeout=15)#timeout 15s if socket errors
+        process = PopenTimeout(shlex.split("siege -c %s -r %s %s -R %s/.siegerc" % (concurrency, count, url, path)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT, timeout=15)#timeout 15s if socket errors
+        output, _ = process.communicate()
         #Search for failed transactions
         match = re.search('Failed transactions:.*?(\d+)\n', output, re.MULTILINE)
         if match:

--- a/toolset/databases/abstract_database.py
+++ b/toolset/databases/abstract_database.py
@@ -106,23 +106,3 @@ class AbstractDatabase:
             rows_updated = int(cls.get_rows_updated(config)) - rows_updated
 
         return queries, rows, rows_updated, cls.margin, trans_failures
-
-    @classmethod
-    def run(cls, cmd, timeout):
-        done = Event()
-        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-
-        watcher = Thread(target=cls.kill_on_timeout, args=(done, timeout, proc))
-        watcher.daemon = True
-        watcher.start()
-
-        data, stderr = proc.communicate()
-        done.set()
-
-        return data
-
-    @staticmethod
-    def kill_on_timeout(done, timeout, proc):
-        if not done.wait(timeout):
-            proc.kill()
-

--- a/toolset/databases/abstract_database.py
+++ b/toolset/databases/abstract_database.py
@@ -88,9 +88,9 @@ class AbstractDatabase:
             rows_updated = int(cls.get_rows_updated(config))
 
         cls.reset_cache(config)
-        #Start siege requests
+        #Start siege requests with timeout (20s)
         path = config.db_root
-        process = PopenTimeout(shlex.split("siege -c %s -r %s %s -R %s/.siegerc" % (concurrency, count, url, path)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT, timeout=15)#timeout 15s if socket errors
+        process = PopenTimeout(shlex.split("siege -c %s -r %s %s -R %s/.siegerc" % (concurrency, count, url, path)), stdout = subprocess.PIPE, stderr = subprocess.STDOUT, timeout=20)
         output, _ = process.communicate()
         #Search for failed transactions
         match = re.search('Failed transactions:.*?(\d+)\n', output, re.MULTILINE)

--- a/toolset/utils/popen.py
+++ b/toolset/utils/popen.py
@@ -1,0 +1,85 @@
+import subprocess
+import time
+import select
+import os
+
+class PopenTimeout(subprocess.Popen):
+    '''
+    Popen class with timeout for Python 2.7
+    see https://stackoverflow.com/questions/1191374/using-module-subprocess-with-timeout
+    '''
+    def communicate(self, input=None, timeout=None):
+        if timeout is None:
+            return subprocess.Popen.communicate(self, input)
+
+        if self.stdin:
+            # Flush stdio buffer, this might block if user
+            # has been writing to .stdin in an uncontrolled
+            # fashion.
+            self.stdin.flush()
+            if not input:
+                self.stdin.close()
+
+        read_set, write_set = [], []
+        stdout = stderr = None
+
+        if self.stdin and input:
+            write_set.append(self.stdin)
+        if self.stdout:
+            read_set.append(self.stdout)
+            stdout = []
+        if self.stderr:
+            read_set.append(self.stderr)
+            stderr = []
+
+        input_offset = 0
+        deadline = time.time() + timeout
+
+        while read_set or write_set:
+            try:
+                rlist, wlist, xlist = select.select(read_set, write_set, [], max(0, deadline - time.time()))
+            except select.error as ex:
+                if ex.args[0] == errno.EINTR:
+                    continue
+                raise
+
+            if not (rlist or wlist):
+                # Just break if timeout
+                # Since we do not close stdout/stderr/stdin, we can call
+                # communicate() several times reading data by smaller pieces.
+                break
+
+            if self.stdin in wlist:
+                chunk = input[input_offset:input_offset + subprocess._PIPE_BUF]
+                try:
+                    bytes_written = os.write(self.stdin.fileno(), chunk)
+                except OSError as ex:
+                    if ex.errno == errno.EPIPE:
+                        self.stdin.close()
+                        write_set.remove(self.stdin)
+                    else:
+                        raise
+                else:
+                    input_offset += bytes_written
+                    if input_offset >= len(input):
+                        self.stdin.close()
+                        write_set.remove(self.stdin)
+
+            # Read stdout / stderr by 1024 bytes
+            for fn, tgt in (
+                (self.stdout, stdout),
+                (self.stderr, stderr),
+            ):
+                if fn in rlist:
+                    data = os.read(fn.fileno(), 1024)
+                    if data == '':
+                        fn.close()
+                        read_set.remove(fn)
+                    tgt.append(data)
+
+        if stdout is not None:
+            stdout = ''.join(stdout)
+        if stderr is not None:
+            stderr = ''.join(stderr)
+
+        return (stdout, stderr)


### PR DESCRIPTION
#### Fix verification blocking during `siege` execution
The verification process may be blocked due to errors issued during the execution of  `siege` requests.

This is currently the case with the verification of **akka-http-slick-postgres** which emits errors:

>[alert] HTTP: unable to determine chunk size
[alert] HTTP: unable to determine chunk size
[alert] HTTP: unable to determine chunk size
[alert] HTTP: unable to determine chunk size
[alert] HTTP: unable to determine chunk size
[alert] HTTP: unable to determine chunk size

 and crashes the verification process. -> see https://github.com/TechEmpower/FrameworkBenchmarks/pull/5145#issuecomment-549007885

The reason why the run on Citrine is currently blocked:

![image](https://user-images.githubusercontent.com/2511052/68072880-e02efa00-fd8a-11e9-8647-9e172b166710.png)
