### PR TITLE
use beef for ntex

### DIFF
--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_off"] }
 tokio = "=0.2.6"
 tokio-postgres = { git="https://github.com/fafhrd91/postgres.git" }
+beef = { version = "0.4.4", features = ["impl_serde"] }
 
 [profile.release]
 lto = true

--- a/frameworks/Rust/ntex/src/db.rs
+++ b/frameworks/Rust/ntex/src/db.rs
@@ -1,8 +1,8 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Write as FmtWrite;
 use std::io;
 
+use beef::lean::Cow;
 use bytes::{Bytes, BytesMut};
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::{Future, FutureExt, StreamExt, TryStreamExt};
@@ -173,7 +173,7 @@ impl PgConnection {
 
             let mut fortunes: SmallVec<[_; 32]> = smallvec::smallvec![Fortune {
                 id: 0,
-                message: Cow::Borrowed("Additional fortune added at request time."),
+                message: Cow::borrowed("Additional fortune added at request time."),
             }];
 
             while let Some(row) = stream.next().await {
@@ -182,7 +182,7 @@ impl PgConnection {
                 })?;
                 fortunes.push(Fortune {
                     id: row.get(0),
-                    message: Cow::Owned(row.get(1)),
+                    message: Cow::owned(row.get(1)),
                 });
             }
 


### PR DESCRIPTION
@fafhrd91 https://github.com/maciejhirsz/beef is a faster `Cow`, there are two versions `beef::Cow` and `beef::lean::Cow`, I tried `beef::lean::Cow` here which uses 2 bytes.

```
before
{'results': [{'endTime': 1596988310,
              'latencyAvg': '8.79ms',
              'latencyMax': '70.97ms',
              'latencyStdev': '6.62ms',
              'startTime': 1596988295,
              'totalRequests': 4719808},
             {'endTime': 1596988327,
              'latencyAvg': '50.13ms',
              'latencyMax': '274.04ms',
              'latencyStdev': '34.41ms',
              'startTime': 1596988312,
              'totalRequests': 3103856},
             {'endTime': 1596988344,
              'latencyAvg': '112.15ms',
              'latencyMax': '465.45ms',
              'latencyStdev': '66.35ms',
              'startTime': 1596988329,
              'totalRequests': 5002304},
             {'endTime': 1596988363,
              'latencyAvg': '496.59ms',
              'latencyMax': '1.25s',
              'latencyStdev': '243.33ms',
              'startTime': 1596988346,
              'totalRequests': 2337216}]}

after
{'results': [{'endTime': 1596992340,
              'latencyAvg': '8.61ms',
              'latencyMax': '75.25ms',
              'latencyStdev': '6.76ms',
              'startTime': 1596992325,
              'totalRequests': 4976336},
             {'endTime': 1596992358,
              'latencyAvg': '48.19ms',
              'latencyMax': '267.83ms',
              'latencyStdev': '32.04ms',
              'startTime': 1596992342,
              'totalRequests': 3131920},
             {'endTime': 1596992375,
              'latencyAvg': '190.70ms',
              'latencyMax': '796.74ms',
              'latencyStdev': '124.03ms',
              'startTime': 1596992360,
              'totalRequests': 3103472},
             {'endTime': 1596992393,
              'latencyAvg': '350.07ms',
              'latencyMax': '976.95ms',
              'latencyStdev': '178.47ms',
              'startTime': 1596992377,
              'totalRequests': 2688192}]}
```

Benchmarks on my computer may not be accurate, quite a lot of stuff I am running while benchmarking, not sure if it affected the benchmarks.