### PR TITLE
[workerman] Testing php8

### DIFF
--- a/frameworks/PHP/workerman/app.php
+++ b/frameworks/PHP/workerman/app.php
@@ -5,10 +5,14 @@ use Workerman\Protocols\Http\Request;
 function init()
 {
     global $world, $fortune, $update;
-    $pdo = new PDO('mysql:host=tfb-database;dbname=hello_world',
-        'benchmarkdbuser', 'benchmarkdbpass',
-        [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_EMULATE_PREPARES    => false]
+    $pdo = new PDO(
+        'mysql:host=tfb-database;dbname=hello_world',
+        'benchmarkdbuser',
+        'benchmarkdbpass',
+        [
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES    => false
+        ]
     );
     $world   = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id=?');
     $fortune = $pdo->prepare('SELECT id,message FROM Fortune');
@@ -42,12 +46,12 @@ function router(Request $request)
 
         case '/update':
             return updateraw($request);
-/*
+
        case '/info':
             ob_start();
             phpinfo();
             return new Response(200, ['Content-Type' => 'text/plain'], ob_get_clean());
-*/
+
         default:
             return new Response(404, [], 'Error 404');
     }

--- a/frameworks/PHP/workerman/app.php
+++ b/frameworks/PHP/workerman/app.php
@@ -47,11 +47,11 @@ function router(Request $request)
         case '/update':
             return updateraw($request);
 
-       case '/info':
+/*        case '/info':
             ob_start();
             phpinfo();
             return new Response(200, ['Content-Type' => 'text/plain'], ob_get_clean());
-
+ */
         default:
             return new Response(404, [], 'Error 404');
     }
@@ -74,7 +74,7 @@ function query($request)
     global $world;
 
     $query_count = 1;
-    $q = $request->get('q');
+    $q = (int) $request->get('q');
     if ($q > 1) {
         $query_count = min($q, 500);
     }
@@ -95,7 +95,7 @@ function updateraw($request)
     global $world, $update;
 
     $query_count = 1;
-    $q = $request->get('q');
+    $q = (int) $request->get('q');
     if ($q > 1) {
         $query_count = min($q, 500);
     }

--- a/frameworks/PHP/workerman/benchmark_config.json
+++ b/frameworks/PHP/workerman/benchmark_config.json
@@ -63,6 +63,29 @@
       "display_name": "workerman-async-db",
       "notes": "",
       "versus": "php"
+    },
+    "php8": {
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "db_url": "/db",
+      "query_url": "/query?q=",
+      "update_url": "/update?q=",
+      "fortune_url": "/fortunes",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "Postgres",
+      "framework": "workerman",
+      "language": "PHP",
+      "flavor": "PHP8",
+      "orm": "Raw",
+      "platform": "workerman",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "workerman-php8",
+      "notes": "",
+      "versus": "php"
     }
   }]
 }

--- a/frameworks/PHP/workerman/benchmark_config.json
+++ b/frameworks/PHP/workerman/benchmark_config.json
@@ -86,6 +86,29 @@
       "display_name": "workerman-php8",
       "notes": "",
       "versus": "php"
+    },
+    "php8-jit": {
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "db_url": "/db",
+      "query_url": "/query?q=",
+      "update_url": "/update?q=",
+      "fortune_url": "/fortunes",
+      "port": 8080,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "database": "Postgres",
+      "framework": "workerman",
+      "language": "PHP",
+      "flavor": "PHP8",
+      "orm": "Raw",
+      "platform": "workerman",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "workerman-php8-jit",
+      "notes": "php8 jit",
+      "versus": "php"
     }
   }]
 }

--- a/frameworks/PHP/workerman/php-jit.ini
+++ b/frameworks/PHP/workerman/php-jit.ini
@@ -1,0 +1,13 @@
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=0
+opcache.save_comments=0
+opcache.enable_file_override=1
+opcache.huge_code_pages=1
+
+mysqlnd.collect_statistics = Off
+
+memory_limit = 512M
+
+opcache.jit_buffer_size=128M
+opcache.jit=tracing

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 RUN apt-get install -yqq composer > /dev/null
 
-RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php7.4-dev libevent-dev > /dev/null
 RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
 COPY php.ini /etc/php/7.4/cli/php.ini

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 RUN apt-get install -yqq composer > /dev/null
 
-RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php7.4-dev libevent-dev > /dev/null
 RUN printf "\n\n /usr/lib/x86_64-linux-gnu/\n\n\nno\n\n\n" | pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
 COPY php.ini /etc/php/7.4/cli/php.ini
@@ -17,7 +17,7 @@ COPY php.ini /etc/php/7.4/cli/php.ini
 ADD ./ /workerman
 WORKDIR /workerman
 
-RUN sed -i "s|PDO('mysql:|PDO('pgsql:|g" app.php
+RUN sed -i "s|'mysql:host|'pgsql:host|g" app.php
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:20.10
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq php8.0 php8.0-common php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
+
+RUN apt-get install -yqq composer > /dev/null
+
+RUN apt-get install -y php8.0-dev libevent-dev > /dev/null
+#RUN apt-get install -y php-pear php8.0-dev libevent-dev php8.0-mbstring php8.0-simplexml php8.0-zip > /dev/null
+#RUN curl -sSL https://pear.php.net/go-pear.phar -o pear > /dev/null \
+#        && pear install event \
+#        && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+
+#RUN curl -sSL https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar -o /usr/local/bin/pickle \
+#        && chmod +x /usr/local/bin/pickle
+#RUN pickle install event && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+
+RUN curl -sSL https://bitbucket.org/osmanov/pecl-event/get/3.0.0-beta.1.zip -o event.zip \
+        && unzip -qq event.zip \
+        && cd osmanov-pecl-event-efcc0739aac6 \
+        && phpize > /dev/null \
+        && ./configure --with-event-core --with-event-extra \
+        && make > /dev/null && make install > /dev/null \
+        && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+ 
+COPY php-jit.ini /etc/php/8.0/cli/php.ini
+
+ADD ./ /workerman
+WORKDIR /workerman
+
+RUN sed -i "s|'mysql:host|'pgsql:host|g" app.php
+
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+
+CMD php /workerman/server.php start

--- a/frameworks/PHP/workerman/workerman-php8.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8.dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:20.10
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
+RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update -yqq > /dev/null && \
+    apt-get install -yqq php8.0 php8.0-common php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
+
+RUN apt-get install -yqq composer > /dev/null
+
+RUN apt-get install -y php8.0-dev libevent-dev > /dev/null
+#RUN apt-get install -y php-pear php8.0-dev libevent-dev php8.0-mbstring php8.0-simplexml php8.0-zip > /dev/null
+#RUN curl -sSL https://pear.php.net/go-pear.phar -o pear > /dev/null \
+#        && pear install event \
+#        && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+
+#RUN curl -sSL https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar -o /usr/local/bin/pickle \
+#        && chmod +x /usr/local/bin/pickle
+#RUN pickle install event && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+
+RUN curl -sSL https://bitbucket.org/osmanov/pecl-event/get/3.0.0-beta.1.zip -o event.zip \
+        && unzip -qq event.zip \
+        && cd osmanov-pecl-event-efcc0739aac6 \
+        && phpize > /dev/null \
+        && ./configure --with-event-core --with-event-extra \
+        && make > /dev/null && make install > /dev/null \
+        && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+ 
+COPY php.ini /etc/php/8.0/cli/php.ini
+
+ADD ./ /workerman
+WORKDIR /workerman
+
+RUN sed -i "s|'mysql:host|'pgsql:host|g" app.php
+
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+
+CMD php /workerman/server.php start

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
PHP 8 will be released on November 26, 2020

No pear in php8, so we need to test the `go-pear` and `pickle`.
But both failed, so installed the event extension manually.

~Later we will add the~ php8 JIT version added.
Testing with Workerman, because it is the best candidate for JIT.

