### PR TITLE
Fix Swoole memory limit error

### DIFF
--- a/frameworks/PHP/swoole/php.ini
+++ b/frameworks/PHP/swoole/php.ini
@@ -1,2 +1,3 @@
 opcache.enable_cli=1
 opcache.validate_timestamps=0
+memory_limit = 512M


### PR DESCRIPTION
Fix Swoole memory limit error in the latest testing report.