### PR TITLE
Revert to 4 x workers

### DIFF
--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -26,7 +26,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx_php7 > /dev/null && \
     make > /dev/null && make install > /dev/null
 
-RUN export WORKERS=$(( 5 * $(nproc) )) && \
+RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s/worker_processes  auto/worker_processes $WORKERS/g" /deploy/nginx.conf
 
 CMD /nginx/sbin/nginx -c /deploy/nginx.conf 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -28,7 +28,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
 
 RUN sed -i "s|mysql:|pgsql:|g" /app.php
 
-RUN export WORKERS=$(( 5 * $(nproc) )) && \
+RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s|worker_processes  auto|worker_processes $WORKERS|g" /deploy/nginx.conf
 
 CMD /nginx/sbin/nginx -c /deploy/nginx.conf

--- a/frameworks/PHP/workerman/server.php
+++ b/frameworks/PHP/workerman/server.php
@@ -6,7 +6,7 @@ use Workerman\Worker;
 use Workerman\Timer;
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
-$http_worker->count         = (int) shell_exec('nproc') * 5;
+$http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->onWorkerStart = function () {
     Header::$date = gmdate('D, d M Y H:i:s').' GMT';
     Timer::add(1, function() {


### PR DESCRIPTION
in php-ngx and workerman

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
