### PR TITLE
Scalene: version bump 0.1.3

### DIFF
--- a/frameworks/Scala/scalene/build.sbt
+++ b/frameworks/Scala/scalene/build.sbt
@@ -1,4 +1,4 @@
-val scaleneUri = uri("https://github.com/DanSimon/Scalene.git#0.1.2")
+val scaleneUri = uri("https://github.com/DanSimon/Scalene.git#0.1.3")
 
 lazy val scaleneRouting = ProjectRef(scaleneUri,"scalene-routing")
 lazy val scaleneSQL = ProjectRef(scaleneUri,"scalene-sql")
@@ -7,12 +7,18 @@ lazy val `scalene-benchmark` = (project in file("."))
   .dependsOn(scaleneRouting)
   .dependsOn(scaleneSQL)
 
-scalaVersion := "2.12.10"
+
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+ case x => MergeStrategy.first
+}
+
+scalaVersion := "2.13.1"
 version := "0.1.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql"        % "42.2.0",
-  "org.json4s"                   %% "json4s-jackson"       % "3.5.3",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.2"
+  "org.json4s"                   %% "json4s-jackson"       % "3.6.7",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.10.2"
 )
 

--- a/frameworks/Scala/scalene/scalene.dockerfile
+++ b/frameworks/Scala/scalene/scalene.dockerfile
@@ -20,4 +20,4 @@ COPY project project
 COPY src src
 COPY build.sbt build.sbt
 RUN sbt assembly -batch
-CMD ["java", "-server", "-Xmx2G", "-Xms2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "target/scala-2.12/scalene-benchmark-assembly-0.1.0-SNAPSHOT.jar"]
+CMD ["java", "-server", "-Xmx2G", "-Xms2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "target/scala-2.13/scalene-benchmark-assembly-0.1.0-SNAPSHOT.jar"]

--- a/frameworks/Scala/scalene/src/main/scala/Benchmark.scala
+++ b/frameworks/Scala/scalene/src/main/scala/Benchmark.scala
@@ -10,6 +10,8 @@ import BasicConversions._
 
 object Main extends App {
 
+  Class.forName("org.postgresql.Driver");
+
   trait JsonMessage
   case class JsonRouteMessage(message: String) extends JsonMessage
   case class DBRouteMessage(id: Int, randomnumber: Int) extends JsonMessage


### PR DESCRIPTION
Bump to latest release which builds for Scala 2.13 and has some performance improvements.