### PR TITLE
bypass encoding/json and use instead jsoniter

### DIFF
--- a/frameworks/Go/gin/gin-scratch.dockerfile
+++ b/frameworks/Go/gin/gin-scratch.dockerfile
@@ -11,8 +11,8 @@ RUN apk update \
     go mod download
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-    go build -ldflags="-s -w" -o server /gin/*.go
-
+    go build -tags=jsoniter -ldflags="-s -w" -o server /gin/*.go
+    
 RUN apk --no-cache add --update ca-certificates
 
 # release layer


### PR DESCRIPTION
The package encoding/json is well known for being slow, this change fix this issue.
https://gin-gonic.com/docs/jsoniter/

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
