### PR TITLE
Revert to Utf8Json for serialization

### DIFF
--- a/frameworks/FSharp/giraffe/src/App/Custom.fs
+++ b/frameworks/FSharp/giraffe/src/App/Custom.fs
@@ -44,12 +44,13 @@ let application : HttpHandler =
     let inline contentLength x = new Nullable<int64> ( int64 x )
 
     let json' data : HttpHandler =
+        let bytes = Utf8Json.JsonSerializer.Serialize(data)
         fun _ ctx -> 
-            ctx.Response.ContentLength <- contentLength BufferSize
+            ctx.Response.ContentLength <- contentLength bytes.Length
             ctx.Response.ContentType <- "application/json"
             ctx.Response.StatusCode <- 200
             task {
-                do! System.Text.Json.JsonSerializer.SerializeAsync(ctx.Response.Body, data)
+                do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
                 return Some ctx
             }
 


### PR DESCRIPTION
Reverting back to Utf8Json serialization as benchmarks have shown it to be faster than `System.Text.Json`, Zebra for example is still using Utf8Json and performing very well.