### PR TITLE
Bump vertx to 3.9.2 + removed 1 dependency (trying to figure out why …

### DIFF
--- a/frameworks/Java/vertx-web/pom.xml
+++ b/frameworks/Java/vertx-web/pom.xml
@@ -7,12 +7,12 @@
 
   <groupId>io.vertx</groupId>
   <artifactId>vertx-web-benchmark</artifactId>
-  <version>3.9.0</version>
+  <version>3.9.2</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <!-- the main class -->
     <main.verticle>io.vertx.benchmark.App</main.verticle>
   </properties>
@@ -74,12 +74,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-afterburner</artifactId>
-      <version>2.10.2</version>
-    </dependency>
-
-    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.2.12</version>
@@ -88,19 +82,6 @@
   </dependencies>
 
   <build>
-
-    <pluginManagement>
-      <plugins>
-        <!-- We specify the Maven compiler plugin as we need to set it to Java 1.8 -->
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-          <configuration>
-            <debug>false</debug>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
 
     <plugins>
       <plugin>

--- a/frameworks/Java/vertx-web/src/main/java/io/vertx/benchmark/App.java
+++ b/frameworks/Java/vertx-web/src/main/java/io/vertx/benchmark/App.java
@@ -1,6 +1,5 @@
 package io.vertx.benchmark;
 
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.github.susom.database.Config;
 import com.github.susom.database.ConfigFrom;
 import com.github.susom.database.DatabaseProviderVertx;
@@ -28,11 +27,6 @@ import java.util.*;
 import static io.vertx.benchmark.Helper.randomWorld;
 
 public class App extends AbstractVerticle {
-
-  static {
-    Json.mapper.registerModule(new AfterburnerModule());
-    Json.prettyMapper.registerModule(new AfterburnerModule());
-  }
 
   /**
    * MongoDB implementation

--- a/frameworks/Java/vertx-web/vertx-web-mongodb.dockerfile
+++ b/frameworks/Java/vertx-web/vertx-web-mongodb.dockerfile
@@ -18,7 +18,7 @@ CMD java \
     -Dvertx.disableTCCL=true                          \
     -Dvertx.disableHttpHeadersValidation=true         \
     -jar                                              \
-    target/vertx-web-benchmark-3.9.0-fat.jar          \
+    target/vertx-web-benchmark-3.9.2-fat.jar          \
     --instances                                       \
     `grep --count ^processor /proc/cpuinfo`           \
     --conf                                            \

--- a/frameworks/Java/vertx-web/vertx-web-postgres.dockerfile
+++ b/frameworks/Java/vertx-web/vertx-web-postgres.dockerfile
@@ -18,7 +18,7 @@ CMD java \
     -Dvertx.disableTCCL=true                          \
     -Dvertx.disableHttpHeadersValidation=true         \
     -jar                                              \
-    target/vertx-web-benchmark-3.9.0-fat.jar          \
+    target/vertx-web-benchmark-3.9.2-fat.jar          \
     --instances                                       \
     `grep --count ^processor /proc/cpuinfo`           \
     --conf                                            \

--- a/frameworks/Java/vertx-web/vertx-web-susom-postgres.dockerfile
+++ b/frameworks/Java/vertx-web/vertx-web-susom-postgres.dockerfile
@@ -18,7 +18,7 @@ CMD java \
     -Dvertx.disableTCCL=true                          \
     -Dvertx.disableHttpHeadersValidation=true         \
     -jar                                              \
-    target/vertx-web-benchmark-3.9.0-fat.jar          \
+    target/vertx-web-benchmark-3.9.2-fat.jar          \
     --instances                                       \
     `grep --count ^processor /proc/cpuinfo`           \
     --conf                                            \

--- a/frameworks/Java/vertx-web/vertx-web.dockerfile
+++ b/frameworks/Java/vertx-web/vertx-web.dockerfile
@@ -18,7 +18,7 @@ CMD java \
     -Dvertx.disableTCCL=true                          \
     -Dvertx.disableHttpHeadersValidation=true         \
     -jar                                              \
-    target/vertx-web-benchmark-3.9.0-fat.jar          \
+    target/vertx-web-benchmark-3.9.2-fat.jar          \
     --instances                                       \
     `grep --count ^processor /proc/cpuinfo`           \
     --conf                                            \


### PR DESCRIPTION
…it breaks only on citrine)

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

For some reason the high perf progres driver code breaks on citrine, I can't really figure out why, except I see some exceptions at start related to json encoding. I've upgraded the project dependencies and removed the dependency that would give a extra boost in perf for the JSON encoder to see if that is the incompatibility...