### PR TITLE
Update dependencies of warp-rust

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "1.0.103", features = ["derive"] }
 tokio = { version = "0.2.21", features = ["macros", "rt-threaded"] }
 tokio-postgres = "0.5.1"
 warp = "0.2.3"
-yarte = "0.12.2"
+yarte = "0.14.1"

--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Konrad Borowski <konrad@borowski.pw>"]
 edition = "2018"
 
 [dependencies]
-futures = "0.3.1"
-rand = { version = "0.7.3", features = ["small_rng"] }
-serde = { version = "1.0.103", features = ["derive"] }
-tokio = { version = "0.2.21", features = ["macros", "rt-threaded"] }
-tokio-postgres = "0.5.1"
-warp = "0.2.3"
+futures = "0.3.12"
+rand = { version = "0.8.2", features = ["small_rng"] }
+serde = { version = "1.0.120", features = ["derive"] }
+tokio = { version = "1.0.2", features = ["macros", "rt-multi-thread"] }
+tokio-postgres = "0.7.0"
+warp = "0.3.0"
 yarte = "0.14.1"

--- a/frameworks/Rust/warp-rust/warp-rust.dockerfile
+++ b/frameworks/Rust/warp-rust/warp-rust.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.44
+FROM rust:1.49
 
 WORKDIR /warp-rust
 COPY src src


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
warp 0.3.0 was released which is a good excuse to update all dependencies.