### PR TITLE
fix: significantly improve webmachine performance

### DIFF
--- a/frameworks/OCaml/webmachine/.dockerignore
+++ b/frameworks/OCaml/webmachine/.dockerignore
@@ -1,0 +1,4 @@
+**/_build/
+**/_opam/
+**/.merlin
+**/.ocamlformat

--- a/frameworks/OCaml/webmachine/haproxy.cfg
+++ b/frameworks/OCaml/webmachine/haproxy.cfg
@@ -4,6 +4,7 @@ global
     maxconn     32768
     user        haproxy
     group       haproxy
+    nbthread    2
     daemon
 
 defaults
@@ -28,7 +29,7 @@ frontend main
     default_backend             tfb
 
 backend tfb
-    balance     roundrobin
+    balance     static-rr
     server  tfb0 127.0.0.1:9000 check
     server  tfb1 127.0.0.1:9001 check
     server  tfb2 127.0.0.1:9002 check

--- a/frameworks/OCaml/webmachine/haproxy.cfg
+++ b/frameworks/OCaml/webmachine/haproxy.cfg
@@ -5,7 +5,6 @@ global
     user        haproxy
     group       haproxy
     nbthread    2
-    daemon
 
 defaults
     mode                    tcp

--- a/frameworks/OCaml/webmachine/src/Makefile
+++ b/frameworks/OCaml/webmachine/src/Makefile
@@ -1,0 +1,15 @@
+BINARY = tfb
+
+.PHONY: install build run gen-opam
+
+install:
+	opam install --yes --deps-only .
+
+gen-opam:
+	dune build @install
+
+build:
+	opam exec -- dune build --profile release $(BINARY).exe
+
+run:
+	./_build/default/bin/$(BINARY).exe

--- a/frameworks/OCaml/webmachine/src/dune-project
+++ b/frameworks/OCaml/webmachine/src/dune-project
@@ -14,6 +14,7 @@
   (dune (>= 2.7.1))
   (webmachine (>= 0.6.2))
   (lwt (>= 5.3.0))
+  (conf-libev (>= 4-11))
   (caqti (>= 1.2.3))
   (caqti-lwt (>= 1.2.0))
   (caqti-driver-postgresql (>= 1.2.4))

--- a/frameworks/OCaml/webmachine/src/tfb.ml
+++ b/frameworks/OCaml/webmachine/src/tfb.ml
@@ -24,7 +24,7 @@ let pool =
   let connection_url =
     "postgresql://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?connect_timeout=15"
   in
-  match Caqti_lwt.connect_pool ~max_size:10 (Uri.of_string connection_url) with
+  match Caqti_lwt.connect_pool ~max_size:4 (Uri.of_string connection_url) with
   | Ok pool -> pool
   | Error err ->
       Printf.eprintf "%s" (Caqti_error.show err);

