### PR TITLE
Replace Box<Trait> with Box<dyn Trait> in Actix

### DIFF
--- a/frameworks/Rust/actix/src/main_platform.rs
+++ b/frameworks/Rust/actix/src/main_platform.rs
@@ -37,7 +37,7 @@ impl Service for App {
     type Request = Request;
     type Response = Response;
     type Error = Error;
-    type Future = Box<Future<Item = Response, Error = Error>>;
+    type Future = Box<dyn Future<Item = Response, Error = Error>>;
 
     #[inline]
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -122,7 +122,7 @@ impl NewService for AppFactory {
     type Error = Error;
     type Service = App;
     type InitError = ();
-    type Future = Box<Future<Item = Self::Service, Error = Self::InitError>>;
+    type Future = Box<dyn Future<Item = Self::Service, Error = Self::InitError>>;
 
     fn new_service(&self, _: &ServerConfig) -> Self::Future {
         const DB_URL: &str =


### PR DESCRIPTION
This resolves depreciation warnings.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
