### PR TITLE
Improve performance serialize to json at ntex

### DIFF
--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main_raw.rs"
 [dependencies]
 ntex = "0.1.18"
 snmalloc-rs = { version = "0.2.15", features = ["native-cpu"] }
-yarte = { version = "0.11", features = ["bytes-buf"] }
+yarte = { version = "0.11", features = ["bytes-buf", "json"] }
 env_logger = "0.7"
 random-fast-rng = "0.1.1"
 bytes = "0.5.3"

--- a/frameworks/Rust/ntex/ntex-db.dockerfile
+++ b/frameworks/Rust/ntex/ntex-db.dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.44
 
+# Disable simd at jsonescape
+ENV CARGO_CFG_JSONESCAPE_DISABLE_AUTO_SIMD=
+
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 
 ADD ./ /ntex

--- a/frameworks/Rust/ntex/ntex-raw.dockerfile
+++ b/frameworks/Rust/ntex/ntex-raw.dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.44
 
+# Disable simd at jsonescape
+ENV CARGO_CFG_JSONESCAPE_DISABLE_AUTO_SIMD=
+
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 
 ADD ./ /ntex

--- a/frameworks/Rust/ntex/ntex.dockerfile
+++ b/frameworks/Rust/ntex/ntex.dockerfile
@@ -1,5 +1,8 @@
 FROM rust:1.44
 
+# Disable simd at jsonescape
+ENV CARGO_CFG_JSONESCAPE_DISABLE_AUTO_SIMD=
+
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 
 ADD ./ /ntex

--- a/frameworks/Rust/ntex/src/db.rs
+++ b/frameworks/Rust/ntex/src/db.rs
@@ -3,18 +3,15 @@ use std::cell::RefCell;
 use std::fmt::Write as FmtWrite;
 use std::io;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::{Future, FutureExt, StreamExt, TryStreamExt};
 use ntex::web::Error;
 use random_fast_rng::{FastRng, Random};
-use simd_json_derive::Serialize;
 use smallvec::{smallvec, SmallVec};
 use tokio_postgres::types::ToSql;
 use tokio_postgres::{connect, Client, NoTls, Statement};
-use yarte::TemplateBytes;
-
-use crate::utils::Writer;
+use yarte::{Serialize, TemplateBytes};
 
 #[derive(Serialize, Debug)]
 pub struct World {
@@ -91,15 +88,11 @@ impl PgConnection {
                 Error::from(io::Error::new(io::ErrorKind::Other, format!("{:?}", e)))
             })?;
 
-            let mut body = BytesMut::with_capacity(40);
-            World {
+            Ok(World {
                 id: row.get(0),
                 randomnumber: row.get(1),
             }
-            .json_write(&mut Writer(&mut body))
-            .unwrap();
-
-            Ok(body.freeze())
+            .to_bytes(40))
         }
     }
 

--- a/frameworks/Rust/ntex/src/main.rs
+++ b/frameworks/Rust/ntex/src/main.rs
@@ -1,12 +1,12 @@
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use ntex::{http, web};
-use simd_json_derive::Serialize;
+use yarte::Serialize;
 
 mod utils;
