### PR TITLE
Update akka-http to v10.2.0 in akka-http-slick-postgres

### DIFF
--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/build.sbt
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/build.sbt
@@ -88,9 +88,6 @@ lazy val commonSettings =
       "-target",
       "1.8"
     ),
-    javaOptions ++= Seq(
-      "-jvm-debug 5555"
-    ),
     transitiveClassifiers := Seq("sources"),
     publishArtifact in (Compile, packageDoc) := false,
     unmanagedSourceDirectories.in(Compile) := Seq(scalaSource.in(Compile).value),

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/build.sbt
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/build.sbt
@@ -15,6 +15,7 @@ lazy val akkaHttpSlickPostgres =
       libraryDependencies ++= Seq(
         library.akkaHttp,
         library.akkaHttpCirce,
+        library.circeGeneric,
         library.akkaSlf4j,
         library.akkaStream,
         library.logbackClassic,
@@ -29,17 +30,19 @@ lazy val akkaHttpSlickPostgres =
 lazy val library =
   new {
     object Version {
-      val akka              = "2.5.22"
-      val akkaHttp          = "10.1.8"
-      val akkaHttpCirce     = "1.23.0"
+      val akka              = "2.6.8"
+      val akkaHttp          = "10.2.0"
+      val akkaHttpCirce     = "1.34.0"
+      val circe             = "0.13.0"
       val logback           = "1.2.3"
-      val postgresql        = "42.2.5"
-      val scalate           = "1.9.1"
-      val slick             = "3.3.0"
+      val postgresql        = "42.2.16"
+      val scalate           = "1.9.6"
+      val slick             = "3.3.2"
     }
 
     val akkaHttp            = "com.typesafe.akka"            %% "akka-http"                   % Version.akkaHttp
     val akkaHttpCirce       = "de.heikoseeberger"            %% "akka-http-circe"             % Version.akkaHttpCirce
+    val circeGeneric        = "io.circe"                     %% "circe-generic"               % Version.circe
     val akkaSlf4j           = "com.typesafe.akka"            %% "akka-slf4j"                  % Version.akka
     val akkaStream          = "com.typesafe.akka"            %% "akka-stream"                 % Version.akka
     val logbackClassic      = "ch.qos.logback"               %  "logback-classic"             % Version.logback
@@ -59,7 +62,7 @@ lazy val commonSettings =
   Seq(
     organization := "net.benchmark.akka.http",
     organizationName := "Akka",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.3",
     scalacOptions ++= Seq(
       "-deprecation",
       "-encoding",
@@ -69,13 +72,9 @@ lazy val commonSettings =
       "-target:jvm-1.8",
       "-unchecked",
       "-Xfatal-warnings",
-      "-Xfuture",
-      "-Xlint",
+      "-Xlint:unused",
       "-Ydelambdafy:method",
-      "-Yno-adapted-args",
-      "-Ypartial-unification",
       "-Ywarn-numeric-widen",
-      "-Ywarn-unused-import",
       "-Ywarn-value-discard"
     ),
     scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings"), // Relax settings for console

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/project/build.properties
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.13

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/project/plugins.sbt
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"             % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % "1.3.16")
 addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"        % "1.15")
-addSbtPlugin("org.wartremover"    % "sbt-wartremover"     % "2.4.2")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover"     % "2.4.10")
 addSbtPlugin("io.get-coursier"    % "sbt-coursier"        % "1.0.3")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/ApiRoutes.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/ApiRoutes.scala
@@ -29,7 +29,7 @@ object ApiRoutes {
       handleExceptions(eh) {
         get {
           worldRoutes.routes() ~
-            fortuneRoutes.route()
+          fortuneRoutes.route()
         }
       }
     }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
@@ -1,6 +1,5 @@
 package net.benchmark.akka.http
 import akka.actor.{ActorRef, ActorSystem, Terminated}
-import akka.stream.ActorMaterializer
 import com.typesafe.config.Config
 import net.benchmark.akka.http.ApiSupervisor.ApiMessages
 import net.benchmark.akka.http.db.{DatabaseConfiguration, DatabaseRepositoryLoader, DatabaseRepositoryLoaderModule}
@@ -17,7 +16,6 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     implicit val system: ActorSystem = ActorSystem("AkkaSlickBenchmarkApp")
-    implicit val mat: ActorMaterializer = ActorMaterializer()
 
     val pus = Runtime.getRuntime.availableProcessors()
     val pusMessage = s"Runtime.getRuntime.availableProcessors says $pus"
@@ -29,7 +27,7 @@ object Main {
     val dbConfig: DatabaseConfig[PostgresProfile] = DatabaseConfiguration.getDefaultDatabaseConfiguration(config)
     val dbLoader: DatabaseRepositoryLoader = new DatabaseRepositoryLoaderModule(dbConfig)
 
-    val api: ActorRef = system.actorOf(ApiSupervisor.props(dbLoader, mat))
+    val api: ActorRef = system.actorOf(ApiSupervisor.props(dbLoader))
 
     api ! ApiMessages.StartApi
 

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/Main.scala
@@ -18,7 +18,7 @@ object Main {
     implicit val system: ActorSystem = ActorSystem("AkkaSlickBenchmarkApp")
 
     val pus = Runtime.getRuntime.availableProcessors()
-    val pusMessage = s"Runtime.getRuntime.availableProcessors says $pus"
+    val pusMessage = s"Runtime.getRuntime.availableProcessors says ${pus.toString}"
     log.info(pusMessage)
     println(pusMessage)
 

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/Fortune.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/Fortune.scala
@@ -1,15 +1,11 @@
 package net.benchmark.akka.http.fortune
-import io.circe.{Decoder, Encoder}
+import io.circe.Codec, io.circe.generic.semiauto.deriveCodec
+
+case class Fortune(id: Int, message: String)
 
 object Fortune {
 
-  implicit val decodeFortune: Decoder[Fortune] =
-    Decoder.forProduct2("id", "message")(Fortune.apply)
-
-  implicit val encodeFortune: Encoder[Fortune] =
-    Encoder.forProduct2("id", "message")(v => (v.id, v.message))
+  implicit val fortuneCodec: Codec[Fortune] = deriveCodec
 
   def tupled = (this.apply _).tupled
 }
-
-case class Fortune(id: Int, message: String)

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneRepositoryModule.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneRepositoryModule.scala
@@ -11,6 +11,7 @@ class FortuneRepositoryModule(val dbConfig: DatabaseConfig[PostgresProfile]) ext
 
   private val fortunes = FortuneTable.fortuneTableQuery
 
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def all(): DatabasePublisher[Fortune] = {
     db.stream(
       fortunes.result.withStatementParameters(rsType = ResultSetType.ForwardOnly,

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneRepositoryModule.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneRepositoryModule.scala
@@ -14,8 +14,8 @@ class FortuneRepositoryModule(val dbConfig: DatabaseConfig[PostgresProfile]) ext
   override def all(): DatabasePublisher[Fortune] = {
     db.stream(
       fortunes.result.withStatementParameters(rsType = ResultSetType.ForwardOnly,
-        rsConcurrency = ResultSetConcurrency.ReadOnly,
-        fetchSize = 100))
+                                              rsConcurrency = ResultSetConcurrency.ReadOnly,
+                                              fetchSize = 100))
   }
 
 }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneTable.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/fortune/FortuneTable.scala
@@ -14,6 +14,6 @@ class FortuneTable(tag: Tag) extends Table[Fortune](tag, "Fortune") {
 
   def message = column[String]("message")
 
-  def * = (id, message) <> (Fortune.tupled, Fortune.unapply)
+  def * = (id, message).<>(Fortune.tupled, Fortune.unapply)
 
 }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/util/Deciders.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/util/Deciders.scala
@@ -1,32 +1,16 @@
 package net.benchmark.akka.http.util
-import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.stream.{ActorAttributes, ActorMaterializerSettings, Attributes, Supervision}
+import akka.stream.{ActorAttributes, Attributes, Supervision}
 import org.slf4j.{Logger, LoggerFactory}
 
 object Deciders {
-
-  def stoppingMat(name: String)(implicit system: ActorSystem): ActorMaterializerSettings = {
-    ActorMaterializerSettings(system)
-      .withSupervisionStrategy(Deciders.StoppingDecider.stoppingDecider(s"materializer_$name"))
-  }
 
   def stopping(name: String): Attributes = {
     ActorAttributes.supervisionStrategy(Deciders.StoppingDecider.stoppingDecider(s"stage_$name"))
   }
 
-  def restartingMat(name: String)(implicit system: ActorSystem): ActorMaterializerSettings = {
-    ActorMaterializerSettings(system)
-      .withSupervisionStrategy(Deciders.RestartingDecider.restartingDecider(s"materializer_$name"))
-  }
-
   def restarting(name: String): Attributes = {
     ActorAttributes.supervisionStrategy(Deciders.RestartingDecider.restartingDecider(s"stage_$name"))
-  }
-
-  def resumingMat(name: String)(implicit system: ActorSystem): ActorMaterializerSettings = {
-    ActorMaterializerSettings(system)
-      .withSupervisionStrategy(Deciders.ResumingDecider.resumingDecider(s"materializer_$name"))
   }
 
   def resuming(name: String): Attributes = {

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/Hello.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/Hello.scala
@@ -1,15 +1,11 @@
 package net.benchmark.akka.http.world
 
-import io.circe.{Decoder, Encoder}
+import io.circe.Codec, io.circe.generic.semiauto.deriveCodec
+
+case class Hello(message: String)
 
 object Hello {
 
-  implicit val decodeWorld: Decoder[Hello] =
-    Decoder.forProduct1("message")(Hello.apply)
-
-  implicit val encodeWorld: Encoder[Hello] =
-    Encoder.forProduct1("message")(v => v.message)
+  implicit val helloCodec: Codec[Hello] = deriveCodec
 
 }
-
-case class Hello(message: String)

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/QueriesRoute.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/QueriesRoute.scala
@@ -33,7 +33,7 @@ class QueriesRoute(wr: WorldRepository) {
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def route(): Route = {
     path("queries") {
-      parameter('queries.?) { pn: Option[String] =>
+      parameter("queries".?) { pn: Option[String] =>
         complete {
           source(parse(pn))
         }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/UpdateRoute.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/UpdateRoute.scala
@@ -40,7 +40,7 @@ class UpdateRoute(wr: WorldRepository, sd: ExecutionContextExecutor) {
 
   def route() = {
     path("updates") {
-      parameter('queries.?) { pn =>
+      parameter("queries".?) { pn: Option[String] =>
         complete(source(parse(pn)))
       }
     }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/World.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/World.scala
@@ -1,15 +1,12 @@
 package net.benchmark.akka.http.world
-import io.circe.{Decoder, Encoder}
+
+import io.circe.Codec, io.circe.generic.semiauto.deriveCodec
+
+case class World(id: Int, randomNumber: Int)
 
 object World {
 
-  implicit val decodeWorld: Decoder[World] =
-    Decoder.forProduct2("id", "randomNumber")(World.apply)
-
-  implicit val encodeWorld: Encoder[World] =
-    Encoder.forProduct2("id", "randomNumber")(v => (v.id, v.randomNumber))
+  implicit val worldCodec: Codec[World] = deriveCodec
 
   def tupled = (this.apply _).tupled
 }
-
-case class World(id: Int, randomNumber: Int)

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/WorldRepositoryModule.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/WorldRepositoryModule.scala
@@ -12,14 +12,17 @@ class WorldRepositoryModule(val dbConfig: DatabaseConfig[PostgresProfile]) exten
 
   private val worlds = WorldTable.worldTableQuery
 
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def find(id: Int): Future[Option[World]] = {
     db.run(worlds.filter(_.id === id).result.headOption)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def require(id: Int): Future[World] = {
     db.run(worlds.filter(_.id === id).result.head)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Any"))
   override def update(world: World): Future[Int] = {
     db.run(worlds.filter(_.id === world.id).map(_.randomNumber).update(world.randomNumber))
   }

--- a/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/WorldTable.scala
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres/src/main/scala/net/benchmark/akka/http/world/WorldTable.scala
@@ -14,5 +14,5 @@ class WorldTable(tag: Tag) extends Table[World](tag, "World") {
 
   def randomNumber = column[Int]("randomnumber")
 
-  def * = (id, randomNumber) <> (World.tupled, World.unapply)
+  def * = (id, randomNumber).<>(World.tupled, World.unapply)
 }


### PR DESCRIPTION
Updated Scala, akka-http and all dependencies to latest versions, adapted the code accordingly, used Codec instead of Decoder for circe (since 0.12), supressed Wart annoying warnings.

```
================================================================================
Verification Summary
--------------------------------------------------------------------------------
| akka-http-slick-postgres
|       fortune       : PASS
|       plaintext     : PASS
|       db            : PASS
|       update        : PASS
|       json          : PASS
|       query         : PASS
================================================================================
```