### PR TITLE
Fix php-unit

### DIFF
--- a/frameworks/PHP/php/php-unit.dockerfile
+++ b/frameworks/PHP/php/php-unit.dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
-RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+#RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq curl php7.3 php7.3-mysql > /dev/null
+    apt-get install -yqq curl php-mysql > /dev/null
 
 RUN curl https://nginx.org/keys/nginx_signing.key | apt-key add - \
-    && add-apt-repository "deb https://packages.nginx.org/unit/ubuntu/ disco unit" -s \
+    && add-apt-repository "deb https://packages.nginx.org/unit/ubuntu/ eoan unit" -s \
     && apt-get -y update \
     && apt-get -y install unit unit-php
 


### PR DESCRIPTION
And update to Ubuntu 19.10

Still using php7.3
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
