### PR TITLE
Update Codeigniter to 3.1.11

### DIFF
--- a/frameworks/PHP/codeigniter/README.md
+++ b/frameworks/PHP/codeigniter/README.md
@@ -17,10 +17,10 @@ Uses the db abstraction class from Codeigniter
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Codeigniter Version 2.1.3](http://ellislab.com/codeigniter)
-* [PHP Version 5.5.17](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
-* [MySQL 5.5.29](https://dev.mysql.com/)
+* [Codeigniter Version 3.1.11](http://ellislab.com/codeigniter)
+* [PHP Version 7.4](http://www.php.net/) with FPM and APC
+* [nginx 1.16.1](http://nginx.org/)
+* [MySQL 8](https://dev.mysql.com/)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/PHP/codeigniter/composer.json
+++ b/frameworks/PHP/codeigniter/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "codeigniter/framework": "3.1.10"
+        "codeigniter/framework": "3.1.11"
     }
 }

--- a/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/conf/php-fpm.conf
@@ -14,14 +14,14 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php/php7.3-fpm.pid
+pid = /run/php/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; into a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-;error_log = /var/log/php7.3-fpm.log
+;error_log = /var/log/php7.4-fpm.log
 error_log = /dev/stderr
 
 
@@ -161,7 +161,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php7.3-fpm.sock
+listen = /run/php/php7.4-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/codeigniter/deploy/nginx-fpm.conf
@@ -38,7 +38,7 @@ http {
     server_names_hash_bucket_size 100;
 
   upstream fastcgi_backend {
-    server unix:/var/run/php/php7.3-fpm.sock;
+    server unix:/var/run/php/php7.4-fpm.sock;
     keepalive 40;
   }
 


### PR DESCRIPTION
and change readme

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
