### PR TITLE
Update all rust frameworks and fix Rust/gotham

### DIFF
--- a/frameworks/Rust/gotham/Cargo.toml
+++ b/frameworks/Rust/gotham/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 gotham = "0.4"
 hyper = "0.12"
 mime = "0.3"
-serde = "1.0"
+serde = "1.0.111"
 serde_derive = "1.0"
 serde_json = "1.0"
 

--- a/frameworks/Rust/gotham/gotham.dockerfile
+++ b/frameworks/Rust/gotham/gotham.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 WORKDIR /gotham
 COPY ./src ./src

--- a/frameworks/Rust/hyper/hyper-db.dockerfile
+++ b/frameworks/Rust/hyper/hyper-db.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 ADD ./ /hyper
 WORKDIR /hyper

--- a/frameworks/Rust/hyper/hyper.dockerfile
+++ b/frameworks/Rust/hyper/hyper.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 ADD ./ /hyper
 WORKDIR /hyper

--- a/frameworks/Rust/iron/iron.dockerfile
+++ b/frameworks/Rust/iron/iron.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 ADD ./ /iron
 WORKDIR /iron

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.41
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake
 

--- a/frameworks/Rust/nickel/nickel.dockerfile
+++ b/frameworks/Rust/nickel/nickel.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 ADD ./ /nickel
 WORKDIR /nickel

--- a/frameworks/Rust/roa/roa-core.dockerfile
+++ b/frameworks/Rust/roa/roa-core.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-diesel.dockerfile
+++ b/frameworks/Rust/roa/roa-diesel.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-pg.dockerfile
+++ b/frameworks/Rust/roa/roa-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-sqlx.dockerfile
+++ b/frameworks/Rust/roa/roa-sqlx.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-tokio.dockerfile
+++ b/frameworks/Rust/roa/roa-tokio.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa.dockerfile
+++ b/frameworks/Rust/roa/roa.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42
+FROM rust:1.44
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/rouille/rouille.dockerfile
+++ b/frameworks/Rust/rouille/rouille.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 WORKDIR /rouille
 COPY src src

--- a/frameworks/Rust/saphir/saphir.dockerfile
+++ b/frameworks/Rust/saphir/saphir.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.41
+FROM rust:1.44
 
 WORKDIR /saphir
 

--- a/frameworks/Rust/thruster/thruster.dockerfile
+++ b/frameworks/Rust/thruster/thruster.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 WORKDIR /thruster
 COPY ./src ./src

--- a/frameworks/Rust/tokio-minihttp/tokio-minihttp.dockerfile
+++ b/frameworks/Rust/tokio-minihttp/tokio-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36
+FROM rust:1.44
 
 ADD ./ /tokio
 WORKDIR /tokio

--- a/frameworks/Rust/warp-rust/warp-rust.dockerfile
+++ b/frameworks/Rust/warp-rust/warp-rust.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.40
+FROM rust:1.44
 
 WORKDIR /warp-rust
 COPY src src


### PR DESCRIPTION
Updates all rust frameworks which also solves the start/stop problem for Rust/gotham

```
gotham: error[E0658]: use of unstable library feature 'ptr_cast'
gotham:   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/object-0.19.0/src/pod.rs:65:66
gotham:    |
gotham: 65 |     unsafe { slice::from_raw_parts(slice::from_ref(val).as_ptr().cast(), size) }
gotham:    |                                                                  ^^^^
gotham:    |
gotham:    = note: for more information, see https://github.com/rust-lang/rust/issues/60602
```