### PR TITLE
Fix concurrency-levels opt pb

### DIFF
--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -166,6 +166,7 @@ def main(argv=None):
     parser.add_argument(
         '--concurrency-levels',
         nargs='+',
+        type=int,
         default=[16, 32, 64, 128, 256, 512],
         help='List of concurrencies to benchmark')
     parser.add_argument(


### PR DESCRIPTION
see https://github.com/TechEmpower/FrameworkBenchmarks/issues/5222#issuecomment-554953386

Force the type of `concurrency-levels` option to be an array of `int`

