### PR TITLE
Avoid deadlocks in CFML updates test

### DIFF
--- a/frameworks/CFML/CFML/src/.cfconfig.json
+++ b/frameworks/CFML/CFML/src/.cfconfig.json
@@ -6,9 +6,11 @@
             "host":"tfb-database",
             "password":"benchmarkdbpass",
             "port":"5432",
-            "username":"benchmarkdbuser"
+            "username":"benchmarkdbuser",
+            "requestExclusive":true
         }
     },
     "inspectTemplate":"never",
-    "maxCFThreads":"512"
+    "maxCFThreads":"512",
+    "adminPassword":"password"
 }

--- a/frameworks/CFML/CFML/src/updates.cfm
+++ b/frameworks/CFML/CFML/src/updates.cfm
@@ -17,15 +17,12 @@
     </cfquery>
     <cfset results.append( { 'id' : qry.id, 'randomNumber' : randRange( 1, 1000 ) } )>
 </cfloop>
-<cfquery datasource="world">
-    update World as w set
-        randomNumber = w2.randomNumber
-    from (values
-        #results.reduce( (acc,r)=>{
-            acc = acc.listAppend( "(#val( r.id )#, #val( r.randomNumber )#)" );
-            return acc;
-         }, '')#
-        ) as w2(id,randomNumber)
-    where w2.id = w.id;
-</cfquery>
+
+<cfloop array="#results#" index="i">
+    <cfquery datasource="world">
+        update World 
+        SET randomNumber = #val( i.randomNumber )#
+        where id = #val( i.id )#;
+    </cfquery>
+</cfloop>
 <cfoutput>#serializeJSON( results )#</cfoutput>


### PR DESCRIPTION
The cfml tests for Lucee and Adobe appear to be getting deadlocks in the updates test.  I'm not sure why, but I refactored them to loop over and make separate updates to individual rows instead of a single update statement that hits all rows at once.  I'm afraid this new way may perform more slowly, but I'm not sure how to avoid the deadlocks with the original method.