### PR TITLE
Downgrade aspnetcore-mono to .NET Core 2.1 Packages

### DIFF
--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
@@ -27,6 +28,5 @@
     <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -27,5 +27,6 @@
     <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -14,19 +14,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
-    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
-    <PackageReference Include="Npgsql" Version="4.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.3" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0" />
+    <PackageReference Include="Npgsql" Version="4.1.3.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net471</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>7.3</LangVersion>
     <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Controllers/HomeController.cs
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Controllers/HomeController.cs
@@ -36,10 +36,12 @@ namespace Benchmarks.Controllers
 
             public Task ExecuteResultAsync(ActionContext context)
             {
-                context.HttpContext.Response.StatusCode = StatusCodes.Status200OK;
-                context.HttpContext.Response.ContentType = "text/plain";
-                context.HttpContext.Response.ContentLength = _helloWorldPayload.Length;
-                return context.HttpContext.Response.Body.WriteAsync(_helloWorldPayload, 0, _helloWorldPayload.Length);
+                var response = context.HttpContext.Response;
+                response.StatusCode = StatusCodes.Status200OK;
+                response.ContentType = "text/plain";
+                var payloadLength = _helloWorldPayload.Length;
+                response.ContentLength = payloadLength;
+                return response.Body.WriteAsync(_helloWorldPayload, 0, payloadLength);
             }
         }
     }

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/FortunesEfMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/FortunesEfMiddleware.cs
@@ -33,11 +33,11 @@ namespace Benchmarks.Middleware
                 var rows = await db.LoadFortunesRows();
 
                 await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+
+                return;
             }
-            else
-            {
-                await _next(httpContext);
-            }
+
+            await _next(httpContext);
         }
     }
 

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/FortunesRawMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/FortunesRawMiddleware.cs
@@ -33,11 +33,11 @@ namespace Benchmarks.Middleware
                 var rows = await db.LoadFortunesRows();
 
                 await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+
+                return;
             }
-            else
-            {
-                await _next(httpContext);
-            }
+
+            await _next(httpContext);
         }
     }
 

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/JsonMiddleware.cs
@@ -4,18 +4,18 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 
 namespace Benchmarks.Middleware
 {
     public class JsonMiddleware
     {
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
-        private static readonly JsonSerializer _json = new JsonSerializer();
         private static readonly UTF8Encoding _encoding = new UTF8Encoding(false);
         private const int _bufferSize = 27;
 
@@ -34,12 +34,7 @@ namespace Benchmarks.Middleware
                 httpContext.Response.ContentType = "application/json";
                 httpContext.Response.ContentLength = _bufferSize;
 
-                using (var sw = new StreamWriter(httpContext.Response.Body, _encoding, bufferSize: _bufferSize))
-                {
-                    _json.Serialize(sw, new { message = "Hello, World!" });
-                }
-
-                return Task.CompletedTask;
+                return JsonSerializer.SerializeAsync<JsonMessage>(httpContext.Response.Body, new JsonMessage { message = "Hello, World!" });
             }
 
             return _next(httpContext);
@@ -52,5 +47,10 @@ namespace Benchmarks.Middleware
         {
             return builder.UseMiddleware<JsonMiddleware>();
         }
+    }
+
+    public struct JsonMessage
+    {
+        public string message { get; set; }
     }
 }

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/MiddlewareHelpers.cs
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/Middleware/MiddlewareHelpers.cs
@@ -30,17 +30,15 @@ namespace Benchmarks.Middleware
                     : 1;
         }
 
-        public static Task RenderFortunesHtml(List<Fortune> model, HttpContext httpContext, HtmlEncoder htmlEncoder)
+        public static Task RenderFortunesHtml(IEnumerable<Fortune> model, HttpContext httpContext, HtmlEncoder htmlEncoder)
         {
             httpContext.Response.StatusCode = StatusCodes.Status200OK;
             httpContext.Response.ContentType = "text/html; charset=UTF-8";
 
             var sb = StringBuilderCache.Acquire();
             sb.Append("<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>");
-            var count = model.Count;
-            for (var i = 0; i < count; i++)
+            foreach (var item in model)
             {
-                var item = model[i];
                 sb.Append("<tr><td>");
                 sb.Append(item.Id.ToString(CultureInfo.InvariantCulture));
                 sb.Append("</td><td>");

--- a/frameworks/CSharp/aspnetcore-mono/Benchmarks/appsettings.postgresql.json
+++ b/frameworks/CSharp/aspnetcore-mono/Benchmarks/appsettings.postgresql.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=1024;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3",
+  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3",
   "Database": "postgresql"
 }

--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
@@ -17,7 +18,6 @@
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="Npgsql" Version="4.0.4" />
     <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
   </ItemGroup>
   
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore-mono/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -10,14 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="Npgsql" Version="4.0.4" />
-    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
+    <PackageReference Include="Npgsql" Version="4.1.3.1" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0" />
   </ItemGroup>
   
 </Project>

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-ef-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-my.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mvc.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-ef-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-my.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-mw.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-my.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/aspnetcore-mono/aspcore-mono.dockerfile
+++ b/frameworks/CSharp/aspnetcore-mono/aspcore-mono.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out


### PR DESCRIPTION
- .NET Core 2.2 is EOL.
- Downgrade to 2.1 for now.
- May upgrade to 5.0 at a later time.
- Updated other references.