### PR TITLE
Fix cakephp fortunes failure

### DIFF
--- a/frameworks/PHP/cakephp/src/Controller/FortunesController.php
+++ b/frameworks/PHP/cakephp/src/Controller/FortunesController.php
@@ -21,15 +21,15 @@ class FortunesController extends AppController {
 
 
 
-	    // stuffing in the dynamic data
+        // stuffing in the dynamic data
         $fortune = $fortunesTable->newEntity([
-	    	'id' => 0,
-		    'message' => 'Additional fortune added at request time.'
-	    ]);
+            'id' => 0,
+            'message' => 'Additional fortune added at request time.'
+        ]);
 
-	    $fortunes = $fortunes->appendItem($fortune);
+        $fortunes = $fortunes->appendItem($fortune);
 
-	    $fortunes = $fortunes->sortBy('message', SORT_ASC, SORT_STRING)->compile(false);
+        $fortunes = $fortunes->sortBy('message', SORT_ASC, SORT_STRING)->compile(false);
 
         $this->set('fortunes', $fortunes);
     }

--- a/frameworks/PHP/cakephp/src/Controller/FortunesController.php
+++ b/frameworks/PHP/cakephp/src/Controller/FortunesController.php
@@ -10,7 +10,6 @@ class FortunesController extends AppController {
         $viewBuilder = $this->viewBuilder();
         $viewBuilder->setLayout('fortunes');
         $viewBuilder->setTemplate('/Fortunes/index');
-        $this->loadModel('Fortune');
 
         $fortunesTable = TableRegistry::getTableLocator()->get('Fortune');
 
@@ -23,7 +22,7 @@ class FortunesController extends AppController {
 
 
 	    // stuffing in the dynamic data
-	    $fortune = TableRegistry::getTableLocator()->get('Fortune')->newEntity([
+        $fortune = $fortunesTable->newEntity([
 	    	'id' => 0,
 		    'message' => 'Additional fortune added at request time.'
 	    ]);

--- a/frameworks/PHP/cakephp/src/Controller/FortunesController.php
+++ b/frameworks/PHP/cakephp/src/Controller/FortunesController.php
@@ -2,13 +2,14 @@
 
 namespace App\Controller;
 
-use App\Model\Entity\Fortune;
 use Cake\ORM\TableRegistry;
 
 class FortunesController extends AppController {
 
     public function index() {
-        $this->viewBuilder()->setLayout('fortunes');
+        $viewBuilder = $this->viewBuilder();
+        $viewBuilder->setLayout('fortunes');
+        $viewBuilder->setTemplate('/Fortunes/index');
         $this->loadModel('Fortune');
 
         $fortunesTable = TableRegistry::getTableLocator()->get('Fortune');


### PR DESCRIPTION
#### Fixed
- `fortunes` failure during [benchmark](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/cakephp/fortune/raw.txt), see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5193 https://github.com/TechEmpower/FrameworkBenchmarks/issues/5189#issuecomment-547373851

Strangely, with **wrk** `Accept` header, **cakePhp** searches the template file in `Fortunes/json/` folder, even if we force the `Content-Type` of the response to `text/html` -> so the template is now specified.

`-H 'Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7'`

ping @joanhey @oozone 