### PR TITLE
Update Finagle/Finatra library versions in benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,4 +1,4 @@
-lazy val finagleVersion = "21.1.0"
+lazy val finagleVersion = "21.2.0"
 
 name := "finagle-benchmark"
 scalaVersion := "2.12.8"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,4 +1,4 @@
-lazy val finatraVersion = "21.1.0"
+lazy val finatraVersion = "21.2.0"
 
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"


### PR DESCRIPTION
Problem

We've just released new versions of these libraries and would like to ensure
that the benchmarks have the latest publicly available versions.

Solution

Update versions as follows:

Finagle to 21.2.0
Finatra to 21.2.0