### PR TITLE
KumbiaPHP with Workerman

### DIFF
--- a/frameworks/PHP/kumbiaphp/bench/app/config/config.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/config/config.php
@@ -3,9 +3,6 @@
 return [
 'application' => [
     'name' => 'KUMBIA PROJECT',
-    'database' => 'default',
-    'dbdate' => 'YYYY-MM-DD',
-    'debug' => 'Off',
     'log_exceptions' => 'Off',
     //'cache_template' => 'On',
     'cache_driver' => 'nixfile',

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/db_controller.php
@@ -10,7 +10,7 @@ class DbController extends AppController
 
     public function index()
     {
-        echo json_encode(World::byId(mt_rand(1, 10000)), JSON_NUMERIC_CHECK);
+        echo json_encode(World::byId(mt_rand(1, 10000)));
     }
 
     public function query($count = 1)
@@ -20,7 +20,7 @@ class DbController extends AppController
         while ($count--) {
             $worlds[] = World::byId(mt_rand(1, 10000));
         }
-        echo json_encode($worlds, JSON_NUMERIC_CHECK);
+        echo json_encode($worlds);
     }
 
     public function update($count = 1)
@@ -33,6 +33,6 @@ class DbController extends AppController
             $row->update();
             $worlds[] = $row;
         }
-        echo json_encode($worlds, JSON_NUMERIC_CHECK);
+        echo json_encode($worlds);
     }
 }

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/fortune_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/fortune_controller.php
@@ -5,7 +5,7 @@ class FortuneController extends AppController
     public function index()
     {
         View::select(null,'fortune');
-        $data = World::all('SELECT id, message FROM Fortune');
+        $data = Fortune::all('SELECT id, message FROM Fortune');
         $data[] = (object) ['id' => 0,'message' => 'Additional fortune added at request time.'];
         usort($data, function($a, $b){return strcmp($a->message, $b->message);});
         $this->data = $data;

--- a/frameworks/PHP/kumbiaphp/bench/app/models/fortune.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/models/fortune.php
@@ -2,8 +2,5 @@
 
 class Fortune extends \Kumbia\ActiveRecord\LiteRecord
 {
-    public static function all()
-    {
-        return parent::all('SELECT id, message FROM Fortune');
-    }
+
 }

--- a/frameworks/PHP/kumbiaphp/bench/app/workerbootstrap.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/workerbootstrap.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * KumbiaPHP web & app Framework.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://wiki.kumbiaphp.com/Licencia
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@kumbiaphp.com so we can send you a copy immediately.
+ *
+ * @copyright  Copyright (c) 2005 - 2020 Kumbia Team (http://www.kumbiaphp.com)
+ * @license    http://wiki.kumbiaphp.com/Licencia     New BSD License
+ */
+
+/**
+ * Esta sección prepara el entorno
+ * Todo esto se puede hacer desde la configuracion del
+ * Servidor/PHP, en caso de no poder usarlo desde ahí
+ * Puedes descomentar  estas lineas.
+ */
+
+//*Locale*
+//setlocale(LC_ALL, 'es_ES');
+
+//*Timezone*
+//ini_set('date.timezone', 'America/New_York');
+
+/**
+ * @TODO
+ * REVISAR ESTA SECCIÓN
+ */
+const APP_CHARSET = 'UTF-8';
+/**
+ * Indicar si la aplicacion se encuentra en produccion
+ * directamente desde el index.php.
+ */
+const PRODUCTION = false;
+
+/**
+ * Descomentar para mostrar los errores.
+ */
+//error_reporting(E_ALL ^ E_STRICT);ini_set('display_errors', 'On');
+
+/**
+ * Define el APP_PATH.
+ *
+ * APP_PATH:
+ * - Ruta al directorio de la aplicación (por defecto la ruta al directorio app)
+ * - Esta ruta se utiliza para cargar los archivos de la aplicacion
+ * - En producción, es recomendable ponerla manual
+ */
+//define('APP_PATH', dirname(__DIR__).'/app/');
+const APP_PATH = '/kumbiaphp/bench/app/';
+/**
+ * Define el CORE_PATH.
+ *
+ * CORE_PATH:
+ * - Ruta al directorio que contiene el núcleo de Kumbia (por defecto la ruta al directorio core)
+ */
+//define('CORE_PATH', dirname(dirname(APP_PATH)).'/vendor/Kumbia/core/');
+const CORE_PATH = '/kumbiaphp/vendor/Kumbia/core/';
+/**
+ * Define el PUBLIC_PATH.
+ *
+ * PUBLIC_PATH:
+ * - Path para genera la Url en los links a acciones y controladores
+ * - Esta ruta la utiliza Kumbia como base para generar las Urls para acceder de lado de
+ *   cliente (con el navegador web) y es relativa al DOCUMENT_ROOT del servidor web
+ *
+ *  EN WORKERMAN ESTA CONSTANTE NO CAMBIA
+ */
+const PUBLIC_PATH = '/';
+
+/**
+ * Carga el gestor de arranque
+ * Por defecto el bootstrap del core.
+ *
+ * @see Bootstrap
+ */
+//require APP_PATH . 'libs/bootstrap.php'; //bootstrap de app
+//require CORE_PATH.'kumbia/bootstrap.php'; //bootstrap del core
+
+require CORE_PATH.'kumbia/workerboot.php';  //bootstrap for workerman

--- a/frameworks/PHP/kumbiaphp/benchmark_config.json
+++ b/frameworks/PHP/kumbiaphp/benchmark_config.json
@@ -44,6 +44,29 @@
             "display_name": "kumbiaphp-raw",
             "notes": "",
             "versus": "php"
+          },
+          "workerman": {
+            "plaintext_url": "/",
+            "json_url": "/json",
+            "db_url": "/db",
+            "query_url": "/db/query/",
+            "fortune_url": "/fortune",
+            "update_url": "/db/update/",
+            "port": 8080,
+            "approach": "Realistic",
+            "classification": "Fullstack",
+            "database": "MySQL",
+            "framework": "KumbiaPHP",
+            "language": "PHP",
+            "flavor": "PHP7",
+            "orm": "micro",
+            "platform": "workerman",
+            "webserver": "None",
+            "os": "Linux",
+            "database_os": "Linux",
+            "display_name": "kumbiaphp-worker",
+            "notes": "",
+            "versus": "workerman"
           }
         }]
       }

