### PR TITLE
PHP adjust emulated prepares default in the databases

### DIFF
--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -1,7 +1,9 @@
 <?php
 
 $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world', 'benchmarkdbuser', 'benchmarkdbpass',
-            [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+            [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES   => false]
+        );
 $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 $fortune = $pdo->prepare('SELECT id,message FROM Fortune');
 

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -12,7 +12,9 @@ $http_worker->onWorkerStart = function () {
     global $pdo, $fortune, $statement;
     $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',
         'benchmarkdbuser', 'benchmarkdbpass',
-        [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC]);
+        [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false]
+    );
     $fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
     $statement = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
 };


### PR DESCRIPTION
### Different defaults in mysql and postresql
By default MySQL use always emulated prepares and PostreSQL native server-side prepares if the cursor is not scrollable.

### Where does this affect
#### php-fpm
In the updates and multiple queries using prepared statements, Postres it's faster as it's using native prepares.
Using native prepared statements for a single query, send 2 round trips to the database, and will be slower. We can't reuse the prepared statements in different requests.
In the single and fortune both use query() without prepared statements.

#### Cli-servers (workerman, php-ngx, ... )
When created the prepared statement once, PostreSql is always faster for using native prepares.
MySQL send a new query every time without the benefit of the server-side prepares.

When created the statement in each request, PostreSQL is slower (~50%) as it need always 2 round trips to database (1 prepare query and 1 execute query).
And MySQL is faster as only send one query.

Now will use both no emulated prepared statements in the first case.
We will check which database is faster using native prepared statements.

### TODO in next PRs

- Change Swoole no async (swoole async don't have this problem)
- Remake updates and multiple queries in all cases.




<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
