### PR TITLE
Fix update in php-ngx and workerman

### DIFF
--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -52,15 +52,17 @@ function update()
         $random->execute([$id]);
 
         $world = ['id' => $id, 'randomNumber' => $random->fetchColumn()];
-        $world['randomNumber'] = mt_rand(1, 10000);
+        $update->execute(
+            [$world['randomNumber'] = mt_rand(1, 10000), $id]
+        );
         $arr[] = $world;
     }
 
-    $pdo->beginTransaction();
-    foreach($arr as $world) {
-        $update->execute([$world['randomNumber'], $world['id']]);
-    }
-    $pdo->commit();
+    // $pdo->beginTransaction();
+    // foreach($arr as $world) {
+    //     $update->execute([$world['randomNumber'], $world['id']]);
+    // }
+    // $pdo->commit();
 
     echo json_encode($arr, JSON_NUMERIC_CHECK);
 }

--- a/frameworks/PHP/workerman/app.php
+++ b/frameworks/PHP/workerman/app.php
@@ -36,16 +36,18 @@ function updateraw()
         $id = mt_rand(1, 10000);
         $random->execute([$id]);
         $world = ['id' => $id, 'randomNumber' => $random->fetchColumn()];
-        $world['randomNumber'] = mt_rand(1, 10000);
+        $update->execute(
+            [$world['randomNumber'] = mt_rand(1, 10000), $id]
+        );
 
         $arr[] = $world;
     }
     
-    $pdo->beginTransaction();
-    foreach($arr as $world) {
-        $update->execute([$world['randomNumber'], $world['id']]);
-    }
-    $pdo->commit();
+    // $pdo->beginTransaction();
+    // foreach($arr as $world) {
+    //     $update->execute([$world['randomNumber'], $world['id']]);
+    // }
+    // $pdo->commit();
 
     return json_encode($arr, JSON_NUMERIC_CHECK);
 }

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -6,7 +6,7 @@ use Workerman\Protocols\Http;
 use Workerman\Worker;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = (int) shell_exec('nproc') * 3;
+$http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->onWorkerStart = function () {
     global $pdo, $statement, $fortune, $random, $update;
     $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',


### PR DESCRIPTION
The curious thing is that it pass in travis and local, but fail the verification in citrine.
And only fail with postgresql.

https://tfb-status.techempower.com/unzip/results.2019-12-27-21-16-34-396.zip/results/20191224064528/php-ngx-pgsql/update/verification.txt

https://tfb-status.techempower.com/unzip/results.2019-12-27-21-16-34-396.zip/results/20191224064528/workerman-pgsql/update/verification.txt

And in travis it's OK:
https://travis-ci.org/TechEmpower/FrameworkBenchmarks/jobs/630974907#L1812
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
