### PR TITLE
fix: make OCaml frameworks use keep alive

### DIFF
--- a/frameworks/OCaml/opium/haproxy.cfg
+++ b/frameworks/OCaml/opium/haproxy.cfg
@@ -7,10 +7,10 @@ global
     nbthread    2
 
 defaults
-    mode                    tcp
+    mode                    http
     log                     global
     option                  dontlognull
-    option http-server-close
+    option http-keep-alive
     option forwardfor       except 127.0.0.0/8
     option                  redispatch
     retries                 3

--- a/frameworks/OCaml/opium/opium-haproxy.dockerfile
+++ b/frameworks/OCaml/opium/opium-haproxy.dockerfile
@@ -24,4 +24,4 @@ COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY start-servers.sh ./start-servers.sh
 RUN sudo chown -R opam: /${DIR} && chmod +x ./start-servers.sh
 
-CMD ./start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q
+ENTRYPOINT ./start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid

--- a/frameworks/OCaml/opium/opium.dockerfile
+++ b/frameworks/OCaml/opium/opium.dockerfile
@@ -18,4 +18,4 @@ COPY ./src ./
 
 RUN sudo chown -R opam: . && make build
 
-CMD _build/default/bin/main.exe
+ENTRYPOINT _build/default/bin/main.exe

--- a/frameworks/OCaml/webmachine/haproxy.cfg
+++ b/frameworks/OCaml/webmachine/haproxy.cfg
@@ -7,10 +7,10 @@ global
     nbthread    2
 
 defaults
-    mode                    tcp
+    mode                    http
     log                     global
     option                  dontlognull
-    option http-server-close
+    option http-keep-alive
     option forwardfor       except 127.0.0.0/8
     option                  redispatch
     retries                 3

--- a/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine-haproxy.dockerfile
@@ -25,4 +25,4 @@ COPY haproxy.cfg /etc/haproxy/haproxy.cfg
 COPY start-servers.sh ./start-servers.sh
 RUN sudo chown -R opam: . && chmod +x ./start-servers.sh
 
-CMD ./start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -q
+ENTRYPOINT ./start-servers.sh && sudo /usr/sbin/haproxy -W -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid

--- a/frameworks/OCaml/webmachine/webmachine.dockerfile
+++ b/frameworks/OCaml/webmachine/webmachine.dockerfile
@@ -19,4 +19,4 @@ COPY ./src /${DIR}
 
 RUN sudo chown -R opam: . && make build
 
-CMD _build/default/tfb.exe
+ENTRYPOINT _build/default/tfb.exe


### PR DESCRIPTION
* tini has problems with subreaping so make bash script the entrypoint
https://github.com/krallin/tini#subreaping

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
