### PR TITLE
Update MySqlConnector to 0.62.0-beta5

### DIFF
--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
-    <PackageReference Include="MySqlConnector" Version="0.60.0" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2"/>

--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
-    <PackageReference Include="MySqlConnector" Version="0.60.0" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2"/>
   </ItemGroup>
   

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0-preview7.19362.6" />
 
     <PackageReference Include="Dapper" Version="1.60.6" />
-    <PackageReference Include="MySqlConnector" Version="0.60.0" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.0-preview7" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="4.0.8" />
-    <PackageReference Include="MySqlConnector" Version="0.60.0" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="3.0.0-*" />
 
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0-preview7.19362.4" />

--- a/frameworks/VB/aspnetcore/Benchmarks/Benchmarks.vbproj
+++ b/frameworks/VB/aspnetcore/Benchmarks/Benchmarks.vbproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Npgsql" Version="4.0.2" />
-    <PackageReference Include="MySqlConnector" Version="0.60.0" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Testing performance improvements in the latest beta of this .NET library.