### PR TITLE
[aiohttp] Eliminate some overhead in jinja environment

### DIFF
--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -1,6 +1,5 @@
 import os
 import multiprocessing
-from pathlib import Path
 
 import asyncpg
 from aiohttp import web
@@ -23,8 +22,6 @@ from .views import (
 )
 
 CONNECTION_ORM = os.getenv('CONNECTION', 'ORM').upper() == 'ORM'
-
-THIS_DIR = Path(__file__).parent
 
 
 def pg_dsn() -> str:

--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -2,9 +2,7 @@ import os
 import multiprocessing
 from pathlib import Path
 
-import aiohttp_jinja2
 import asyncpg
-import jinja2
 from aiohttp import web
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -81,14 +79,6 @@ def setup_routes(app):
 
 def create_app():
     app = web.Application()
-
-    jinja2_loader = jinja2.FileSystemLoader(str(THIS_DIR / 'templates'))
-    # Negative cache size eliminates overhead of LRUCache. Overhead is unnessary for
-    # most applications (as the default of 400 will never be reached).
-    # Disabling auto_reload reduces some overhead that is probably only useful in local development.
-    aiohttp_jinja2.setup(app, loader=jinja2_loader, cache_size=-1, auto_reload=False)
-
     app.cleanup_ctx.append(db_ctx)
-
     setup_routes(app)
     return app

--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -83,7 +83,10 @@ def create_app():
     app = web.Application()
 
     jinja2_loader = jinja2.FileSystemLoader(str(THIS_DIR / 'templates'))
-    aiohttp_jinja2.setup(app, loader=jinja2_loader)
+    # Negative cache size eliminates overhead of LRUCache. Overhead is unnessary for
+    # most applications (as the default of 400 will never be reached).
+    # Disabling auto_reload reduces some overhead that is probably only useful in local development.
+    aiohttp_jinja2.setup(app, loader=jinja2_loader, cache_size=-1, auto_reload=False)
 
     app.cleanup_ctx.append(db_ctx)
 

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -1,5 +1,6 @@
 from functools import partial
 from operator import attrgetter, itemgetter
+from pathlib import Path
 from random import randint
 
 import jinja2

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -105,7 +105,7 @@ async def fortunes(request):
     fortunes.append(Fortune(id=0, message='Additional fortune added at request time.'))
     fortunes.sort(key=attrgetter('message'))
     content = template.render(fortunes=fortunes)
-    return web.Response(text=content, content_type='text/html')
+    return Response(text=content, content_type='text/html')
 
 
 async def fortunes_raw(request):
@@ -117,7 +117,7 @@ async def fortunes_raw(request):
     fortunes.append(dict(id=0, message='Additional fortune added at request time.'))
     fortunes.sort(key=itemgetter('message'))
     content = template.render(fortunes=fortunes)
-    return web.Response(text=content, content_type='text/html')
+    return Response(text=content, content_type='text/html')
 
 
 async def updates(request):

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp==3.7.3
-aiohttp-jinja2==1.4.2
 asyncpg==0.21.0
 cchardet==2.1.7
 gunicorn==20.0.4

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -2,6 +2,7 @@ aiohttp==3.7.3
 asyncpg==0.21.0
 cchardet==2.1.7
 gunicorn==20.0.4
+jinja2==2.11.2
 psycopg2==2.8.6
 SQLAlchemy==1.4.0b1
 ujson==2.0.3


### PR DESCRIPTION
I noticed that uvicorn is practically cheating by pre-loading a jinja template, without using the rest of the jinja environment like a regular application would.

Rather than copying that cheat, I had a look at what unneeded overheads existed in the jinja environment. The cache_size causes LRUCache to be replaced with a simple dict. auto_reload ensures we only check the disk on the first load.


I'm not sure exactly how the benchmarks are run, but it would probably be a good idea if the benchmarks did a dummy run first, which allows connections to be created and caches to be populated. Then do the real benchmark. Or maybe a best of 3 runs or similar (as long as the app is not reloaded between runs). This would ensure the comparisons are fairer without needing every framework to implement logic to ensure things are prepopulated before the benchmark runs.