### PR TITLE
Adding support for mimalloc

### DIFF
--- a/frameworks/C++/drogon/drogon-core.dockerfile
+++ b/frameworks/C++/drogon/drogon-core.dockerfile
@@ -28,6 +28,7 @@ ENV IROOT=/install
 ENV DROGON_ROOT=$IROOT/drogon
 ENV PG_ROOT=$IROOT/postgres-batch_mode_ubuntu
 ENV TEST_PATH=/drogon_benchmark/build
+ENV MIMALLOC_ROOT=$IROOT/mimalloc
 
 WORKDIR $IROOT
 
@@ -36,6 +37,13 @@ RUN tar -xvzf batch_mode_ubuntu.tar.gz
 WORKDIR $PG_ROOT
 
 RUN ./configure --prefix=/usr CFLAGS='-O2 -pipe'
+RUN make && make install
+
+RUN git clone https://github.com/microsoft/mimalloc
+WORKDIR $MIMALLOC_ROOT
+RUN mkdir build
+WORKDIR $MIMALLOC_ROOT/build
+RUN cmake -DCMAKE_BUILD_TYPE=release ..
 RUN make && make install
 
 WORKDIR $IROOT

--- a/frameworks/C++/drogon/drogon_benchmark/CMakeLists.txt
+++ b/frameworks/C++/drogon/drogon_benchmark/CMakeLists.txt
@@ -38,7 +38,12 @@ endforeach()
 
 add_executable(${PROJECT_NAME} ${BENCHMARK_SOURCES})
 find_package(Drogon REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
+find_package(mimalloc 1.0 REQUIRED)
+
+target_link_libraries(${PROJECT_NAME} 
+    PRIVATE Drogon::Drogon
+    PUBLIC mimalloc-static
+)
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Adding support for custom allocator `mimalloc`

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
