### PR TITLE
Fix symfony problems (cache + failed transactions + missing queries)

### DIFF
--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -18,10 +18,11 @@ class DbController
 
     private function getUniqueRandomNumbers($count, $min, $max)
     {
-        $res = array();
+        $res = [];
         do {
             $res[\mt_rand($min, $max)] = 1;
         } while (\count($res) < $count);
+
         return \array_keys($res);
     }
 

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -74,15 +74,13 @@ class DbController
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
-            $this->entityManager->transactional(function ($em) use ($id, &$worlds) {
-                $world = $this->worldRepository->find($id);
-                if ($world) {
-                    $randomNumber = mt_rand(1, 10000);
-                    $world->setRandomNumber($randomNumber);
-                    $worlds[] = $world;
-                    $em->persist($world);
-                }
-            });
+            $world = $this->worldRepository->find($id);
+            if ($world) {
+                $randomNumber = mt_rand(1, 10000);
+                $world->setRandomNumber($randomNumber);
+                $worlds[] = $world;
+                $this->entityManager->persist($world);
+            }
         }
 
         return new JsonResponse($worlds);

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Repository\WorldRepository;
@@ -9,7 +10,6 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DbController
 {
-
     /** @var EntityManagerInterface */
     private $entityManager;
 
@@ -33,7 +33,6 @@ class DbController
     }
 
     /**
-     *
      * @Route("/db")
      */
     public function db(): JsonResponse
@@ -42,7 +41,6 @@ class DbController
     }
 
     /**
-     *
      * @Route("/queries")
      */
     public function queries(Request $request): JsonResponse
@@ -61,7 +59,6 @@ class DbController
     }
 
     /**
-     *
      * @Route("/updates")
      */
     public function update(Request $request): JsonResponse
@@ -74,7 +71,8 @@ class DbController
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
             $world = $this->worldRepository->find($id);
