### PR TITLE
Enable LTO for warp-rust

### DIFF
--- a/frameworks/Rust/warp-rust/Cargo.toml
+++ b/frameworks/Rust/warp-rust/Cargo.toml
@@ -12,3 +12,8 @@ tokio = { version = "1.0.2", features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.0"
 warp = "0.3.0"
 yarte = "0.14.1"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
This makes compilation slower, but this isn't a compilation time benchmark, so that's fine.