### PR TITLE
tech-empower: Update Finagle/Finatra Version to 20.6.0

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,4 +1,4 @@
-lazy val finagleVersion = "20.5.0"
+lazy val finagleVersion = "20.6.0"
 
 name := "finagle-benchmark"
 scalaVersion := "2.12.8"
@@ -6,7 +6,7 @@ version := finagleVersion
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-http" % finagleVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.10"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.0"
 )
 
 assemblyJarName in assembly := "finagle-benchmark.jar"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,4 +1,4 @@
-lazy val finatraVersion = "20.4.1"
+lazy val finatraVersion = "20.6.0"
 
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
   ("com.twitter" %% "finatra-http" % finatraVersion).
     exclude("com.sun.activation", "javax.activation"),
   "org.slf4j" % "slf4j-nop" % "1.7.30",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.10",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.0",
 )
 
 excludeDependencies ++= Seq(


### PR DESCRIPTION
Problem / Solution

Twitter has just completed the June 2020 release of Finagle and Finatra. This
commit updates the TechEmpower Framework Benchmarks to use the latest
versions of Finagle and Finatra.
