### PR TITLE
Update GenHTTP to server version 2.8.3

### DIFF
--- a/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="GenHTTP.Core" Version="2.8.1" />
-    <PackageReference Include="GenHTTP.Modules.Webservices" Version="2.8.1" />
+    <PackageReference Include="GenHTTP.Core" Version="2.8.3" />
+    <PackageReference Include="GenHTTP.Modules.Webservices" Version="2.8.3" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Update to latest server version which provides additional bug fixes regarding the new pipeline-based parser engine of the server.