### PR TITLE
Use testMetadata instead of test_metadata in results file

### DIFF
--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -336,7 +336,7 @@ class Results:
         toRet['succeeded'] = self.succeeded
         toRet['failed'] = self.failed
         toRet['verify'] = self.verify
-        toRet['test_metadata'] = self.benchmarker.metadata.to_jsonable()
+        toRet['testMetadata'] = self.benchmarker.metadata.to_jsonable()
 
         return toRet
 


### PR DESCRIPTION
Fix an issue with https://github.com/TechEmpower/FrameworkBenchmarks/pull/5336 where the results test metadata key was using an underscore instead of camel case. This is to be consistent with all the other keys in the results file.