### PR TITLE
[swoole] Add opcache

### DIFF
--- a/frameworks/PHP/swoole/swoole-no-async.dockerfile
+++ b/frameworks/PHP/swoole/swoole-no-async.dockerfile
@@ -3,7 +3,7 @@ FROM php:7.4
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole
 
-RUN docker-php-ext-install pdo_mysql > /dev/null
+RUN docker-php-ext-install opcache pdo_mysql > /dev/null
 
 ADD ./ /swoole
 WORKDIR /swoole

--- a/frameworks/PHP/swoole/swoole-postgres.dockerfile
+++ b/frameworks/PHP/swoole/swoole-postgres.dockerfile
@@ -1,5 +1,7 @@
 FROM php:7.4
 
+RUN docker-php-ext-install opcache  > /dev/null
+
 ENV SWOOLE_VERSION=4.5.1
 
 RUN     apt-get update && apt-get install -y libpq-dev \

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -3,6 +3,8 @@ FROM php:7.4
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole
 
+RUN docker-php-ext-install opcache  > /dev/null
+
 WORKDIR /swoole
 
 COPY swoole-server.php swoole-server.php


### PR DESCRIPTION
Apparently the oficial PHP images in Dockerhub don't have OPCache installed :open_mouth: 
I can't believe it. This is incredible in 2020.

If the results are better, later we will add it to the rest of fw using that images.