### PR TITLE
Yii2-raw fortunes: faster data structure

### DIFF
--- a/frameworks/PHP/yii2/app/controllers/RawController.php
+++ b/frameworks/PHP/yii2/app/controllers/RawController.php
@@ -46,12 +46,10 @@ class RawController extends Controller
      */
     public function actionFortunes()
     {
-        $fortunes = Yii::$app->db->createCommand('SELECT id, message FROM Fortune')->queryAll();
-        $fortunes[] = ['id' => 0, 'message' => 'Additional fortune added at request time.'];
+        $fortunes = Yii::$app->db->createCommand('SELECT id, message FROM Fortune')->queryAll(\PDO::FETCH_KEY_PAIR );
+        $fortunes[0] = 'Additional fortune added at request time.';
 
-        usort($fortunes, function ($left, $right) {
-            return strcmp($left['message'], $right['message']);
-        });
+        asort($fortunes);
 
         $this->view->title = 'Fortunes';
 

--- a/frameworks/PHP/yii2/app/views/raw/fortunes.php
+++ b/frameworks/PHP/yii2/app/views/raw/fortunes.php
@@ -3,4 +3,4 @@
 
 use yii\helpers\Html;
 
-?><table><tr><th>id</th><th>message</th></tr><?php foreach ($fortunes as $fortune): ?><tr><td><?=$fortune['id']?></td><td><?=Html::encode($fortune['message'])?></td></tr><?php endforeach?></table>
+?><table><tr><th>id</th><th>message</th></tr><?php foreach ($fortunes as $id => $fortune): ?><tr><td><?=$id?></td><td><?=Html::encode($fortune)?></td></tr><?php endforeach?></table>


### PR DESCRIPTION
Fetching MySQL results as [id => message] instead of [[id, message]]
made it possible to sort using PHP's internal asort() instead of
usort+userfunction.

At max concurrency, there were 6.1% more requests answered.
