### PR TITLE
Fix CI for PRs targeting non-master branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          echo "TARGET_BRANCH_NAME=$(echo ${GITHUB_BASE_REF##*/})" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
           echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
@@ -59,7 +60,7 @@ jobs:
           COMMIT_MESSAGE="${COMMIT_MESSAGE//$'\r'/'%0D'}"
           echo "::set-output name=commit_message::$COMMIT_MESSAGE"
           echo "::set-output name=branch_name::$BRANCH_NAME"
-          echo "::set-output name=branch_name::$BRANCH_NAME"
+          echo "::set-output name=target_branch_name::$TARGET_BRANCH_NAME"
           echo "::set-output name=previous_commit::$PREVIOUS_COMMIT"
       - id: verify_out
         name: Write verify job matrix
@@ -74,6 +75,7 @@ jobs:
     outputs:
       commit_message: ${{ steps.event_out.outputs.commit_message }}
       branch_name: ${{ steps.event_out.outputs.branch_name }}
+      target_branch_name: ${{ steps.event_out.outputs.target_branch_name }}
       previous_commit: ${{ steps.event_out.outputs.previous_commit }}
       verify_matrix: ${{ steps.verify_out.outputs.verify_matrix }}
   verify:
@@ -91,6 +93,7 @@ jobs:
       TESTDIR: ${{ matrix.TESTDIR }}
       COMMIT_MESSAGE: ${{ needs.setup.outputs.commit_message }}
       BRANCH_NAME: ${{ needs.setup.outputs.branch_name }}
+      TARGET_BRANCH_NAME: ${{ needs.setup.outputs.target_branch_name }}
       PREVIOUS_COMMIT: ${{ needs.setup.outputs.previous_commit }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:

--- a/toolset/github_actions/github_actions_diff.py
+++ b/toolset/github_actions/github_actions_diff.py
@@ -60,14 +60,15 @@ curr_branch = ""
 is_PR = (os.getenv("PR_NUMBER") != "")
 previous_commit = os.getenv("PREVIOUS_COMMIT")
 
+diff_target = os.getenv("TARGET_BRANCH_NAME") if is_PR else previous_commit
+
 if is_PR:
     curr_branch = "HEAD"
     # Also fetch master to compare against
-    subprocess.check_output(['bash', '-c', 'git fetch origin master:master'])
+    subprocess.check_output(['bash', '-c', 'git fetch origin {0}:{0}'
+                            .format(diff_target)])
 else:
     curr_branch = os.getenv("GITHUB_SHA")
-
-diff_target = "master" if is_PR else previous_commit
 
 # https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github
 changes = clean_output(


### PR DESCRIPTION
Demonstrating this is difficult (or at least hard to explain what's going on), but the short of it is that when a non-master branch is targeted in a PR, the differ previously still treated the diff target as master. You'd think this would be fine, but it isn't. 

Specifically, the `git merge HEAD master` in `github_actions_diff.py` was returning empty. I read a little about it, and while I could probably try to understand it better in relation to the specific commands GH actions uses to checkout PRs, changing the target branch for diffing to be the target branch of the PR fixed the issue and seemed like a better/simpler option. So that's all this does. The differ now directly compares against the PR target rather than master.

Fwiw, here are the demonstrations.
- Workflow for a PR targeting a local branch of mine without these changes, but with Gemini changes: https://github.com/ajohnstonTE/FrameworkBenchmarks/actions/runs/481616316
- Workflow for a PR targeting the same local branch with the changes and the Gemini changes: https://github.com/ajohnstonTE/FrameworkBenchmarks/actions/runs/481615424

The first build fails to do the diff, and runs no language jobs. The second one correctly generates the diff and sets up the Java job.