### PR TITLE
Downgrade gnet for the moment

### DIFF
--- a/frameworks/Go/gnet/src/go.mod
+++ b/frameworks/Go/gnet/src/go.mod
@@ -2,4 +2,4 @@ module gnet
 
 go 1.14
 
-require github.com/panjf2000/gnet v1.0.1
+require github.com/panjf2000/gnet v1.0.2

--- a/frameworks/Go/gnet/src/go.mod
+++ b/frameworks/Go/gnet/src/go.mod
@@ -2,4 +2,4 @@ module gnet
 
 go 1.14
 
-require github.com/panjf2000/gnet v1.1.5
+require github.com/panjf2000/gnet v1.0.1

--- a/frameworks/Go/gnet/src/go.sum
+++ b/frameworks/Go/gnet/src/go.sum
@@ -5,8 +5,8 @@ github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FW
 github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
 github.com/panjf2000/ants/v2 v2.3.1 h1:9iOZHO5XlSO1Gs5K7x06uDFy8bkicWlhOKGh/TufAZg=
 github.com/panjf2000/ants/v2 v2.3.1/go.mod h1:LtwNaBX6OeF5qRtQlaeGndalVwJlS2ueur7uwoAHbPA=
-github.com/panjf2000/gnet v1.1.5 h1:AX9WCGskfYXmO6/O6zk2Y68a7wxx2OOGZy/NcOzdDcQ=
-github.com/panjf2000/gnet v1.1.5/go.mod h1:o5PiLj4HiorqL/r2shIbwWrhoKf3o4DGFmvy7EJyMH0=
+github.com/panjf2000/gnet v1.0.1 h1:IhaLkjtdtJax5N1uwRUnCIbkDV8bIeLTvReShNFw4AI=
+github.com/panjf2000/gnet v1.0.1/go.mod h1:Ux2Nc2pRFNk57YpDhHaZ9jaB4taAiqMBkcAWe/mWxmI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -22,8 +22,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
-golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/frameworks/Go/gnet/src/go.sum
+++ b/frameworks/Go/gnet/src/go.sum
@@ -5,8 +5,8 @@ github.com/libp2p/go-reuseport v0.0.1 h1:7PhkfH73VXfPJYKQ6JwS5I/eVcoyYi9IMNGc6FW
 github.com/libp2p/go-reuseport v0.0.1/go.mod h1:jn6RmB1ufnQwl0Q1f+YxAj8isJgDCQzaaxIFYDhcYEA=
 github.com/panjf2000/ants/v2 v2.3.1 h1:9iOZHO5XlSO1Gs5K7x06uDFy8bkicWlhOKGh/TufAZg=
 github.com/panjf2000/ants/v2 v2.3.1/go.mod h1:LtwNaBX6OeF5qRtQlaeGndalVwJlS2ueur7uwoAHbPA=
-github.com/panjf2000/gnet v1.0.1 h1:IhaLkjtdtJax5N1uwRUnCIbkDV8bIeLTvReShNFw4AI=
-github.com/panjf2000/gnet v1.0.1/go.mod h1:Ux2Nc2pRFNk57YpDhHaZ9jaB4taAiqMBkcAWe/mWxmI=
+github.com/panjf2000/gnet v1.0.2 h1:dkg1huhYozbciSU/yeMIpyMiT16qKpLr7vSBMqLfKpg=
+github.com/panjf2000/gnet v1.0.2/go.mod h1:Ux2Nc2pRFNk57YpDhHaZ9jaB4taAiqMBkcAWe/mWxmI=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/frameworks/Go/gnet/src/main.go
+++ b/frameworks/Go/gnet/src/main.go
@@ -25,6 +25,9 @@ func (hc *httpCodec) Encode(c gnet.Conn, buf []byte) (out []byte, err error) {
 
 func (hc *httpCodec) Decode(c gnet.Conn) (out []byte, err error) {
 	buf := c.Read()
+	if buf == nil {
+		return
+	}
 	c.ResetBuffer()
 
 	// process the pipeline


### PR DESCRIPTION
There are some potential bugs on the latest version of gnet, caused by some new code, so downgrade it until I fixed those issues.