### PR TITLE
Phalcon-mongodb tag broken and faster sort

### DIFF
--- a/frameworks/PHP/phalcon/README.md
+++ b/frameworks/PHP/phalcon/README.md
@@ -23,11 +23,11 @@ Uses Phalcons template engine 'Volt'
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Phalcon 3.3.1](http://phalconphp.com/)
-* [PHP Version 7.2.2](http://www.php.net/) with FPM, OPcache and Phalcon extension
-* [nginx 1.12.2](http://nginx.org/)
-* [MySQL 5.7.21](https://dev.mysql.com/)
-* [MongoDB 3.6](https://mongodb.org/)
+* [Phalcon 4](http://phalconphp.com/)
+* [PHP Version 7.4](http://www.php.net/) with FPM, OPcache and Phalcon extension
+* [nginx 1.16](http://nginx.org/)
+* [MySQL 8](https://dev.mysql.com/)
+* [MongoDB 4](https://mongodb.org/)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/PHP/phalcon/app/controllers/BenchController.php
+++ b/frameworks/PHP/phalcon/app/controllers/BenchController.php
@@ -99,17 +99,7 @@ class BenchController extends \Phalcon\Mvc\Controller
     {
         usort($fortunes,
                 function($left, $right) {
-                    $l = $left['message'];
-                    $r = $right['message'];
-                    if ($l === $r) {
-                        return 0;
-                    } else {
-                        if ($l > $r) {
-                            return 1;
-                        } else {
-                            return -1;
-                        }
-                    }
+                    return $left['message'] <=> $right['message'];
                 });
         return $fortunes;
     }
@@ -120,5 +110,4 @@ class BenchController extends \Phalcon\Mvc\Controller
         $response->setHeader("Content-Type", "application/json");
         return $response;
     }
-
 }

--- a/frameworks/PHP/phalcon/app/controllers/MongobenchController.php
+++ b/frameworks/PHP/phalcon/app/controllers/MongobenchController.php
@@ -29,17 +29,7 @@ class MongobenchController extends BenchController
     {
         usort($fortunes,
                 function($left, $right) {
-                    $l = $left->message;
-                    $r = $right->message;
-                    if ($l === $r) {
-                        return 0;
-                    } else {
-                        if ($l > $r) {
-                            return 1;
-                        } else {
-                            return -1;
-                        }
-                    }
+                    return $left->message <=> $right->message;
                 });
         return $fortunes;
     }

--- a/frameworks/PHP/phalcon/benchmark_config.json
+++ b/frameworks/PHP/phalcon/benchmark_config.json
@@ -42,7 +42,8 @@
       "database_os": "Linux",
       "display_name": "phalcon",
       "notes": "",
-      "versus": "php"
+      "versus": "php",
+      "tags": ["broken"]
     },
     "micro": {
       "json_url": "/json",

--- a/frameworks/PHP/phalcon/deploy/nginx.conf
+++ b/frameworks/PHP/phalcon/deploy/nginx.conf
@@ -1,4 +1,5 @@
 user www-data;
+daemon off;
 worker_processes  auto;
 error_log stderr error;
 worker_rlimit_nofile 200000;

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -25,4 +25,4 @@ RUN mv /phalcon/public/index-micro.php /phalcon/public/index.php
 RUN chmod -R 777 app
 
 CMD service php7.4-fpm start && \
-    nginx -c /phalcon/deploy/nginx.conf -g "daemon off;"
+    nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,26 +1,26 @@
-FROM ubuntu:19.04
+FROM ubuntu:19.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.3 php7.3-common php7.3-cli php7.3-fpm php7.3-mysql php7.3-mongodb  > /dev/null
+    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql php7.4-mongodb  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 
-COPY deploy/conf/* /etc/php/7.3/fpm/
+COPY deploy/conf/* /etc/php/7.4/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
 
-RUN apt-get install -yqq php7.3-phalcon  > /dev/null
+RUN apt-get install -yqq php7.4-phalcon  > /dev/null
 
-RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet --ignore-platform-reqs
 
 RUN chmod -R 777 app
 
-CMD service php7.3-fpm start && \
+CMD service php7.4-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf -g "daemon off;"

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -23,4 +23,4 @@ RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --q
 RUN chmod -R 777 app
 
 CMD service php7.4-fpm start && \
-    nginx -c /phalcon/deploy/nginx.conf -g "daemon off;"
+    nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -23,4 +23,4 @@ RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --i
 RUN chmod -R 777 app
 
 CMD service php7.4-fpm start && \
-    nginx -c /phalcon/deploy/nginx.conf -g "daemon off;"
+    nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/public/index-micro.php
+++ b/frameworks/PHP/phalcon/public/index-micro.php
@@ -86,17 +86,7 @@ try {
         );
 
         usort($fortunes, function($left, $right) {
-            $l = $left['message'];
-            $r = $right['message'];
-            if ($l === $r) {
-                return 0;
-            } else {
-                if ($l > $r) {
-                    return 1;
-                } else {
-                    return -1;
-                }
-            }
+            return $left['message'] <=> $right['message'];
         });
 
         header("Content-Type: text/html; charset=utf-8");


### PR DESCRIPTION
In the logs when verify the phalcon-mongodb:
`PHP Fatal error:  Uncaught Error: Class 'Phalcon\Mvc\Collection' not found in /phalcon/vendor/phalcon/incubator/Library/Phalcon/Mvc/MongoCollection.php`

I's a bug in Phalcon mongodb:
https://github.com/phalcon/incubator/issues/880
**So tag broken, till fixed.**

Faster sort in all variants for fortunes test.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