--- a/frameworks/OCaml/webmachine/src/webmachine-tfb.opam
+++ b/frameworks/OCaml/webmachine/src/webmachine-tfb.opam
@@ -8,6 +8,8 @@ bug-reports: "https://github.com/TechEmpower/FrameworkBenchmarks/issues"
 depends: [
   "dune" {>= "2.7" & >= "2.7.1"}
   "webmachine" {>= "0.6.2"}
+  "lwt" {>= "5.3.0"}
+  "conf-libev" {>= "4-11"}
   "caqti" {>= "1.2.3"}
   "caqti-lwt" {>= "1.2.0"}
   "caqti-driver-postgresql" {>= "1.2.4"}

--- a/frameworks/OCaml/webmachine/start-servers.sh
+++ b/frameworks/OCaml/webmachine/start-servers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CPU_COUNT=$(nproc)
 P=9000

--- a/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
@@ -17,12 +17,12 @@ RUN make install
 
 COPY ./src /${DIR}
 
-RUN sudo chown -R opam: /${DIR} && make build
+RUN sudo chown -R opam: . && make build
 
 # try to keep everything above here in sync with other dockerfiles in project for more efficent use of docker build cache
 RUN sudo dnf install --assumeyes haproxy
 COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY start-servers.sh ./start-servers.sh
-RUN sudo chown -R opam: /${DIR} && chmod +x ./start-servers.sh
+RUN sudo chown -R opam: . && chmod +x ./start-servers.sh
 
-CMD /${DIR}/start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q -db
+CMD ./start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q

--- a/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
@@ -1,27 +1,28 @@
-FROM fedora:32
+FROM ocurrent/opam:fedora-32-ocaml-4.11
 
-#ARG BENCHMARK_ENV=local
+ENV DIR webmachine
 
-ENV VERSION 4.11.1
-#ENV BENCHMARK_ENV $BENCHMARK_ENV
+# https://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html
+# https://linux.die.net/man/1/ocamlrun
+# https://blog.janestreet.com/memory-allocator-showdown/
+ENV OCAMLRUNPARAM a=2,o=240
 
-WORKDIR /webmachine
+RUN sudo dnf install --assumeyes diffutils postgresql-devel libev-devel
 
-RUN dnf install --assumeyes opam diffutils postgresql-devel
-RUN opam init --disable-sandboxing --auto-setup --compiler ${VERSION}
-# uncomment this line to take better advantage of docker build cache when developing
-#RUN opam install --yes dune webmachine caqti caqti-lwt caqti-driver-postgresql cohttp-lwt-unix ptime ezjsonm lwt_ppx
+WORKDIR /${DIR}
 
-COPY ./src /webmachine
-# comment the below line while developing to make better use of the docker build cache
-RUN opam install --yes --deps-only ./webmachine-tfb.opam
+COPY src/webmachine-tfb.opam src/Makefile /${DIR}/
 
-RUN eval $(opam env) ; dune build --profile release tfb.exe
+RUN make install
 
-# try to keep everything above here in sync with webmachine.dockerfile for more efficent use of docker build cache
-RUN dnf install --assumeyes haproxy
+COPY ./src /${DIR}
+
+RUN sudo chown -R opam: /${DIR} && make build
+
+# try to keep everything above here in sync with other dockerfiles in project for more efficent use of docker build cache
+RUN sudo dnf install --assumeyes haproxy
 COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY start-servers.sh ./start-servers.sh
-RUN chmod +x /webmachine/start-servers.sh
+RUN sudo chown -R opam: /${DIR} && chmod +x ./start-servers.sh
 
-CMD /webmachine/start-servers.sh ; /usr/sbin/haproxy -Ws -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q
+CMD /${DIR}/start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q -db

--- a/frameworks/OCaml/webmachine/webmachine.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine.dockerfile
@@ -1,21 +1,22 @@
-FROM fedora:32
+FROM ocurrent/opam:fedora-32-ocaml-4.11
 
-#ARG BENCHMARK_ENV=local
+ENV DIR webmachine
 
-ENV VERSION 4.11.1
-#ENV BENCHMARK_ENV $BENCHMARK_ENV
+# https://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html
+# https://linux.die.net/man/1/ocamlrun
+# https://blog.janestreet.com/memory-allocator-showdown/
+ENV OCAMLRUNPARAM a=2,o=240
 
-WORKDIR /webmachine
+RUN sudo dnf install --assumeyes diffutils postgresql-devel libev-devel
 
-RUN dnf install --assumeyes opam diffutils postgresql-devel
-RUN opam init --disable-sandboxing --auto-setup --compiler ${VERSION}
-# uncomment this line to take better advantage of docker build cache when developing
-#RUN opam install --yes dune webmachine caqti caqti-lwt caqti-driver-postgresql cohttp-lwt-unix ptime ezjsonm lwt_ppx
+WORKDIR /${DIR}
 
-COPY ./src /webmachine
-# comment the below line while developing to make better use of the docker build cache
-RUN opam install --yes --deps-only ./webmachine-tfb.opam
+COPY src/webmachine-tfb.opam src/Makefile /${DIR}/
 
-RUN eval $(opam env) ; dune build --profile release tfb.exe
+RUN make install
 
-CMD /webmachine/_build/default/tfb.exe
+COPY ./src /${DIR}
+
+RUN sudo chown -R opam: /${DIR} && make build
+
+CMD /${DIR}/_build/default/tfb.exe

--- a/frameworks/OCaml/webmachine/webmachine.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine.dockerfile
@@ -17,6 +17,6 @@ RUN make install
 
 COPY ./src /${DIR}
 
-RUN sudo chown -R opam: /${DIR} && make build
+RUN sudo chown -R opam: . && make build
 
-CMD /${DIR}/_build/default/tfb.exe
+CMD _build/default/tfb.exe


### PR DESCRIPTION
* installing libev-devel and conf-libev enables epoll instead of select
* multithreading haproxy improves throughput
* GC tweaks
* use upstream docker image with ocaml preinstalled to save some time

These changes _triple_ (:exclamation:) performance on my local machine.

See #6041 for my first PR that introduced webmachine.