### PR TITLE
Updates for httpbeast and jester

### DIFF
--- a/frameworks/Nim/httpbeast/httpbeast.dockerfile
+++ b/frameworks/Nim/httpbeast/httpbeast.dockerfile
@@ -1,7 +1,14 @@
-FROM nimlang/nim:1.0.4
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y libgc-dev gcc build-essential curl git
+
+ENV CHOOSENIM_NO_ANALYTICS 1
+ENV CHOOSENIM_CHOOSE_VERSION 1.4.0
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+ENV PATH $PATH:/root/.nimble/bin
 
 ADD ./ /httpbeast
 WORKDIR /httpbeast
-RUN nimble c -d:release --threads:on -y techempower.nim
+RUN nimble c -d:danger --threads:on -y techempower.nim
 
 CMD ./techempower

--- a/frameworks/Nim/httpbeast/techempower.nimble
+++ b/frameworks/Nim/httpbeast/techempower.nimble
@@ -10,5 +10,5 @@ skipExt = @["nim"]
 
 # Dependencies
 
-requires "nim >= 1.0.0"
-requires "httpbeast >= 0.2.2"
+# We lock dependencies here on purpose.
+requires "httpbeast#v0.2.2"

--- a/frameworks/Nim/jester/jester.dockerfile
+++ b/frameworks/Nim/jester/jester.dockerfile
@@ -1,7 +1,14 @@
-FROM nimlang/nim:1.0.4
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y libgc-dev gcc build-essential curl git
+
+ENV CHOOSENIM_NO_ANALYTICS 1
+ENV CHOOSENIM_CHOOSE_VERSION 1.4.0
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+ENV PATH $PATH:/root/.nimble/bin
 
 ADD ./ /jester
 WORKDIR /jester
-RUN nimble c -d:release --threads:on -y techempower.nim
+RUN nimble c -d:danger --threads:on -y techempower.nim
 
 CMD ./techempower

--- a/frameworks/Nim/jester/techempower.nimble
+++ b/frameworks/Nim/jester/techempower.nimble
@@ -11,4 +11,7 @@ skipExt = @["nim"]
 # Dependencies
 
 requires "nim >= 1.0.0"
-requires "jester >= 0.4.3"
+
+# We lock dependencies here on purpose.
+requires "httpbeast#v0.2.2"
+requires "jester 0.5.0"


### PR DESCRIPTION
I noticed that the throughput for httpbeast and Jester has regressed since round 17 (7 million QPS vs 4.3 million in round 19).

I reverted back to the old dockerfiles to try and figure out the cause, but I didn't see an improvement locally. Furthermore I am also able to get a much higher QPS when I run the httpbeast server directly in WSL vs via the `tfb` script in Docker (5.3 million vs. 3.5 million), unfortunately I wasn't able to figure out the cause of this. If anyone has any ideas of what else I could check that would be most welcome :)

For now this PR updates the Nim version and Jester version used for the benchmark, we also now use the `-d:danger` flag which gives more performance (`-d:release` used to be `-d:danger`).

Tested with ``./tfb --mode benchmark --test httpbeast --type plaintext --concurrency-levels 1024 --pipeline-concurrency-levels 1024``:

Before changes: ``Requests/sec: 3132999.40``

After changes: ``Requests/sec: 3576906.09``