### PR TITLE
Yii2: fix a bug in the parsing of integer GET parameters

### DIFF
--- a/frameworks/PHP/yii2/app/helpers/Query.php
+++ b/frameworks/PHP/yii2/app/helpers/Query.php
@@ -6,12 +6,12 @@ class Query
 {
     public static function clamp($value): int
     {
-        if (!is_numeric($value) || $value < 1) {
+        if (!ctype_digit($value) || $value < 1) {
             return 1;
         } elseif ($value > 500) {
             return 500;
         } else {
-            return $value;
+            return (int) $value;
         }
     }
 }


### PR DESCRIPTION
Without this fix, the yii2 and yii2-raw applications accept values like "2.5" or "+9.876e2". Non-integer floats greater than 1 triggered infinite loops in routes /queries and /updates.