-use utils::{Writer, SIZE};
+use utils::SIZE;
 
 #[derive(Serialize)]
 pub struct Message {
@@ -14,15 +14,14 @@ pub struct Message {
 }
 
 async fn json() -> web::HttpResponse {
-    let message = Message {
-        message: "Hello, World!",
-    };
-    let mut body = BytesMut::with_capacity(SIZE);
-    message.json_write(&mut Writer(&mut body)).unwrap();
-
     let mut res = web::HttpResponse::with_body(
         http::StatusCode::OK,
-        http::body::Body::Bytes(body.freeze()),
+        http::body::Body::Bytes(
+            Message {
+                message: "Hello, World!",
+            }
+            .to_bytes(SIZE),
+        ),
     );
     res.headers_mut().insert(
         http::header::SERVER,

--- a/frameworks/Rust/ntex/src/main_db.rs
+++ b/frameworks/Rust/ntex/src/main_db.rs
@@ -75,9 +75,10 @@ impl Service for App {
 
                 Box::pin(async move {
                     let worlds = fut.await?;
+                    let size = 35 * worlds.len();
                     let mut res = Response::with_body(
                         StatusCode::OK,
-                        Body::Bytes(worlds.to_bytes(35 * worlds.len())),
+                        Body::Bytes(worlds.to_bytes(size)),
                     );
                     let hdrs = res.headers_mut();
                     hdrs.insert(SERVER, h_srv);
@@ -93,9 +94,10 @@ impl Service for App {
 
                 Box::pin(async move {
                     let worlds = fut.await?;
+                    let size = 35 * worlds.len();
                     let mut res = Response::with_body(
                         StatusCode::OK,
-                        Body::Bytes(worlds.to_bytes(35 * worlds.len())),
+                        Body::Bytes(worlds.to_bytes(size)),
                     );
                     let hdrs = res.headers_mut();
                     hdrs.insert(SERVER, h_srv);

--- a/frameworks/Rust/ntex/src/main_db.rs
+++ b/frameworks/Rust/ntex/src/main_db.rs
@@ -5,20 +5,18 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::BytesMut;
 use futures::future::ok;
 use ntex::http::body::Body;
 use ntex::http::header::{HeaderValue, CONTENT_TYPE, SERVER};
 use ntex::http::{HttpService, KeepAlive, Request, Response, StatusCode};
 use ntex::service::{Service, ServiceFactory};
 use ntex::web::Error;
-use simd_json_derive::Serialize;
+use yarte::Serialize;
 
 mod db;
 mod utils;
 
 use crate::db::PgConnection;
-use crate::utils::Writer;
 
 struct App {
     db: PgConnection,
@@ -77,10 +75,10 @@ impl Service for App {
 
                 Box::pin(async move {
                     let worlds = fut.await?;
-                    let mut body = BytesMut::with_capacity(35 * worlds.len());
-                    worlds.json_write(&mut Writer(&mut body)).unwrap();
-                    let mut res =
-                        Response::with_body(StatusCode::OK, Body::Bytes(body.freeze()));
+                    let mut res = Response::with_body(
+                        StatusCode::OK,
+                        Body::Bytes(worlds.to_bytes(35 * worlds.len())),
+                    );
                     let hdrs = res.headers_mut();
                     hdrs.insert(SERVER, h_srv);
                     hdrs.insert(CONTENT_TYPE, h_ct);
@@ -95,10 +93,10 @@ impl Service for App {
 
                 Box::pin(async move {
                     let worlds = fut.await?;
-                    let mut body = BytesMut::with_capacity(35 * worlds.len());
-                    worlds.json_write(&mut Writer(&mut body)).unwrap();
-                    let mut res =
-                        Response::with_body(StatusCode::OK, Body::Bytes(body.freeze()));
+                    let mut res = Response::with_body(
+                        StatusCode::OK,
+                        Body::Bytes(worlds.to_bytes(35 * worlds.len())),
+                    );
                     let hdrs = res.headers_mut();
                     hdrs.insert(SERVER, h_srv);
                     hdrs.insert(CONTENT_TYPE, h_ct);

--- a/frameworks/Rust/ntex/src/main_raw.rs
+++ b/frameworks/Rust/ntex/src/main_raw.rs
@@ -11,7 +11,7 @@ use ntex::codec::{AsyncRead, AsyncWrite, Decoder};
 use ntex::fn_service;
 use ntex::http::{h1, Request};
 use ntex::rt::net::TcpStream;
-use simd_json_derive::Serialize;
+use yarte::Serialize;
 
 mod utils;
 
@@ -37,14 +37,12 @@ impl App {
     fn handle_request(&mut self, req: Request) {
         match req.path() {
             "/json" => {
-                let message = Message {
-                    message: "Hello, World!",
-                };
                 self.write_buf.extend_from_slice(JSON);
                 self.codec.set_date_header(&mut self.write_buf);
-                message
-                    .json_write(&mut utils::Writer(&mut self.write_buf))
-                    .unwrap();
+                Message {
+                    message: "Hello, World!",
+                }
+                .to_bytes_mut(&mut self.write_buf);
             }
             "/plaintext" => {
                 self.write_buf.extend_from_slice(PLAIN);

--- a/frameworks/Rust/ntex/src/utils.rs
+++ b/frameworks/Rust/ntex/src/utils.rs
@@ -1,22 +1,9 @@
 #![allow(dead_code)]
-use std::{cmp, io};
+use std::cmp;
 
 use atoi::FromRadix10;
-use bytes::BytesMut;
 
 pub const SIZE: usize = 27;
-
-pub struct Writer<'a>(pub &'a mut BytesMut);
-
-impl<'a> io::Write for Writer<'a> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
 
 pub fn get_query_param(query: &str) -> u16 {
     let q = if let Some(pos) = query.find("q") {


### PR DESCRIPTION
@fafhrd91 I have forked `simd-json-derive` I have implemented it directly over the `bytes::BytesMut`. The advantage is that it does not use intermediate buffers, serializing on a single alloc. This is perfect for the `Word` struct, as seen in the result:
### Old
```json
 "db": {
      "ntex-db": [
        {
          "latencyAvg": "331.62us",
          "latencyMax": "11.84ms",
          "latencyStdev": "217.48us",
          "totalRequests": 732443,
          "startTime": 1593489086,
          "endTime": 1593489101
        },
        {
          "latencyAvg": "589.14us",
          "latencyMax": "10.34ms",
          "latencyStdev": "382.99us",
          "totalRequests": 837341,
          "startTime": 1593489103,
          "endTime": 1593489118
        },
        {
          "latencyAvg": "1.05ms",
          "latencyMax": "12.67ms",
          "latencyStdev": "738.02us",
          "totalRequests": 962237,
          "startTime": 1593489120,
          "endTime": 1593489135
        },
        {
          "latencyAvg": "1.91ms",
          "latencyMax": "16.50ms",
          "latencyStdev": "1.41ms",
          "totalRequests": 1061544,
          "startTime": 1593489137,
          "endTime": 1593489152
        },
        {
          "latencyAvg": "3.53ms",
          "latencyMax": "35.39ms",
          "latencyStdev": "2.47ms",
          "totalRequests": 1127646,
          "startTime": 1593489154,
          "endTime": 1593489169
        },
        {
          "latencyAvg": "6.54ms",
          "latencyMax": "47.44ms",
          "latencyStdev": "3.93ms",
          "totalRequests": 1179279,
          "startTime": 1593489171,
          "endTime": 1593489186
        }
      ]
    },
```

#### New
```json
"db": {
      "ntex-db": [
        {
          "latencyAvg": "325.77us",
          "latencyMax": "11.29ms",
          "latencyStdev": "238.57us",
          "totalRequests": 747967,
          "startTime": 1593488128,
          "endTime": 1593488143
        },
        {
          "latencyAvg": "568.11us",
          "latencyMax": "10.99ms",
          "latencyStdev": "331.87us",
          "totalRequests": 862393,
          "startTime": 1593488145,
          "endTime": 1593488160
        },
        {
          "latencyAvg": "1.02ms",
          "latencyMax": "12.46ms",
          "latencyStdev": "720.79us",
          "totalRequests": 984987,
          "startTime": 1593488162,
          "endTime": 1593488177
        },
        {
          "latencyAvg": "1.91ms",
          "latencyMax": "23.67ms",
          "latencyStdev": "1.49ms",
          "totalRequests": 1079151,
          "startTime": 1593488179,
          "endTime": 1593488194
        },
        {
          "latencyAvg": "3.38ms",
          "latencyMax": "27.17ms",
          "latencyStdev": "2.26ms",
          "totalRequests": 1165541,
          "startTime": 1593488196,
          "endTime": 1593488211
        },
        {
          "latencyAvg": "6.28ms",
          "latencyMax": "47.12ms",
          "latencyStdev": "3.61ms",
          "totalRequests": 1217962,
          "startTime": 1593488213,
          "endTime": 1593488228
        }
      ]
    },
```

However I have not used it in `Message` struct because `simd-json-derive` escape algorithm is a little faster in short cases, less than 16 bytes, than `v_jsonescape`