### PR TITLE
Add some tweaks for the Lwan framework

### DIFF
--- a/frameworks/C/lwan/Makefile
+++ b/frameworks/C/lwan/Makefile
@@ -8,6 +8,7 @@ CFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects -DNDEBUG \
 	-fauto-profile=/lwan/src/gcda/techempower.gcov
 
 LDFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects \
+	/usr/local/lib/mimalloc-1.2/libmimalloc.a \
 	-Wl,-whole-archive /lwan/build/src/lib/liblwan.a -Wl,-no-whole-archive \
 	`pkg-config mariadb --libs` \
 	`pkg-config sqlite3 --libs` \

--- a/frameworks/C/lwan/Makefile
+++ b/frameworks/C/lwan/Makefile
@@ -4,7 +4,8 @@ CFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects -DNDEBUG \
 	-include /lwan/build/lwan-build-config.h \
 	-I /lwan/src/lib \
 	`pkg-config mariadb --cflags` \
-	`pkg-config sqlite3 --cflags`
+	`pkg-config sqlite3 --cflags` \
+	-fauto-profile=/lwan/src/gcda/techempower.gcov
 
 LDFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects \
 	-Wl,-whole-archive /lwan/build/src/lib/liblwan.a -Wl,-no-whole-archive \

--- a/frameworks/C/lwan/Makefile
+++ b/frameworks/C/lwan/Makefile
@@ -1,13 +1,13 @@
 .PHONY: all
 
-CFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects -DNDEBUG \
+CFLAGS = -mtune=native -march=native -O3 -fno-plt -flto -ffat-lto-objects -DNDEBUG \
 	-include /lwan/build/lwan-build-config.h \
 	-I /lwan/src/lib \
 	`pkg-config mariadb --cflags` \
 	`pkg-config sqlite3 --cflags` \
 	-fauto-profile=/lwan/src/gcda/techempower.gcov
 
-LDFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects \
+LDFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects -Wl,-z,now,-z,relro \
 	/usr/local/lib/mimalloc-1.2/libmimalloc.a \
 	-Wl,-whole-archive /lwan/build/src/lib/liblwan.a -Wl,-no-whole-archive \
 	`pkg-config mariadb --libs` \

--- a/frameworks/C/lwan/lwan.dockerfile
+++ b/frameworks/C/lwan/lwan.dockerfile
@@ -10,7 +10,7 @@ WORKDIR /lwan
 
 RUN wget https://github.com/lpereira/lwan/archive/b52c9f5e17542800a762f19bc9073bd8b3b95cb3.tar.gz -O - | tar xz --strip-components=1 && \
     mkdir build && cd build && \
-    cmake /lwan -DCMAKE_BUILD_TYPE=Release && \
+    cmake /lwan -DCMAKE_BUILD_TYPE=Release -DUSE_ALTERNATIVE_MALLOC=mimalloc && \
     make lwan-static
 
 RUN make clean && make

--- a/frameworks/C/lwan/lwan.dockerfile
+++ b/frameworks/C/lwan/lwan.dockerfile
@@ -8,7 +8,7 @@ RUN apt install -yqq \
 ADD ./ /lwan
 WORKDIR /lwan
 
-RUN wget https://github.com/lpereira/lwan/archive/d7fc0d27fbea5c68d61444033517d0e962e822e6.tar.gz -O - | tar xz --strip-components=1 && \
+RUN wget https://github.com/lpereira/lwan/archive/b52c9f5e17542800a762f19bc9073bd8b3b95cb3.tar.gz -O - | tar xz --strip-components=1 && \
     mkdir build && cd build && \
     cmake /lwan -DCMAKE_BUILD_TYPE=Release && \
     make lwan-static

--- a/frameworks/C/lwan/lwan.dockerfile
+++ b/frameworks/C/lwan/lwan.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 RUN apt update -yqq
 RUN apt install -yqq \
@@ -8,7 +8,10 @@ RUN apt install -yqq \
 ADD ./ /lwan
 WORKDIR /lwan
 
-RUN wget https://github.com/lpereira/lwan/archive/b52c9f5e17542800a762f19bc9073bd8b3b95cb3.tar.gz -O - | tar xz --strip-components=1 && \
+RUN mkdir mimalloc && \
+    wget https://github.com/microsoft/mimalloc/archive/acb03c54971c4b0a43a6d17ea55a9d5feb88972f.tar.gz -O - | tar xz --strip-components=1 -C mimalloc && \
+    cd mimalloc && mkdir build && cd build && CFLAGS="-flto -ffat-lto-objects" cmake .. -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=OFF && make -j install && cd ../.. && \
+    wget https://github.com/lpereira/lwan/archive/b52c9f5e17542800a762f19bc9073bd8b3b95cb3.tar.gz -O - | tar xz --strip-components=1 && \
     mkdir build && cd build && \
     cmake /lwan -DCMAKE_BUILD_TYPE=Release -DUSE_ALTERNATIVE_MALLOC=mimalloc && \
     make lwan-static

--- a/frameworks/C/lwan/src/database.c
+++ b/frameworks/C/lwan/src/database.c
@@ -316,8 +316,8 @@ db_prepare_sqlite(const struct db *db, const char *sql, const size_t sql_len)
     if (!stmt_sqlite)
         return NULL;
 
-    int ret = sqlite3_prepare(db_sqlite->sqlite, sql, (int)sql_len,
-                              &stmt_sqlite->sqlite, NULL);
+    int ret = sqlite3_prepare_v2(db_sqlite->sqlite, sql, (int)sql_len,
+                                 &stmt_sqlite->sqlite, NULL);
     if (ret != SQLITE_OK) {
         free(stmt_sqlite);
         return NULL;

--- a/frameworks/C/lwan/src/json.h
+++ b/frameworks/C/lwan/src/json.h
@@ -55,26 +55,11 @@ enum json_tokens {
 struct json_obj_descr {
     const char *field_name;
 
-    /* Alignment can be 1, 2, 4, or 8.  The macros to create
-     * a struct json_obj_descr will store the alignment's
-     * power of 2 in order to keep this value in the 0-3 range
-     * and thus use only 2 bits.
-     */
-    uint32_t align_shift : 2;
 
-    /* 127 characters is more than enough for a field name. */
-    uint32_t field_name_len : 7;
-
-    /* Valid values here (enum json_tokens): JSON_TOK_STRING,
-     * JSON_TOK_NUMBER, JSON_TOK_TRUE, JSON_TOK_FALSE,
-     * JSON_TOK_OBJECT_START, JSON_TOK_LIST_START.  (All others
-     * ignored.) Maximum value is '}' (125), so this has to be 7 bits
-     * long.
-     */
-    uint32_t type : 7;
-
-    /* 65535 bytes is more than enough for many JSON payloads. */
-    uint32_t offset : 16;
+    uint32_t align_shift;
+    uint32_t field_name_len;
+    uint32_t type;
+    uint32_t offset;
 
     union {
         struct {


### PR DESCRIPTION
This adds a few tweaks:

- Uses a new Lwan, with some optimizations to reduce memory allocations during fast paths
- Uses a new third-party memory allocator
- Builds everything with profile-guided-optimization data obtained from local runs (requires container running in new Ubuntu version due to a linker bug)
- A variety of tweaks in the benchmark harness