### PR TITLE
Various toolset changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,8 @@ before_script:
   - if [ "$RUN_TESTS" ]; then docker build -t techempower/tfb - < ./Dockerfile; fi
 
   # Stop services that would claim ports we may need
-  - sudo service mysql stop
-  - sudo service postgresql stop
+  - sudo service mysql stop || true
+  - sudo service postgresql stop || true
 
 script:
   # run-ci.py runs the diffing to see if travis needs to test this framework. Ideally/eventually,

--- a/toolset/databases/mongodb/mongodb.dockerfile
+++ b/toolset/databases/mongodb/mongodb.dockerfile
@@ -2,8 +2,8 @@ FROM buildpack-deps:bionic
 
 COPY ./ ./
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 68818C72E52529D4
-RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 4B7C549A058F8B6B
+RUN echo "deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org.list
 RUN apt-get -yqq update > /dev/null
 RUN DEBIAN_FRONTEND=noninteractive apt-get -yqq install apt-transport-https mongodb-org > /dev/null
 

--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,8 +1,12 @@
 FROM buildpack-deps:bionic
 
+RUN apt update && apt install -yqq libluajit-5.1-dev libssl-dev luajit
+
 WORKDIR /wrk
 RUN curl -sL https://github.com/wg/wrk/archive/4.1.0.tar.gz | tar xz --strip-components=1
-RUN make > /dev/null
+ENV LDFLAGS="-O3 -march=native -flto"
+ENV CFLAGS="-I /usr/include/luajit-2.1 $LDFLAGS"
+RUN make WITH_LUAJIT=/usr WITH_OPENSSL=/usr -j "$(nproc)"
 RUN cp wrk /usr/local/bin
 
 WORKDIR /


### PR DESCRIPTION
* Update MongoDB to version 4.2
* Improve the wrk build - extra optimizations and parallel compilation are enabled. Also, the system LuaJIT and OpenSSL versions are used, which reduces the build time.
* Make the Travis CI tests more robust - there is no longer an assumption that MySQL and PostgreSQL are installed.