### PR TITLE
Update MySQL JDBC driver to 8.0.18

### DIFF
--- a/frameworks/Clojure/compojure/project.clj
+++ b/frameworks/Clojure/compojure/project.clj
@@ -7,7 +7,7 @@
                  [ring/ring-json "0.4.0"]
                  [korma "0.5.0-RC1"]
                  [log4j "1.2.15" :exclusions [javax.mail/mail javax.jms/jms com.sun.jdmk/jmxtools com.sun.jmx/jmxri]]
-                 [mysql/mysql-connector-java "5.1.47"]
+                 [mysql/mysql-connector-java "8.0.18"]
                  [com.mchange/c3p0 "0.9.5.4"]
                  [org.clojure/java.jdbc "0.7.9"]
                  [hikari-cp "1.8.3"]

--- a/frameworks/Clojure/compojure/src/hello/handler.clj
+++ b/frameworks/Clojure/compojure/src/hello/handler.clj
@@ -27,9 +27,9 @@
 ;; MySQL database connection
 (defdb db-mysql
   (mysql {
-          :classname "com.mysql.jdbc.Driver"
+          :classname "com.mysql.cj.jdbc.Driver"
           :subprotocol "mysql"
-          :subname "//tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
+          :subname "//tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false"
           :user "benchmarkdbuser"
           :password "benchmarkdbpass"
           ;;OPTIONAL KEYS
@@ -48,7 +48,9 @@
                     :minimum-idle       10
                     :maximum-pool-size  512
                     :pool-name          "db-pool"
-                    :jdbc-url           "jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
+                    :driver-class-name  "com.mysql.cj.jdbc.Driver"
+                    :datasource-class-name "com.mysql.cj.jdbc.MysqlDataSource"
+                    :jdbc-url           "jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false"
                     :username           "benchmarkdbuser"
                     :password           "benchmarkdbpass"
                     :register-mbeans    false}))

--- a/frameworks/Clojure/pedestal/project.clj
+++ b/frameworks/Clojure/pedestal/project.clj
@@ -8,7 +8,7 @@
                  [io.pedestal/pedestal.jetty "0.5.2"]
                  [org.clojure/java.jdbc "0.4.2"]
                  [korma "0.4.2"]
-                 [mysql/mysql-connector-java "5.1.47"]
+                 [mysql/mysql-connector-java "8.0.18"]
                  [com.zaxxer/HikariCP "2.5.1" :exclusions [[org.slf4j/slf4j-api]]]
                  [hiccup "1.0.5"]]
   :min-lein-version "2.0.0"

