### PR TITLE
Fix mysql start issue.

### DIFF
--- a/toolset/databases/mysql/my.cnf
+++ b/toolset/databases/mysql/my.cnf
@@ -4,7 +4,7 @@
 
 [client]
 port            = 3306
-socket          = /var/run/mysqld/mysqld.sock
+socket          = /tmp/mysqld.sock
 
 #######################
 # mysqld              #
@@ -18,15 +18,15 @@ default-storage-engine = innodb
 default_authentication_plugin = mysql_native_password
 
 user            = mysql
-pid-file        = /var/run/mysqld/mysqld.pid
-socket          = /var/run/mysqld/mysqld.sock
+pid-file        = /var/lib/mysql/mysqld.pid
+socket          = /tmp/mysqld.sock
 port            = 3306
 skip-external-locking
 skip-name-resolve
 lower_case_table_names = 1
 
-character-set-server=utf8
-collation-server=utf8_general_ci
+character-set-server=UTF8MB4
+collation-server=utf8mb4_unicode_ci
 
 #
 # * Fine Tuning
@@ -42,6 +42,7 @@ table_open_cache        = 800
 table_definition_cache  = 800
 max_heap_table_size     = 128M
 tmp_table_size          = 128M
+mysqlx                  = 0
 
 #
 # monitoring off

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -8,7 +8,7 @@ RUN cp mysql.list /etc/apt/sources.list.d/
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8C718D3B5072E1F5
 
 RUN apt-get update > /dev/null
-RUN apt-get install -yqq locales > /dev/null
+RUN apt-get install -yqq apt-utils locales > /dev/null
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -35,10 +35,10 @@ RUN cp -R -p /var/log/mysql /ssd/log
 # do not see running processes from prior RUN calls; therefor, each command here
 # that relies on the mysql server running will explicitly start the server and
 # perform the work required.
-RUN chown -R mysql:mysql /var/lib/mysql /var/log/mysql /var/run/mysqld /ssd && \
-    mysqld & \
-    until mysql -uroot -psecret -e "exit"; do sleep 1; done && \
-    mysqladmin -uroot -psecret flush-hosts && \
-    mysql -uroot -psecret < create.sql
+RUN chown -R mysql:mysql /var/lib/mysql /var/log/mysql /usr/sbin/mysqld /ssd && \
+  mysqld & \
+  until mysql -uroot -psecret -e "exit"; do sleep 1; done && \
+  mysqladmin -uroot -psecret flush-hosts && \
+  mysql -uroot -psecret < create.sql
 
-CMD chown -R mysql:mysql /var/lib/mysql /var/log/mysql /var/run/mysqld /ssd && mysqld
+CMD chown -R mysql:mysql /var/lib/mysql /var/log/mysql /usr/sbin/mysqld /ssd && mysqld


### PR DESCRIPTION
Looks like this fixes the issue with start though this is not pinned to a specific version of MySQL like before so maybe we should work on getting the official MySQL versioned container working.

The current MySql version being installed is 8.0.19.