### PR TITLE
PHP Yii2: faster Dependency Injection

### DIFF
--- a/frameworks/PHP/yii2/app/index.php
+++ b/frameworks/PHP/yii2/app/index.php
@@ -1,39 +1,53 @@
 <?php
 
-// comment out the following two lines when deployed to production
-//defined('YII_DEBUG') or define('YII_DEBUG', false);
-//defined('YII_ENV') or define('YII_ENV', 'prod');
-//error_reporting(E_ALL);
-//ini_set('display_errors','on');
+// uncomment the following block to debug this app
+/*
+defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', 'dev');
+error_reporting(E_ALL);
+ini_set('display_errors','on');
+ */
 
-require(__DIR__ . '/../vendor/yiisoft/yii2/Yii.php');
+define('YII_ENABLE_ERROR_HANDLER', false);
+
+require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
 
 $config = [
-    'id' => 'basic',
+    'id' => 'benchmark',
     'basePath' => __DIR__,
     'components' => [
-        'db' => [
-            'class' => 'yii\db\Connection',
-            'dsn' => 'mysql:host=tfb-database;dbname=hello_world',
-            'username' => 'benchmarkdbuser',
-            'password' => 'benchmarkdbpass',
-            'charset' => 'utf8',
-            'attributes' => [
-                PDO::ATTR_PERSISTENT => true,
-            ],
-            'enableLogging' => false,
-            'enableProfiling' => false,
-            'enableSchemaCache' => true,
-            'schemaCache' => 'cache',
-            'schemaCacheDuration' => 3600,
-        ],
-        'cache' => [
-            'class' => 'yii\caching\FileCache',
-            'cachePath' => '/tmp/yii2-cache',
-        ],
-        'urlManager' => [
-            'enablePrettyUrl' => true,
-        ],
+        // Functions are faster than array declarations,
+        // since they avoid the cost of Dependency Injection.
+        'db' => function() {
+            return new yii\db\Connection([
+                'dsn' => 'mysql:host=tfb-database;dbname=hello_world',
+                'username' => 'benchmarkdbuser',
+                'password' => 'benchmarkdbpass',
+                'charset' => 'utf8',
+                'attributes' => [
+                    PDO::ATTR_PERSISTENT => true,
+                ],
+                'enableLogging' => false,
+                'enableProfiling' => false,
+                'enableSchemaCache' => true,
+                'schemaCache' => 'cache',
+                'schemaCacheDuration' => 3600,
+            ]);
+        },
+        'cache' => function() {
+            return new yii\caching\FileCache([
+                'cachePath' => '/tmp/yii2-cache',
+                'gcProbability' => 0,
+            ]);
+        },
+        'urlManager' => function() {
+            return new yii\web\UrlManager([
+                'enablePrettyUrl' => true,
+            ]);
+        },
+        // These components are overloaded for a small gain in performance (no DI)
+        'request' => function() { return new yii\web\Request(); },
+        'response' => function() { return new yii\web\Response(); },
     ],
 ];
 


### PR DESCRIPTION
Declare components with functions, not arrays.

This reduces the cost of Dependency Injection in Yii2.
For a request like /site/json, the calls to the method
`Container::getDependencies()` went down from 7 to 3.
This method still has the 3rd highest exclusive time (was 2nd).

The overall gain per request was small but noticeable: at max concurrency, 3.3% more requests for the fortune benchmark, and 18.7% more for the simpler json benchmark.