### PR TITLE
Update plain php variants to Ubuntu 20.04

### DIFF
--- a/frameworks/PHP/php/php-activerecord.dockerfile
+++ b/frameworks/PHP/php/php-activerecord.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 COPY ./ ./
 

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Left php-unit, not ready the package

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
