### PR TITLE
Fix failing ffead-cpp mongo tests

### DIFF
--- a/frameworks/C++/ffead-cpp/install_ffead-cpp-framework-forsql.sh
+++ b/frameworks/C++/ffead-cpp/install_ffead-cpp-framework-forsql.sh
@@ -49,8 +49,8 @@ sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdorm.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormmongo.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormmysql.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormpostgresql.xml
-sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdorm.xml
-sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmongo.xml
+#sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdorm.xml
+#sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmongo.xml
 sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmysql.xml
 sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormpostgresql.xml
 sed -i 's|127.0.0.1|tfb-database|g' resources/sample-odbcinst.ini

--- a/frameworks/C++/ffead-cpp/install_ffead-cpp-framework.sh
+++ b/frameworks/C++/ffead-cpp/install_ffead-cpp-framework.sh
@@ -49,8 +49,8 @@ sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdorm.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormmongo.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormmysql.xml
 sed -i 's|localhost|tfb-database|g' web/te-benchmark-um/config/sdormpostgresql.xml
-sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdorm.xml
-sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmongo.xml
+#sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdorm.xml
+#sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmongo.xml
 sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormmysql.xml
 sed -i 's|<pool-size>30</pool-size>|<pool-size>${MAX_THREADS}</pool-size>|g' web/te-benchmark-um/config/sdormpostgresql.xml
 sed -i 's|127.0.0.1|tfb-database|g' resources/sample-odbcinst.ini


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
