### PR TITLE
php-h2o update php7.4 and ubuntu 19.10

### DIFF
--- a/frameworks/PHP/php/deploy/h2o.conf
+++ b/frameworks/PHP/php/deploy/h2o.conf
@@ -2,6 +2,7 @@ server-name: "h2o"
 user: www-data
 max-connections: 65536
 error-log: /dev/stderr
+num-threads: x
 
 listen:
   port: 8080

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,20 +1,21 @@
-FROM ubuntu:16.04
+FROM ubuntu:19.10
 
 COPY ./ ./
 
-RUN apt-get update && \
-    apt-get install -yqq autoconf bison cmake curl file flex g++ git libnuma-dev libpq-dev libssl-dev \
-                     libtool libyajl-dev make wget software-properties-common > /dev/null
+RUN apt update > /dev/null && \
+    apt install -yqq autoconf bison cmake curl file flex g++ git libnuma-dev libpq-dev libssl-dev \
+                     libtool libyajl-dev libz-dev make wget software-properties-common > /dev/null
 
 ### Install php
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql  > /dev/null
+    apt-get install -yqq php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
 ### Install h2o
 
@@ -29,5 +30,7 @@ RUN wget -qO "$H2O_ARCHIVE" "https://github.com/h2o/h2o/archive/$H2O_ARCHIVE" &&
           -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib -DWITH_MRUBY=off . && \
     make -j "$(nproc)" install  > /dev/null
 
-CMD service php7.3-fpm start && \
+CMD export WORKERS=$(( 2 * $(nproc) )) && \
+    sed -i "s/num-threads: x/num-threads: $WORKERS/g" /deploy/h2o.conf && \
+    service php7.4-fpm start && \
     /h2o/bin/h2o -c /deploy/h2o.conf


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
