### PR TITLE
update docker image for akka-http

### DIFF
--- a/frameworks/Scala/akka-http/akka-http-slick-postgres.dockerfile
+++ b/frameworks/Scala/akka-http/akka-http-slick-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u222_1.3.3_2.13.1
+FROM hseeberger/scala-sbt:8u265_1.3.13_2.13.3
 
 WORKDIR /akka-http-slick-postgres
 

--- a/frameworks/Scala/akka-http/akka-http.dockerfile
+++ b/frameworks/Scala/akka-http/akka-http.dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u222_1.3.3_2.13.1
+FROM hseeberger/scala-sbt:8u265_1.3.13_2.13.3
 
 WORKDIR /akka-http
 


### PR DESCRIPTION
update docker image to hseeberger/scala-sbt:8u265_1.3.13_2.13.3
this docker image brings:
- jdk1.8u265
- sbt 1.3.13
- scala 2.13.3