### PR TITLE
Fix a warning from tfb stating that quarkus is not defining a default…

### DIFF
--- a/frameworks/Java/quarkus/benchmark_config.json
+++ b/frameworks/Java/quarkus/benchmark_config.json
@@ -20,9 +20,7 @@
         "display_name": "quarkus",
         "notes": "",
         "versus": "Netty"
-      }
-    },
-    {
+      },
       "hibernate": {
         "db_url": "/hibernate/db",
         "query_url": "/hibernate/queries?queries=",
@@ -42,9 +40,7 @@
         "display_name": "quarkus-hibernate",
         "notes": "",
         "versus": "Netty"
-      }
-    },
-    {
+      },
       "pgclient": {
         "db_url": "/pgclient/db",
         "query_url": "/pgclient/queries?queries=",


### PR DESCRIPTION
… config

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
