### PR TITLE
Attempt to improve performance

### DIFF
--- a/frameworks/Java/httpserver/httpserver-postgres.dockerfile
+++ b/frameworks/Java/httpserver/httpserver-postgres.dockerfile
@@ -7,4 +7,4 @@ RUN mvn compile assembly:single -q
 FROM openjdk:11.0.3-jdk-slim
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
-CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "postgres"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar", "postgres"]

--- a/frameworks/Java/httpserver/httpserver.dockerfile
+++ b/frameworks/Java/httpserver/httpserver.dockerfile
@@ -7,4 +7,4 @@ RUN mvn compile assembly:single -q
 FROM openjdk:11.0.3-jdk-slim
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
-CMD ["java", "-server", "-Xss256k", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]

--- a/frameworks/Java/httpserver/src/main/java/benchmarks/Server.java
+++ b/frameworks/Java/httpserver/src/main/java/benchmarks/Server.java
@@ -9,6 +9,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.util.*;
+import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/frameworks/Java/httpserver/src/main/java/benchmarks/Server.java
+++ b/frameworks/Java/httpserver/src/main/java/benchmarks/Server.java
@@ -51,7 +51,7 @@ public class Server {
         config.setJdbcUrl("jdbc:postgresql://tfb-database:5432/hello_world");
         config.setUsername("benchmarkdbuser");
         config.setPassword("benchmarkdbpass");
-        config.setMaximumPoolSize(64);
+        config.setMaximumPoolSize(512);
         return new HikariDataSource(config);
     }
 
@@ -71,6 +71,7 @@ public class Server {
             t.getResponseHeaders().add("Server", SERVER_NAME);
             t.sendResponseHeaders(200, HELLO_LENGTH);
             t.getResponseBody().write(HELLO_BYTES);
+            t.getResponseBody().flush();
             t.getResponseBody().close();
         };
     }
@@ -90,6 +91,7 @@ public class Server {
             t.getResponseHeaders().add("Server", SERVER_NAME);
             t.sendResponseHeaders(200, bytes.length);
             t.getResponseBody().write(bytes);
+            t.getResponseBody().flush();
             t.getResponseBody().close();
         };
     }
@@ -113,6 +115,7 @@ public class Server {
                 t.getResponseHeaders().add("Server", SERVER_NAME);
                 t.sendResponseHeaders(200, bytes.length);
                 t.getResponseBody().write(bytes);
+                t.getResponseBody().flush();
                 t.getResponseBody().close();
             } catch (SQLException | ParseException e) {
                 throw new IOException(e);
@@ -127,9 +130,8 @@ public class Server {
         if (settings.contains("debug"))
             System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
         // create server
-        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
-        server.setExecutor(new ThreadPoolExecutor(
-            8, Integer.MAX_VALUE, 300, TimeUnit.SECONDS, new SynchronousQueue<>()));
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 1024 * 8);
+        server.setExecutor(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
         // add context handlers
         server.createContext("/plaintext", createPlaintextHandler());
         server.createContext("/json", createJSONHandler());


### PR DESCRIPTION
Does two things aimed at increasing performance:

1. `HttpServer server = HttpServer.create(new InetSocketAddress(port), 1024 * 8);` specifies 8k backlog which is what `firenio` has - no idea if this matters
2. `server.setExecutor(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));`

The second point makes the change effectively:
```Java
server.setExecutor(new ThreadPoolExecutor(8, Integer.MAX_VALUE, 
                                      300, TimeUnit.SECONDS, 
                                      new SynchronousQueue<>()));
```
to
```Java
server.setExecutor(new ThreadPoolExecutor(nThreads, nThreads,
                                      0L, TimeUnit.MILLISECONDS,
                                      new LinkedBlockingQueue<Runnable>()));
```