### PR TITLE
Add "tags" support

### DIFF
--- a/frameworks/C/libreactor/benchmark_config.json
+++ b/frameworks/C/libreactor/benchmark_config.json
@@ -19,7 +19,8 @@
         "database_os": "Linux",
         "display_name": "libreactor",
         "notes": "",
-        "versus": "None"
+        "versus": "None",
+        "tags": ["broken"]
       }
     }
   ]

--- a/frameworks/C/onion/benchmark_config.json
+++ b/frameworks/C/onion/benchmark_config.json
@@ -21,7 +21,8 @@
       "database_os": "Linux",
       "display_name": "onion",
       "notes": "",
-      "versus": "onion"
+      "versus": "onion",
+      "tags": ["broken"]
     }
   }]
 }

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -124,6 +124,11 @@ def main(argv=None):
         dest='test_lang',
         help='name of language directory containing all tests to run')
     parser.add_argument(
+        '--tag',
+        nargs='+',
+        dest='tag',
+        help='tests to be run by tag name')
+    parser.add_argument(
         '--exclude', default=None, nargs='+', help='names of tests to exclude')
     parser.add_argument(
         '--type',

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -152,7 +152,11 @@ def main(argv=None):
         action='store_true',
         default=False,
         help='lists all the known tests that can run')
-
+    parser.add_argument(
+        '--list-tag',
+        dest='list_tag',
+        default=False,
+        help='lists all the known tests with a specific tag')
     # Benchmark options
     parser.add_argument(
         '--duration',
@@ -220,6 +224,13 @@ def main(argv=None):
 
             for test in all_tests:
                 log(test.name)
+
+        elif config.list_tag:
+            all_tests = benchmarker.metadata.gather_tests()
+
+            for test in all_tests:
+                if hasattr(test, "tags") and config.list_tag in test.tags:
+                    log(test.name)
 
         elif config.parse:
             all_tests = benchmarker.metadata.gather_tests()

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -38,6 +38,7 @@ class BenchmarkConfig:
         self.clean = args.clean
         self.mode = args.mode
         self.list_tests = args.list_tests
+        self.list_tag = args.list_tag
         self.max_concurrency = max(args.concurrency_levels)
         self.concurrency_levels = args.concurrency_levels
         self.cached_query_levels = args.cached_query_levels

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -50,6 +50,7 @@ class BenchmarkConfig:
         self.test = args.test
         self.test_dir = args.test_dir
         self.test_lang = args.test_lang
+        self.tag = args.tag
         self.network_mode = args.network_mode
         self.server_docker_host = None
         self.database_docker_host = None

--- a/toolset/utils/metadata.py
+++ b/toolset/utils/metadata.py
@@ -105,10 +105,17 @@ class Metadata:
 
             # Filter
             for test in config_tests:
+                if self.benchmarker.config.tag and hasattr(test, "tags"):
+                    if "broken" in test.tags:
+                        continue
+                    for t in self.benchmarker.config.tag:
+                        if t in test.tags and test.name not in exclude:
+                            tests.append(test)
+                            break
                 if len(include) > 0:
                     if test.name in include:
                         tests.append(test)
-                elif test.name not in exclude:
+                elif test.name not in exclude and not self.benchmarker.config.tag:
                     tests.append(test)
 
         # Ensure we were able to locate everything that was
@@ -121,7 +128,7 @@ class Metadata:
 
         tests.sort(key=lambda x: x.name)
 
-        return tests
+        return list(set(tests))
 
     def tests_to_run(self):
         '''
@@ -245,7 +252,8 @@ class Metadata:
             "database_os": test.database_os,
             "display_name": test.display_name,
             "notes": test.notes,
-            "versus": test.versus
+            "versus": test.versus,
+            "tags": hasattr(test, "tags") and test.tags or []
         }, all_tests))
 
         with open(

--- a/toolset/utils/metadata.py
+++ b/toolset/utils/metadata.py
@@ -105,13 +105,14 @@ class Metadata:
 
             # Filter
             for test in config_tests:
-                if self.benchmarker.config.tag and hasattr(test, "tags"):
+                if hasattr(test, "tags"):
                     if "broken" in test.tags:
                         continue
-                    for t in self.benchmarker.config.tag:
-                        if t in test.tags and test.name not in exclude:
-                            tests.append(test)
-                            break
+                    if self.benchmarker.config.tag:
+                        for t in self.benchmarker.config.tag:
+                            if t in test.tags and test.name not in exclude:
+                                tests.append(test)
+                                break
                 if len(include) > 0:
                     if test.name in include:
                         tests.append(test)


### PR DESCRIPTION
This PR creates a new optional property in the `benchmark_config.json` called `tags`. This property accepts an array of strings and allows us to add some extra information about a test for display purposes on the results site, for testing a specific subset, etc.

Right now, I'm imagining 3 reserved tags:

- `tpr`: Marks a test as part of the [TechEmpower Performance Ratings](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/TechEmpower-Performance-Rating-(TPR))
- `verified`: [The Framework has been verified](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Verified-Tag)
- `broken`: The framework is currently not working properly. This allows us to skip the test in travis and on our main testing environments to avoid wasting time. It also allows us to poll benchmark configs for this tag to easily generate a list of tests that need help. I'd consider this a first step before removing the test entirely.

To run tests by tag:

```
tfb --mode test --tag tpr
```

The `--tag` flag can work with other flags to test a subset, like testing all verified Java frameworks:

```
tfb --mode test --test-lang Java --tag verified
```

Edit:

Also added `--list-tag` to list all tests with a specific tag:

```
tfb --list-tag broken

# Output as this PR stands
libreactor
onion
```