### PR TITLE
Upgrade http4s and make queries in parallel instead of sequentially

### DIFF
--- a/frameworks/Scala/http4s/README.md
+++ b/frameworks/Scala/http4s/README.md
@@ -3,7 +3,6 @@
 ## Infrastructure Software Versions
 
 The tests were run with:
-
-* [AdoptOpenJDK 11 (`x86_64-alpine-jre-11.0.3_7`)](https://hub.docker.com/r/adoptopenjdk/openjdk11)
-* [http4s 0.20.3](http://http4s.org/)
-* [doobie 0.7.0](https://tpolecat.github.io/doobie/)
+* [OpenJDK](https://hub.docker.com/_/openjdk) 8 for building and the latest alpine for running, as per the [Scala JDK Compatibility page](https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html)
+* [http4s 0.21.3](http://http4s.org/)
+* [doobie 0.8.8](https://tpolecat.github.io/doobie/)

--- a/frameworks/Scala/http4s/build.sbt
+++ b/frameworks/Scala/http4s/build.sbt
@@ -2,35 +2,33 @@ name := "http4s"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.1"
 
 scalacOptions ++= Seq(
   "-deprecation",
-  "-encoding", "UTF-8",
+  "-encoding",
+  "UTF-8",
   "-feature",
   "-unchecked",
   "-language:reflectiveCalls",
-  "-Yno-adapted-args",
-  "-Ypartial-unification",
   "-Ywarn-numeric-widen",
-  "-Xfuture",
   "-Xlint"
 )
 
 enablePlugins(SbtTwirl)
 
-TwirlKeys.templateImports += "http4s.techempower.benchmark._"
-
-val http4sVersion = "0.20.3"
-val doobieVersion = "0.7.0"
+val http4sVersion = "0.21.3"
+val doobieVersion = "0.8.8"
 
 libraryDependencies ++= Seq(
   "org.http4s" %% "http4s-blaze-server" % http4sVersion,
   "org.http4s" %% "http4s-dsl" % http4sVersion,
   "org.http4s" %% "http4s-twirl" % http4sVersion,
-  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.51.3",
+  "org.http4s" %% "http4s-circe" % http4sVersion,
+  // Optional for auto-derivation of JSON codecs
+  "io.circe" %% "circe-generic" % "0.13.0",
   "org.tpolecat" %% "doobie-core" % doobieVersion,
   "org.tpolecat" %% "doobie-hikari" % doobieVersion,
-  "org.postgresql" % "postgresql" % "42.2.6",
+  "org.tpolecat" %% "doobie-postgres" % doobieVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3"
 )

--- a/frameworks/Scala/http4s/http4s.dockerfile
+++ b/frameworks/Scala/http4s/http4s.dockerfile
@@ -1,15 +1,17 @@
-FROM adoptopenjdk/openjdk11:x86_64-alpine-jre-11.0.3_7
-RUN apk add bash
+FROM openjdk:8 AS builder
 WORKDIR /http4s
 COPY project project
 COPY src src
 COPY build.sbt build.sbt
 COPY sbt sbt
 RUN ./sbt assembly -batch && \
-    mv target/scala-2.12/http4s-assembly-1.0.jar . && \
+    mv target/scala-2.13/http4s-assembly-1.0.jar . && \
     rm -Rf target && \
     rm -Rf project/target && \
     rm -Rf ~/.sbt && \
     rm -Rf ~/.ivy2 && \
     rm -Rf /var/cache
+FROM openjdk:alpine
+WORKDIR /http4s
+COPY --from=builder /http4s/http4s-assembly-1.0.jar /http4s/http4s-assembly-1.0.jar
 CMD ["java", "-server", "-Xms2g", "-Xmx2g", "-XX:NewSize=1g", "-XX:MaxNewSize=1g", "-XX:InitialCodeCacheSize=256m", "-XX:ReservedCodeCacheSize=256m", "-XX:+UseParallelGC", "-XX:+UseNUMA", "-XX:-UseBiasedLocking", "-XX:+AlwaysPreTouch", "-jar", "http4s-assembly-1.0.jar", "tfb-database"]

--- a/frameworks/Scala/http4s/project/build.properties
+++ b/frameworks/Scala/http4s/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.9

--- a/frameworks/Scala/http4s/project/plugins.sbt
+++ b/frameworks/Scala/http4s/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")

--- a/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
+++ b/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
@@ -4,15 +4,14 @@ import java.util.concurrent.ThreadLocalRandom
 
 import cats.effect._
 import cats.implicits._
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import com.github.plokhotnyuk.jsoniter_scala.macros._
+import io.circe.generic.auto._
+import io.circe.syntax._
 import doobie._
-import doobie.hikari.HikariTransactor
 import doobie.implicits._
+import doobie.hikari.HikariTransactor
 import doobie.util.ExecutionContexts
 import org.http4s._
 import org.http4s.dsl._
-import org.http4s.headers.`Content-Type`
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
@@ -24,46 +23,38 @@ case class Fortune(id: Int, message: String)
 
 // Extract queries parameter (with default and min/maxed)
 object Queries {
-  def unapply(params: Map[String,Seq[String]]): Option[Int] =
-    Some(params.get("queries").getOrElse(Nil).headOption match {
+  def unapply(params: Map[String, Seq[String]]): Option[Int] =
+    Some(params.getOrElse("queries", Nil).headOption match {
       case None => 1
-      case Some(x) => Math.max(1, Math.min(500, scala.util.Try(x.toInt).getOrElse(1)))
+      case Some(x) =>
+        Math.max(1, Math.min(500, scala.util.Try(x.toInt).getOrElse(1)))
     })
 }
 
-object JsonSupport {
-  implicit val messageCodec: JsonValueCodec[Message] = JsonCodecMaker.make[Message](CodecMakerConfig())
-  implicit val worldCodec: JsonValueCodec[World] = JsonCodecMaker.make[World](CodecMakerConfig())
-  implicit val worldListCodec: JsonValueCodec[List[World]] = JsonCodecMaker.make[List[World]](CodecMakerConfig())
-  implicit val fortuneCodec: JsonValueCodec[Fortune] = JsonCodecMaker.make[Fortune](CodecMakerConfig())
-
-  implicit def jsonEncoder[T: JsonValueCodec]: EntityEncoder[IO, T] =
-    EntityEncoder
-      .byteArrayEncoder[IO]
-      .contramap((data: T) => writeToArray(data))
-      .withContentType(`Content-Type`(MediaType.application.json, Some(Charset.`UTF-8`)))
-}
-
 object WebServer extends IOApp with Http4sDsl[IO] {
-  import JsonSupport._
+  import org.http4s.circe.CirceEntityEncoder._
 
-  def openDatabase(host: String, poolSize: Int): Resource[IO, HikariTransactor[IO]] =
+  def openDatabase(host: String,
+                   poolSize: Int): Resource[IO, HikariTransactor[IO]] =
     for {
       ce <- ExecutionContexts.fixedThreadPool[IO](32) // our connect EC
-      te <- ExecutionContexts.cachedThreadPool[IO]    // our transaction TE
+      be <- Blocker[IO] // our blocking EC
       xa <- HikariTransactor.newHikariTransactor[IO](
         "org.postgresql.Driver",
         s"jdbc:postgresql://$host/hello_world",
         "benchmarkdbuser",
         "benchmarkdbpass",
         ce,
-        te
+        be
       )
-      _  <- Resource.liftF(
-        xa.configure(ds => IO {
-         ds.setMaximumPoolSize(poolSize)
-         ds.setMinimumIdle(poolSize)
-        })
+      _ <- Resource.liftF(
+        xa.configure(
+          ds =>
+            IO {
+              ds.setMaximumPoolSize(poolSize)
+              ds.setMinimumIdle(poolSize)
+          }
+        )
       )
     } yield xa
 
@@ -72,9 +63,7 @@ object WebServer extends IOApp with Http4sDsl[IO] {
 
   // Update the randomNumber field with a random number
   def updateRandomNumber(world: World): IO[World] =
-    randomWorldId.map(id =>
-      world.copy(randomNumber = id)
-    )
+    randomWorldId.map(id => world.copy(randomNumber = id))
 
   // Select a World object from the database by ID
   def selectWorld(xa: Transactor[IO], id: Int): IO[World] =
@@ -102,7 +91,8 @@ object WebServer extends IOApp with Http4sDsl[IO] {
   def updateWorlds(xa: Transactor[IO], newWorlds: List[World]): IO[Int] = {
     val sql = "update World set randomNumber = ? where id = ?"
     // Reason for sorting: https://github.com/TechEmpower/FrameworkBenchmarks/pull/4214#issuecomment-489358881
-    val update = Update[(Int, Int)](sql).updateMany(newWorlds.sortBy(_.id).map(w => (w.randomNumber, w.id)))
+    val update = Update[(Int, Int)](sql)
+      .updateMany(newWorlds.sortBy(_.id).map(w => (w.randomNumber, w.id)))
     update.transact(xa)
   }
 
@@ -126,38 +116,32 @@ object WebServer extends IOApp with Http4sDsl[IO] {
 
   // HTTP service definition
   def service(xa: Transactor[IO]) =
-    addServerHeader(
-      HttpRoutes.of[IO] {
-        case GET -> Root / "plaintext" =>
-          Ok("Hello, World!")
+    addServerHeader(HttpRoutes.of[IO] {
+      case GET -> Root / "plaintext" =>
+        Ok("Hello, World!")
 
-        case GET -> Root / "json" =>
-          Ok(Message("Hello, World!"))
+      case GET -> Root / "json" =>
+        Ok(Message("Hello, World!").asJson)
 
-        case GET -> Root / "db" =>
-          Ok(selectRandomWorld(xa))
+      case GET -> Root / "db" =>
+        Ok(selectRandomWorld(xa).map(_.asJson))
 
-        case GET -> Root / "queries" :? Queries(numQueries) =>
-          Ok(getWorlds(xa, numQueries))
+      case GET -> Root / "queries" :? Queries(numQueries) =>
+        Ok(getWorlds(xa, numQueries).map(_.asJson))
 
-        case GET -> Root / "fortunes" =>
-          Ok(
-            for {
-              oldFortunes <- getFortunes(xa)
-              newFortunes = getSortedFortunes(oldFortunes)
-            } yield html.index(newFortunes)
-          )
+      case GET -> Root / "fortunes" =>
+        Ok(for {
+          oldFortunes <- getFortunes(xa)
+          newFortunes = getSortedFortunes(oldFortunes)
+        } yield html.index(newFortunes))
 
-        case GET -> Root / "updates" :? Queries(numQueries) =>
-          Ok(
-            for {
-              worlds <- getWorlds(xa, numQueries)
-              newWorlds <- getNewWorlds(worlds)
-              _ <- updateWorlds(xa, newWorlds)
-            } yield newWorlds
-          )
-      }
-    )
+      case GET -> Root / "updates" :? Queries(numQueries) =>
+        Ok(for {
+          worlds <- getWorlds(xa, numQueries)
+          newWorlds <- getNewWorlds(worlds)
+          _ <- updateWorlds(xa, newWorlds)
+        } yield newWorlds.asJson)
+    })
 
   // Given a fully constructed HttpService, start the server and wait for completion
   def startServer(service: HttpRoutes[IO]) =

--- a/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
+++ b/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
@@ -14,6 +14,7 @@ import doobie.hikari.HikariTransactor
 import doobie.util.ExecutionContexts
 import org.http4s._
 import org.http4s.dsl._
+import org.http4s.circe._
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
@@ -34,8 +35,6 @@ object Queries {
 }
 
 object WebServer extends IOApp with Http4sDsl[IO] {
-  import org.http4s.circe.CirceEntityEncoder._
-
   def openDatabase(host: String,
                    poolSize: Int): Resource[IO, HikariTransactor[IO]] =
     for {

--- a/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
+++ b/frameworks/Scala/http4s/src/main/scala/http4s/techempower/benchmark/WebServer.scala
@@ -3,7 +3,9 @@ package http4s.techempower.benchmark
 import java.util.concurrent.ThreadLocalRandom
 
 import cats.effect._
-import cats.implicits._
+import cats.instances.list._
+import cats.syntax.parallel._
+import cats.syntax.traverse._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import doobie._
@@ -80,7 +82,7 @@ object WebServer extends IOApp with Http4sDsl[IO] {
 
   // Select a specified number of random World objects from the database
   def getWorlds(xa: Transactor[IO], numQueries: Int): IO[List[World]] =
-    (0 until numQueries).toList.traverse(_ => selectRandomWorld(xa))
+    (0 until numQueries).toList.parTraverse(_ => selectRandomWorld(xa))
 
   // Update the randomNumber field with a new random number, for a list of World objects
   def getNewWorlds(worlds: List[World]): IO[List[World]] =

--- a/frameworks/Scala/http4s/src/main/twirl/index.scala.html
+++ b/frameworks/Scala/http4s/src/main/twirl/index.scala.html
@@ -1,3 +1,4 @@
+@import http4s.techempower.benchmark.Fortune
 @(fortunes: Seq[Fortune])
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

This PR upgrades http4s/doobie dependencies and Scala to their latest versions.

Additionally it also changes the JSON library to [Circe](https://github.com/circe/circe) as it is more common and thus realistic.

There is also a performance improvement regarding the queries as they were being executed sequentially instead of parallel, seriously affecting performance.