### PR TITLE
Fix laravel & Laravel-swoole cache pbs

### DIFF
--- a/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
+++ b/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
@@ -19,7 +19,7 @@ class Controller extends BaseController {
 
 	public function queries($queries = 1) {
 		$rows = [];
-		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries), 1, 10000);
+		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries));
 		foreach ($numbers as $id) {
 			$rows[] = World::find($id);
 		}
@@ -45,7 +45,7 @@ class Controller extends BaseController {
 	public function updates($queries = 1) {
 		$rows = [];
 
-		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries), 1, 10000);
+		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries));
 		foreach ($numbers as $id) {
 			$row = World::find($id);
 			$row->randomNumber = \mt_rand(1, 10000);
@@ -71,10 +71,10 @@ class Controller extends BaseController {
 		}
 	}
 
-	private function getUniqueRandomNumbers($count, $min, $max) {
+	private function getUniqueRandomNumbers($count) {
 		$res = [];
 		do {
-			$res[\mt_rand($min, $max)] = 1;
+			$res[\mt_rand(1, 10000)] = 1;
 		} while (\count($res) < $count);
 		return \array_keys($res);
 	}

--- a/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
+++ b/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Http\Controllers;
 
 use App\Models\Fortune;
@@ -9,19 +8,22 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController {
 
 	public function json() {
-		return ['message' => 'Hello, World!'];
+		return [
+			'message' => 'Hello, World!'
+		];
 	}
 
 	public function db() {
-		return World::find(random_int(1, 10000));
+		return World::find(\mt_rand(1, 10000));
 	}
 
 	public function queries($queries = 1) {
 		$queries = $this->clamp($queries);
 
 		$rows = [];
-		while ($queries--) {
-			$rows[] = World::find(random_int(1, 10000));
+		$numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+		foreach ($numbers as $id) {
+			$rows[] = World::find($id);
 		}
 
 		return $rows;
@@ -37,7 +39,9 @@ class Controller extends BaseController {
 		$rows->add($insert);
 		$rows = $rows->sortBy("message");
 
-		return view("fortunes", ["rows" => $rows]);
+		return view("fortunes", [
+			"rows" => $rows
+		]);
 	}
 
 	public function updates($queries = 1) {
@@ -45,9 +49,10 @@ class Controller extends BaseController {
 
 		$rows = [];
 
-		while ($queries--) {
-			$row = World::find(random_int(1, 10000));
-			$row->randomNumber = random_int(1, 10000);
+		$numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+		foreach ($numbers as $id) {
+			$row = World::find($id);
+			$row->randomNumber = \mt_rand(1, 10000);
 			$row->save();
 
 			$rows[] = $row;
@@ -61,12 +66,20 @@ class Controller extends BaseController {
 	}
 
 	private function clamp($value): int {
-		if (!is_numeric($value) || $value < 1) {
+		if (! \is_numeric($value) || $value < 1) {
 			return 1;
 		} else if ($value > 500) {
 			return 500;
 		} else {
 			return $value;
 		}
+	}
+
+	private function getUniqueRandomNumbers($count, $min, $max) {
+		$res = [];
+		do {
+			$res[\mt_rand($min, $max)] = 1;
+		} while (\count($res) < $count);
+		return \array_keys($res);
 	}
 }

--- a/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
+++ b/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
@@ -18,10 +18,8 @@ class Controller extends BaseController {
 	}
 
 	public function queries($queries = 1) {
-		$queries = $this->clamp($queries);
-
 		$rows = [];
-		$numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries), 1, 10000);
 		foreach ($numbers as $id) {
 			$rows[] = World::find($id);
 		}
@@ -34,22 +32,20 @@ class Controller extends BaseController {
 
 		$insert = new Fortune();
 		$insert->id = 0;
-		$insert->message = "Additional fortune added at request time.";
+		$insert->message = 'Additional fortune added at request time.';
 
 		$rows->add($insert);
-		$rows = $rows->sortBy("message");
+		$rows = $rows->sortBy('message');
 
-		return view("fortunes", [
-			"rows" => $rows
+		return view('fortunes', [
+			'rows' => $rows
 		]);
 	}
 
 	public function updates($queries = 1) {
-		$queries = $this->clamp($queries);
-
 		$rows = [];
 
-		$numbers = $this->getUniqueRandomNumbers($queries, 1, 10000);
+		$numbers = $this->getUniqueRandomNumbers($this->clamp($queries), 1, 10000);
 		foreach ($numbers as $id) {
 			$row = World::find($id);
 			$row->randomNumber = \mt_rand(1, 10000);
@@ -62,7 +58,7 @@ class Controller extends BaseController {
 	}
 
 	public function plaintext() {
-		return response("Hello, World!")->header('Content-Type', 'text/plain');
+		return response('Hello, World!')->header('Content-Type', 'text/plain');
 	}
 
 	private function clamp($value): int {

--- a/frameworks/PHP/laravel/app/Models/Fortune.php
+++ b/frameworks/PHP/laravel/app/Models/Fortune.php
@@ -1,12 +1,11 @@
 <?php
-
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 class Fortune extends Model {
 
-	protected $table = "Fortune";
+	protected $table = 'Fortune';
+
 	public $timestamps = false;
-	
 }

--- a/frameworks/PHP/laravel/app/Models/World.php
+++ b/frameworks/PHP/laravel/app/Models/World.php
@@ -1,12 +1,11 @@
 <?php
-
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
 class World extends Model {
 
-	protected $table = "World";
-	public $timestamps = false;
+	protected $table = 'World';
 
+	public $timestamps = false;
 }


### PR DESCRIPTION
#### Fixed
- **Eloquent** first-level cache problem (with the random selection of ids to be loaded from the database) see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5222 and https://github.com/TechEmpower/FrameworkBenchmarks/pull/5145#issuecomment-544735202

see [missing queries](https://tfb-status.techempower.com/unzip/results.2019-11-08-05-13-52-474.zip/results/20191104142847/laravel/update/verification.txt) for Update test in last run

#### Optimization
 - remove double quote usage for strings
 - Force global namespace usage
- Replace `random_int` with `mt_rand` (10x faster)

ping @fturmel @joanhey 