### PR TITLE
warp-rust 0.2

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.103", features = ["derive"] }
-warp = "0.1.20"
+tokio = { version = "0.2.9", features = ["macros"] }
+warp = "0.2.0"

--- a/frameworks/Rust/warp-rust/README.md
+++ b/frameworks/Rust/warp-rust/README.md
@@ -2,7 +2,7 @@
 
 warp is a composable web server framework based on hyper.
 
-* [API Documentation](https://docs.rs/warp/0.1)
+* [API Documentation](https://docs.rs/warp/0.2)
 
 ### Test Type Implementation Source Code
 

--- a/frameworks/Rust/warp-rust/src/main.rs
+++ b/frameworks/Rust/warp-rust/src/main.rs
@@ -7,15 +7,16 @@ struct Message {
     message: &'static str,
 }
 
-fn main() {
-    let json = warp::path("json").map(|| {
+#[tokio::main]
+async fn main() {
+    let json = warp::path!("json").map(|| {
         warp::reply::json(&Message {
             message: "Hello, world!",
         })
     });
-    let plaintext = warp::path("plaintext").map(|| "Hello, World!");
+    let plaintext = warp::path!("plaintext").map(|| "Hello, World!");
     let routes = json
         .or(plaintext)
         .map(|reply| warp::reply::with_header(reply, header::SERVER, "warp"));
-    warp::serve(routes).run(([0, 0, 0, 0], 8080))
+    warp::serve(routes).run(([0, 0, 0, 0], 8080)).await;
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Upgrading warp to 0.2.0. I plan adding more paths with addition of `async`/`await` support in warp 0.2.0, but I figured I may as well start with upgrading the version, as it's a big change.