### PR TITLE
change concurrency level for ocaml/tiny_httpd

### DIFF
--- a/frameworks/OCaml/tiny_httpd/src/src/bin/tiny.ml
+++ b/frameworks/OCaml/tiny_httpd/src/src/bin/tiny.ml
@@ -1,7 +1,7 @@
 module S = Tiny_httpd
 
 let () =
-  let server = S.create ~addr:"0.0.0.0" () in
+  let server = S.create ~addr:"0.0.0.0" ~max_connections:256 () in
   let headers = [ ("Server", "tiny_httpd") ] in
   (* say hello *)
   S.add_route_handler ~meth:`GET server


### PR DESCRIPTION
see if it affects latency

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
