### PR TITLE
fix: opium is built on top of the httpaf platform

### DIFF
--- a/frameworks/OCaml/httpaf/benchmark_config.json
+++ b/frameworks/OCaml/httpaf/benchmark_config.json
@@ -13,7 +13,7 @@
         "language": "OCaml",
         "flavor": "None",
         "orm": "None",
-        "platform": "None",
+        "platform": "httpaf",
         "webserver": "None",
         "os": "Linux",
         "database_os": "Linux",

--- a/frameworks/OCaml/opium/benchmark_config.json
+++ b/frameworks/OCaml/opium/benchmark_config.json
@@ -22,7 +22,7 @@
         "database_os": "Linux",
         "display_name": "opium",
         "notes": "",
-        "versus": "None"
+        "versus": "httpaf"
       },
       "haproxy": {
         "json_url": "/json",
@@ -45,7 +45,7 @@
         "database_os": "Linux",
         "display_name": "opium-haproxy",
         "notes": "",
-        "versus": "None"
+        "versus": "httpaf"
       }
   }]
 }


### PR DESCRIPTION
opium is built on top of httpaf so I think these changes should show how much overhead is introduced by opium itself as httpaf was added in #6131.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
