### PR TITLE
Add multiple database queries test for warp-rust

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Konrad Borowski <konrad@borowski.pw>"]
 edition = "2018"
 
 [dependencies]
+futures = "0.3.1"
 rand = "0.7.3"
 serde = { version = "1.0.103", features = ["derive"] }
 tokio = { version = "0.2.9", features = ["macros"] }

--- a/frameworks/Rust/warp-rust/README.md
+++ b/frameworks/Rust/warp-rust/README.md
@@ -9,6 +9,7 @@ warp is a composable web server framework based on hyper.
 * [JSON](src/main.rs)
 * [PLAINTEXT](src/main.rs)
 * [DB](src/main.rs)
+* [QUERIES](src/main.rs)
 
 ## Test URLs
 ### JSON
@@ -22,3 +23,7 @@ http://localhost:8080/plaintext
 ### DB
 
 http://localhost:8080/db
+
+### QUERIES
+
+http://localhost:8080/queries/[1...500]

--- a/frameworks/Rust/warp-rust/benchmark_config.json
+++ b/frameworks/Rust/warp-rust/benchmark_config.json
@@ -6,6 +6,7 @@
         "json_url": "/json",
         "plaintext_url": "/plaintext",
         "db_url": "/db",
+        "query_url": "/queries/",
         "port": 8080,
         "approach": "Realistic",
         "classification": "Micro",

--- a/frameworks/Rust/warp-rust/src/main.rs
+++ b/frameworks/Rust/warp-rust/src/main.rs
@@ -1,6 +1,8 @@
 mod db;
 
 use crate::db::Database;
+use futures::stream::futures_unordered::FuturesUnordered;
+use futures::{FutureExt, StreamExt};
 use rand::distributions::{Distribution, Uniform};
 use serde::Serialize;
 use warp::http::header;
@@ -34,12 +36,30 @@ fn db(database: &'static Database) -> impl Filter<Extract = impl Reply, Error = 
     })
 }
 
+fn queries(
+    database: &'static Database,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let between = Uniform::from(1..=10_000);
+    let clamped = warp::path!(u32).map(|queries: u32| queries.max(1).min(500));
+    warp::path!("queries" / ..)
+        .and(clamped.or(warp::any().map(|| 1)).unify())
+        .and_then(move |queries| {
+            let mut rng = rand::thread_rng();
+            (0..queries)
+                .map(|_| database.get_world_by_id(between.sample(&mut rng)))
+                .collect::<FuturesUnordered<_>>()
+                .collect::<Vec<_>>()
+                .map(|worlds| Ok::<_, Rejection>(warp::reply::json(&worlds)))
+        })
+}
+
 fn routes(
     database: &'static Database,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     json()
         .or(plaintext())
         .or(db(database))
+        .or(queries(database))
         .map(|reply| warp::reply::with_header(reply, header::SERVER, "warp"))
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
