### PR TITLE
[php-ngx] Update to PHP8

### DIFF
--- a/frameworks/PHP/php-ngx/app-async.php
+++ b/frameworks/PHP/php-ngx/app-async.php
@@ -37,7 +37,7 @@ function query()
     $my = new php\ngx\mysql();
     yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
     $query_count = 1;
-    $params      = ngx::query_args()['q'];
+    $params      = (int) ngx::query_args()['q'];
     if ($params > 1) {
         $query_count = min($params, 500);
     }
@@ -68,7 +68,7 @@ function update()
     $my = new php\ngx\mysql();
     yield from $my->connect(DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME);
     $query_count = 1;
-    $params      = ngx::query_args()['q'];
+    $params      = (int) ngx::query_args()['q'];
     if ($params > 1) {
         $query_count = min($params, 500);
     }

--- a/frameworks/PHP/php-ngx/app.php
+++ b/frameworks/PHP/php-ngx/app.php
@@ -24,7 +24,7 @@ function query()
     ngx_header_set('Content-Type', 'application/json');
 
     $query_count = 1;
-    $params      = ngx::query_args()['q'];
+    $params      = (int) ngx::query_args()['q'];
     if ($params > 1) {
         $query_count = min($params, 500);
     }
@@ -42,7 +42,7 @@ function update()
     ngx_header_set('Content-Type', 'application/json');
 
     $query_count = 1;
-    $params      = ngx::query_args()['q'];
+    $params      = (int) ngx::query_args()['q'];
     if ($params > 1) {
         $query_count = min($params, 500);
     }

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,20 +6,20 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php7.4 php7.4-common php7.4-dev libphp7.4-embed php7.4-mysql nginx > /dev/null
+                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    php8.0-cli php8.0-dev libphp8.0-embed php8.0-mysql nginx > /dev/null
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.2
+ENV NGINX_VERSION=1.19.6
 
-RUN git clone -b v0.0.24 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
     cd nginx-${NGINX_VERSION} && \
-    export PHP_LIB=/usr/lib && \ 
-    ./configure --user=www --group=www \
+    export PHP_LIB=/usr/lib && \
+    bash ./configure --user=www --group=www \
             --prefix=/nginx \
             --with-ld-opt="-Wl,-rpath,$PHP_LIB" \
             --add-module=/ngx_php7/third_party/ngx_devel_kit \

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,20 +6,20 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php7.4 php7.4-common php7.4-dev libphp7.4-embed php7.4-mysql nginx > /dev/null
+                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    php8.0-cli php8.0-dev libphp8.0-embed php8.0-mysql nginx > /dev/null
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.2
+ENV NGINX_VERSION=1.19.6
 
-RUN git clone -b v0.0.24 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
     cd nginx-${NGINX_VERSION} && \
-    export PHP_LIB=/usr/lib && \ 
-    ./configure --user=www --group=www \
+    export PHP_LIB=/usr/lib && \
+    bash ./configure --user=www --group=www \
             --prefix=/nginx \
             --with-ld-opt="-Wl,-rpath,$PHP_LIB" \
             --add-module=/ngx_php7/third_party/ngx_devel_kit \

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,20 +6,20 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php7.4 php7.4-common php7.4-dev libphp7.4-embed php7.4-pgsql nginx > /dev/null
+                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    php8.0-cli php8.0-dev libphp8.0-embed php8.0-pgsql nginx > /dev/null
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.2
+ENV NGINX_VERSION=1.19.6
 
-RUN git clone -b v0.0.24 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
     cd nginx-${NGINX_VERSION} && \
-    export PHP_LIB=/usr/lib && \ 
-    ./configure --user=www --group=www \
+    export PHP_LIB=/usr/lib && \
+    bash ./configure --user=www --group=www \
             --prefix=/nginx \
             --with-ld-opt="-Wl,-rpath,$PHP_LIB" \
             --add-module=/ngx_php7/third_party/ngx_devel_kit \

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,20 +6,19 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlibc zlib1g zlib1g-dev libpcre3 libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php7.4 php7.4-common php7.4-dev libphp7.4-embed php7.4-mysql nginx > /dev/null
-
+                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    php8.0-cli php8.0-dev libphp8.0-embed php8.0-mysql nginx > /dev/null
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.2
+ENV NGINX_VERSION=1.19.6
 
-RUN git clone -b v0.0.24 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
     cd nginx-${NGINX_VERSION} && \
     export PHP_LIB=/usr/lib && \ 
-    ./configure --user=www --group=www \
+    bash ./configure --user=www --group=www \
             --prefix=/nginx \
             --with-ld-opt="-Wl,-rpath,$PHP_LIB" \
             --add-module=/ngx_php7/third_party/ngx_devel_kit \


### PR DESCRIPTION
Update:

-  php-ngx 0.0.25
- nginx 1.19.6
- Ubuntu 20.10

When it's ready the new toolset, we will add the JIT variant.


<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
