### PR TITLE
Lithium: 1 connection for batch mode. Use the -batch prefix for postgres batch mode.

### DIFF
--- a/frameworks/C++/lithium/benchmark_config.json
+++ b/frameworks/C++/lithium/benchmark_config.json
@@ -50,7 +50,7 @@
         "notes": "",
         "versus": "None"
       },
-      "postgres-pipeline": {
+      "postgres-batch": {
         "db_url"         : "/db",
         "query_url"      : "/queries?N=",
         "fortune_url"    : "/fortunes",
@@ -67,32 +67,10 @@
         "webserver": "None",
         "os": "Linux",
         "database_os": "Linux",
-        "display_name": "Lithium-postgres-pipeline",
-        "notes": "",
-        "versus": "None"
-      },
-      "postgres-pipeline-monothread": {
-        "db_url"         : "/db",
-        "query_url"      : "/queries?N=",
-        "fortune_url"    : "/fortunes",
-        "update_url"     : "/updates?N=",
-        "port": 8080,
-        "approach": "Realistic",
-        "classification": "Micro",
-        "database": "Postgres",
-        "framework": "Lithium",
-        "language": "C++",
-        "flavor": "None",
-        "orm": "Full",
-        "platform": "None",
-        "webserver": "None",
-        "os": "Linux",
-        "database_os": "Linux",
-        "display_name": "Lithium-postgres-pipeline-1t",
+        "display_name": "Lithium-postgres-batch",
         "notes": "",
         "versus": "None"
       }
-
 
     }
   ]

--- a/frameworks/C++/lithium/compile_clang-batch.sh
+++ b/frameworks/C++/lithium/compile_clang-batch.sh
@@ -17,9 +17,9 @@ fi
 
 wget https://raw.githubusercontent.com/matt-42/lithium/$COMMIT/single_headers/lithium_http_backend.hh
 
-clang++ -fprofile-instr-generate=./profile.prof -flto -DPROFILE_MODE -DN_SQL_CONNECTIONS=2  -DMONOTHREAD=$MONOTHREAD -DNDEBUG -D$DB_FLAG -O3 -march=native -std=c++17 ./lithium_pipeline.cc $CXX_FLAGS -lpthread -lboost_context -lssl -lcrypto -o /lithium_tbf
+clang++ -fprofile-instr-generate=./profile.prof -flto -DPROFILE_MODE -DN_SQL_CONNECTIONS=1  -DMONOTHREAD=$MONOTHREAD -DNDEBUG -D$DB_FLAG -O3 -march=native -std=c++17 ./lithium_pipeline.cc $CXX_FLAGS -lpthread -lboost_context -lssl -lcrypto -o /lithium_tbf
 /lithium_tbf tfb-database 8081
 llvm-profdata-10 merge -output=./profile.pgo  ./profile.prof
-clang++ -fprofile-instr-use=./profile.pgo -flto -DNDEBUG -D$DB_FLAG -DN_SQL_CONNECTIONS=2  -DMONOTHREAD=$MONOTHREAD -O3 -march=native -std=c++17 ./lithium_pipeline.cc $CXX_FLAGS -lpthread -lboost_context -lssl -lcrypto -o /lithium_tbf
+clang++ -fprofile-instr-use=./profile.pgo -flto -DNDEBUG -D$DB_FLAG -DN_SQL_CONNECTIONS=1  -DMONOTHREAD=$MONOTHREAD -O3 -march=native -std=c++17 ./lithium_pipeline.cc $CXX_FLAGS -lpthread -lboost_context -lssl -lcrypto -o /lithium_tbf
 
 /lithium_tbf tfb-database 8080

--- a/frameworks/C++/lithium/lithium-postgres-batch-monothread.dockerfile
+++ b/frameworks/C++/lithium/lithium-postgres-batch-monothread.dockerfile
@@ -9,4 +9,8 @@ COPY ./ ./
 RUN ./compile_libpq.sh batchmode
 ENV LD_LIBRARY_PATH=/usr/lib
 
-CMD ./compile_clang-pipeline.sh TFB_PGSQL 0
+CMD ./compile_clang-batch.sh TFB_PGSQL 1
+
+
+#ENV LD_LIBRARY_PATH=/usr/lib
+#CMD /lithium_tbf tfb-database 8080

--- a/frameworks/C++/lithium/lithium-postgres-batch.dockerfile
+++ b/frameworks/C++/lithium/lithium-postgres-batch.dockerfile
@@ -9,8 +9,4 @@ COPY ./ ./
 RUN ./compile_libpq.sh batchmode
 ENV LD_LIBRARY_PATH=/usr/lib
 
-CMD ./compile_clang-pipeline.sh TFB_PGSQL 1
-
-
-#ENV LD_LIBRARY_PATH=/usr/lib
-#CMD /lithium_tbf tfb-database 8080
+CMD ./compile_clang-batch.sh TFB_PGSQL 0

--- a/frameworks/C++/lithium/lithium.cc
+++ b/frameworks/C++/lithium/lithium.cc
@@ -10,9 +10,26 @@
 using namespace li;
 
 template <typename B>
-void escape_html_entities(B& buffer, const std::string& data)
+void escape_html_entities(B& buffer, const std::string_view& data)
 {
-    for(size_t pos = 0; pos != data.size(); ++pos) {
+  size_t pos = 0;
+  auto search_for_special = [&] () {
+    size_t start = pos;
+    size_t end = pos;
+    for(;pos != data.size(); ++pos) {
+      char c = data[pos];
+      if (c > '>' || (c != '&' && c != '\"' && c != '\'' && c != '<' && c == '>'))
+        end = pos + 1;
+      else break;
+    }
+
+    if (start != end)
+      buffer << std::string_view(data.data() + start, end - start);
+  };
+  
+    for(; pos != data.size(); ++pos) {
+      search_for_special();
+      if (pos >= data.size()) return;
         switch(data[pos]) {
             case '&':  buffer << "&amp;";       break;
             case '\"': buffer << "&quot;";      break;

--- a/frameworks/C++/lithium/lithium_pipeline.cc
+++ b/frameworks/C++/lithium/lithium_pipeline.cc
@@ -10,9 +10,26 @@
 using namespace li;
 
 template <typename B>
-void escape_html_entities(B& buffer, const std::string& data)
+void escape_html_entities(B& buffer, const std::string_view& data)
 {
-    for(size_t pos = 0; pos != data.size(); ++pos) {
+  size_t pos = 0;
+  auto search_for_special = [&] () {
+    size_t start = pos;
+    size_t end = pos;
+    for(;pos != data.size(); ++pos) {
+      char c = data[pos];
+      if (c > '>' || (c != '&' && c != '\"' && c != '\'' && c != '<' && c == '>'))
+        end = pos + 1;
+      else break;
+    }
+
+    if (start != end)
+      buffer << std::string_view(data.data() + start, end - start);
+  };
+  
+    for(; pos != data.size(); ++pos) {
+      search_for_special();
+      if (pos >= data.size()) return;
         switch(data[pos]) {
             case '&':  buffer << "&amp;";       break;
             case '\"': buffer << "&quot;";      break;


### PR DESCRIPTION

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
