### PR TITLE
Update to PHP 7.4

### DIFF
--- a/frameworks/PHP/php/php-activerecord.dockerfile
+++ b/frameworks/PHP/php/php-activerecord.dockerfile
@@ -1,25 +1,25 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/activerecord/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx7.conf -g "daemon off;"

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -1,25 +1,25 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  php7.3-mbstring > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  php7.4-mbstring > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/eloquent/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx7.conf -g "daemon off;"

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -1,25 +1,25 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  php7.3-mbstring > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  php7.4-mbstring > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/eloquent/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx7.conf -g "daemon off;"

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -1,21 +1,21 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-COPY deploy/conf/php-fpm-pools.conf /etc/php/7.3/fpm/php-fpm.conf
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 512|pm.max_children = 256|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+COPY deploy/conf/php-fpm-pools.conf /etc/php/7.4/fpm/php-fpm.conf
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 512|pm.max_children = 256|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx-pools.conf -g "daemon off;"

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,23 +1,23 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-RUN sed -i "s|listen = /run/php/php7.3-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.3/fpm/php-fpm.conf
-RUN sed -i "s|server unix:/var/run/php/php7.3-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
+RUN sed -i "s|listen = /run/php/php7.4-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.4/fpm/php-fpm.conf
+RUN sed -i "s|server unix:/var/run/php/php7.4-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx7.conf -g "daemon off;"

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /php/deploy/nginx7.conf -g "daemon off;"


### PR DESCRIPTION
And with Ubuntu 19.10.

Later I'll send more PRs to update the rest of frameworks.

The new 7.4 have a new `preload` in the OPCache, for faster framework run. But that will be specific for every framework. So we will update with `preload` when are ready the frameworks.


<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
