### PR TITLE
Switch to dynamic CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ jobs:
         name: Write verify job matrix
         run: |
           # Use of jq for JSON array creation from https://stackoverflow.com/a/26809318
+          # The following creates a JSON object as follows:
+          # include:
+          #   - TESTLANG: {lang}
+          # with a TESTLANG object in the include array for each language under frameworks
           VERIFY_MATRIX=$(ls -1 frameworks | jq -R | jq -sc "{include: map({TESTLANG: .})}")
           echo "::set-output name=verify_matrix::$VERIFY_MATRIX"
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 jobs:
   setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Commit branch/name extraction from:
       # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
@@ -36,7 +36,7 @@ jobs:
           echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
           echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-      - id: out
+      - id: event_out
         name: Write event outputs
         run: |
           # Escape the multiline string for Github Actions, see https://github.community/t/set-output-truncates-multiline-strings/16852/3
@@ -45,53 +45,22 @@ jobs:
           COMMIT_MESSAGE="${COMMIT_MESSAGE//$'\r'/'%0D'}"
           echo "::set-output name=commit_message::$COMMIT_MESSAGE"
           echo "::set-output name=branch_name::$BRANCH_NAME"
+      - id: verify_out
+        name: Write verify job matrix
+        run: |
+          # Use of jq for JSON array creation from https://stackoverflow.com/a/26809318
+          VERIFY_MATRIX=$(ls -1 frameworks | jq -R | jq -sc "{include: map({TESTLANG: .})}")
+          echo "::set-output name=verify_matrix::$VERIFY_MATRIX"
     outputs:
-      commit_message: ${{ steps.out.outputs.commit_message }}
-      branch_name: ${{ steps.out.outputs.branch_name }}
+      commit_message: ${{ steps.event_out.outputs.commit_message }}
+      branch_name: ${{ steps.event_out.outputs.branch_name }}
+      verify_matrix: ${{ steps.verify_out.outputs.verify_matrix }}
   verify:
     needs: setup
     if: ${{ !contains(needs.setup.outputs.commit_message, '[ci skip]') }}
     runs-on: ubuntu-18.04
     strategy:
-      matrix:
-        include:
-          - TESTLANG: "C"
-          - TESTLANG: "C++"
-          - TESTLANG: "CSharp"
-          - TESTLANG: "Clojure"
-          - TESTLANG: "Crystal"
-          - TESTLANG: "D"
-          - TESTLANG: "Dart"
-          - TESTLANG: "Dylan"
-          - TESTLANG: "Elixir"
-          - TESTLANG: "Erlang"
-          - TESTLANG: "FSharp"
-          - TESTLANG: "Go"
-          - TESTLANG: "Groovy"
-          - TESTLANG: "Haskell"
-          - TESTLANG: "Java"
-          - TESTLANG: "JavaScript"
-          - TESTLANG: "Julia"
-          - TESTLANG: "Kotlin"
-          - TESTLANG: "Lisp"
-          - TESTLANG: "Lua"
-          - TESTLANG: "Mumps"
-          - TESTLANG: "Nim"
-          - TESTLANG: "OCaml"
-          - TESTLANG: "PHP"
-          - TESTLANG: "Perl"
-          - TESTLANG: "Prolog"
-          - TESTLANG: "Python"
-          - TESTLANG: "Racket"
-          - TESTLANG: "Ruby"
-          - TESTLANG: "Rust"
-          - TESTLANG: "Scala"
-          - TESTLANG: "Swift"
-          - TESTLANG: "TypeScript"
-          - TESTLANG: "Ur"
-          - TESTLANG: "V"
-          - TESTLANG: "VB"
-          - TESTLANG: "Vala"
+      matrix: ${{ fromJSON(needs.setup.outputs.verify_matrix) }}
       # Disable fail-fast to allow all failing frameworks/etc to fail in a
       # single build, rather than stopping when the first one fails.
       fail-fast: false


### PR DESCRIPTION
Updates the CI to instead dynamically create a job for each language, rather than have them be manually entered.

Note: The runs-on upgrade to 20.04 is only in the setup job, so it won't affect the TFB verification tests themselves.