### PR TITLE
Fix dotnet docker images (every .NET server now failing)

### DIFF
--- a/frameworks/CSharp/aspnetcore/aspcore-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-ado-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-ado-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-my.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-dap-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc-ef-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mvc.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mvc.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-dap-my.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-dap-my.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-dap-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-ef-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw-json.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-mw.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-mw.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-pgo-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-pgo-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-pgo-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-pgo-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-pgo.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-pgo.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg-up.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg-up.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx-pg.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out /p:IsDatabase=true
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore-rhtx.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/aspnetcore/aspcore.dockerfile
+++ b/frameworks/CSharp/aspnetcore/aspcore.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/beetlex/beetlex-core-updb.dockerfile
+++ b/frameworks/CSharp/beetlex/beetlex-core-updb.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 ENTRYPOINT ["dotnet", "PlatformBenchmarks.dll","updb"]

--- a/frameworks/CSharp/beetlex/beetlex-core.dockerfile
+++ b/frameworks/CSharp/beetlex/beetlex-core.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 ENTRYPOINT ["dotnet", "PlatformBenchmarks.dll"]

--- a/frameworks/CSharp/beetlex/beetlex-debug.dockerfile
+++ b/frameworks/CSharp/beetlex/beetlex-debug.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY PlatformBenchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 ENTRYPOINT ["dotnet", "PlatformBenchmarks.dll","debug"]

--- a/frameworks/CSharp/carter/carter.dockerfile
+++ b/frameworks/CSharp/carter/carter.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/easyrpc/easyrpc.dockerfile
+++ b/frameworks/CSharp/easyrpc/easyrpc.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/CSharp/genhttp/genhttp.dockerfile
+++ b/frameworks/CSharp/genhttp/genhttp.dockerfile
@@ -10,7 +10,7 @@ COPY Benchmarks/ .
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/core/runtime-deps:5.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine
 WORKDIR /app
 COPY --from=build /app .
 

--- a/frameworks/CSharp/genhttp/genhttp.dockerfile
+++ b/frameworks/CSharp/genhttp/genhttp.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers

--- a/frameworks/CSharp/nancy/nancy-netcore.dockerfile
+++ b/frameworks/CSharp/nancy/nancy-netcore.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /source
 COPY src .
 RUN dotnet publish -c Release -f net5.0 -o /app
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app .

--- a/frameworks/CSharp/tetsuweb/tetsuweb.dockerfile
+++ b/frameworks/CSharp/tetsuweb/tetsuweb.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmark .
 RUN dotnet publish -c Release -o out

--- a/frameworks/CSharp/tetsuweb/tetsuweb.dockerfile
+++ b/frameworks/CSharp/tetsuweb/tetsuweb.dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY Benchmark .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/runtime:5.0
+FROM mcr.microsoft.com/dotnet/runtime:5.0
 WORKDIR /app
 COPY --from=build /app/out ./
 

--- a/frameworks/FSharp/falco/falco-rhtx.dockerfile
+++ b/frameworks/FSharp/falco/falco-rhtx.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/falco/falco.dockerfile
+++ b/frameworks/FSharp/falco/falco.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/frank/frank-rhtx.dockerfile
+++ b/frameworks/FSharp/frank/frank-rhtx.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/frank/frank.dockerfile
+++ b/frameworks/FSharp/frank/frank.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe-stripped.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-stripped.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe-utf8direct.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-utf8direct.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/giraffe/giraffe.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/suave/suave.dockerfile
+++ b/frameworks/FSharp/suave/suave.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out

--- a/frameworks/FSharp/zebra/zebra-simple.dockerfile
+++ b/frameworks/FSharp/zebra/zebra-simple.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/FSharp/zebra/zebra.dockerfile
+++ b/frameworks/FSharp/zebra/zebra.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY src/App .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/PHP/peachpie/peachpie.dockerfile
+++ b/frameworks/PHP/peachpie/peachpie.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY . .
 RUN dotnet publish -c Release -o out Server
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV COMPlus_ReadyToRun 0
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/VB/aspnetcore/aspcore-vb-mw-ado-my.dockerfile
+++ b/frameworks/VB/aspnetcore/aspcore-vb-mw-ado-my.dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 COPY Benchmarks/appsettings.mysql.json ./out/appsettings.json
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/VB/aspnetcore/aspcore-vb-mw-ado-pg.dockerfile
+++ b/frameworks/VB/aspnetcore/aspcore-vb-mw-ado-pg.dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 COPY Benchmarks/appsettings.postgresql.json ./out/appsettings.json
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/frameworks/VB/aspnetcore/aspcore-vb-mw.dockerfile
+++ b/frameworks/VB/aspnetcore/aspcore-vb-mw.dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app
 COPY Benchmarks .
 RUN dotnet publish -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./


### PR DESCRIPTION
Just started breaking because `core/` has been dropped from the path