### PR TITLE
Fix grizzly-jersey cache pb

### DIFF
--- a/frameworks/Java/grizzly/src-jersey/main/java/hello/WorldResource.java
+++ b/frameworks/Java/grizzly/src-jersey/main/java/hello/WorldResource.java
@@ -59,7 +59,7 @@ public class WorldResource {
 			try {
 		        //Pick unique random numbers 
 		        final AtomicInteger i = new AtomicInteger(0);
-		        ThreadLocalRandom.current().ints(1, 10000).distinct().limit(queries).forEach(
+		        ThreadLocalRandom.current().ints(1, 10001).distinct().limit(queries).forEach(
 		            (randomValue)->worlds[i.getAndAdd(1)] = (World) session.byId(World.class).load(randomValue)
 		        );
 				return worlds;
@@ -89,7 +89,7 @@ public class WorldResource {
 
 				// 1. Read and update the entities from the DB
 		        final AtomicInteger ii = new AtomicInteger(0);
-		        ThreadLocalRandom.current().ints(1, 10000).distinct().limit(queries).forEach(
+		        ThreadLocalRandom.current().ints(1, 10001).distinct().limit(queries).forEach(
 		            (randomValue)->{
 		            		final World world = (World) session.byId(World.class).load(randomValue);
 		            		world.setRandomNumber(randomWorld());

--- a/frameworks/Java/grizzly/src-jersey/main/java/hello/WorldResource.java
+++ b/frameworks/Java/grizzly/src-jersey/main/java/hello/WorldResource.java
@@ -4,6 +4,7 @@ import hello.domain.World;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -56,9 +57,11 @@ public class WorldResource {
 			Session session = emf.createEntityManager().unwrap(Session.class);
 			session.setDefaultReadOnly(true);
 			try {
-				for (int i = 0; i < queries; i++) {
-					worlds[i] = (World) session.byId(World.class).load(randomWorld());
-				}
+		        //Pick unique random numbers 
+		        final AtomicInteger i = new AtomicInteger(0);
+		        ThreadLocalRandom.current().ints(1, 10000).distinct().limit(queries).forEach(
+		            (randomValue)->worlds[i.getAndAdd(1)] = (World) session.byId(World.class).load(randomValue)
+		        );
 				return worlds;
 			} finally {
 				session.close();
@@ -85,13 +88,16 @@ public class WorldResource {
 				// in the configuration file
 
 				// 1. Read and update the entities from the DB
-				for (int i = 0; i < queries; i++) {
-					final World world = (World) session.byId(World.class).load(randomWorld());
-					world.setRandomNumber(randomWorld());
-					worlds[i] = world;
-				}
+		        final AtomicInteger ii = new AtomicInteger(0);
+		        ThreadLocalRandom.current().ints(1, 10000).distinct().limit(queries).forEach(
+		            (randomValue)->{
+		            		final World world = (World) session.byId(World.class).load(randomValue);
+		            		world.setRandomNumber(randomWorld());
+		            		worlds[ii.getAndAdd(1)]=world;
+		            	}
+		        );
 
-				// 2. Sort the array to prevent transaction deadlock in the DB
+		        // 2. Sort the array to prevent transaction deadlock in the DB
 				Arrays.sort(worlds, Comparator.comparingInt(World::getId));
 
 				// 3. Actually save the entities


### PR DESCRIPTION
#### Fixed
- **Hibernate** first-level cache problem (with the random selection of ids to be loaded from the database) see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5222 and https://github.com/TechEmpower/FrameworkBenchmarks/pull/5145#issuecomment-544735202

see [failure](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/grizzly-jersey) in last run

@nbrady-techempower @michaelhixson  @zloster 
I left the `atomicCounter` version for now. We will have to try the [primitiveSet](https://github.com/michaelhixson/jmh-benchmark-tfb-world-ids/blob/18421109bad30bf8d7b2cc4bf317739ea2f8c768/src/main/java/rnd/WorldIdsBenchmark.java#L109) version on another run.

