### PR TITLE
Revert "use beef for ntex (#5926)"

### DIFF
--- a/frameworks/Rust/ntex/Cargo.toml
+++ b/frameworks/Rust/ntex/Cargo.toml
@@ -33,7 +33,6 @@ serde = { version = "1.0", features = ["derive"] }
 log = { version = "0.4", features = ["release_max_level_off"] }
 tokio = "=0.2.6"
 tokio-postgres = { git="https://github.com/fafhrd91/postgres.git" }
-beef = { version = "0.4.4", features = ["impl_serde"] }
 
 [profile.release]
 lto = true

--- a/frameworks/Rust/ntex/src/db.rs
+++ b/frameworks/Rust/ntex/src/db.rs
@@ -1,8 +1,8 @@
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::Write as FmtWrite;
 use std::io;
 
-use beef::lean::Cow;
 use bytes::{Bytes, BytesMut};
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::{Future, FutureExt, StreamExt, TryStreamExt};
@@ -173,7 +173,7 @@ impl PgConnection {
 
             let mut fortunes: SmallVec<[_; 32]> = smallvec::smallvec![Fortune {
                 id: 0,
-                message: Cow::borrowed("Additional fortune added at request time."),
+                message: Cow::Borrowed("Additional fortune added at request time."),
             }];
 
             while let Some(row) = stream.next().await {
@@ -182,7 +182,7 @@ impl PgConnection {
                 })?;
                 fortunes.push(Fortune {
                     id: row.get(0),
-                    message: Cow::owned(row.get(1)),
+                    message: Cow::Owned(row.get(1)),
                 });
             }
 


### PR DESCRIPTION
This reverts commit 4f1942cd2cab20ba67d54690c4c6950c8374d6e7.

@fafhrd91 

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
