### PR TITLE
Locks down the version of the base jdk image

### DIFF
--- a/frameworks/Java/gemini/gemini-mysql.dockerfile
+++ b/frameworks/Java/gemini/gemini-mysql.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-mysql.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11-jdk
+FROM openjdk:11.0.7-slim
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin

--- a/frameworks/Java/gemini/gemini-postgres.dockerfile
+++ b/frameworks/Java/gemini/gemini-postgres.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini-postgres.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11-jdk
+FROM openjdk:11.0.7-slim
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin

--- a/frameworks/Java/gemini/gemini.dockerfile
+++ b/frameworks/Java/gemini/gemini.dockerfile
@@ -9,7 +9,7 @@ RUN mvn -q compile
 RUN mv src/main/webapp/WEB-INF/configuration/gemini.conf src/main/webapp/WEB-INF/configuration/Base.conf
 RUN mvn -q war:war
 
-FROM openjdk:11-jdk
+FROM openjdk:11.0.7-slim
 RUN apt update -qqy && apt install -yqq curl > /dev/null
 
 WORKDIR /resin


### PR DESCRIPTION
Accidentally used a base image with a tag that will point at newer versions over time.