### PR TITLE
Redhat transport and corert port changes

### DIFF
--- a/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore-corert/aspcore-corert-rhtx.dockerfile
@@ -9,4 +9,4 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 
-ENTRYPOINT ["./PlatformBenchmarks", "--server.urls=http://+:8080", "KestrelTransport=LinuxTransport"]
+ENTRYPOINT ["./PlatformBenchmarks", "--server.urls=http://+:80", "KestrelTransport=LinuxTransport"]

--- a/frameworks/CSharp/aspnetcore-corert/aspcore-corert.dockerfile
+++ b/frameworks/CSharp/aspnetcore-corert/aspcore-corert.dockerfile
@@ -9,4 +9,4 @@ FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 
-ENTRYPOINT ["./PlatformBenchmarks", "--server.urls=http://+:8080"]
+ENTRYPOINT ["./PlatformBenchmarks", "--server.urls=http://+:80"]

--- a/frameworks/CSharp/aspnetcore-corert/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore-corert/benchmark_config.json
@@ -4,7 +4,7 @@
     "default": {
       "plaintext_url": "/p",
       "json_url": "/j",
-      "port": 8080,
+      "port": 80,
       "approach": "Stripped",
       "classification": "Platform",
       "database": "None",
@@ -23,7 +23,7 @@
     "rhtx": {
       "plaintext_url": "/p",
       "json_url": "/j",
-      "port": 8080,
+      "port": 80,
       "approach": "Stripped",
       "classification": "Platform",
       "database": "None",

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
@@ -4,7 +4,7 @@ COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.2 AS runtime
-ENV ASPNETCORE_URLS http://+:8080
+ENV ASPNETCORE_URLS http://+:80
 WORKDIR /app
 COPY --from=build /app/out ./
 COPY Benchmarks/appsettings.json ./appsettings.json

--- a/frameworks/CSharp/aspnetcore/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore/benchmark_config.json
@@ -23,7 +23,7 @@
     "rhtx": {
       "plaintext_url": "/p",
       "json_url": "/j",
-      "port": 8080,
+      "port": 80,
       "approach": "Realistic",
       "classification": "Platform",
       "database": "None",


### PR DESCRIPTION
Change ports for the non "official" versions; which will reduce the size of the "Host" header in the request

Only changing the non-official versions as it may break in deployment as port 80 is a privileged port; and so close to actual round kicking off that would be a bad thing to do for the "official" version.

/cc @tmds @MichalStrehovsky 


@nbrady-techempower another issue for rule normalisation  😉