### PR TITLE
Fixes a few database bugs:

### DIFF
--- a/toolset/databases/mongodb/create.js
+++ b/toolset/databases/mongodb/create.js
@@ -1,7 +1,7 @@
 use hello_world
 db.world.drop()
 for (var i = 1; i <= 10000; i++) {
-  db.world.save( { _id: i, id: i, randomNumber: (Math.floor(Math.random() * 10000) + 1) })
+  db.world.save( { _id: i, id: i, randomNumber: (Math.min(Math.floor(Math.random() * 10000) + 1), 10000) })
 }
 
 db.world.createIndex({_id: 1})

--- a/toolset/databases/mysql/create.sql
+++ b/toolset/databases/mysql/create.sql
@@ -14,8 +14,8 @@ CREATE TABLE  world (
 ENGINE=INNODB;
 CREATE USER 'benchmarkdbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
 CREATE USER 'benchmarkdbuser'@'localhost' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
-GRANT SELECT, UPDATE ON hello_world.world TO 'benchmarkdbuser'@'%';
-GRANT SELECT, UPDATE ON hello_world.world TO 'benchmarkdbuser'@'localhost';
+GRANT ALL PRIVILEGES ON hello_world.world TO 'benchmarkdbuser'@'%';
+GRANT ALL PRIVILEGES ON hello_world.world TO 'benchmarkdbuser'@'localhost';
 
 DELIMITER #
 CREATE PROCEDURE load_data()
@@ -27,7 +27,7 @@ declare v_counter int unsigned default 0;
   TRUNCATE TABLE world;
   START TRANSACTION;
   while v_counter < v_max do
-    INSERT INTO world (randomNumber) VALUES ( floor(0 + (rand() * 10000)) );
+    INSERT INTO world (randomNumber) VALUES ( least(floor(1 + (rand() * 10000)), 10000) );
     SET v_counter=v_counter+1;
   end while;
   commit;
@@ -44,8 +44,8 @@ CREATE TABLE  fortune (
   PRIMARY KEY  (id)
 )
 ENGINE=INNODB;
-GRANT SELECT ON hello_world.fortune TO 'benchmarkdbuser'@'%';
-GRANT SELECT ON hello_world.fortune TO 'benchmarkdbuser'@'localhost';
+GRANT ALL PRIVILEGES ON hello_world.fortune TO 'benchmarkdbuser'@'%';
+GRANT ALL PRIVILEGES ON hello_world.fortune TO 'benchmarkdbuser'@'localhost';
 
 INSERT INTO fortune (message) VALUES ('fortune: No such file or directory');
 INSERT INTO fortune (message) VALUES ('A computer scientist is someone who fixes things that aren''t broken.');

--- a/toolset/databases/postgres/create-postgres-database.sql
+++ b/toolset/databases/postgres/create-postgres-database.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION pg_stat_statements;
-
 CREATE USER benchmarkdbuser WITH PASSWORD 'benchmarkdbpass';
 
 ALTER USER benchmarkdbuser WITH SUPERUSER;

--- a/toolset/databases/postgres/create-postgres.sql
+++ b/toolset/databases/postgres/create-postgres.sql
@@ -1,21 +1,23 @@
 BEGIN;
 
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
 CREATE TABLE  World (
   id integer NOT NULL,
   randomNumber integer NOT NULL default 0,
   PRIMARY KEY  (id)
 );
-GRANT SELECT, UPDATE ON World to benchmarkdbuser;
+GRANT ALL PRIVILEGES ON World to benchmarkdbuser;
 
 INSERT INTO World (id, randomnumber)
-SELECT x.id, floor(random() * 10000 + 1) FROM generate_series(1,10000) as x(id);
+SELECT x.id, least(floor(random() * 10000 + 1), 10000) FROM generate_series(1,10000) as x(id);
 
 CREATE TABLE Fortune (
   id integer NOT NULL,
   message varchar(2048) NOT NULL,
   PRIMARY KEY  (id)
 );
-GRANT SELECT ON Fortune to benchmarkdbuser;
+GRANT ALL PRIVILEGES ON Fortune to benchmarkdbuser;
 
 INSERT INTO Fortune (id, message) VALUES (1, 'fortune: No such file or directory');
 INSERT INTO Fortune (id, message) VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');
@@ -35,17 +37,17 @@ CREATE TABLE  "World" (
   randomNumber integer NOT NULL default 0,
   PRIMARY KEY  (id)
 );
-GRANT SELECT, UPDATE ON "World" to benchmarkdbuser;
+GRANT ALL PRIVILEGES ON "World" to benchmarkdbuser;
 
 INSERT INTO "World" (id, randomnumber)
-SELECT x.id, floor(random() * 10000 + 1) FROM generate_series(1,10000) as x(id);
+SELECT x.id, least(floor(random() * 10000 + 1), 10000) FROM generate_series(1,10000) as x(id);
 
 CREATE TABLE "Fortune" (
   id integer NOT NULL,
   message varchar(2048) NOT NULL,
   PRIMARY KEY  (id)
 );
-GRANT SELECT ON "Fortune" to benchmarkdbuser;
+GRANT ALL PRIVILEGES ON "Fortune" to benchmarkdbuser;
 
 INSERT INTO "Fortune" (id, message) VALUES (1, 'fortune: No such file or directory');
 INSERT INTO "Fortune" (id, message) VALUES (2, 'A computer scientist is someone who fixes things that aren''t broken.');


### PR DESCRIPTION
* Lottery that your database has a randomnumber=0 from the creation (meaning that database-query verifications have a 1/10,000 chance of failing) has been removed.
* Fixes the extension never being installed on the correct schema.
* Fixes the priviledge issue where the toolset (and others) cannot perform writes to any table. This is a holdover from legacy support where the databases were persisted to disk and reused on every test, thus keeping TestA from breaking TestB by dropping all tables (etc). Since the databases are docker containers, edits are never persisted from run to run, so write permission is fine, and is wanted in anticipation of future verifications.