### PR TITLE
[aiohttp] Set max pool size again

### DIFF
--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -53,7 +53,7 @@ async def db_ctx(app: web.Application):
     min_size = max(int(max_size / 2), 1)
     print(f'connection pool: min size: {min_size}, max size: {max_size}, orm: {CONNECTION_ORM}')
     if CONNECTION_ORM:
-        engine = create_async_engine(dsn, future=True)
+        engine = create_async_engine(dsn, future=True, pool_size=max_size)
         app['db_session'] = sessionmaker(engine, class_=AsyncSession)
     else:
         app['pg'] = await asyncpg.create_pool(dsn=dsn, min_size=min_size, max_size=max_size, loop=app.loop)


### PR DESCRIPTION
Seems to result in a slight performance improvement.

I don't see any obvious way to use the min_size in sqlalchemy, which in aiopg appears to pre create the connections, so they are ready before the tests run.