### PR TITLE
Revert "Php use 2048 child processes"

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/php-fpm.conf
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 2048
+pm.max_children = 1024
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -14,7 +14,7 @@ WORKDIR /kumbiaphp
 
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 -q https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 CMD service php7.4-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /kumbiaphp
 RUN git clone -b v1.0.0-rc.2 --single-branch --depth 1 https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
 RUN git clone -b master --single-branch --depth 1 https://github.com/KumbiaPHP/ActiveRecord.git vendor/Kumbia/ActiveRecord
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 CMD service php7.4-fpm start && \
     nginx -c /kumbiaphp/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/php/deploy/conf/php-fpm-pools.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm-pools.conf
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 1024
+pm.max_children = 512
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
@@ -567,4 +567,4 @@ listen.group = www-data
 ;listen.mode = 0660
 
 pm = static
-pm.max_children = 1024
+pm.max_children = 512

--- a/frameworks/PHP/php/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/php/deploy/conf/php-fpm.conf
@@ -238,7 +238,7 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 2048
+pm.max_children = 1024
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'

--- a/frameworks/PHP/php/php-activerecord.dockerfile
+++ b/frameworks/PHP/php/php-activerecord.dockerfile
@@ -14,7 +14,7 @@ COPY deploy/conf/* /etc/php/7.4/fpm/
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/activerecord/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -14,7 +14,7 @@ COPY deploy/conf/* /etc/php/7.4/fpm/
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/eloquent/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:19.10
+FROM ubuntu:16.04
 
 COPY ./ ./
 
-RUN apt update > /dev/null && \
-    apt install -yqq autoconf bison cmake curl file flex g++ git libnuma-dev libpq-dev libssl-dev \
-                     libtool libyajl-dev libz-dev make wget software-properties-common > /dev/null
+RUN apt-get update && \
+    apt-get install -yqq autoconf bison cmake curl file flex g++ git libnuma-dev libpq-dev libssl-dev \
+                     libtool libyajl-dev make wget software-properties-common > /dev/null
+
 ### Install php
-ENV DEBIAN_FRONTEND noninteractive
 
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
+    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
 
-COPY deploy/conf/* /etc/php/7.4/fpm/
+COPY deploy/conf/* /etc/php/7.3/fpm/
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
 
 ### Install h2o
 
@@ -29,5 +29,5 @@ RUN wget -qO "$H2O_ARCHIVE" "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" &&
           -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=off . && \
     make -j "$(nproc)" install  > /dev/null
 
-CMD service php7.4-fpm start && \
+CMD service php7.3-fpm start && \
     /h2o/bin/h2o -c /deploy/h2o.conf

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -14,7 +14,7 @@ COPY deploy/conf/* /etc/php/7.4/fpm/
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 COPY deploy/eloquent/composer* ./
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -17,7 +17,7 @@ RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" dbquery.php
 RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" fortune.php
 RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" updateraw.php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -13,7 +13,7 @@ ADD ./ /php
 WORKDIR /php
 
 COPY deploy/conf/php-fpm-pools.conf /etc/php/7.4/fpm/php-fpm.conf
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 256|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 512|pm.max_children = 256|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /php
 RUN sed -i "s|listen = /run/php/php-fpm.sock|listen = 127.0.0.1:9001|g" /etc/php/7.4/fpm/php-fpm.conf
 RUN sed -i "s|server unix:/var/run/php/php-fpm.sock;|server 127.0.0.1:9001;|g" deploy/nginx7.conf
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -12,7 +12,7 @@ COPY deploy/conf/* /etc/php/7.4/fpm/
 ADD ./ /php
 WORKDIR /php
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 2048|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /php
 


### PR DESCRIPTION
Reverts TechEmpower/FrameworkBenchmarks#5457

Some changes in some stacks are worst for perfomance, after the last patches for the "TCP SACK PANIC".