### PR TITLE
Add yarte@0.9.8 in ntex-db bench

### DIFF
--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main_raw.rs"
 [dependencies]
 ntex = "0.1.18"
 snmalloc-rs = "0.2.6"
-markup = "0.4.1"
 yarte = { version = "0.9.5", features = ["fixed"] }
 serde = "1.0"
 serde_derive = "1.0"
@@ -32,7 +31,6 @@ http = "0.2"
 simd-json = "0.3.9"
 simd-json-derive = { git = "https://github.com/simd-lite/simd-json-derive.git" }
 log = { version = "0.4", features = ["release_max_level_off"] }
-v_htmlescape = "0.4.5"
 tokio = "=0.2.6"
 tokio-postgres = { git="https://github.com/fafhrd91/postgres.git" }
 

--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main_raw.rs"
 ntex = "0.1.18"
 snmalloc-rs = "0.2.6"
 markup = "0.4.1"
-yarte = "0.9.1"
+yarte = { version = "0.9.5", features = ["fixed"] }
 serde = "1.0"
 serde_derive = "1.0"
 env_logger = "0.7"

--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main_raw.rs"
 [dependencies]
 ntex = "0.1.18"
 snmalloc-rs = "0.2.6"
-yarte = { version = "0.9.5", features = ["fixed"] }
+yarte = { version = "0.9.8", features = ["fixed"] }
 serde = "1.0"
 serde_derive = "1.0"
 env_logger = "0.7"

--- a/frameworks/Rust/ntex/src/utils.rs
+++ b/frameworks/Rust/ntex/src/utils.rs
@@ -36,28 +36,6 @@ pub fn get_query_param(query: &str) -> u16 {
     cmp::min(500, cmp::max(1, q))
 }
 
-markup::define! {
-    FortunesTemplate(fortunes: Vec<Fortune>) {
-        {markup::doctype()}
-        html {
-            head {
-                title { "Fortunes" }
-            }
-            body {
-                table {
-                    tr { th { "id" } th { "message" } }
-                    @for item in {fortunes} {
-                        tr {
-                            td { {item.id} }
-                            td { {markup::raw(v_htmlescape::escape(&item.message))} }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 #[derive(TemplateFixed)]
 #[template(path = "fortune.hbs")]
 pub struct FortunesYarteTemplate {

--- a/frameworks/Rust/ntex/src/utils.rs
+++ b/frameworks/Rust/ntex/src/utils.rs
@@ -4,7 +4,7 @@ use std::{cmp, io};
 use atoi::FromRadix10;
 use bytes::BytesMut;
 use serde_derive::Serialize;
-use yarte::Template;
+use yarte::TemplateFixed;
 
 #[allow(non_snake_case)]
 #[derive(Serialize, Debug)]
@@ -58,7 +58,7 @@ markup::define! {
     }
 }
 
-#[derive(Template)]
+#[derive(TemplateFixed)]
 #[template(path = "fortune.hbs")]
 pub struct FortunesYarteTemplate {
     pub fortunes: Vec<Fortune>,


### PR DESCRIPTION
@fafhrd91  It is a test without commitment.
In this new implementation, there is no possibility of buffer overruns, since before writing it is checked that it is within the limits.

[Unit bench, 50 elem, 100KK < id](https://travis-ci.org/github/botika/template-bench-rs/jobs/694909228#L1003)
```
TechEmpower Fortunes/Markup time:        [12.413 us 12.419 us 12.427 us]
TechEmpower Fortunes/Yarte time:         [11.315 us 11.323 us 11.332 us]
TechEmpower Fortunes/Yarte Fixed time:   [5.4315 us 5.4438 us 5.4576 us]
```