### PR TITLE
warp-rust: Use the rt-threaded feature in tokio

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 futures = "0.3.1"
 rand = "0.7.3"
 serde = { version = "1.0.103", features = ["derive"] }
-tokio = { version = "0.2.9", features = ["macros"] }
+tokio = { version = "0.2.21", features = ["macros", "rt-threaded"] }
 tokio-postgres = "0.5.1"
-warp = "0.2.0"
+warp = "0.2.3"


### PR DESCRIPTION
This should create a runtime that uses all logical cores. Tokio and warp had their versions bumped up.