### PR TITLE
Add 60 seconds sleep to clear host connections

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -141,6 +141,9 @@ class Benchmarker:
                 self.time_logger.mark_started_database()
 
             # Start webapp
+            # Wait 60 seconds before starting webapp to ensure all host connections are closed
+            log("Sleeping 60 seconds...", prefix=log_prefix)
+            time.sleep(60)
             container = test.start()
             self.time_logger.mark_test_starting()
             if container is None:

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -59,8 +59,8 @@ class Benchmarker:
 
         with open(os.path.join(self.results.directory, 'benchmark.log'),
                   'w') as benchmark_log:
-            for idx, test in self.tests:
-                if idx == len(self.tests):
+            for test in self.tests:
+                if self.tests.index(test) + 1 == len(self.tests):
                     self.last_test = True
                 log("Running Test: %s" % test.name, border='-')
                 with self.config.quiet_out.enable():

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -33,6 +33,8 @@ class Benchmarker:
         self.results = Results(self)
         self.docker_helper = DockerHelper(self)
 
+        self.last_test = False
+
     ##########################################################################################
     # Public methods
     ##########################################################################################
@@ -57,7 +59,9 @@ class Benchmarker:
 
         with open(os.path.join(self.results.directory, 'benchmark.log'),
                   'w') as benchmark_log:
-            for test in self.tests:
+            for idx, test in self.tests:
+                if idx == len(self.tests):
+                    self.last_test = True
                 log("Running Test: %s" % test.name, border='-')
                 with self.config.quiet_out.enable():
                     if not self.__run_test(test, benchmark_log):
@@ -92,9 +96,10 @@ class Benchmarker:
                 file=file,
                 color=Fore.RED if success else '')
         self.time_logger.log_test_end(log_prefix=prefix, file=file)
-        # Sleep for 60 seconds to ensure all host connects are closed
-        log("Clean up: Sleep 60 seconds...", prefix=prefix, file=file)
-        time.sleep(60)
+        if not self.last_test:
+            # Sleep for 60 seconds to ensure all host connects are closed
+            log("Clean up: Sleep 60 seconds...", prefix=prefix, file=file)
+            time.sleep(60)
         return success
 
     def __run_test(self, test, benchmark_log):

--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -92,6 +92,9 @@ class Benchmarker:
                 file=file,
                 color=Fore.RED if success else '')
         self.time_logger.log_test_end(log_prefix=prefix, file=file)
+        # Sleep for 60 seconds to ensure all host connects are closed
+        log("Clean up: Sleep 60 seconds...", prefix=prefix, file=file)
+        time.sleep(60)
         return success
 
     def __run_test(self, test, benchmark_log):
@@ -141,9 +144,6 @@ class Benchmarker:
                 self.time_logger.mark_started_database()
 
             # Start webapp
-            # Wait 60 seconds before starting webapp to ensure all host connections are closed
-            log("Sleeping 60 seconds...", prefix=log_prefix)
-            time.sleep(60)
             container = test.start()
             self.time_logger.mark_test_starting()
             if container is None:


### PR DESCRIPTION
tl;dr We believe that some frameworks are hitting the OS limit for open connections and, if the next test spins up too fast, it may have trouble creating network connections. Because we're using `--host`, these connections are lingering on the host and stuck in a `TIME_WAIT` state that automatically close after a default of 60 seconds. Here, we're giving enough time for the host to close these connections before the next test starts. 

🤞 that this solves #4092 

Edit: Changed my mind about where to put this. Rather than before a test container starts, I put it in the `__exit_test` cleanup. This makes sure building database containers and all the other things that need to happen at the start of a test can reach the interwebs.