### PR TITLE
Switch to latest version of GenHTTP web server engine

### DIFF
--- a/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="GenHTTP.Core" Version="2.5.0" />
-    <PackageReference Include="GenHTTP.Modules.Webservices" Version="2.5.0" />
+    <PackageReference Include="GenHTTP.Core" Version="2.6.0" />
+    <PackageReference Include="GenHTTP.Modules.Webservices" Version="2.6.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Updates the test project to reference GenHTTP v2.6 which further improves performance and stability.
