### PR TITLE
fix-javascript-ex4x-README.md  graalvm.org url bug

### DIFF
--- a/frameworks/JavaScript/es4x/README.md
+++ b/frameworks/JavaScript/es4x/README.md
@@ -12,7 +12,7 @@
 ## Important Libraries
 The tests were run with:
 * [Eclipse Vert.x](https://vertx.io/)
-* [GraalVM 1.0.0 rc6](https://graalvm.org/)
+* [GraalVM](https://www.graalvm.org/)
 * [ES4X](https://reactiverse.io/es4x/)
 
 ## Test URLs


### PR DESCRIPTION
https://graalvm.org can not access. https://www.graalvm.org is OK.