### PR TITLE
Yii2: enable the ORM cache on the DB schema

### DIFF
--- a/frameworks/PHP/yii2/app/controllers/SiteController.php
+++ b/frameworks/PHP/yii2/app/controllers/SiteController.php
@@ -57,9 +57,7 @@ class SiteController extends Controller
 
         $fortunes[] = $runtimeFortune;
 
-        usort($fortunes, function ($left, $right) {
-            return strcmp($left->message, $right->message);
-        });
+        usort($fortunes, [Fortune::class, 'cmp']);
 
         $this->view->title = 'Fortunes';
 

--- a/frameworks/PHP/yii2/app/controllers/SiteController.php
+++ b/frameworks/PHP/yii2/app/controllers/SiteController.php
@@ -76,7 +76,7 @@ class SiteController extends Controller
         while ($queries--) {
             $world = World::findOne(random_int(1, 10000));
             $world->randomNumber = random_int(1, 10000);
-            $world->save();
+            $world->save(false);
 
             $worlds[] = $world;
         }

--- a/frameworks/PHP/yii2/app/index.php
+++ b/frameworks/PHP/yii2/app/index.php
@@ -20,7 +20,16 @@ $config = [
             'charset' => 'utf8',
             'attributes' => [
                 PDO::ATTR_PERSISTENT => true,
-            ]
+            ],
+            'enableLogging' => false,
+            'enableProfiling' => false,
+            'enableSchemaCache' => true,
+            'schemaCache' => 'cache',
+            'schemaCacheDuration' => 3600,
+        ],
+        'cache' => [
+            'class' => 'yii\caching\FileCache',
+            'cachePath' => '/tmp/yii2-cache',
         ],
         'urlManager' => [
             'enablePrettyUrl' => true,

--- a/frameworks/PHP/yii2/app/models/Fortune.php
+++ b/frameworks/PHP/yii2/app/models/Fortune.php
@@ -14,4 +14,9 @@ class Fortune extends ActiveRecord
     {
         return 'fortune';
     }
+
+    public static function cmp(Fortune $left, Fortune $right): int
+    {
+        return \strcmp($left->message, $right->message);
+    }
 }

--- a/frameworks/PHP/yii2/composer.json
+++ b/frameworks/PHP/yii2/composer.json
@@ -1,7 +1,6 @@
 {
 	"require": {
 		"yidas/yii2-composer-bower-skip": "~2.0.13",
-		"yiisoft/yii2": "~2.0.14",
-		"yiisoft/yii2-bootstrap": "~2.0.8"
+		"yiisoft/yii2": "~2.0.14"
 	}
 }

--- a/frameworks/PHP/yii2/composer.lock
+++ b/frameworks/PHP/yii2/composer.lock
@@ -250,66 +250,6 @@
             "time": "2019-03-22T21:26:26+00:00"
         },
         {
-            "name": "yiisoft/yii2-bootstrap",
-            "version": "2.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yiisoft/yii2-bootstrap.git",
-                "reference": "4677951dda712dd99d5bf2a127eaee118dfea860"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-bootstrap/zipball/4677951dda712dd99d5bf2a127eaee118dfea860",
-                "reference": "4677951dda712dd99d5bf2a127eaee118dfea860",
-                "shasum": ""
-            },
-            "require": {
-                "bower-asset/bootstrap": "3.4.* | 3.3.* | 3.2.* | 3.1.*",
-                "yiisoft/yii2": "~2.0.6"
-            },
-            "type": "yii2-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "yii\\bootstrap\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Paul Klimov",
-                    "email": "klimov.paul@gmail.com"
-                },
-                {
-                    "name": "Alexander Makarov",
-                    "email": "sam@rmcreative.ru",
-                    "homepage": "http://rmcreative.ru/"
-                },
-                {
-                    "name": "Antonio Ramirez",
-                    "email": "amigo.cobos@gmail.com"
-                },
-                {
-                    "name": "Qiang Xue",
-                    "email": "qiang.xue@gmail.com",
-                    "homepage": "http://www.yiiframework.com/"
-                }
-            ],
-            "description": "The Twitter Bootstrap extension for the Yii framework",
-            "keywords": [
-                "bootstrap",
-                "yii2"
-            ],
-            "time": "2019-01-29T21:39:45+00:00"
-        },
-        {
             "name": "yiisoft/yii2-composer",
             "version": "2.0.7",
             "source": {

--- a/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/conf/php-fpm.conf
@@ -14,14 +14,14 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php/php7.3-fpm.pid
+pid = /run/php/php7.4-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; into a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-;error_log = /var/log/php7.3-fpm.log
+;error_log = /var/log/php7.4-fpm.log
 error_log = /dev/stderr
 
 
@@ -124,7 +124,7 @@ systemd_interval = 0
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-;include=/etc/php/7.3/fpm/pool.d/*.conf
+;include=/etc/php/7.4/fpm/pool.d/*.conf
 
 ; Start a new pool named 'www'.
 ; the variable $pool can be used in any directive and will be replaced by the
@@ -161,7 +161,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /run/php/php7.3-fpm.sock
+listen = /run/php/php7.4-fpm.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)
@@ -357,7 +357,7 @@ pm.max_spare_servers = 512
 ;   last request memory:  0
 ;
 ; Note: There is a real-time FPM status monitoring sample web page available
-;       It's available in: /usr/share/php/7.3/fpm/status.html
+;       It's available in: /usr/share/php/7.4/fpm/status.html
 ;
 ; Note: The value must start with a leading slash (/). The value can be
 ;       anything, but it may not be a good idea to use the .php extension or it

--- a/frameworks/PHP/yii2/deploy/nginx-fpm.conf
+++ b/frameworks/PHP/yii2/deploy/nginx-fpm.conf
@@ -18,7 +18,7 @@ http {
     keepalive_requests 10000;
 
     upstream fastcgi_backend {
-        server unix:/var/run/php/php7.3-fpm.sock;
+        server unix:/var/run/php/php7.4-fpm.sock;
         keepalive 40;
     }
 


### PR DESCRIPTION
This PR gets better performance from the Yii2 application.

The 5 commits are independent of each other. The most important one enables the cache of the DB schema, which provides a huge boost in performances when requests use the DB.

Other changes are documented in their respective commit messages. The first commit is a simple cleanup from a past renaming that was incomplete. The other commits provide small performance gains. They were tested in my local instance.