### PR TITLE
Workerman add date header with 1s timer

### DIFF
--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -9,6 +9,7 @@ use Workerman\Lib\Timer;
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->onWorkerStart = function () {
+    Header::$date = 'Date: '.gmdate('D, d M Y H:i:s').' GMT';
     Timer::add(1, function() {
         Header::$date = 'Date: '.gmdate('D, d M Y H:i:s').' GMT';
     });

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -4,19 +4,28 @@ require_once __DIR__.'/app.php';
 
 use Workerman\Protocols\Http;
 use Workerman\Worker;
+use Workerman\Lib\Timer;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->onWorkerStart = function () {
+    Timer::add(1, function() {
+        Header::$date = 'Date: '.gmdate('D, d M Y H:i:s').' GMT';
+    });
     init();
 };
 
 $http_worker->onMessage = static function ($connection) {
 
-    Http::header('Date: '.gmdate('D, d M Y H:i:s').' GMT');
+    Http::header(Header::$date);
 
     $connection->send(router());
     
 };
 
 Worker::runAll();
+
+
+class Header {
+    public static $date = null;
+}


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
