### PR TITLE
Update MySqlConnector (in aspnetcore) to 1.0.1

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Benchmarks.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
 
     <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
+    <PackageReference Include="MySqlConnector" Version="1.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
   </ItemGroup>
 </Project>

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
@@ -64,7 +64,7 @@ namespace Benchmarks.Data
             id.Value = _random.Next(1, 10001);
             cmd.Parameters.Add(id);
 
-            (cmd as MySql.Data.MySqlClient.MySqlCommand)?.Prepare();
+            (cmd as MySqlConnector.MySqlCommand)?.Prepare();
 
             return cmd;
         }
@@ -145,7 +145,7 @@ namespace Benchmarks.Data
                 db.ConnectionString = _connectionString;
                 await db.OpenAsync();
 
-                (cmd as MySql.Data.MySqlClient.MySqlCommand)?.Prepare();
+                (cmd as MySqlConnector.MySqlCommand)?.Prepare();
 
                 using (var rdr = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection))
                 {

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
@@ -15,7 +15,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using Npgsql;
 
 namespace Benchmarks
@@ -75,7 +75,7 @@ namespace Benchmarks
             {
                 if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
                 {
-                    services.AddSingleton<DbProviderFactory>(MySqlClientFactory.Instance);
+                    services.AddSingleton<DbProviderFactory>(MySqlConnectorFactory.Instance);
                 }
             }
 


### PR DESCRIPTION
This update addresses a breaking API change in the library: https://github.com/mysql-net/MySqlConnector/issues/824