-            $world->setRandomNumber(\mt_rand(1, 10000));
+            while($id === $newId = \mt_rand(1, 10000)) {}
+            $world->setRandomNumber($newId);
             $worlds[] = $world;
             $this->entityManager->flush();
         }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -74,7 +74,7 @@ class DbController
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
-            $this->entityManager->transactional(function ($em) use ($id, $worlds) {
+            $this->entityManager->transactional(function ($em) use ($id, &$worlds) {
                 $world = $this->worldRepository->find($id);
                 if ($world) {
                     $randomNumber = mt_rand(1, 10000);

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -71,8 +71,7 @@ class DbController
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
             $world = $this->worldRepository->find($id);
-            while($id === $newId = \mt_rand(1, 10000)) {}
-            $world->setRandomNumber($newId);
+            $world->setRandomNumber(\mt_rand(1, 10000));
             $worlds[] = $world;
             $this->entityManager->flush();
         }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Controller;
 
 use App\Repository\WorldRepository;
@@ -10,10 +9,21 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DbController
 {
+
     /** @var EntityManagerInterface */
     private $entityManager;
+
     /** @var WorldRepository */
     private $worldRepository;
+
+    private function getUniqueRandomNumbers($count, $min, $max)
+    {
+        $res = array();
+        do {
+            $res[\mt_rand($min, $max)] = 1;
+        } while (\count($res) < $count);
+        return \array_keys($res);
+    }
 
     public function __construct(EntityManagerInterface $entityManager, WorldRepository $worldRepository)
     {
@@ -22,6 +32,7 @@ class DbController
     }
 
     /**
+     *
      * @Route("/db")
      */
     public function db(): JsonResponse
@@ -32,6 +43,7 @@ class DbController
     }
 
     /**
+     *
      * @Route("/queries")
      */
     public function queries(Request $request): JsonResponse
@@ -41,15 +53,16 @@ class DbController
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = [];
-
-        for ($i = 0; $i < $queries; ++$i) {
-            $worlds[] = $this->worldRepository->find(mt_rand(1, 10000));
+        $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+        foreach ($numbers as $id) {
+            $worlds[] = $this->worldRepository->find($id);
         }
 
         return new JsonResponse($worlds);
     }
 
     /**
+     *
      * @Route("/updates")
      */
     public function update(Request $request): JsonResponse
@@ -59,8 +72,9 @@ class DbController
 
         $worlds = [];
 
-        for ($i = 0; $i < $queries; ++$i) {
-            $world = $this->worldRepository->find(mt_rand(1, 10000));
+        $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+        foreach ($numbers as $id) {
+            $world = $this->worldRepository->find($id);
             if ($world) {
                 $randomNumber = mt_rand(1, 10000);
                 $world->setRandomNumber($randomNumber);

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -73,15 +73,21 @@ class DbController
         $worlds = [];
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
-        foreach ($numbers as $id) {
-            $world = $this->worldRepository->find($id);
-            if ($world) {
-                $randomNumber = mt_rand(1, 10000);
-                $world->setRandomNumber($randomNumber);
-                $worlds[] = $world;
-                $this->entityManager->persist($world);
+        do {
+            $id = \current($numbers);
+            $res = $this->entityManager->transactional(function ($em) use ($id, &$worlds) {
+                $world = $this->worldRepository->find($id);
+                if ($world) {
+                    $randomNumber = mt_rand(1, 10000);
+                    $world->setRandomNumber($randomNumber);
+                    $worlds[] = $world;
+                    $em->persist($world);
+                }
+            });
+            if ($res) {
+                \array_splice($numbers, 0, 1);
             }
-        }
+        } while (\count($numbers) > 0);
 
         return new JsonResponse($worlds);
     }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -73,18 +73,15 @@ class DbController
         $worlds = [];
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
-        foreach ($numbers as $index => $id) {
+        foreach ($numbers as $id) {
             $world = $this->worldRepository->find($id);
             if ($world) {
                 $randomNumber = mt_rand(1, 10000);
                 $world->setRandomNumber($randomNumber);
                 $worlds[] = $world;
-                if ($index % 2 == 0) {
-                    $this->entityManager->flush();
-                }
+                $this->entityManager->flush();
             }
         }
-        $this->entityManager->flush();
         return new JsonResponse($worlds);
     }
 }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -73,15 +73,18 @@ class DbController
         $worlds = [];
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
-        foreach ($numbers as $id) {
+        foreach ($numbers as $index => $id) {
             $world = $this->worldRepository->find($id);
             if ($world) {
                 $randomNumber = mt_rand(1, 10000);
                 $world->setRandomNumber($randomNumber);
                 $worlds[] = $world;
-                $this->entityManager->flush();
+                if ($index % 2 == 0) {
+                    $this->entityManager->flush();
+                }
             }
         }
+        $this->entityManager->flush();
         return new JsonResponse($worlds);
     }
 }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -74,15 +74,16 @@ class DbController
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
-            $world = $this->worldRepository->find($id);
-            if ($world) {
-                $randomNumber = mt_rand(1, 10000);
-                $world->setRandomNumber($randomNumber);
-                $worlds[] = $world;
-            }
+            $this->entityManager->transactional(function ($em) use ($id, $worlds) {
+                $world = $this->worldRepository->find($id);
+                if ($world) {
+                    $randomNumber = mt_rand(1, 10000);
+                    $world->setRandomNumber($randomNumber);
+                    $worlds[] = $world;
+                    $em->persist($world);
+                }
+            });
         }
-
-        $this->entityManager->flush();
 
         return new JsonResponse($worlds);
     }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -37,9 +37,7 @@ class DbController
      */
     public function db(): JsonResponse
     {
-        $world = $this->worldRepository->find(mt_rand(1, 10000));
-
-        return new JsonResponse($world);
+        return new JsonResponse($this->worldRepository->find(\mt_rand(1, 10000)));
     }
 
     /**
@@ -49,7 +47,7 @@ class DbController
     public function queries(Request $request): JsonResponse
     {
         $queries = (int) $request->query->get('queries', 1);
-        $queries = min(max($queries, 1), 500);
+        $queries = \min(\max($queries, 1), 500);
 
         // possibility for enhancement is the use of SplFixedArray -> http://php.net/manual/de/class.splfixedarray.php
         $worlds = [];
@@ -68,19 +66,16 @@ class DbController
     public function update(Request $request): JsonResponse
     {
         $queries = (int) $request->query->get('queries', 1);
-        $queries = min(500, max(1, $queries));
+        $queries = \min(500, \max(1, $queries));
 
         $worlds = [];
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
         foreach ($numbers as $id) {
             $world = $this->worldRepository->find($id);
-            if ($world) {
-                $randomNumber = mt_rand(1, 10000);
-                $world->setRandomNumber($randomNumber);
-                $worlds[] = $world;
-                $this->entityManager->flush();
-            }
+            $world->setRandomNumber(\mt_rand(1, 10000));
+            $worlds[] = $world;
+            $this->entityManager->flush();
         }
         return new JsonResponse($worlds);
     }

--- a/frameworks/PHP/symfony/src/Controller/DbController.php
+++ b/frameworks/PHP/symfony/src/Controller/DbController.php
@@ -73,22 +73,15 @@ class DbController
         $worlds = [];
 
         $numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
-        do {
-            $id = \current($numbers);
-            $res = $this->entityManager->transactional(function ($em) use ($id, &$worlds) {
-                $world = $this->worldRepository->find($id);
-                if ($world) {
-                    $randomNumber = mt_rand(1, 10000);
-                    $world->setRandomNumber($randomNumber);
-                    $worlds[] = $world;
-                    $em->persist($world);
-                }
-            });
-            if ($res) {
-                \array_splice($numbers, 0, 1);
+        foreach ($numbers as $id) {
+            $world = $this->worldRepository->find($id);
+            if ($world) {
+                $randomNumber = mt_rand(1, 10000);
+                $world->setRandomNumber($randomNumber);
+                $worlds[] = $world;
+                $this->entityManager->flush();
             }
-        } while (\count($numbers) > 0);
-
+        }
         return new JsonResponse($worlds);
     }
 }

--- a/frameworks/PHP/symfony/src/Controller/FortunesController.php
+++ b/frameworks/PHP/symfony/src/Controller/FortunesController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Controller;
 
 use App\Entity\Fortune;
@@ -10,8 +9,10 @@ use Twig\Environment;
 
 class FortunesController
 {
+
     /** @var Environment */
     private $twig;
+
     /** @var FortuneRepository */
     private $fortuneRepository;
 
@@ -22,6 +23,7 @@ class FortunesController
     }
 
     /**
+     *
      * @Route("/fortunes")
      */
     public function fortunes(): Response
@@ -34,19 +36,13 @@ class FortunesController
 
         $fortunes[] = $runtimeFortune;
 
-        usort(
-            $fortunes,
-            static function ($left, $right) {
-                return $left->message <=> $right->message;
-            }
-        );
+        \usort($fortunes, static function ($left, $right) {
+            return $left->message <=> $right->message;
+        });
 
-        $content = $this->twig->render(
-            'fortunes.html.twig',
-            [
-                'fortunes' => $fortunes,
-            ]
-        );
+        $content = $this->twig->render('fortunes.html.twig', [
+            'fortunes' => $fortunes
+        ]);
 
         return new Response($content);
     }


### PR DESCRIPTION
#### Fixed
- **Doctrine** first-level cache problem (with the random selection of ids to be loaded from the database) see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5222 and https://github.com/TechEmpower/FrameworkBenchmarks/pull/5145#issuecomment-544735202
- failures in `Update` test -> The `entityManager flush` must be done for each `World` instance considering the concurrency level.

see in last run:
  - [Query](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/symfony/query/verification.txt) 
  - [Update](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/symfony/update/verification.txt)

Ping @joanhey @kaznovac @jderusse for checking