### PR TITLE
racket: bump Racket version to 7.8

### DIFF
--- a/frameworks/Racket/racket/racket.dockerfile
+++ b/frameworks/Racket/racket/racket.dockerfile
@@ -11,7 +11,7 @@ RUN echo 'APT::Get::Install-Recommends "false";' > /etc/apt/apt.conf.d/00-genera
 
 FROM debian AS racket
 
-ARG RACKET_VERSION=7.7
+ARG RACKET_VERSION=7.8
 
 RUN apt-get update -q \
     && apt-get install --no-install-recommends -q -y \


### PR DESCRIPTION
Racket 7.8 was released this week and it contains some web server perf. improvements.