### PR TITLE
Update Crystal/kemal to use Crystal 0.32.1 and newer shards

### DIFF
--- a/frameworks/Crystal/kemal/kemal.dockerfile
+++ b/frameworks/Crystal/kemal/kemal.dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.26.1
+FROM crystallang/crystal:0.32.1
 
 WORKDIR /kemal
 COPY views views
@@ -9,7 +9,7 @@ COPY shard.yml shard.yml
 
 ENV GC_MARKERS 1
 ENV KEMAL_ENV production
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_idle_pool_size=56
 
 RUN echo test
 RUN shards install

--- a/frameworks/Crystal/kemal/kemal.dockerfile
+++ b/frameworks/Crystal/kemal/kemal.dockerfile
@@ -11,7 +11,6 @@ ENV GC_MARKERS 1
 ENV KEMAL_ENV production
 ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_idle_pool_size=56
 
-RUN echo test
 RUN shards install
 RUN crystal build --release --no-debug server-postgres.cr
 

--- a/frameworks/Crystal/kemal/kemal.dockerfile
+++ b/frameworks/Crystal/kemal/kemal.dockerfile
@@ -11,6 +11,7 @@ ENV GC_MARKERS 1
 ENV KEMAL_ENV production
 ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
 
+RUN echo test
 RUN shards install
 RUN crystal build --release --no-debug server-postgres.cr
 

--- a/frameworks/Crystal/kemal/shard.lock
+++ b/frameworks/Crystal/kemal/shard.lock
@@ -2,15 +2,15 @@ version: 1.0
 shards:
   db:
     github: crystal-lang/crystal-db
-    version: 0.5.0
+    version: 0.8.0
 
   exception_page:
     github: crystal-loot/exception_page
-    version: 0.1.1
+    version: 0.1.2
 
   kemal:
     github: kemalcr/kemal
-    version: 0.24.0
+    version: 0.26.1
 
   kilt:
     github: jeromegn/kilt
@@ -18,7 +18,7 @@ shards:
 
   pg:
     github: will/crystal-pg
-    version: 0.15.0
+    version: 0.20.0
 
   pool:
     github: ysbaddaden/pool
@@ -26,9 +26,9 @@ shards:
 
   radix:
     github: luislavena/radix
-    version: 0.3.8
+    version: 0.3.9
 
   redis:
     github: stefanwille/crystal-redis
-    version: 2.0.0
+    version: 2.5.3
 

--- a/frameworks/Crystal/kemal/shard.yml
+++ b/frameworks/Crystal/kemal/shard.yml
@@ -6,10 +6,10 @@ license: MIT
 dependencies:
   pg:
     github: will/crystal-pg
-    version: 0.15.0
+    version: 0.20.0
   kemal:
     github: kemalcr/kemal
-    version: 0.24.0
+    version: 0.26.1
   redis:
     github: stefanwille/crystal-redis
-    version: 2.0.0
+    version: 2.5.3


### PR DESCRIPTION
Removed the “max pool size” parameter from the DB URL since the new shard version has a different behavior. 