### PR TITLE
[php-ngx] Try to Upgrade function `query` to `query2`.

### DIFF
--- a/frameworks/PHP/php-ngx/app-async.php
+++ b/frameworks/PHP/php-ngx/app-async.php
@@ -13,7 +13,7 @@ function fortune()
     ngx_header_set('Content-Type', 'text/html;charset=UTF-8');
     $my = new php\ngx\mysql();
     yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
-    $ret = yield from $my->query('SELECT id,message FROM Fortune');
+    $ret = yield from $my->query2('SELECT id,message FROM Fortune');
 
     foreach ($ret as $row) {
         $arr[$row['id']] = $row['message'];
@@ -43,7 +43,7 @@ function query()
     }
 
     while ($query_count--) {
-        $arr[] = (yield from $my->query('SELECT id,randomNumber FROM World WHERE id = '.mt_rand(1, 10000)))[0];
+        $arr[] = (yield from $my->query2('SELECT id,randomNumber FROM World WHERE id = '.mt_rand(1, 10000)))[0];
     }
     unset($my);
     echo json_encode($arr);
@@ -57,7 +57,7 @@ function db()
     yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
 
     echo json_encode(
-        (yield from $my->query('SELECT id,randomNumber FROM World WHERE id = '.mt_rand(1, 10000)))[0]
+        (yield from $my->query2('SELECT id,randomNumber FROM World WHERE id = '.mt_rand(1, 10000)))[0]
     );
     unset($my);
 }
@@ -75,10 +75,10 @@ function update()
 
     while ($query_count--) {
         $id     = mt_rand(1, 10000);
-        $world  = (yield from $my->query("SELECT id,randomNumber FROM World WHERE id = $id"))[0];
+        $world  = (yield from $my->query2("SELECT id,randomNumber FROM World WHERE id = $id"))[0];
         
         $world['randomNumber'] = mt_rand(1, 10000);
-        yield from $my->query("UPDATE World SET randomNumber = {$world['randomNumber']} WHERE id = $id");
+        yield from $my->query2("UPDATE World SET randomNumber = {$world['randomNumber']} WHERE id = $id");
         $arr[] = $world;
     }
     unset($my);


### PR DESCRIPTION
In ngx_php7 version of 0.0.24, try Upgrade function `query` to `query2` with async mysql driver. 
And what's the difference of between `query` and `query2` that the `query2` added page buffer of 4k about recv io.

@joanhey 
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
