### PR TITLE
Increase number of Python/flask workers

### DIFF
--- a/frameworks/Python/flask/gunicorn_conf.py
+++ b/frameworks/Python/flask/gunicorn_conf.py
@@ -5,7 +5,7 @@ import sys
 _is_pypy = hasattr(sys, 'pypy_version_info')
 _is_travis = os.environ.get('TRAVIS') == 'true'
 
-workers = multiprocessing.cpu_count() * 3
+workers = multiprocessing.cpu_count() * 8
 if _is_travis:
     workers = 2
 


### PR DESCRIPTION
As per: http://calpaterson.com/async-python-is-not-faster.html

The number of `gunicorn` workers is probably too low for Flask. Cal recommends overshooting then dialling back _(and also that the cost of too many workers is higher than the cost of too few)_, so I've upped the number of workers to a (seemingly crazy) 8 to see what happens.
