### PR TITLE
Update Deno Standard Library version from `v0.50.0` to `0.87.0`

### DIFF
--- a/frameworks/TypeScript/deno/src/handlers.ts
+++ b/frameworks/TypeScript/deno/src/handlers.ts
@@ -1,7 +1,7 @@
 import {
   ServerRequest,
   Response
-} from "https://deno.land/std@v0.50.0/http/server.ts";
+} from "https://deno.land/std@0.87.0/http/server.ts";
 
 interface Handler {
   (request: ServerRequest): Promise<void>

--- a/frameworks/TypeScript/deno/src/main.ts
+++ b/frameworks/TypeScript/deno/src/main.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std@v0.50.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.87.0/http/server.ts";
 
 import { handlers } from "./handlers.ts";
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Fixed the error `Warning std versions prefixed with'v' were deprecated recently. Please change your import to https://deno.land/std@0.50.0/http/server.ts (at https://deno.land/ std@v0.50.0/http/server.ts)`

For details, see [results.2021-01-13-13-38-00-107-deno/build.deno.log](https://tfb-status.techempower.com/unzip/results.2021-01-13-13-38-00-107.zip/results/20201229183947/deno/build/deno.log)