### PR TITLE
libreactor: Enable SO_ATTACH_REUSEPORT_CBPF

### DIFF
--- a/frameworks/C/libreactor/libreactor-server.dockerfile
+++ b/frameworks/C/libreactor/libreactor-server.dockerfile
@@ -7,10 +7,9 @@ WORKDIR /build
 
 ENV CC=gcc-10 AR=gcc-ar-10 NM=gcc-nm-10 RANLIB=gcc-ranlib-10
 
-RUN git clone https://github.com/fredrikwidlund/libdynamic && \
-    cd libdynamic && \
-    git checkout aee8f053c113 && \
-    ./autogen.sh && \
+RUN wget -q https://github.com/fredrikwidlund/libdynamic/releases/download/v2.2.0/libdynamic-2.2.0.tar.gz && \
+    tar xfz libdynamic-2.2.0.tar.gz && \
+    cd libdynamic-2.2.0 && \
     ./configure && \
     make install
 

--- a/frameworks/C/libreactor/libreactor.dockerfile
+++ b/frameworks/C/libreactor/libreactor.dockerfile
@@ -7,10 +7,9 @@ WORKDIR /build
 
 ENV CC=gcc-10 AR=gcc-ar-10 NM=gcc-nm-10 RANLIB=gcc-ranlib-10
 
-RUN git clone https://github.com/fredrikwidlund/libdynamic && \
-    cd libdynamic && \
-    git checkout aee8f053c113 && \
-    ./autogen.sh && \
+RUN wget -q https://github.com/fredrikwidlund/libdynamic/releases/download/v2.2.0/libdynamic-2.2.0.tar.gz && \
+    tar xfz libdynamic-2.2.0.tar.gz && \
+    cd libdynamic-2.2.0 && \
     ./configure && \
     make install
 

--- a/frameworks/C/libreactor/src/helpers.h
+++ b/frameworks/C/libreactor/src/helpers.h
@@ -7,6 +7,6 @@ void json(server_context *context, clo *json_object);
 
 void enable_reuseport_cbpf(server *s);
 
-void setup();
+int fork_workers();
 
 #endif /* HELPERS_H_INCLUDED */

--- a/frameworks/C/libreactor/src/helpers.h
+++ b/frameworks/C/libreactor/src/helpers.h
@@ -5,6 +5,8 @@ void plaintext(server_context *context, char *response);
 
 void json(server_context *context, clo *json_object);
 
+void enable_reuseport_cbpf(server *s);
+
 void setup();
 
 #endif /* HELPERS_H_INCLUDED */

--- a/frameworks/C/libreactor/src/libreactor-server.c
+++ b/frameworks/C/libreactor/src/libreactor-server.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <err.h>
+#include <sys/eventfd.h>
 
 #include <dynamic.h>
 #include <reactor.h>
@@ -44,12 +45,20 @@ static core_status server_handler(core_event *event)
 
 int main()
 {
+  int parent_eventfd;
   server s;
 
-  setup();
+  // fork_workers() forks a separate child/worker process for each available cpu and returns an eventfd from the parent
+  // The eventfd is used to signal the parent. This guarantees the forking order needed for REUSEPORT_CBPF to work well
+  parent_eventfd = fork_workers();
+
   core_construct(NULL);
   server_construct(&s, server_handler, &s);
   server_open(&s, 0, 8080);
+
+  // Signal the parent process so that it can proceed with the next fork
+  eventfd_write(parent_eventfd, (eventfd_t) 1);
+  close(parent_eventfd);
 
   core_loop(NULL);
   core_destruct(NULL);

--- a/frameworks/C/libreactor/src/libreactor.c
+++ b/frameworks/C/libreactor/src/libreactor.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <err.h>
+#include <sys/eventfd.h>
 
 #include <dynamic.h>
 #include <reactor.h>
@@ -42,13 +43,21 @@ static core_status server_handler(core_event *event)
 
 int main()
 {
+  int parent_eventfd;
   server s;
 
-  setup();
+  // fork_workers() forks a separate child/worker process for each available cpu and returns an eventfd from the parent
+  // The eventfd is used to signal the parent. This guarantees the forking order needed for REUSEPORT_CBPF to work well
+  parent_eventfd = fork_workers();
+
   core_construct(NULL);
   server_construct(&s, server_handler, &s);
   server_open(&s, 0, 8080);
   enable_reuseport_cbpf(&s);
+
+  // Signal the parent process so that it can proceed with the next fork
+  eventfd_write(parent_eventfd, (eventfd_t) 1);
+  close(parent_eventfd);
 
   core_loop(NULL);
   core_destruct(NULL);

--- a/frameworks/C/libreactor/src/libreactor.c
+++ b/frameworks/C/libreactor/src/libreactor.c
@@ -48,6 +48,7 @@ int main()
   core_construct(NULL);
   server_construct(&s, server_handler, &s);
   server_open(&s, 0, 8080);
+  enable_reuseport_cbpf(&s);
 
   core_loop(NULL);
   core_destruct(NULL);


### PR DESCRIPTION
The SO_ATTACH_REUSEPORT_CBPF socket option attaches a BPF "program" that automatically assigns a packet to a given socket based on the core id of the CPU that initially received the packet and did the IRQ processing. This improves data locality and therefore increases performance.