### PR TITLE
[swoole] Update to PHP 8

### DIFF
--- a/frameworks/PHP/swoole/swoole-no-async.dockerfile
+++ b/frameworks/PHP/swoole/swoole-no-async.dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:8.0-cli
 
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole

--- a/frameworks/PHP/swoole/swoole.dockerfile
+++ b/frameworks/PHP/swoole/swoole.dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:8.0-cli
 
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole


### PR DESCRIPTION
Postgresql variant failed at compiling `swoole/ext-postresql`
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
