### PR TITLE
Master diff-only builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,5 @@
 name: build
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
 jobs:
   setup:
     runs-on: ubuntu-20.04
@@ -26,6 +22,7 @@ jobs:
           echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
           echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+          echo "PREVIOUS_COMMIT=$(git log --format=%H -n 1 HEAD~1)" >> $GITHUB_ENV
       # In case of a pull_request event, the commit we care about is HEAD^2, that
       # is, the second parent of the pull request merge commit.
       # The current branch name is directly given by GITHUB_HEAD_REF
@@ -36,6 +33,7 @@ jobs:
           echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
           echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+          echo "PREVIOUS_COMMIT=$(git log --format=%H -n 1 HEAD^2~1)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: '2.7'
@@ -44,7 +42,11 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          DIFF=$(./toolset/github_actions/github_actions_diff.py)
+          echo "DIFF<<EOF" >> $GITHUB_ENV
+          echo "$(./toolset/github_actions/github_actions_diff.py)" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Determine which (if any) tests need to be run
+        run: |
           echo "RUN_TESTS<<EOF" >> $GITHUB_ENV
           echo "$(grep -oP "github-actions-run-tests \K(.*)" <<< $DIFF || true)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -57,6 +59,8 @@ jobs:
           COMMIT_MESSAGE="${COMMIT_MESSAGE//$'\r'/'%0D'}"
           echo "::set-output name=commit_message::$COMMIT_MESSAGE"
           echo "::set-output name=branch_name::$BRANCH_NAME"
+          echo "::set-output name=branch_name::$BRANCH_NAME"
+          echo "::set-output name=previous_commit::$PREVIOUS_COMMIT"
       - id: verify_out
         name: Write verify job matrix
         run: |
@@ -70,6 +74,7 @@ jobs:
     outputs:
       commit_message: ${{ steps.event_out.outputs.commit_message }}
       branch_name: ${{ steps.event_out.outputs.branch_name }}
+      previous_commit: ${{ steps.event_out.outputs.previous_commit }}
       verify_matrix: ${{ steps.verify_out.outputs.verify_matrix }}
   verify:
     needs: setup
@@ -86,6 +91,7 @@ jobs:
       TESTDIR: ${{ matrix.TESTDIR }}
       COMMIT_MESSAGE: ${{ needs.setup.outputs.commit_message }}
       BRANCH_NAME: ${{ needs.setup.outputs.branch_name }}
+      PREVIOUS_COMMIT: ${{ needs.setup.outputs.previous_commit }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - uses: actions/checkout@v2
@@ -95,8 +101,7 @@ jobs:
         with:
           python-version: '2.7'
           architecture: 'x64'
-      - id: get_diff
-        name: Get all changes vs master
+      - name: Get all changes vs master
         # Runs github_actions_diff, with the the output accessible in later steps
         run: |
           # Write the result to env.DIFF for later steps

--- a/toolset/github_actions/github_actions_diff.py
+++ b/toolset/github_actions/github_actions_diff.py
@@ -60,6 +60,7 @@ curr_branch = ""
 is_PR = (os.getenv("PR_NUMBER") != "")
 # BRANCH_NAME is the the name of the branch
 is_master = os.getenv("BRANCH_NAME") == "master"
+previous_commit = os.getenv("PREVIOUS_COMMIT")
 
 if is_PR:
     curr_branch = "HEAD"
@@ -68,12 +69,14 @@ if is_PR:
 elif not is_master:
     curr_branch = os.getenv("GITHUB_SHA")
 
+diff_target = "master" if is_PR else previous_commit
+
 # https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
 changes = clean_output(
     subprocess.check_output([
         'bash', '-c',
-        'git --no-pager diff --name-only {0} $(git merge-base {0} master)'
-            .format(curr_branch)
+        'git --no-pager diff --name-only {0} $(git merge-base {0} {1})'
+            .format(curr_branch, diff_target)
     ]))
 print("Determining what to run based on the following file changes: \n{!s}"
     .format('\n'.join(changes.split('\n')[0:10])))
@@ -108,7 +111,7 @@ else:
             test_dirs.append(framework)
 
 # Forced full run
-if (not is_PR and is_master) or re.search(r'\[ci run-all\]', last_commit_msg, re.M):
+if re.search(r'\[ci run-all\]', last_commit_msg, re.M):
     print("All tests have been forced to run from the commit message.")
     run_tests = test_dirs
     quit_diffing()


### PR DESCRIPTION
Updates the CI to not force a full rebuild on push to a branch, and instead only build the changes. PR builds/diffs will still work as they did before.

Also removes the branch filter for build triggers, so that any git flow still can have this same CI flow.