### PR TITLE
Update Armeria to 0.98.0

### DIFF
--- a/frameworks/Java/armeria/pom.xml
+++ b/frameworks/Java/armeria/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.target>11</maven.compiler.target>
 
     <!-- Dependency versions -->
-    <armeria.version>0.93.0</armeria.version>
+    <armeria.version>0.98.0</armeria.version>
   </properties>
 
   <dependencies>

--- a/frameworks/Java/armeria/src/main/java/hello/App.java
+++ b/frameworks/Java/armeria/src/main/java/hello/App.java
@@ -1,10 +1,5 @@
 package hello;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 
@@ -14,19 +9,12 @@ import hello.services.PostgresFortunesService;
 
 public final class App {
   public static void main(String[] args) {
-    ServerBuilder sb = new ServerBuilder();
+    ServerBuilder sb = Server.builder();
 
     sb.http(8080)
       .annotatedService(new HelloService())
       .annotatedService(new PostgresDbService())
-      .annotatedService(new PostgresFortunesService())
-      .decorator((delegate, ctx, req) -> {
-        ctx.addAdditionalResponseHeader(HttpHeaderNames.SERVER, "armeria");
-        ctx.addAdditionalResponseHeader(HttpHeaderNames.DATE,
-                                        DateTimeFormatter.RFC_1123_DATE_TIME.format(
-                                                ZonedDateTime.now(ZoneOffset.UTC)));
-        return delegate.serve(ctx, req);
-      });
+      .annotatedService(new PostgresFortunesService());
 
     Server server = sb.build();
     server.start().join();

--- a/frameworks/Java/armeria/src/main/java/hello/services/HelloService.java
+++ b/frameworks/Java/armeria/src/main/java/hello/services/HelloService.java
@@ -1,7 +1,6 @@
 package hello.services;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -22,8 +21,7 @@ public class HelloService {
 
   @Get("/json")
   @ProducesJson
-  // TODO(anuraaga): Change return type to Message after https://github.com/line/armeria/issues/2078
-  public CompletableFuture<Message> json() {
-    return CompletableFuture.completedFuture(new Message("Hello, World!"));
+  public Message json() {
+    return new Message("Hello, World!");
   }
 }

--- a/frameworks/Java/armeria/src/main/java/hello/services/PostgresDbService.java
+++ b/frameworks/Java/armeria/src/main/java/hello/services/PostgresDbService.java
@@ -81,7 +81,7 @@ public class PostgresDbService {
     return 1 + ThreadLocalRandom.current().nextInt(10000);
   }
 
-  private int getSanitizedCount(String count) {
+  private static int getSanitizedCount(String count) {
     try {
       int intCount = Integer.parseInt(count);
       if (intCount < 1) {


### PR DESCRIPTION
- `new ServerBuilder()` has been deprecated in favor or `Server.builder()`.
- `Server` and `Date` headers are now added by default.
- There's no need to return a `CompletableFuture` to run in an event loop.