### PR TITLE
feat: make tiny_httpd fork to increase throughput

### DIFF
--- a/frameworks/OCaml/tiny_httpd/src/src/bin/tiny.ml
+++ b/frameworks/OCaml/tiny_httpd/src/src/bin/tiny.ml
@@ -1,9 +1,8 @@
 module S = Tiny_httpd
 
 let () =
-  let server = S.create ~addr:"0.0.0.0" () in
+  let server = S.create ~addr:"0.0.0.0" ~port:8080 () in
   let headers = [ ("Server", "tiny_httpd") ] in
-  (* say hello *)
   S.add_route_handler ~meth:`GET server
     S.Route.(exact "plaintext" @/ string @/ return)
     (fun _ _req ->
@@ -18,7 +17,24 @@ let () =
       let json = Lib.Message_t.{ message = "Hello, World!" } in
       S.Response.make_string ~headers
         (Ok (Lib.Message_j.string_of_message json)));
-  Printf.printf "listening on http://%s:%d\n%!" (S.addr server) (S.port server);
-  match S.run server with
-  | Ok () -> ()
-  | Error e -> raise e
+  let nproc =
+    match Sys.getenv "CORE_COUNT" with
+    | x -> int_of_string x
+    | exception Not_found ->
+        Unix.open_process_in "getconf _NPROCESSORS_ONLN"
+        |> input_line
+        |> int_of_string
+  in
+  for i = 1 to nproc do
+    flush_all ();
+    if Unix.fork () = 0 then (
+      (* child *)
+      Printf.eprintf "Listening on %s:%d (child %d)\n" (S.addr server)
+        (S.port server) i;
+      match S.run server with
+      | Ok () -> ()
+      | Error e -> raise e )
+  done;
+  while true do
+    Unix.pause ()
+  done

--- a/frameworks/OCaml/tiny_httpd/tiny_httpd.dockerfile
+++ b/frameworks/OCaml/tiny_httpd/tiny_httpd.dockerfile
@@ -17,4 +17,4 @@ COPY ./src /${DIR}
 
 RUN sudo chown -R opam: . && eval $(opam env) && dune build --profile release
 
-ENTRYPOINT _build/default/src/bin/tiny.exe
+ENTRYPOINT ["_build/default/src/bin/tiny.exe"]


### PR DESCRIPTION
Hi @c-cube!

I tried forking tiny_httpd on startup but I'm getting met with this:

```
❯ ./_build/default/src/bin/tiny.exe
Listening on 0.0.0.0:8080 (child 2)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 3)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 4)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 5)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 6)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 7)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
Listening on 0.0.0.0:8080 (child 8)
Fatal error: exception Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
```

I'm not sure here but could this be because each forked process [creates its own socket](https://github.com/c-cube/tiny_httpd/blob/21f474332071fa07ce5b89b2e460f3e0962ddbcc/src/Tiny_httpd.ml#L947-L950) within the `run` function?

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
