### PR TITLE
Remove unnecessary `unsafe impl Send` from actix

### DIFF
--- a/frameworks/Rust/actix/src/db.rs
+++ b/frameworks/Rust/actix/src/db.rs
@@ -14,8 +14,6 @@ pub struct DbExecutor {
     rng: ThreadRng,
 }
 
-unsafe impl Send for DbExecutor {}
-
 impl Actor for DbExecutor {
     type Context = SyncContext<Self>;
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
While looking at `actix` code, I noticed suspicious `unsafe impl Send` with `ThreadRng` (`ThreadRng` is not thread-safe, it shouldn't be marked as thread-safe). However, as it happens, the code didn't actually make use of this unsafe implementation, so it could be easily removed.

This makes the code look more realistic.