### PR TITLE
Lithium: pgo for cached-world.

### DIFF
--- a/frameworks/C++/lithium/lithium.cc
+++ b/frameworks/C++/lithium/lithium.cc
@@ -50,6 +50,7 @@ void siege(int port) {
   http_benchmark(sockets, 2, 1000, "GET /queries?N=20 HTTP/1.1\r\n\r\n");
   http_benchmark(sockets, 2, 1000, "GET /fortunes HTTP/1.1\r\n\r\n");
   http_benchmark(sockets, 2, 1000, "GET /updates?N=20 HTTP/1.1\r\n\r\n");
+  http_benchmark(sockets, 2, 1000, "GET /cached-world?N=100 HTTP/1.1\r\n\r\n");
   http_benchmark_close(sockets);
 }
 #endif
@@ -162,7 +163,6 @@ int main(int argc, char* argv[]) {
   });
 
   my_api.get("/cached-worlds") = [&](http_request& request, http_response& response) {
-    sql_db.max_async_connections_per_thread_ = queries_nconn;
     std::string N_str = request.get_parameters(s::N = std::optional<std::string>()).N.value_or("1");
     int N = atoi(N_str.c_str());
     


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
