### PR TITLE
Symfony : Ubuntu 19.04 -> 19.10

### DIFF
--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
### Fixed
**Symfony** and **Symfony-raw** not starting...
 - no `php-7.4` package in **Ubuntu 19.04** (without adding ppa:ondrej/php repo)