### PR TITLE
Fix mysql start issues with mysql docker container vs build one.

### DIFF
--- a/toolset/databases/mysql/create.sql
+++ b/toolset/databases/mysql/create.sql
@@ -2,8 +2,6 @@
 # http://stackoverflow.com/questions/37719818/the-server-time-zone-value-aest-is-unrecognized-or-represents-more-than-one-ti
 SET GLOBAL time_zone = '+00:00';
 
-# modified from SO answer http://stackoverflow.com/questions/5125096/for-loop-in-mysql
-CREATE DATABASE hello_world;
 USE hello_world;
 
 CREATE TABLE  world (
@@ -12,10 +10,6 @@ CREATE TABLE  world (
   PRIMARY KEY  (id)
 )
 ENGINE=INNODB;
-CREATE USER 'benchmarkdbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
-CREATE USER 'benchmarkdbuser'@'localhost' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
-GRANT SELECT, UPDATE ON hello_world.world TO 'benchmarkdbuser'@'%';
-GRANT SELECT, UPDATE ON hello_world.world TO 'benchmarkdbuser'@'localhost';
 
 DELIMITER #
 CREATE PROCEDURE load_data()
@@ -44,8 +38,6 @@ CREATE TABLE  fortune (
   PRIMARY KEY  (id)
 )
 ENGINE=INNODB;
-GRANT SELECT ON hello_world.fortune TO 'benchmarkdbuser'@'%';
-GRANT SELECT ON hello_world.fortune TO 'benchmarkdbuser'@'localhost';
 
 INSERT INTO fortune (message) VALUES ('fortune: No such file or directory');
 INSERT INTO fortune (message) VALUES ('A computer scientist is someone who fixes things that aren''t broken.');

--- a/toolset/databases/mysql/my.cnf
+++ b/toolset/databases/mysql/my.cnf
@@ -74,5 +74,3 @@ max_prepared_stmt_count  = 1048576
 quick
 quote-names
 max_allowed_packet      = 16M
-
-!includedir /etc/mysql/conf.d/

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,44 +1,11 @@
-FROM buildpack-deps:bionic
+FROM mysql:8
 
-ADD create.sql create.sql
-ADD my.cnf my.cnf
-ADD mysql.list mysql.list
+EXPOSE 3306
 
-RUN cp mysql.list /etc/apt/sources.list.d/
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8C718D3B5072E1F5
+ENV MYSQL_DATABASE=hello_world
+ENV MYSQL_USER=benchmarkdbuser
+ENV MYSQL_PASSWORD=benchmarkdbpass
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=1
 
-RUN apt-get update > /dev/null
-RUN apt-get install -yqq locales > /dev/null
-
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-# https://bugs.mysql.com/bug.php?id=90695
-RUN ["/bin/bash", "-c", "debconf-set-selections <<< \"mysql-server mysql-server/lowercase-table-names select Enabled\""]
-RUN ["/bin/bash", "-c", "debconf-set-selections <<< \"mysql-community-server mysql-community-server/data-dir select 'Y'\""]
-RUN ["/bin/bash", "-c", "debconf-set-selections <<< \"mysql-community-server mysql-community-server/root-pass password secret\""]
-RUN ["/bin/bash", "-c", "debconf-set-selections <<< \"mysql-community-server mysql-community-server/re-root-pass password secret\""]
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-server > /dev/null
-
-RUN mv /etc/mysql/my.cnf /etc/mysql/my.cnf.orig
-RUN cp my.cnf /etc/mysql/my.cnf
-
-RUN rm -rf /ssd/mysql
-RUN rm -rf /ssd/log/mysql
-RUN cp -R -p /var/lib/mysql /ssd/
-RUN cp -R -p /var/log/mysql /ssd/log
-
-# It may seem weird that we call `service mysql start` several times, but the RUN
-# directive is a 1-time operation for building this image. Subsequent RUN calls
-# do not see running processes from prior RUN calls; therefor, each command here
-# that relies on the mysql server running will explicitly start the server and
-# perform the work required.
-RUN chown -R mysql:mysql /var/lib/mysql /var/log/mysql /var/run/mysqld /ssd && \
-    mysqld & \
-    until mysql -uroot -psecret -e "exit"; do sleep 1; done && \
-    mysqladmin -uroot -psecret flush-hosts && \
-    mysql -uroot -psecret < create.sql
-
-CMD chown -R mysql:mysql /var/lib/mysql /var/log/mysql /var/run/mysqld /ssd && mysqld
+ADD create.sql /docker-entrypoint-initdb.d/
+ADD my.cnf /etc/mysql/conf.d/

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8
+FROM mysql:8.0.18
 
 EXPOSE 3306
 


### PR DESCRIPTION
Maybe there is a reason you are using the built container vs the stock docker hub MySQL. Let me know and I can look into it more but this word for a few tests that I tested it on and makes it much simpler.