### PR TITLE
Align rocker compiler version with runtime version

### DIFF
--- a/frameworks/Java/vertx-web/pom.xml
+++ b/frameworks/Java/vertx-web/pom.xml
@@ -106,7 +106,7 @@
       <plugin>
         <groupId>com.fizzed</groupId>
         <artifactId>rocker-maven-plugin</artifactId>
-        <version>1.3.0</version>
+        <version>0.24.0</version>
         <executions>
           <execution>
             <id>generate-rocker-templates</id>
@@ -117,6 +117,7 @@
             <configuration>
               <templateDirectory>${project.basedir}/src/main/resources</templateDirectory>
               <optimize>true</optimize>
+              <javaVersion>1.8</javaVersion>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
The runtime version of the template engine is not aligned with the compiler version. This may be the root cause of the failure on CI. This PR attempts to normalize the versions to the runtime version, plus the generated code language level.