### PR TITLE
Enable HTTP/1.1 pipelining for warp-rust

### DIFF
--- a/frameworks/Rust/warp-rust/src/main.rs
+++ b/frameworks/Rust/warp-rust/src/main.rs
@@ -121,6 +121,13 @@ fn routes(pool: &'static PgPool) -> impl Filter<Extract = impl Reply, Error = Re
 #[tokio::main]
 async fn main() -> Result<(), sqlx::Error> {
     let pool = Box::leak(Box::new(PgPool::connect(DATABASE_URL).await?));
-    warp::serve(routes(pool)).run(([0, 0, 0, 0], 8080)).await;
+    warp::serve(routes(pool))
+        // .unstable_pipeline() enables HTTP/1.1 pipelining. Regular applications
+        // probably shouldn't use this method as it's undocumented and not very
+        // useful as most HTTP clients don't support HTTP/1.1 pipelining anymore
+        // and it "can slow down non-pipelined responses" according to warp's code.
+        .unstable_pipeline()
+        .run(([0, 0, 0, 0], 8080))
+        .await;
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
This is using an undocumented method that has a following comment.

```rust
// Generally shouldn't be used, as it can slow down non-pipelined responses.
//
// It's only real use is to make silly pipeline benchmarks look better.
```

I think it's fine to enable HTTP/1.1 pipelining for warp-rust because Framework Benchmarks wiki says the following.

> Server support for HTTP/1.1 pipelining is assumed. Servers that do not support pipelining may be included but should downgrade gracefully. If you are unsure about your server's behavior with pipelining, test with the wrk load generation tool used in our tests.