### PR TITLE
Fix larvel-s to not use JIT

### DIFF
--- a/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
+++ b/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0
+FROM php:8.0-cli
 
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole

--- a/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
+++ b/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
@@ -5,8 +5,8 @@ RUN pecl install swoole > /dev/null && \
 RUN docker-php-ext-install pdo_mysql pcntl opcache > /dev/null
 
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
-RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
-RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+#RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+#RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 ADD ./ /laravel
 WORKDIR /laravel

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -5,7 +5,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip \
+    php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 RUN apt-get install -yqq php8.0-mbstring php8.0-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null

--- a/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
+++ b/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
@@ -5,8 +5,8 @@ RUN pecl install swoole > /dev/null && \
 RUN docker-php-ext-install pdo_mysql pcntl opcache > /dev/null
 
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
-RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
-RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+#RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+#RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 ADD ./ /lumen
 WORKDIR /lumen

--- a/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
+++ b/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0
+FROM php:8.0-cli
 
 RUN pecl install swoole > /dev/null && \
     docker-php-ext-enable swoole

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -5,7 +5,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
+    apt-get install -yqq nginx git unzip \
+    php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 RUN apt-get install -yqq php8.0-mbstring php8.0-xml  > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null


### PR DESCRIPTION
#6184

Swoole can't use JIT.
`Warning: JIT is incompatible with third party extensions that setup user opcode handlers. JIT disabled.`

https://tfb-status.techempower.com/unzip/results.2021-01-18-10-23-39-324.zip/results/20210113214749/laravel-laravel-s/build/laravel-laravel-s.log
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
