### PR TITLE
More memory in kumbiaphp-workerman

### DIFF
--- a/frameworks/PHP/kumbiaphp/deploy/conf/cliphp.ini
+++ b/frameworks/PHP/kumbiaphp/deploy/conf/cliphp.ini
@@ -3,6 +3,9 @@ opcache.enable_cli=1
 opcache.validate_timestamps=0
 opcache.save_comments=0
 opcache.enable_file_override=1
+opcache.memory_consumption=256
+opcache.interned_strings_buffer=16
 opcache.huge_code_pages=1
 
 mysqlnd.collect_statistics = Off
+memory_limit = 512M


### PR DESCRIPTION
To fix the problem:
https://tfb-status.techempower.com/unzip/results.2020-03-16-08-39-33-880.zip/results/20200312173333/kumbiaphp-workerman/run/kumbiaphp-workerman.log
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
