### PR TITLE
Fix rails problems (cache + socks)

### DIFF
--- a/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
+++ b/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
@@ -18,8 +18,9 @@ class HelloWorldController < ApplicationController
     queries = 1 if queries < 1
     queries = 500 if queries > 500
 
-    results = (1..queries).map do
-      World.find(Random.rand(1..10000))
+    numbers = (1..10000).to_a.sample(queries)
+    results = numbers.each do |id|
+      World.find(id)
     end
 
     render json: results
@@ -36,10 +37,11 @@ class HelloWorldController < ApplicationController
     queries = 1 if queries < 1
     queries = 500 if queries > 500
 
-    worlds = (1..queries).map do
+    numbers = (1..10000).to_a.sample(queries)
+    worlds = numbers.each do |id|
       # get a random row from the database, which we know has 10000
       # rows with ids 1 - 10000
-      world = World.select(:id, :randomNumber).find(Random.rand(1..10000))
+      world = World.select(:id, :randomNumber).find(id)
       world.update_attribute(:randomNumber, Random.rand(1..10000))
       world
     end

--- a/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
+++ b/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
@@ -19,7 +19,7 @@ class HelloWorldController < ApplicationController
     queries = 500 if queries > 500
 
     numbers = (1..10000).to_a.sample(queries)
-    results = numbers.each do |id|
+    results = numbers.map do |id|
       World.find(id)
     end
 
@@ -38,7 +38,7 @@ class HelloWorldController < ApplicationController
     queries = 500 if queries > 500
 
     numbers = (1..10000).to_a.sample(queries)
-    worlds = numbers.each do |id|
+    worlds = numbers.map do |id|
       # get a random row from the database, which we know has 10000
       # rows with ids 1 - 10000
       world = World.select(:id, :randomNumber).find(id)

--- a/frameworks/Ruby/rails/config/auto_tune.rb
+++ b/frameworks/Ruby/rails/config/auto_tune.rb
@@ -6,7 +6,7 @@
 require 'etc'
 
 KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (watch smem -k)
-MIN_WORKERS = 6
+MIN_WORKERS = 15
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
 MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)

--- a/frameworks/Ruby/rails/config/auto_tune.rb
+++ b/frameworks/Ruby/rails/config/auto_tune.rb
@@ -6,7 +6,7 @@
 require 'etc'
 
 KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (watch smem -k)
-MIN_WORKERS = 2
+MIN_WORKERS = 6
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
 MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)

--- a/frameworks/Ruby/rails/config/auto_tune.rb
+++ b/frameworks/Ruby/rails/config/auto_tune.rb
@@ -27,7 +27,7 @@ def auto_tune
 
   workers = [
     [(1.0 * avail_mem / KB_PER_WORKER).floor, MIN_WORKERS].max,
-    (Etc.nprocessors * MAX_WORKERS_PER_VCPU).ceil
+    [(Etc.nprocessors * MAX_WORKERS_PER_VCPU).ceil, MIN_WORKERS].max
   ].min
 
   threads_per_worker = [

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -17,9 +17,9 @@ test:
 production_mysql:
   <<: *common
   adapter: mysql2
-  pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  pool: 64
 
 production_postgresql:
   <<: *common
   adapter: postgresql
-  pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
+  pool: 64

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -17,9 +17,9 @@ test:
 production_mysql:
   <<: *common
   adapter: mysql2
-  pool: 256
+  pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>
 
 production_postgresql:
   <<: *common
   adapter: postgresql
-  pool: 256
+  pool: <%= ENV["DB_POOL"] || ENV['RAILS_MAX_THREADS'] || 5 %>

--- a/frameworks/Ruby/rails/config/mri_puma.rb
+++ b/frameworks/Ruby/rails/config/mri_puma.rb
@@ -5,3 +5,24 @@ num_workers, num_threads = auto_tune
 
 workers num_workers
 threads num_threads, num_threads
+
+preload_app!
+
+# If you are preloading your application and using Active Record, it's
+# recommended that you close any connections to the database before workers
+# are forked to prevent connection leakage.
+#
+before_fork do
+  ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
+end
+
+# The code in the `on_worker_boot` will be called if you are using
+# clustered mode by specifying a number of `workers`. After each worker
+# process is booted, this block will be run. If you are using the `preload_app!`
+# option, you will want to use this block to reconnect to any threads
+# or connections that may have been created at application boot, as Ruby
+# cannot share connections between processes.
+#
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end

--- a/frameworks/Ruby/rails/config/unicorn.rb
+++ b/frameworks/Ruby/rails/config/unicorn.rb
@@ -4,7 +4,7 @@ require_relative 'auto_tune'
 num_workers, = auto_tune
 worker_processes num_workers
 
-listen "/tmp/.sock", :backlog => 256
+listen "/tmp/.sock", :backlog => 512
 
 preload_app true
 


### PR DESCRIPTION
#### Fixed
- **rails** first-level cache problem (with the random selection of ids to be loaded from the database) see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5222 and https://github.com/TechEmpower/FrameworkBenchmarks/pull/5145#issuecomment-544735202
see in last run:
  - [rails failure](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/rails/query/verification.txt) 
  - [rails-postgresql failure](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/rails-postgresql/query/verification.txt)
- **rails-unicorn** `resource temporarily unavailable` error see [logs](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/rails-unicorn/run/rails-unicorn.log)

#### Fixed or not
- **rails-postgresql** `Update` test failures see [verification file](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/rails-postgresql/update/verification.txt) -> try to change pool size (`256` was a problem?) The pool should not be initialized with a value corresponding to `MAX_CONCURRENCY/worker_count` ?


I'm not a **Rails** specialist, it was just for trying to pass the green check.
Among other things, there are still some problems:
- The `Update` test is unpredictable with Postgres
- The exessive number of db queries and rows read for the `Db` and `Fortune` tests with Mysql (see [Db verification](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/rails/db/verification.txt))

@rjnienaber @nbrady-techempower @mwpastore @hamiltont @gregors 