### PR TITLE
Gemini Firenio Performance Tweaks

### DIFF
--- a/frameworks/Java/gemini/benchmark_config.json
+++ b/frameworks/Java/gemini/benchmark_config.json
@@ -66,7 +66,7 @@
       },
       "firenio": {
         "plaintext_url": "/test/plaintext",
-        "port": 8300,
+        "port": 8080,
         "approach": "Realistic",
         "classification": "Fullstack",
         "database": "None",

--- a/frameworks/Java/gemini/gemini-firenio.dockerfile
+++ b/frameworks/Java/gemini/gemini-firenio.dockerfile
@@ -9,6 +9,6 @@ RUN mvn -q clean install
 
 WORKDIR target
 
-EXPOSE 8300
+EXPOSE 8080
 
 CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dlite=false", "-Dcore=1", "-Dframe=16", "-DreadBuf=512", "-Dpool=true", "-Ddirect=true", "-Dinline=true", "-Dlevel=1", "-Dread=false", "-Depoll=true", "-Dnodelay=true", "-Dcachedurl=false", "-DunsafeBuf=true", "-jar", "GhApplication-0.0.1.jar"]


### PR DESCRIPTION
This is the reason why we don't normally allow for `SNAPSHOT` dependencies (or dependencies that aren't version locked) - I deployed a new snapshot on which of course broke the API that the implementation currently merged relies.

I will remove `gemini-firenio` after its continuous run and will re-add when that module has an official release.