### PR TITLE
racket: tune nginx conf

### DIFF
--- a/frameworks/Racket/racket/config/nginx.conf
+++ b/frameworks/Racket/racket/config/nginx.conf
@@ -1,30 +1,36 @@
 daemon off;
-worker_processes 4;
+worker_processes auto;
+worker_cpu_affinity auto;
+timer_resolution 1s;
 error_log stderr error;
 
 events {
-  worker_connections 16384;
+  multi_accept on;
+  worker_connections 65535;
 }
 
 http {
-  access_log  off;
+  access_log    off;
+  server_tokens off;
+  msie_padding  off;
 
   sendfile    on;
   tcp_nopush  on;
   tcp_nodelay on;
 
+  keepalive_timeout  65;
+  keepalive_disable  none;
+  keepalive_requests 1000000;
+
   include /racket/config/upstream.conf;
 
   server {
-    listen 8080 default;
+    listen 8080 default_server reuseport deferred backlog=65535 fastopen=4096;
 
     location / {
       proxy_pass            http://app;
       proxy_http_version    1.1;
-      proxy_connect_timeout 90s;
-      proxy_send_timeout    90s;
-      proxy_read_timeout    90s;
-      proxy_buffers         32 8k;
+      proxy_set_header      Connection "";
     }
   }
 }

--- a/frameworks/Racket/racket/servlet.rkt
+++ b/frameworks/Racket/racket/servlet.rkt
@@ -236,7 +236,7 @@
   (define stop
     (serve
      #:dispatch app
-     #:listen-ip "127.0.0.1"
+     #:listen-ip "0.0.0.0"
      #:port port
      #:confirmation-channel ch
      #:safety-limits (make-safety-limits


### PR DESCRIPTION
I spent a little more time tuning the nginx config today. This improves throughput by about 4-5x on the plaintext benchmark compared to the previous PR.