### PR TITLE
[genhttp] Replace 'FindAsync' with 'FirstOrDefaultAsync' because it is terribly slow

### DIFF
--- a/frameworks/CSharp/genhttp/Benchmarks/Tests/CacheResource.cs
+++ b/frameworks/CSharp/genhttp/Benchmarks/Tests/CacheResource.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
 using Benchmarks.Model;
 
 using GenHTTP.Modules.Webservices;
-
-using Microsoft.Extensions.Caching.Memory;
 
 namespace Benchmarks.Tests
 {
@@ -67,7 +68,7 @@ namespace Benchmarks.Tests
                 }
                 else
                 {
-                    var resolved = await context.World.FindAsync(id);
+                    var resolved = await context.World.FirstOrDefaultAsync(w => w.Id == id);
 
                     _Cache.Set(key, resolved);
 

--- a/frameworks/CSharp/genhttp/Benchmarks/Tests/DbResource.cs
+++ b/frameworks/CSharp/genhttp/Benchmarks/Tests/DbResource.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using Microsoft.EntityFrameworkCore;
+
 using GenHTTP.Modules.Webservices;
 
 using Benchmarks.Model;
@@ -19,7 +21,7 @@ namespace Benchmarks.Tests
 
             using var context = DatabaseContext.CreateNoTracking();
 
-            return await context.World.FindAsync(id);
+            return await context.World.FirstOrDefaultAsync(w => w.Id == id);
         }
 
     }

--- a/frameworks/CSharp/genhttp/Benchmarks/Tests/QueryResource.cs
+++ b/frameworks/CSharp/genhttp/Benchmarks/Tests/QueryResource.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using Microsoft.EntityFrameworkCore;
+
 using Benchmarks.Model;
 
 using GenHTTP.Modules.Webservices;
@@ -34,7 +36,7 @@ namespace Benchmarks.Tests
             {
                 var id = _Random.Next(1, 10001);
 
-                result.Add(await context.World.FindAsync(id));
+                result.Add(await context.World.FirstOrDefaultAsync(w => w.Id == id));
             }
 
             return result;

--- a/frameworks/CSharp/genhttp/Benchmarks/Tests/UpdateResource.cs
+++ b/frameworks/CSharp/genhttp/Benchmarks/Tests/UpdateResource.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.EntityFrameworkCore;
+
 using Benchmarks.Model;
 
 using GenHTTP.Modules.Webservices;
@@ -35,7 +37,7 @@ namespace Benchmarks.Tests
             {
                 foreach (var id in ids)
                 {
-                    var record = await context.World.FindAsync(id);
+                    var record = await context.World.FirstOrDefaultAsync(w => w.Id == id);
 
                     var old = record.RandomNumber;
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
