### PR TITLE
Lwan: fix crash in lwan-lua benchmark

### DIFF
--- a/frameworks/C/lwan/Makefile
+++ b/frameworks/C/lwan/Makefile
@@ -10,7 +10,6 @@ CFLAGS = -mtune=native -march=native -O3 -fno-plt -flto -ffat-lto-objects -DNDEB
 	-fauto-profile=/lwan/src/gcda/techempower.gcov
 
 LDFLAGS = -mtune=native -march=native -O3 -flto -ffat-lto-objects -Wl,-z,now,-z,relro \
-	/usr/local/lib/mimalloc-1.2/libmimalloc.a \
 	-Wl,-whole-archive /lwan/build/src/lib/liblwan.a -Wl,-no-whole-archive \
 	`pkg-config mariadb --libs` \
 	`pkg-config sqlite3 --libs` \

--- a/frameworks/C/lwan/Makefile
+++ b/frameworks/C/lwan/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all
 
 CFLAGS = -mtune=native -march=native -O3 -fno-plt -flto -ffat-lto-objects -DNDEBUG \
+	-falign-functions=32 -malign-data=abi \
 	-include /lwan/build/lwan-build-config.h \
 	-I /lwan/src/lib \
 	`pkg-config mariadb --cflags` \

--- a/frameworks/C/lwan/lwan-lua.dockerfile
+++ b/frameworks/C/lwan/lwan-lua.dockerfile
@@ -18,7 +18,7 @@ RUN mkdir luajit && \
     cd luajit && \
     PREFIX=/usr CFLAGS="-O3 -mtune=native -march=native -flto -ffat-lto-objects" make -j install
 
-RUN wget https://github.com/lpereira/lwan/archive/b61c4ff17a516c9045abdd614db191072f0fd19b.tar.gz -O - | tar xz --strip-components=1 && \
+RUN wget https://github.com/lpereira/lwan/archive/a75278f067189fc93ea41b25e5ec46f5eb95b217.tar.gz -O - | tar xz --strip-components=1 && \
     mkdir build && cd build && \
     cmake /lwan -DCMAKE_BUILD_TYPE=Release -DUSE_ALTERNATIVE_MALLOC=mimalloc && \
     make lwan-static

--- a/frameworks/C/lwan/lwan-lua.dockerfile
+++ b/frameworks/C/lwan/lwan-lua.dockerfile
@@ -9,7 +9,7 @@ ADD ./ /lwan
 WORKDIR /lwan
 
 RUN mkdir mimalloc && \
-    wget https://github.com/microsoft/mimalloc/archive/acb03c54971c4b0a43a6d17ea55a9d5feb88972f.tar.gz -O - | tar xz --strip-components=1 -C mimalloc && \
+    wget https://github.com/microsoft/mimalloc/archive/6e1ca96a4965c776c10698c24dae576523178ef5.tar.gz -O - | tar xz --strip-components=1 -C mimalloc && \
     cd mimalloc && mkdir build && cd build && \
     CFLAGS="-flto -ffat-lto-objects" cmake .. -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=OFF && make -j install
 
@@ -26,10 +26,6 @@ RUN wget https://github.com/lpereira/lwan/archive/b61c4ff17a516c9045abdd614db191
 RUN make clean && make
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/lib
-ENV USE_MYSQL=1
-ENV MYSQL_USER=benchmarkdbuser
-ENV MYSQL_PASS=benchmarkdbpass
-ENV MYSQL_DB=hello_world
-ENV MYSQL_HOST=tfb-database
+ENV LD_PRELOAD=/usr/local/lib/mimalloc-1.6/libmimalloc.so
 
 CMD ["./techempower"]

--- a/frameworks/C/lwan/lwan.dockerfile
+++ b/frameworks/C/lwan/lwan.dockerfile
@@ -18,7 +18,7 @@ RUN mkdir luajit && \
     cd luajit && \
     PREFIX=/usr CFLAGS="-O3 -mtune=native -march=native -flto -ffat-lto-objects" make -j install
 
-RUN wget https://github.com/lpereira/lwan/archive/b61c4ff17a516c9045abdd614db191072f0fd19b.tar.gz -O - | tar xz --strip-components=1 && \
+RUN wget https://github.com/lpereira/lwan/archive/a75278f067189fc93ea41b25e5ec46f5eb95b217.tar.gz -O - | tar xz --strip-components=1 && \
     mkdir build && cd build && \
     cmake /lwan -DCMAKE_BUILD_TYPE=Release -DUSE_ALTERNATIVE_MALLOC=mimalloc && \
     make lwan-static

--- a/frameworks/C/lwan/lwan.dockerfile
+++ b/frameworks/C/lwan/lwan.dockerfile
@@ -9,7 +9,7 @@ ADD ./ /lwan
 WORKDIR /lwan
 
 RUN mkdir mimalloc && \
-    wget https://github.com/microsoft/mimalloc/archive/acb03c54971c4b0a43a6d17ea55a9d5feb88972f.tar.gz -O - | tar xz --strip-components=1 -C mimalloc && \
+    wget https://github.com/microsoft/mimalloc/archive/6e1ca96a4965c776c10698c24dae576523178ef5.tar.gz -O - | tar xz --strip-components=1 -C mimalloc && \
     cd mimalloc && mkdir build && cd build && \
     CFLAGS="-flto -ffat-lto-objects" cmake .. -DCMAKE_BUILD_TYPE=Release -DMI_SECURE=OFF && make -j install
 
@@ -31,5 +31,6 @@ ENV MYSQL_USER=benchmarkdbuser
 ENV MYSQL_PASS=benchmarkdbpass
 ENV MYSQL_DB=hello_world
 ENV MYSQL_HOST=tfb-database
+ENV LD_PRELOAD=/usr/local/lib/mimalloc-1.6/libmimalloc.so
 
 CMD ["./techempower"]


### PR DESCRIPTION
Latest continuous run found an issue that manifested in the Lua benchmark.  This has been fixed in Lwan upstream, and this PR updates the installation to contain the fix.  (It also updates the 3rd-party memory allocator.)