--- a/frameworks/PHP/kumbiaphp/composer.json
+++ b/frameworks/PHP/kumbiaphp/composer.json
@@ -1,0 +1,5 @@
+{
+	"require": {
+		"workerman/workerman": "^3.5"
+	}
+}

--- a/frameworks/PHP/kumbiaphp/deploy/conf/cliphp.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/cliphp.ini
@@ -1,0 +1,8 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=0
+opcache.save_comments=0
+opcache.enable_file_override=1
+opcache.huge_code_pages=1
+
+mysqlnd.collect_statistics = Off

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:19.10
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq git unzip php7.4 php7.4-common php7.4-cli php7.4-mysql  > /dev/null
+
+RUN apt-get install -yqq composer > /dev/null
+
+RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
+RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
+
+ADD ./ /kumbiaphp
+WORKDIR /kumbiaphp
+
+RUN git clone -b dev --single-branch --depth 1 https://github.com/KumbiaPHP/KumbiaPHP.git vendor/Kumbia
+RUN git clone -b master --single-branch --depth 1 https://github.com/KumbiaPHP/ActiveRecord.git vendor/Kumbia/ActiveRecord
+
+RUN sed -i "s|header(|\\\Workerman\\\Protocols\\\Http::header(|g" bench/app/controllers/*.php
+#RUN sed -i "s|mysql:host|pgsql:host|g" bench/app/config/databases.php
+
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+
+CMD php server.php start

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
@@ -12,6 +12,8 @@ RUN apt-get install -yqq composer > /dev/null
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
 RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
+COPY deploy/conf/cliphp.ini /etc/php/7.4/cli/php.ini
+
 ADD ./ /kumbiaphp
 WORKDIR /kumbiaphp
 

--- a/frameworks/PHP/kumbiaphp/server.php
+++ b/frameworks/PHP/kumbiaphp/server.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__.'/bench/app/workerbootstrap.php';
+require_once __DIR__.'/vendor/autoload.php';
+
+use Workerman\Worker;
+
+$http_worker                = new Worker('http://0.0.0.0:8080');
+$http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->onWorkerStart = static function () {
+
+    kumbiaInit();
+};
+
+$http_worker->onMessage = static function ($connection) {
+
+    $connection->send(kumbiaSend());
+};
+
+Worker::runAll();


### PR DESCRIPTION
Initial changes to use Workerman.

Later We will update the ORM to take advantage of a persistent application.

But now, We can follow the progress.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
