### PR TITLE
Revert workerman to x3 workers

### DIFF
--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -6,7 +6,7 @@ use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->count         = (int) shell_exec('nproc') * 3;
 $http_worker->onWorkerStart = function () {
     global $pdo, $statement, $fortune, $random, $update;
     $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-mysql  > /dev/null
+    apt-get install -yqq php7.4 php7.4-common php7.4-cli php7.4-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
-RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
-COPY php.ini /etc/php/7.3/cli/php.ini
+COPY php.ini /etc/php/7.4/cli/php.ini
 
 ADD ./ /workerman
 WORKDIR /workerman

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-pgsql > /dev/null
+    apt-get install -yqq php7.4 php7.4-common php7.4-cli php7.4-pgsql php7.4-xml > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
-RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
-COPY php.ini /etc/php/7.3/cli/php.ini
+COPY php.ini /etc/php/7.4/cli/php.ini
 
 ADD ./ /workerman
 WORKDIR /workerman

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-mysql  > /dev/null
+    apt-get install -yqq php7.4 php7.4-common php7.4-cli php7.4-xml php7.4-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
-RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.3/cli/conf.d/event.ini
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
-COPY php.ini /etc/php/7.3/cli/php.ini
+COPY php.ini /etc/php/7.4/cli/php.ini
 
 ADD ./ /workerman
 WORKDIR /workerman


### PR DESCRIPTION
And update versions:
Ubuntu 19.10
PHP 7.4
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
