### PR TITLE
Use SmallRng in warp-rust

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-rand = "0.7.3"
+rand = { version = "0.7.3", features = ["small_rng"] }
 serde = { version = "1.0.103", features = ["derive"] }
 tokio = { version = "0.2.21", features = ["macros", "rt-threaded"] }
 tokio-postgres = "0.5.1"


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

I'm not sure whether this is fine. See, tests should be "production-grade" (I probably would never use `SmallRng` in production), but at the same time I feel like using a worse RNG algorithm will make the benchmark more comparable with implementations in other programming languages, and in fact there are already implementations written in Rust that use `SmallRng`.

Currently `SmallRng` uses a [permuted congruential generator](https://en.wikipedia.org/wiki/Permuted_congruential_generator) with 128-bit state (albeit this will change in the near future - `SmallRng` was replaced with xoshiro256** on `rand` crate master).

Figured I would send that anyway and ask you for opinion whether this okay.