### PR TITLE
Fix parsing of docker build output in docker_helper

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -44,16 +44,14 @@ class DockerHelper:
                     forcerm=True,
                     timeout=3600,
                     pull=True,
-                    buildargs=buildargs
+                    buildargs=buildargs,
+                    decode=True
                 )
                 buffer = ""
                 for token in output:
-                    if token.startswith('{"stream":'):
-                        token = json.loads(token)
-                        token = token[token.keys()[0]].encode('utf-8')
-                        buffer += token
-                    elif token.startswith('{"errorDetail":'):
-                        token = json.loads(token)
+                    if 'stream' in token:
+                        buffer += token[token.keys()[0]].encode('utf-8')
+                    elif 'errorDetail' in token:
                         raise Exception(token['errorDetail']['message'])
                     while "\n" in buffer:
                         index = buffer.index("\n")


### PR DESCRIPTION
Fixes: #6065 

When parsing the list of docker build output, some of the lines had multiple json objects. In the tests I ran, it was always a newline character.

The python docker library has a parameter to automatically parse the output into dicts. Switching to that solved the problem. https://docker-py.readthedocs.io/en/4.0.2/api.html?highlight=APIClient#module-docker.api.build