### PR TITLE
Update Express (node version, packages, cluster mode)

### DIFF
--- a/frameworks/JavaScript/express/README.md
+++ b/frameworks/JavaScript/express/README.md
@@ -12,8 +12,8 @@ This is the Express portion of a [benchmarking test suite](../) comparing a vari
 
 ## Infrastructure Software Versions
 The tests were run with:
-* [Node.js v8.1.0](http://nodejs.org/)
-* [Express 4.16.2](http://expressjs.com/)
+* [Node.js v14.15.0](http://nodejs.org/)
+* [Express 4.17.1](http://expressjs.com/)
 
 ## Resources
 * http://nodejs.org/api/cluster.html

--- a/frameworks/JavaScript/express/express-graphql-mongodb.dockerfile
+++ b/frameworks/JavaScript/express/express-graphql-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-graphql-mysql.dockerfile
+++ b/frameworks/JavaScript/express/express-graphql-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-graphql-postgres.dockerfile
+++ b/frameworks/JavaScript/express/express-graphql-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-mongodb.dockerfile
+++ b/frameworks/JavaScript/express/express-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-mysql.dockerfile
+++ b/frameworks/JavaScript/express/express-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-postgres.dockerfile
+++ b/frameworks/JavaScript/express/express-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express.dockerfile
+++ b/frameworks/JavaScript/express/express.dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.3.1-slim
+FROM node:14.15.0-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/graphql-mongodb-app.js
+++ b/frameworks/JavaScript/express/graphql-mongodb-app.js
@@ -1,26 +1,37 @@
+const cluster = require('cluster')
+const numCPUs = require('os').cpus().length
 const express = require('express');
 const mongoose = require('mongoose');
 const app = express();
 const bodyParser = require('body-parser');
 const port = 8080;
 
-app.use(bodyParser.urlencoded({ extended:false }));
-app.use(bodyParser.json());
-
 mongoose.Promise = global.Promise;
 
 mongoose.connect('mongodb://tfb-database/hello_world').then(() => {
-    console.log('connected to mongo tfb-database hello_world');
+  console.log('connected to mongo tfb-database hello_world');
 }).catch((err) => {
-    console.log('Failed connection attempt to Mongo: ', err);
+  console.log('Failed connection attempt to Mongo: ', err);
 });
 
-const resolvers = require('./resolver-mongo');
+if (cluster.isMaster) {
+  // Fork workers.
+  for (let i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
 
-// Routes
+  cluster.on('exit', (worker, code, signal) =>
+    console.log('worker ' + worker.pid + ' died'));
+} else {
+  app.use(bodyParser.urlencoded({ extended:false }));
+  app.use(bodyParser.json());
 
-require('/routes.js')(app, resolvers);
+  const resolvers = require('./resolver-mongo');
 
-app.listen(port, () => {
+  // Routes
+  require('/routes.js')(app, resolvers);
+
+  app.listen(port, () => {
     console.log(`Listening on localhost:${port}`);
-});
+  });
+}

--- a/frameworks/JavaScript/express/graphql-mysql-app.js
+++ b/frameworks/JavaScript/express/graphql-mysql-app.js
@@ -1,17 +1,28 @@
+const cluster = require('cluster')
+const numCPUs = require('os').cpus().length
 const express = require('express');
 const app = express();
 const bodyParser = require('body-parser');
 const port = 8080;
 
-app.use(bodyParser.urlencoded({ extended:false }));
-app.use(bodyParser.json());
+if (cluster.isMaster) {
+  // Fork workers.
+  for (let i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
 
-// Routes
+  cluster.on('exit', (worker, code, signal) =>
+    console.log('worker ' + worker.pid + ' died'));
+} else {
+  app.use(bodyParser.urlencoded({ extended:false }));
+  app.use(bodyParser.json());
 
-const resolvers = require('./resolver');
+  const resolvers = require('./resolver');
 
-require('./routes')(app, resolvers);
+  // Routes
+  require('./routes')(app, resolvers);
 
-app.listen(port, () => {
+  app.listen(port, () => {
     console.log(`Listening on localhost:${port}`);
-});
+  });
+}

--- a/frameworks/JavaScript/express/package.json
+++ b/frameworks/JavaScript/express/package.json
@@ -3,18 +3,17 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "body-parser": "1.18.2",
+    "body-parser": "1.19.0",
     "dateformat": "3.0.3",
     "escape-html": "1.0.3",
-    "express": "4.16.2",
+    "express": "4.17.1",
     "express-graphql": "0.6.12",
     "graphql": "0.13.2",
     "graphql-tools": "3.1.1",
     "mongoose": "5.7.5",
-    "mysql": "2.16.0",
-    "mysql2": "1.6.5",
-    "pg": "4.5.7",
-    "pg-promise": "8.4.6",
+    "mysql2": "2.2.5",
+    "pg": "8.5.0",
+    "pg-promise": "10.7.3",
     "pug": "2.0.1",
     "sequelize": "5.15.1"
   }

--- a/frameworks/JavaScript/express/postgresql-app.js
+++ b/frameworks/JavaScript/express/postgresql-app.js
@@ -1,89 +1,101 @@
-const express = require('express'),
-  app = express(),
-  bodyParser = require('body-parser'),
+
+/**
+ * Module dependencies.
+ */
+
+const cluster = require('cluster'),
+  numCPUs = require('os').cpus().length,
+  express = require('express'),
   pgp = require('pg-promise')(),
   helper = require('./helper');
 
+// Middleware
+const bodyParser = require('body-parser');
+
 const connection = {
-    db: 'hello_world',
-    username: 'benchmarkdbuser',
-    password: 'benchmarkdbpass',
-    host: 'tfb-database',
-    dialect: 'postgres'
+  db: 'hello_world',
+  username: 'benchmarkdbuser',
+  password: 'benchmarkdbpass',
+  host: 'tfb-database',
+  dialect: 'postgres'
 }
 
 const db = pgp(`postgres://${connection.username}:${connection.password}@${connection.host}:5432/${connection.db}`);
 
-app.set('view engine', 'pug');
-app.set('views', __dirname + '/views');
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+if (cluster.isMaster) {
+  // Fork workers.
+  for (let i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
 
-// Set headers for all routes
-app.use((req, res, next) => {
+  cluster.on('exit', (worker, code, signal) =>
+    console.log('worker ' + worker.pid + ' died'));
+} else {
+  const app = module.exports = express();
+
+  app.set('view engine', 'pug');
+  app.set('views', __dirname + '/views');
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(bodyParser.json());
+
+  // Set headers for all routes
+  app.use((req, res, next) => {
     res.setHeader("Server", "Express");
     return next();
-});
+  });
 
-// Routes
-app.get('/db', async (req, res) => {
-
+  // Routes
+  app.get('/db', async (req, res) => {
     let world = await getRandomWorld();
 
     res.setHeader("Content-Type", "application/json");
     res.json(world);
-});
+  });
 
-app.get('/queries', async (req, res) => {
-
+  app.get('/queries', async (req, res) => {
     const results = [],
-        queries = Math.min(parseInt(req.query.queries) || 1, 500);
+      queries = Math.min(parseInt(req.query.queries) || 1, 500);
 
     for (let i = 0; i < queries; i++) {
-        
-        results.push(await getRandomWorld());
+      results.push(await getRandomWorld());
     }
 
     res.json(results)
-});
+  });
 
-app.get('/fortunes', async (req, res) => {
-
+  app.get('/fortunes', async (req, res) => {
     let fortunes = await getAllFortunes()
     const newFortune = { id: 0, message: "Additional fortune added at request time." };
     fortunes.push(newFortune);
     fortunes.sort((a, b) => (a.message < b.message) ? -1 : 1);
 
     res.render('fortunes/index', { fortunes: fortunes });
-});
+  });
 
-app.get('/updates', async (req, res) => {
+  app.get('/updates', async (req, res) => {
     const results = [],
-        queries = Math.min(parseInt(req.query.queries) || 1, 500);
+      queries = Math.min(parseInt(req.query.queries) || 1, 500);
 
     for (let i = 1; i <= queries; i++) {
-
-        results.push(await updateRandomWorld())
+      results.push(await updateRandomWorld())
     }
 
     res.json(results);
-});
+  });
 
-const getRandomWorld = async () => {
-
+  const getRandomWorld = async () => {
     return await db.one(`select * from world where id = ${helper.randomizeNum()}`, [true])
-};
+  };
 
-const updateRandomWorld = async () => {
-
+  const updateRandomWorld = async () => {
     return await db.oneOrNone(`update world set randomNumber = ${helper.randomizeNum()} where id = ${helper.randomizeNum()} returning id, randomNumber`, [true])
-};
+  };
 
-const getAllFortunes = async () => {
-
+  const getAllFortunes = async () => {
     return await db.many('select * from fortune', [true]);
-};
+  };
 
-app.listen(8080, () => {
+  app.listen(8080, () => {
     console.log('listening on port 8080');
-});
+  });
+}


### PR DESCRIPTION
Changes the following for Express:

- Update mysql2, pg, pg-promise, express, body-parser
- Update node version
- Use cluster mode for express-graphql-mongodb
- Use cluster mode for express-postgres
- Use cluster mode for express-graphql-postgres
- Use cluster mode for express-graphql-mysql
- Update README.md for express

All changes were tested.