### PR TITLE
Yii2: update the readme

### DIFF
--- a/frameworks/PHP/yii2/README.md
+++ b/frameworks/PHP/yii2/README.md
@@ -1,58 +1,19 @@
 # Yii2 Benchmarking Test
 
-This is the Yii2 portion of a [benchmarking test suite](../) comparing a variety of web development platforms.
+This is the Yii2 portion of a [benchmarking test suite](../../../) comparing a variety of web development platforms.
 
-This uses PHP's composer for dependency resolution. Note 
-that [issue 5083](https://github.com/yiisoft/yii2/issues/5083)
-affects the `composer.json` file defined here (also see 
-[this](https://github.com/francoispluchino/composer-asset-plugin/issues/29) and [this](https://stackoverflow.com/questions/25882271/cannot-update-yii2-via-composer-bower-asset-jquery-could-not-be-found))
+- The [yii2-raw controller](app/controllers/RawController.php) sends raw SQL queries with the Yii DAO.
+- The [yii2 controller](app/controllers/SiteController.php) uses the full ORM embedded with Yii2.
 
-### JSON Encoding Test
-Uses the PHP standard [JSON encoder](http://www.php.net/manual/en/function.json-encode.php).
+This is a realistic implementation, which keeps an ordinary structure and avoids frameworks shortcuts.
 
-* [JSON test controller](app/controllers/SiteController.php)
+## Infrastructure Software
 
-
-### Data-Store/Database Mapping Test
-Uses the Yii2 Fluent Query Builder.
-
-* [DB test controller](app/controllers/SiteController.php)
-
-### Template Test
-Uses Php template
-
-* [Template test controller](application/controllers/Bench.php)
-
-
-## Infrastructure Software Versions
-The tests were run with:
-
-* [Yii2 Version 2](http://yiiframework.com/)
-* [PHP Version 5.4.*](http://www.php.net/) with FPM and APC
-* [nginx 1.4.0](http://nginx.org/)
-* [MySQL 5.5.29](https://dev.mysql.com/)
+* [Yii2](http://yiiframework.com/)
+* [PHP](http://www.php.net/)
+* [nginx](http://nginx.org/)
+* [MySQL](https://dev.mysql.com/)
 
 ## Test URLs
-### JSON Encoding Test
 
-http://localhost/site/json
-
-### Data-Store/Database Mapping Test
-
-http://localhost/site/db
-
-### Variable Query Test
-    
-http://localhost/site/db?queries=2
-
-### Templating Test
-
-http://localhost/site/fortunes
-
-### Update Test
-
-http://localhost/site/updates?queries=2
-
-### Plain Text Test
-
-http://localhost/site/plaintext
+See [benchmark_config.json](benchmark_config.json) for mapping tests to URLs.


### PR DESCRIPTION
The previous readme was obsolete for the most part. It referenced outdated benchmarks ("Templates") and technologies ("PHP 5.4", "APC"), alongside broken links (".../Bench.php" ?) and URLs ("/site/db?queries=").