--- a/frameworks/Clojure/pedestal/src/pedestal/service.clj
+++ b/frameworks/Clojure/pedestal/src/pedestal/service.clj
@@ -32,7 +32,7 @@
   (mysql {
     :classname "com.mysql.jdbc.Driver"
     :subprotocol "mysql"
-    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
+    :subname "//127.0.0.1:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false"
     :user "benchmarkdbuser"
     :password "benchmarkdbpass"
     ;;OPTIONAL KEYS

--- a/frameworks/Java/activeweb/pom.xml
+++ b/frameworks/Java/activeweb/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>8.0.18</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/frameworks/Java/activeweb/src/main/java/app/config/DbConfig.java
+++ b/frameworks/Java/activeweb/src/main/java/app/config/DbConfig.java
@@ -37,15 +37,15 @@ public class DbConfig extends AbstractDBConfig {
                 "&useUnbufferedInput=false" +
                 "&useReadAheadInput=false" +
                 "&maintainTimeStats=false" +
-                "&useServerPrepStmts" +
+                "&useServerPrepStmts=true" +
                 "&cacheRSMetadata=true" +
                 "&useSSL=false";
 
         environment("development").jndi("java:comp/env/jdbc/hello_world");
 
         //need to set ACTIVE_ENV=local to run on dev box.
-        environment("local").jdbc("com.mysql.jdbc.Driver", "jdbc:mysql://tfb-database/hello_world?" + jdbcParams, "benchmarkdbuser", "benchmarkdbpass");
+        environment("local").jdbc("com.mysql.cj.jdbc.Driver", "jdbc:mysql://tfb-database/hello_world?" + jdbcParams, "benchmarkdbuser", "benchmarkdbpass");
 
-        environment("development").testing().jdbc("com.mysql.jdbc.Driver", "jdbc:mysql://tfb-database/hello_world?" + jdbcParams, "benchmarkdbuser", "benchmarkdbpass");
+        environment("development").testing().jdbc("com.mysql.cj.jdbc.Driver", "jdbc:mysql://tfb-database/hello_world?" + jdbcParams, "benchmarkdbuser", "benchmarkdbpass");
     }
 }

--- a/frameworks/Java/activeweb/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/activeweb/src/main/webapp/WEB-INF/resin-web.xml
@@ -2,11 +2,10 @@
 
 <database jndi-name='jdbc/hello_world'>
   <driver>
-    <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</url>
+    <type>com.mysql.cj.jdbc.MysqlConnectionPoolDataSource</type>
+    <url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
-    <useUnicode/>
   </driver>
 </database>
 

--- a/frameworks/Java/blade/pom.xml
+++ b/frameworks/Java/blade/pom.xml
@@ -18,7 +18,7 @@
         <netty.version>4.1.36.Final</netty.version>
         <anima.version>0.2.6</anima.version>
         <hikaricp.version>3.3.1</hikaricp.version>
-        <mysql-conn.version>5.1.47</mysql-conn.version>
+        <mysql-conn.version>8.0.18</mysql-conn.version>
         <blade-jetbrick.version>0.1.3</blade-jetbrick.version>
         <jetbrick-version>2.1.10</jetbrick-version>
     </properties>

--- a/frameworks/Java/blade/src/main/resources/application.properties
+++ b/frameworks/Java/blade/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-jdbc.url=jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
+jdbc.url=jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false
 jdbc.username=benchmarkdbuser
 jdbc.password=benchmarkdbpass
 

--- a/frameworks/Java/dropwizard/hello-world-mysql.yml
+++ b/frameworks/Java/dropwizard/hello-world-mysql.yml
@@ -20,7 +20,7 @@ logging:
 
 database:
   # the name of your JDBC driver
-  driverClass: com.mysql.jdbc.Driver
+  driverClass: com.mysql.cj.jdbc.Driver
 
   # the username
   user: benchmarkdbuser
@@ -29,12 +29,12 @@ database:
   password: benchmarkdbpass
 
   # the JDBC URL
-  url: jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
+  url: jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false
 
   # any properties specific to your JDBC driver:
   properties:
     charSet: UTF-8
-    hibernate.dialect: org.hibernate.dialect.MySQLDialect
+    hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
     # enable batch updates in Hibernate
     hibernate.jdbc.batch_size: 30
     hibernate.jdbc.batch_versioned_data: true

--- a/frameworks/Java/dropwizard/pom.xml
+++ b/frameworks/Java/dropwizard/pom.xml
@@ -17,7 +17,7 @@
 		<dropwizard.version>1.3.12</dropwizard.version>
 		<javax-activation.version>1.1.1</javax-activation.version>
 		<jaxb.version>2.3.0</jaxb.version>
-		<mysql-connector-java.version>5.1.47</mysql-connector-java.version>
+		<mysql-connector-java.version>8.0.18</mysql-connector-java.version>
 		<mongojack.version>2.9.4</mongojack.version>
 		<postgres-jdbc.version>42.2.5</postgres-jdbc.version>
 		<maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>

--- a/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/HelloWorldService.java
+++ b/frameworks/Java/dropwizard/src/main/java/com/example/helloworld/HelloWorldService.java
@@ -40,7 +40,7 @@ public class HelloWorldService extends Application<HelloWorldConfiguration> {
 
     @Override
     public void run(HelloWorldConfiguration config, Environment environment) throws UnknownHostException {
-        if ("com.mysql.jdbc.Driver".equals(config.getDatabaseConfiguration().getDriverClass())) { // register below for default dropwizard test only
+        if ("com.mysql.cj.jdbc.Driver".equals(config.getDatabaseConfiguration().getDriverClass())) { // register below for default dropwizard test only
             environment.jersey().register(new JsonResource()); // Test type 1: JSON serialization
             environment.jersey().register(new TextResource()); // Test type 6: Plaintext
         }

--- a/frameworks/Java/gemini/pom.xml
+++ b/frameworks/Java/gemini/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.47</version>
+            <version>8.0.18</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/frameworks/Java/gemini/src/main/webapp/WEB-INF/configuration/gemini-mysql.conf
+++ b/frameworks/Java/gemini/src/main/webapp/WEB-INF/configuration/gemini-mysql.conf
@@ -87,7 +87,7 @@ db.Driver.SupportsAbsolute = yes
 db.Driver.SupportsGetRow = yes
 db.Driver.Jdbc1 = no
 
-db.ConnectString = tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false
+db.ConnectString = tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts=true&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false
 db.LoginName = benchmarkdbuser
 db.LoginPass = benchmarkdbpass
 

--- a/frameworks/Java/grizzly/pom-jersey.xml
+++ b/frameworks/Java/grizzly/pom-jersey.xml
@@ -28,7 +28,7 @@
 		<maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
 		<maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
 		<mustache.version>0.9.6</mustache.version>
-		<mysql-connector.version>5.1.47</mysql-connector.version>
+		<mysql-connector.version>8.0.18</mysql-connector.version>
 	</properties>
 
 	<dependencies>

--- a/frameworks/Java/grizzly/src-jersey/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/grizzly/src-jersey/main/resources/META-INF/persistence.xml
@@ -11,7 +11,7 @@
 		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 		<properties>
 			<property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect" />
 			<property name="hibernate.cache.use_query_cache" value="false" />
 			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.jdbc.batch_size" value="30" />
@@ -19,8 +19,8 @@
 			<property name="hibernate.hikari.minimumIdle" value="192" />
 			<property name="hibernate.hikari.maximumPoolSize" value="192" />
 			<property name="hibernate.hikari.idleTimeout" value="30000" />
-			<property name="hibernate.hikari.dataSourceClassName" value="com.mysql.jdbc.jdbc2.optional.MysqlDataSource" />
-			<property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false" />
+			<property name="hibernate.hikari.dataSourceClassName" value="com.mysql.cj.jdbc.MysqlDataSource" />
+			<property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false" />
 			<property name="hibernate.hikari.dataSource.user" value="benchmarkdbuser" />
 			<property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" />
 			<property name="hibernate.show_sql" value="false" />

--- a/frameworks/Java/light-java/pom.xml
+++ b/frameworks/Java/light-java/pom.xml
@@ -27,7 +27,7 @@
         <version.logback>1.2.3</version.logback>
         <version.undertow>2.0.21.Final</version.undertow>
         <version.hikaricp>3.3.1</version.hikaricp>
-        <version.mysql>5.1.47</version.mysql>
+        <version.mysql>8.0.18</version.mysql>
         <version.postgres>42.2.5</version.postgres>
         <version.dsl-json>1.8.4</version.dsl-json>
         <version.mustache>0.9.6</version.mustache>

--- a/frameworks/Java/minijax/pom.xml
+++ b/frameworks/Java/minijax/pom.xml
@@ -14,7 +14,7 @@
         <eclipselink.version>2.7.4</eclipselink.version>
         <jpa.version>2.2.1</jpa.version>
         <minijax.version>0.3.14</minijax.version>
-        <mysql-connector.version>6.0.6</mysql-connector.version>
+        <mysql-connector.version>8.0.18</mysql-connector.version>
         <shade.version>3.1.0</shade.version>
     </properties>
     <dependencies>

--- a/frameworks/Java/ninja-standalone/pom.xml
+++ b/frameworks/Java/ninja-standalone/pom.xml
@@ -23,7 +23,7 @@
         <hibernate-validator.version>6.0.9.Final</hibernate-validator.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
-        <mysql.version>5.1.47</mysql.version>
+        <mysql.version>8.0.18</mysql.version>
         <ninja.version>6.5.0</ninja.version>
         <xml-apis.version>2.0.2</xml-apis.version>
     </properties>

--- a/frameworks/Java/ninja-standalone/src/main/java/conf/application.conf
+++ b/frameworks/Java/ninja-standalone/src/main/java/conf/application.conf
@@ -31,7 +31,7 @@ application.session.transferred_over_https_only=false
 ninja.migration.run=false
 
 %prod.ninja.jpa.persistence_unit_name = mysql
-%prod.db.connection.url=jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false
+%prod.db.connection.url=jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false
 %prod.db.connection.username=benchmarkdbuser
 %prod.db.connection.password=benchmarkdbpass
 

--- a/frameworks/Java/ninja-standalone/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/ninja-standalone/src/main/resources/META-INF/persistence.xml
@@ -7,8 +7,8 @@
   <persistence-unit name="mysql" transaction-type="RESOURCE_LOCAL">
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <properties>
-      <property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
-      <property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
+      <property name="hibernate.connection.driver_class" value="com.mysql.cj.jdbc.Driver" />
+      <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect" />
       <property name="hibernate.show_sql" value="false" />
       <property name="hibernate.format_sql" value="false" />
       <property name="hibernate.jdbc.batch_size" value="100" />
@@ -17,9 +17,11 @@
       <property name="hibernate.hikari.minimumIdle" value="256" />
       <property name="hibernate.hikari.maximumPoolSize" value="256" />
       <property name="hibernate.hikari.idleTimeout" value="30000" />
-      <property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?useSSL=false&amp;jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true" />
+
+<!-- It seems these settings are comming from the application.conf -->
+ <!--     <property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?useSSL=false&amp;jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true" />
       <property name="hibernate.hikari.dataSource.user" value="benchmarkdbuser" />
-      <property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" />
+      <property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" /> -->
     </properties>
   </persistence-unit>
 

--- a/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-ebean-hikaricp/build.sbt
@@ -9,5 +9,5 @@ scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   guice,
   javaJdbc,
-  "mysql" % "mysql-connector-java" % "5.1.47"
+  "mysql" % "mysql-connector-java" % "8.0.18"
 )

--- a/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jooq-hikaricp/build.sbt
@@ -11,6 +11,6 @@ val jOOQVersion = "3.10.3"
 libraryDependencies ++= Seq(
   guice,
   javaJdbc,
-  "mysql" % "mysql-connector-java" % "5.1.47",
+  "mysql" % "mysql-connector-java" % "8.0.18",
   "org.jooq" % "jooq" % jOOQVersion,
 )

--- a/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
+++ b/frameworks/Java/play2-java/play2-java-jpa-hikaricp/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   guice,
   javaJpa,
-  "mysql" % "mysql-connector-java" % "5.1.47",
+  "mysql" % "mysql-connector-java" % "8.0.18",
   "org.hibernate" % "hibernate-core" % "5.4.1.Final"
 )
 

--- a/frameworks/Java/proteus/pom.xml
+++ b/frameworks/Java/proteus/pom.xml
@@ -247,7 +247,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.18</version>
 		</dependency>
 	  	<dependency>
 			<groupId>org.postgresql</groupId>

--- a/frameworks/Java/rapidoid/pom.xml
+++ b/frameworks/Java/rapidoid/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.18</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/frameworks/Java/restexpress/pom.xml
+++ b/frameworks/Java/restexpress/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.18</version>
 		</dependency>
 	</dependencies>
 

--- a/frameworks/Java/restexpress/src/main/java/hello/config/MysqlConfig.java
+++ b/frameworks/Java/restexpress/src/main/java/hello/config/MysqlConfig.java
@@ -7,7 +7,7 @@ import javax.sql.DataSource;
 import org.apache.commons.dbcp.datasources.SharedPoolDataSource;
 import org.restexpress.common.exception.ConfigurationException;
 
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 
 public class MysqlConfig {
 	private static final String PREFIX = "mysql.";
@@ -52,7 +52,11 @@ public class MysqlConfig {
 		}
 
 		if (useConfigs != null) {
-			ds.setUseConfigs(useConfigs);
+			try {
+				ds.setUseConfigs(useConfigs);
+			} catch (java.sql.SQLException e) {
+				throw new ConfigurationException("Unable to set DataSource config", e);
+			}
 		}
 		return ds;
 	}

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -131,7 +131,7 @@
 				<dependency>
 					<groupId>mysql</groupId>
 					<artifactId>mysql-connector-java</artifactId>
-					<version>5.1.47</version>
+					<version>8.0.18</version>
 				</dependency>
 			</dependencies>
 			<build>

--- a/frameworks/Java/servlet/src/main/resources/WEB-INF/mysql/resin-web.xml
+++ b/frameworks/Java/servlet/src/main/resources/WEB-INF/mysql/resin-web.xml
@@ -2,13 +2,12 @@
 
 	<database jndi-name='jdbc/hello_world'>
 		<driver>
-			<type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource
+			<type>com.mysql.cj.jdbc.MysqlConnectionPoolDataSource
 			</type>
-			<url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false
+			<url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false
 			</url>
 			<user>benchmarkdbuser</user>
 			<password>benchmarkdbpass</password>
-			<useUnicode />
 		</driver>
 	</database>
 

--- a/frameworks/Java/spark/pom.xml
+++ b/frameworks/Java/spark/pom.xml
@@ -15,7 +15,7 @@
         <spark-version>2.9.0</spark-version>
         <hibernate-version>5.4.2.Final</hibernate-version>
         <gson-version>2.8.5</gson-version>
-        <mysql-connector-version>5.1.47</mysql-connector-version>
+        <mysql-connector-version>8.0.18</mysql-connector-version>
         <slf4j-version>1.7.25</slf4j-version>
         <exec.mainClass>hello.web.SparkApplication</exec.mainClass>
     </properties>

--- a/frameworks/Java/spark/src/main/resources/hibernate-local.cfg.xml
+++ b/frameworks/Java/spark/src/main/resources/hibernate-local.cfg.xml
@@ -4,7 +4,7 @@
 <hibernate-configuration>
     <session-factory>
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="hibernate.connection.url">jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</property>
+        <property name="hibernate.connection.url">jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false</property>
         <property name="hibernate.connection.username">benchmarkdbuser</property>
         <property name="hibernate.connection.password">benchmarkdbpass</property>
     </session-factory>

--- a/frameworks/Java/tapestry/pom.xml
+++ b/frameworks/Java/tapestry/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
           <groupId>mysql</groupId>
           <artifactId>mysql-connector-java</artifactId>
-          <version>5.1.47</version>
+          <version>8.0.18</version>
         </dependency>
 
         <!-- This adds automatic compression of JavaScript and CSS when in production mode. -->

--- a/frameworks/Java/tapestry/src/main/webapp/WEB-INF/resin-web.xml
+++ b/frameworks/Java/tapestry/src/main/webapp/WEB-INF/resin-web.xml
@@ -2,11 +2,10 @@
 
 <database jndi-name='jdbc/hello_world'>
   <driver>
-    <type>com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource</type>
-    <url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false</url>
+    <type>com.mysql.cj.jdbc.MysqlConnectionPoolDataSource</type>
+    <url>jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false</url>
     <user>benchmarkdbuser</user>
     <password>benchmarkdbpass</password>
-    <useUnicode/>
   </driver>
 </database>
 

--- a/frameworks/Java/undertow-jersey/pom.xml
+++ b/frameworks/Java/undertow-jersey/pom.xml
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.47</version>
+      <version>8.0.18</version>
     </dependency>
 
     <dependency>

--- a/frameworks/Java/undertow-jersey/src/main/resources/META-INF/persistence.xml
+++ b/frameworks/Java/undertow-jersey/src/main/resources/META-INF/persistence.xml
@@ -20,9 +20,9 @@
 			<property name="hibernate.c3p0.max_size" value="192" />
 			<property name="hibernate.c3p0.timeout" value="1800" />
 			<property name="hibernate.c3p0.max_statements" value="2048" />
-			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
-			<property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
-			<property name="hibernate.connection.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect" />
+			<property name="hibernate.connection.driver_class" value="com.mysql.cj.jdbc.Driver" />
+			<property name="hibernate.connection.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false" />
 			<property name="hibernate.connection.username" value="benchmarkdbuser" />
 			<property name="hibernate.connection.password" value="benchmarkdbpass" />
 		</properties>

--- a/frameworks/Java/undertow-jersey/src/main/resources/hikarycp/META-INF/persistence.xml
+++ b/frameworks/Java/undertow-jersey/src/main/resources/hikarycp/META-INF/persistence.xml
@@ -20,9 +20,9 @@
 			<property name="hibernate.hikari.maximumPoolSize" value="192" />
 			<property name="hibernate.hikari.idleTimeout" value="30000" />
 			<property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider" />
-			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQLDialect" />
-			<property name="hibernate.hikari.dataSourceClassName" value="com.mysql.jdbc.jdbc2.optional.MysqlDataSource" />
-			<property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts&amp;cacheRSMetadata=true&amp;useSSL=false" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect" />
+			<property name="hibernate.hikari.dataSourceClassName" value="com.mysql.cj.jdbc.MysqlDataSource" />
+			<property name="hibernate.hikari.dataSource.url" value="jdbc:mysql://tfb-database:3306/hello_world?jdbcCompliantTruncation=false&amp;elideSetAutoCommits=true&amp;useLocalSessionState=true&amp;cachePrepStmts=true&amp;cacheCallableStmts=true&amp;alwaysSendSetIsolation=false&amp;prepStmtCacheSize=4096&amp;cacheServerConfiguration=true&amp;prepStmtCacheSqlLimit=2048&amp;zeroDateTimeBehavior=convertToNull&amp;traceProtocol=false&amp;useUnbufferedInput=false&amp;useReadAheadInput=false&amp;maintainTimeStats=false&amp;useServerPrepStmts=true&amp;cacheRSMetadata=true&amp;useSSL=false" />
 			<property name="hibernate.hikari.dataSource.user" value="benchmarkdbuser" />
 			<property name="hibernate.hikari.dataSource.password" value="benchmarkdbpass" />
 		</properties>

--- a/frameworks/Java/wicket/pom.xml
+++ b/frameworks/Java/wicket/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.47</version>
+			<version>8.0.18</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/frameworks/Java/wildfly-ee/wildfly-ee.dockerfile
+++ b/frameworks/Java/wildfly-ee/wildfly-ee.dockerfile
@@ -8,7 +8,7 @@ COPY wildfly-config.txt wildfly-config.txt
 RUN apt-get update
 RUN apt-get install -yqq wget
 RUN wget -q -O- http://download.jboss.org/wildfly/$wfly/wildfly-$wfly.tar.gz | tar xz
-RUN wget -q http://central.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar -O mysql-connector-java.jar
+RUN wget -q http://central.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar -O mysql-connector-java.jar
 RUN mvn clean package -q
 RUN ./wildfly-$wfly/bin/jboss-cli.sh --file=wildfly-config.txt
 CMD ./wildfly-$wfly/bin/standalone.sh -b 0.0.0.0

--- a/frameworks/JavaScript/ringojs/app/models.js
+++ b/frameworks/JavaScript/ringojs/app/models.js
@@ -2,9 +2,11 @@ const { Store, Cache } = require('ringo-sqlstore');
 
 // create and configure store
 const connectionPool = module.singleton("connectionPool", function () {
-  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
+  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts=true&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
   return Store.initConnectionPool({
     "url": "jdbc:mysql://tfb-database/hello_world" + mysqlConnectionProperties,
+// This is not the correct driver but it is used as a workaround.
+// The library ringo-sqlstore needs updating
     "driver": "com.mysql.jdbc.Driver",
     "username": "benchmarkdbuser",
     "password": "benchmarkdbpass",

--- a/frameworks/JavaScript/ringojs/ringo-main.js
+++ b/frameworks/JavaScript/ringojs/ringo-main.js
@@ -110,7 +110,7 @@ exports.app = function (req) {
 
 
 const datasource = module.singleton('pooling-datasource', function () {
-  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
+  const mysqlConnectionProperties = "?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useServerPrepStmts=true&enableQueryTimeouts=false&useUnbufferedIO=false&useReadAheadInput=false&maintainTimeStats=false&cacheRSMetadata=true&useSSL=false";
   return sql.connect("jdbc:mysql://tfb-database/hello_world" + mysqlConnectionProperties, 'benchmarkdbuser', 'benchmarkdbpass');
 });
 

--- a/frameworks/JavaScript/ringojs/ringojs-convenient.dockerfile
+++ b/frameworks/JavaScript/ringojs/ringojs-convenient.dockerfile
@@ -16,6 +16,6 @@ COPY ringo-convenient-main.js ringo-convenient-main.js
 RUN ringo-admin install grob/ringo-sqlstore
 RUN ringo-admin install ringo/stick
 RUN ringo-admin install orfon/reinhardt
-RUN curl -sL -o ${RINGOJS_HOME}/packages/ringo-sqlstore/jars/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar
+RUN curl -sL -o ${RINGOJS_HOME}/packages/ringo-sqlstore/jars/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar
 
 CMD ["ringo", "--production", "-J-server", "-J-Xmx1g", "-J-Xms1g", "ringo-convenient-main.js", "--host", "0.0.0.0"]

--- a/frameworks/JavaScript/ringojs/ringojs.dockerfile
+++ b/frameworks/JavaScript/ringojs/ringojs.dockerfile
@@ -15,6 +15,6 @@ COPY ringo-main.js ringo-main.js
 
 RUN ringo-admin install oberhamsi/sql-ringojs-client
 RUN ringo-admin install orfon/reinhardt
-RUN curl -sL -o ${RINGOJS_HOME}/packages/sql-ringojs-client/jars/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar
+RUN curl -sL -o ${RINGOJS_HOME}/packages/sql-ringojs-client/jars/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar
 
 CMD ["ringo", "--production", "-J-server", "-J-Xmx1g", "-J-Xms1g", "ringo-main.js", "--host", "0.0.0.0"]

--- a/frameworks/Kotlin/ktor/ktor/pom.xml
+++ b/frameworks/Kotlin/ktor/ktor/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hikaricp.version>3.2.0</hikaricp.version>
         <logback.version>1.2.3</logback.version>
-        <mysql.version>5.1.47</mysql.version>
+        <mysql.version>8.0.18</mysql.version>
         <postgresql.version>42.2.5</postgresql.version>
     </properties>
 

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres.dockerfile
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u181_2.12.8_1.2.8
+FROM hseeberger/scala-sbt:8u222_1.3.3_2.13.1
 
 WORKDIR /akka-http-slick-postgres
 

--- a/frameworks/Scala/akka-http/akka-http.dockerfile
+++ b/frameworks/Scala/akka-http/akka-http.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u212_2.13.0_1.2.8
+FROM hseeberger/scala-sbt:8u222_1.3.3_2.13.1
 
 WORKDIR /akka-http
 

--- a/frameworks/Scala/akka-http/akka-http/build.sbt
+++ b/frameworks/Scala/akka-http/akka-http/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http" % "10.1.8",
   "com.typesafe.akka" %% "akka-stream" % "2.5.23",
   "de.heikoseeberger" %% "akka-http-jsoniter-scala" % "1.27.0",
-  "mysql" % "mysql-connector-java" % "5.1.47",
+  "mysql" % "mysql-connector-java" % "8.0.18",
   "com.zaxxer" % "HikariCP" % "3.3.1",
   "org.scalatra.scalate" %% "scalate-core" % "1.9.4",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test"

--- a/frameworks/Scala/akka-http/akka-http/src/main/resources/application.conf
+++ b/frameworks/Scala/akka-http/akka-http/src/main/resources/application.conf
@@ -18,7 +18,7 @@ akka {
         dbport: 3306
         dbuser: "benchmarkdbuser"
         dbpass: "benchmarkdbpass"
-        jdbc-url: "jdbc:mysql://"${akka.http.benchmark.mysql.dbhost}":"${akka.http.benchmark.mysql.dbport}"/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts&cacheRSMetadata=true&useSSL=false"
+        jdbc-url: "jdbc:mysql://"${akka.http.benchmark.mysql.dbhost}":"${akka.http.benchmark.mysql.dbport}"/hello_world?jdbcCompliantTruncation=false&elideSetAutoCommits=true&useLocalSessionState=true&cachePrepStmts=true&cacheCallableStmts=true&alwaysSendSetIsolation=false&prepStmtCacheSize=4096&cacheServerConfiguration=true&prepStmtCacheSqlLimit=2048&zeroDateTimeBehavior=convertToNull&traceProtocol=false&useUnbufferedInput=false&useReadAheadInput=false&maintainTimeStats=false&useServerPrepStmts=true&cacheRSMetadata=true&useSSL=false"
         connection-pool-size: 512
         thread-pool-size: 512
       }

--- a/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-anorm/build.sbt
@@ -10,5 +10,5 @@ libraryDependencies ++= Seq(
   guice,
   jdbc,
   "com.typesafe.play" %% "anorm" % "2.5.3",
-  "mysql" % "mysql-connector-java" % "5.1.47"
+  "mysql" % "mysql-connector-java" % "8.0.18"
 )

--- a/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
+++ b/frameworks/Scala/play2-scala/play2-scala-slick/build.sbt
@@ -9,6 +9,6 @@ scalaVersion := "2.12.8"
 libraryDependencies ++= Seq(
   guice,
   "com.typesafe.play" %% "play-slick" % "3.0.3",
-  "mysql" % "mysql-connector-java" % "5.1.47",
+  "mysql" % "mysql-connector-java" % "8.0.18",
   filters
 )


### PR DESCRIPTION
There are package path reorganisations - new driver class and moving of the JDBC2 various DataSource implementations

Projects that aren't updated:
Clojure/http-kit - the http-kit-raw with hikari-cp is problematic. There is some problem and directly setting the datasource class is ignored.
Java/act - the hibernate library is quite old (5.1.x). Directly setting the `jpa.dialect` (recommend by the logs from Act) was not working.

@greenlaw110 You may want to check it.