### PR TITLE
Update fortunes path and v_escape at actix, ntex, hyper, may-minihttp

### DIFF
--- a/frameworks/Rust/actix/Cargo.toml
+++ b/frameworks/Rust/actix/Cargo.toml
@@ -34,7 +34,7 @@ actix-service = "1.0.1"
 snmalloc-rs = "0.2.6"
 askama = "0.8"
 markup = "0.4.1"
-yarte = "0.9"
+yarte = "0.11"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -49,7 +49,7 @@ simd-json-derive = { git = "https://github.com/simd-lite/simd-json-derive.git" }
 diesel = { version = "1.4.3", features = ["postgres"] }
 url = { version="1.7", features=["query_encoding"] }
 log = { version = "0.4", features = ["release_max_level_debug"] }
-v_htmlescape = "0.4.5"
+v_htmlescape = "0.10"
 tokio = "=0.2.6"
 tokio-postgres = { git="https://github.com/fafhrd91/rust-postgres.git" }
 

--- a/frameworks/Rust/actix/benchmark_config.json
+++ b/frameworks/Rust/actix/benchmark_config.json
@@ -20,7 +20,7 @@
       "versus": ""
     },
     "core": {
-      "fortune_url": "/fortune",
+      "fortune_url": "/fortunes",
       "db_url": "/db",
       "query_url": "/queries?q=",
       "update_url": "/updates?q=",
@@ -59,7 +59,7 @@
     },
     "diesel": {
       "db_url": "/db",
-      "fortune_url": "/fortune",
+      "fortune_url": "/fortunes",
       "query_url": "/queries?q=",
       "update_url": "/updates?q=",
       "port": 8080,
@@ -79,7 +79,7 @@
     },
     "pg": {
       "db_url": "/db",
-      "fortune_url": "/fortune",
+      "fortune_url": "/fortunes",
       "query_url": "/queries?q=",
       "update_url": "/updates?q=",
       "port": 8080,

--- a/frameworks/Rust/actix/src/main_diesel.rs
+++ b/frameworks/Rust/actix/src/main_diesel.rs
@@ -113,7 +113,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .data(addr.clone())
             .service(web::resource("/db").to(world_row))
-            .service(web::resource("/fortune").to(fortune))
+            .service(web::resource("/fortunes").to(fortune))
             .service(web::resource("/queries").to(queries))
             .service(web::resource("/updates").to(updates))
     })

--- a/frameworks/Rust/actix/src/main_pg.rs
+++ b/frameworks/Rust/actix/src/main_pg.rs
@@ -129,7 +129,7 @@ async fn main() -> std::io::Result<()> {
                         .data_factory(|| PgConnection::connect(DB_URL))
                         .service(web::resource("/db").to(world_row))
                         .service(web::resource("/queries").to(queries))
-                        .service(web::resource("/fortune").to(fortune))
+                        .service(web::resource("/fortunes").to(fortune))
                         .service(web::resource("/updates").to(updates)),
                     |_| AppConfig::default(),
                 ))

--- a/frameworks/Rust/actix/src/main_platform.rs
+++ b/frameworks/Rust/actix/src/main_platform.rs
@@ -63,7 +63,7 @@ impl Service for App {
                     Ok(res)
                 })
             }
-            "/fortune" => {
+            "/fortunes" => {
                 let h_srv = self.hdr_srv.clone();
                 let h_ct = self.hdr_cthtml.clone();
                 let fut = self.db.tell_fortune();

--- a/frameworks/Rust/hyper/Cargo.toml
+++ b/frameworks/Rust/hyper/Cargo.toml
@@ -35,7 +35,7 @@ serde_derive = "1.0"
 tokio-core = { git = "https://github.com/seanmonstar/tokio-core", branch = "0.1.11-fix" }
 # Disable postgres' runtime feature as well...
 tokio-postgres = { version = "0.4.0-rc.3", default-features = false }
-v_htmlescape = "0.4"
+v_htmlescape = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/frameworks/Rust/hyper/benchmark_config.json
+++ b/frameworks/Rust/hyper/benchmark_config.json
@@ -19,7 +19,7 @@
       "notes": ""
     },
     "db": {
-      "fortune_url": "/fortune",
+      "fortune_url": "/fortunes",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Micro",

--- a/frameworks/Rust/hyper/src/main_db.rs
+++ b/frameworks/Rust/hyper/src/main_db.rs
@@ -56,7 +56,7 @@ fn main() {
                     headers.insert(SERVER, server_header.clone());
 
                     match req.uri.path() {
-                        "/fortune" => {
+                        "/fortunes" => {
                             future::Either::A(db_conn.tell_fortune().map(move |fortunes| {
                                 let mut buf = String::with_capacity(2048);
                                 let _ = write!(&mut buf, "{}", FortunesTemplate { fortunes });

--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -10,7 +10,7 @@ mimalloc = "0.1"
 num_cpus = "1.0"
 oorandom = "11"
 smallvec = "1.1"
-v_htmlescape = "0.4"
+v_htmlescape = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 may = "0.3"

--- a/frameworks/Rust/may-minihttp/benchmark_config.json
+++ b/frameworks/Rust/may-minihttp/benchmark_config.json
@@ -5,7 +5,7 @@
       "default": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",
-        "fortune_url": "/fortune",
+        "fortune_url": "/fortunes",
         "db_url": "/db",
         "query_url": "/queries?q=",
         "update_url": "/updates?q=",

--- a/frameworks/Rust/may-minihttp/src/main.rs
+++ b/frameworks/Rust/may-minihttp/src/main.rs
@@ -245,7 +245,7 @@ impl HttpService for Techempower {
                 rsp.header("Content-Type: application/json");
                 serde_json::to_writer(BodyWriter(rsp.body_mut()), &world)?;
             }
-            "/fortune" => {
+            "/fortunes" => {
                 let fortunes = self.db.tell_fortune().unwrap();
                 rsp.header("Content-Type: text/html; charset=utf-8");
                 write!(rsp.body_mut(), "{}", FortunesTemplate { fortunes }).unwrap();

--- a/frameworks/Rust/ntex/benchmark_config.json
+++ b/frameworks/Rust/ntex/benchmark_config.json
@@ -20,7 +20,7 @@
       "versus": ""
     },
     "db": {
-      "fortune_url": "/fortune",
+      "fortune_url": "/fortunes",
       "db_url": "/db",
       "query_url": "/query?q=",
       "update_url": "/update?q=",

--- a/frameworks/Rust/ntex/src/main_db.rs
+++ b/frameworks/Rust/ntex/src/main_db.rs
@@ -53,7 +53,7 @@ impl Service for App {
                     Ok(res)
                 })
             }
-            "/fortune" => {
+            "/fortunes" => {
                 let h_srv = self.hdr_srv.clone();
                 let h_ct = self.hdr_cthtml.clone();
                 let fut = self.db.tell_fortune();


### PR DESCRIPTION
In the current bench it's failed for this reason. 
```
Route for fortunes must be at least 9 characters, found '/fortune' instead
```
https://tfb-status.techempower.com/results/96a52386-fa9c-44e8-9bcb-dcdc9e09f2dd

I have updated the version of v_escape, in all of them. On the other hand, for the owners of these cases it could work faster using the algorithm in `sse2` since they do not exceed 128 bytes and the algorithm is a little more efficient. Declaring the environment variable `CARGO_CFG_HTMLESCAPE_DISABLE_AUTO_AVX` before compile. 
