### PR TITLE
Improvements to Elixir benchmarks

### DIFF
--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -15,7 +15,7 @@ config :hello, Hello.Repo,
   database: "hello_world",
   hostname: "tfb-database",
   pool_size: 40,
-  queue_target: 500,
+  queue_target: 5000,
   log: false
 
 config :logger,

--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -14,9 +14,7 @@ config :hello, Hello.Repo,
   password: "benchmarkdbpass",
   database: "hello_world",
   hostname: "tfb-database",
-  pool_size: 14,
-  queue_target: 5000,
-  queue_interval: 5000,
+  pool_size: 40,
   log: false
 
 config :logger,

--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -15,6 +15,7 @@ config :hello, Hello.Repo,
   database: "hello_world",
   hostname: "tfb-database",
   pool_size: 40,
+  queue_target: 500,
   log: false
 
 config :logger,

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -56,12 +56,13 @@ defmodule Hello.PageController do
       params["queries"]
       |> query_range()
       |> parallel(fn _ ->
-          random = :rand.uniform(@random_max)
-
+        world =
           World
-          |> Repo.get(random)
-          |> Ecto.Changeset.change(randomnumber: random_but(random))
-          |> Repo.update!()
+          |> Repo.get(:rand.uniform(@random_max))
+
+        world
+        |> Ecto.Changeset.change(randomnumber: random_but(world.randomnumber))
+        |> Repo.update!()
       end)
       |> Jason.encode_to_iodata!()
 

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -56,12 +56,13 @@ defmodule Hello.PageController do
       params["queries"]
       |> query_range()
       |> parallel(fn _ ->
-        random = :rand.uniform(@random_max)
-
         Repo.checkout(fn ->
-          World
-          |> Repo.get(random)
-          |> Ecto.Changeset.change(randomnumber: random_but(random))
+          world =
+            World
+            |> Repo.get(random)
+
+          world
+          |> Ecto.Changeset.change(randomnumber: random_but(world.randomnumber))
           |> Repo.update!()
         end)
       end)

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -56,13 +56,14 @@ defmodule Hello.PageController do
       params["queries"]
       |> query_range()
       |> parallel(fn _ ->
-        world =
-          World
-          |> Repo.get(:rand.uniform(@random_max))
+        random = :rand.uniform(@random_max)
 
-        world
-        |> Ecto.Changeset.change(randomnumber: random_but(world.randomnumber))
-        |> Repo.update!()
+        Repo.checkout(fn ->
+          World
+          |> Repo.get(random)
+          |> Ecto.Changeset.change(randomnumber: random_but(random))
+          |> Repo.update!()
+        end)
       end)
       |> Jason.encode_to_iodata!()
 

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -56,15 +56,12 @@ defmodule Hello.PageController do
       params["queries"]
       |> query_range()
       |> parallel(fn _ ->
-        Repo.checkout(fn ->
-          world =
-            World
-            |> Repo.get(:rand.uniform(@random_max))
+          random = :rand.uniform(@random_max)
 
-          world
-          |> Ecto.Changeset.change(randomnumber: random_but(world.randomnumber))
+          World
+          |> Repo.get(random)
+          |> Ecto.Changeset.change(randomnumber: random_but(random))
           |> Repo.update!()
-        end)
       end)
       |> Jason.encode_to_iodata!()
 

--- a/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
+++ b/frameworks/Elixir/phoenix/web/controllers/page_controller.ex
@@ -59,7 +59,7 @@ defmodule Hello.PageController do
         Repo.checkout(fn ->
           world =
             World
-            |> Repo.get(random)
+            |> Repo.get(:rand.uniform(@random_max))
 
           world
           |> Ecto.Changeset.change(randomnumber: random_but(world.randomnumber))

--- a/frameworks/Elixir/plug/config/releases.exs
+++ b/frameworks/Elixir/plug/config/releases.exs
@@ -9,4 +9,5 @@ config :framework_benchmarks, FrameworkBenchmarks.Repo,
   hostname: "tfb-database",
   port: 5432,
   pool_size: 40,
+  queue_target: 500,
   log: false

--- a/frameworks/Elixir/plug/config/releases.exs
+++ b/frameworks/Elixir/plug/config/releases.exs
@@ -8,7 +8,5 @@ config :framework_benchmarks, FrameworkBenchmarks.Repo,
   database: "hello_world",
   hostname: "tfb-database",
   port: 5432,
-  pool_size: 300,
-  queue_target: 5000,
-  queue_interval: 5000,
+  pool_size: 40,
   log: false

--- a/frameworks/Elixir/plug/config/releases.exs
+++ b/frameworks/Elixir/plug/config/releases.exs
@@ -9,5 +9,5 @@ config :framework_benchmarks, FrameworkBenchmarks.Repo,
   hostname: "tfb-database",
   port: 5432,
   pool_size: 40,
-  queue_target: 500,
+  queue_target: 5000,
   log: false


### PR DESCRIPTION
We increase the pool_size to 40. The original pool_size was
 way too low, which was proved by the fact we had to increase
 the queue_target and queue_interval, which means we were often
 waiting more than 5s to get hold of a connection. Also see
 the discussion in #5153. We also rollback the original queue
 values. If we are getting more timeouts, the best solution is
 most likely to bump pool size again.
