### PR TITLE
Fix Phalcon

### DIFF
--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -5,7 +5,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql php7.4-mongodb  > /dev/null
+    apt-get install -yqq nginx git unzip \
+    php7.4-cli php7.4-fpm php7.4-mysql php7.4-mongodb php7.4-mbstring > /dev/null
 
 RUN apt-get install -yqq composer > /dev/null
 


### PR DESCRIPTION
Added mbstring extension.

It's not posible update to ubuntu 20.10 or php8.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
