### PR TITLE
Switch back to .NET Core 3.1 because .NET 5 is neither supported not yet released

### DIFF
--- a/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/genhttp/Benchmarks/Benchmarks.csproj
@@ -2,8 +2,7 @@
   
   <PropertyGroup>
     
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     
     <AssemblyTitle>GenHTTP Benchmarks</AssemblyTitle>

--- a/frameworks/CSharp/genhttp/genhttp.dockerfile
+++ b/frameworks/CSharp/genhttp/genhttp.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -10,7 +10,7 @@ COPY Benchmarks/ .
 RUN dotnet publish -c release -o /app -r linux-musl-x64 --self-contained true --no-restore /p:PublishTrimmed=true /p:PublishReadyToRun=true
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-alpine
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine
 WORKDIR /app
 COPY --from=build /app .
 


### PR DESCRIPTION
Currently, tests are failing on Citrine only (CI as well as local tests work). Issues have been introduced with the PRs regarding new tests and switch to .NET 5. Will go back to .NET Core 3.1 for now because the server does not officially support .NET 5 yet, and there might be issues with the RC in terms of optimized, native alpine images.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
