### PR TITLE
php-ngx-psql change to 3x workers

### DIFF
--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -28,6 +28,6 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
 
 RUN sed -i "s|mysql:|pgsql:|g" /app.php
 
-CMD export WORKERS=$(( 2 * $(nproc) )) && \
+CMD export WORKERS=$(( 3 * $(nproc) )) && \
     sed -i "s/worker_processes  auto/worker_processes $WORKERS/g" /deploy/nginx.conf && \
     /nginx/sbin/nginx -c /deploy/nginx.conf 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
