### PR TITLE
Improvements to webflux

### DIFF
--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
@@ -51,7 +51,7 @@ public class WebfluxHandler {
     public Mono<ServerResponse> queries(ServerRequest request) {
         int queries = getQueries(request);
 
-        Flux<World> worlds = Flux.range(0, queries)
+        Mono<List<World>> worlds = Flux.range(0, queries)
                 .flatMap(i -> dbRepository.getWorld(randomWorldNumber()))
                 .collectList();
 
@@ -77,7 +77,7 @@ public class WebfluxHandler {
     public Mono<ServerResponse> updates(ServerRequest request) {
         int count = getQueries(request);
         
-        Flux<World> worlds = Flux.range(0, queries)
+        Mono<List<World>> worlds = Flux.range(0, queries)
                 .flatMap(i -> dbRepository.findAndUpdateWorld(randomWorldNumber(), randomWorldNumber()))
                 .collectList();
 

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
@@ -51,12 +51,13 @@ public class WebfluxHandler {
     public Mono<ServerResponse> queries(ServerRequest request) {
         int queries = getQueries(request);
 
-        Mono<World>[] worlds = new Mono[queries];
-        Arrays.setAll(worlds, i -> dbRepository.getWorld(randomWorldNumber()));
+        Flux<World> worlds = Flux.range(0, queries)
+                .flatMap(i -> dbRepository.getWorld(randomWorldNumber()))
+                .collectList();
 
         return ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Flux.merge(worlds).collectList(), new ParameterizedTypeReference<List<World>>() {
+                .body(worlds, new ParameterizedTypeReference<List<World>>() {
                 });
     }
 
@@ -75,13 +76,14 @@ public class WebfluxHandler {
 
     public Mono<ServerResponse> updates(ServerRequest request) {
         int count = getQueries(request);
-        Mono<World>[] worlds = new Mono[count];
-
-        Arrays.setAll(worlds, i -> dbRepository.findAndUpdateWorld(randomWorldNumber(), randomWorldNumber()));
+        
+        Flux<World> worlds = Flux.range(0, queries)
+                .flatMap(i -> dbRepository.findAndUpdateWorld(randomWorldNumber(), randomWorldNumber()))
+                .collectList();
 
         return ServerResponse.ok()
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Flux.merge(worlds).collectList(), new ParameterizedTypeReference<List<World>>() {
+                .body(worlds, new ParameterizedTypeReference<List<World>>() {
                 });
     }
 

--- a/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
+++ b/frameworks/Java/spring-webflux/src/main/java/benchmark/web/WebfluxHandler.java
@@ -75,7 +75,7 @@ public class WebfluxHandler {
     }
 
     public Mono<ServerResponse> updates(ServerRequest request) {
-        int count = getQueries(request);
+        int queries = getQueries(request);
         
         Mono<List<World>> worlds = Flux.range(0, queries)
                 .flatMap(i -> dbRepository.findAndUpdateWorld(randomWorldNumber(), randomWorldNumber()))


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Using `Flux.range` is a better idea, which also avoids the allocation of the array.

Here is the benchmark on my Macbook:

```
Flux.range(0,100).flatMap(i->Mono.just(0)).collectList();
```
v.s
```
Mono[] all = new Mono[100];
Arrays.setAll(all, i->Mono.just(0));
Flux.merge(all).collectList();
```

range     38.794  +- 3.037 ns
merge    338.280+- 6.544 ns