### PR TITLE
This will correctly generate random numbers

### DIFF
--- a/toolset/databases/mongodb/create.js
+++ b/toolset/databases/mongodb/create.js
@@ -1,7 +1,7 @@
 use hello_world
 db.world.drop()
 for (var i = 1; i <= 10000; i++) {
-  db.world.save( { _id: i, id: i, randomNumber: (Math.min(Math.floor(Math.random() * 10000) + 1), 10000) })
+  db.world.save( { _id: i, id: i, randomNumber: Math.min(Math.floor(Math.random() * 10000) + 1, 10000) })
 }
 
 db.world.createIndex({_id: 1})


### PR DESCRIPTION
I broke MongoDB's ability to generate random numbers for the `world` table in #5881 