### PR TITLE
Include test metadata in the results.json file

### DIFF
--- a/toolset/utils/metadata.py
+++ b/toolset/utils/metadata.py
@@ -234,12 +234,12 @@ class Metadata:
 
         return tests
 
-    def list_test_metadata(self):
+    def to_jsonable(self):
         '''
-        Prints the metadata for all the available tests
+        Returns an array suitable for jsonification
         '''
         all_tests = self.gather_tests()
-        all_tests_json = json.dumps(map(lambda test: {
+        return map(lambda test: {
             "project_name": test.project_name,
             "name": test.name,
             "approach": test.approach,
@@ -256,7 +256,13 @@ class Metadata:
             "notes": test.notes,
             "versus": test.versus,
             "tags": hasattr(test, "tags") and test.tags or []
-        }, all_tests))
+        }, all_tests)
+
+    def list_test_metadata(self):
+        '''
+        Prints the metadata for all the available tests
+        '''
+        all_tests_json = json.dumps(self.to_jsonable())
 
         with open(
                 os.path.join(self.benchmarker.results.directory,

--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -336,7 +336,7 @@ class Results:
         toRet['succeeded'] = self.succeeded
         toRet['failed'] = self.failed
         toRet['verify'] = self.verify
-        toRet['metadata'] = self.benchmarker.metadata.to_jsonable()
+        toRet['test_metadata'] = self.benchmarker.metadata.to_jsonable()
 
         return toRet
 

--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -336,6 +336,7 @@ class Results:
         toRet['succeeded'] = self.succeeded
         toRet['failed'] = self.failed
         toRet['verify'] = self.verify
+        toRet['metadata'] = self.benchmarker.metadata.to_jsonable()
 
         return toRet
 


### PR DESCRIPTION
Handles `#2` in https://github.com/TechEmpower/tfb-status/issues/19

- break up the jsonable logic for Metadata to its own function
- use this jsonable function when generating results.json

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
