### PR TITLE
Label PRs with failing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,17 @@ jobs:
   setup:
     runs-on: ubuntu-20.04
     steps:
+      # Required for workflow triggers like the auto-label for failing PRs
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+      - uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: pr
+          path: pr/
       # Commit branch/name extraction from:
       # https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
       #

--- a/.github/workflows/label-failing-pr.yml
+++ b/.github/workflows/label-failing-pr.yml
@@ -1,0 +1,46 @@
+name: Label PR if failed
+on:
+  workflow_run:
+    workflows: [ "build" ]
+    types:
+      - completed
+jobs:
+  apply_label:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          # scripts lightly modified from https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+      - name: Label PR
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            await github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              labels: ['PR: Please Update']
+            });


### PR DESCRIPTION
Automatically labels PRs with failing workflows as `PR: Please Update`. The changes here will not take effect until this PR is merged (as in, I cannot demonstrate the functionality on this PR itself, the new workflow has to be in master to be triggered). The labels are applied in a separate workflow for security reasons/so that PRs from forks (aka all PRs) can have labels applied.

Here's a demonstration of a failing PR from a fork other than my own targeting my master branch, which had the label applied: https://github.com/ajohnstonTE/FrameworkBenchmarks/pull/21