### PR TITLE
Update Zebra and Giraffe to netcoreapp3.1

### DIFF
--- a/frameworks/FSharp/giraffe/giraffe-stripped.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-stripped.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe-utf8direct.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-utf8direct.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/src/App/App.fsproj
+++ b/frameworks/FSharp/giraffe/src/App/App.fsproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>App</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -12,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="Giraffe" Version="4.0.1" />
-    <PackageReference Include="Npgsql" Version="4.1.0" />
-    <PackageReference Update="FSharp.Core" Version="4.7" />
+    <PackageReference Include="Npgsql" Version="4.1.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/frameworks/FSharp/zebra/src/App/App.fsproj
+++ b/frameworks/FSharp/zebra/src/App/App.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>App</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -11,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="Npgsql" Version="4.1.0" />
+    <PackageReference Include="Npgsql" Version="4.1.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Update="FSharp.Core" Version="4.7.0" />
   </ItemGroup>

--- a/frameworks/FSharp/zebra/zebra-simple.dockerfile
+++ b/frameworks/FSharp/zebra/zebra-simple.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/zebra/zebra.dockerfile
+++ b/frameworks/FSharp/zebra/zebra.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0 AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./


### PR DESCRIPTION
This only updates the F# projects to run on .NET Core 3.1