### PR TITLE
Add ColdBox framework on CFML language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ obj
 [Dd]ebug/
 [Rr]elease/
 *.fsproj.user
+
+# CFML
+frameworks/CFML/coldbox/src/coldbox/

--- a/frameworks/CFML/CFML/README.md
+++ b/frameworks/CFML/CFML/README.md
@@ -1,4 +1,7 @@
-# CFML Lucee Benchmarking Test
+# CFML Lucee/Adobe Benchmarking Test
+
+The default test runs on Lucee Server.  The Adobe version runs on Adobe ColdFusion. 
+The code is the same between both CF engines.
 
 ### Test Type Implementation Source Code
 
@@ -15,6 +18,7 @@ The tests were run with:
 * [CommandBox](https://commandbox.ortusbooks.com/)
 * [ortussolutions/commandbox Docker image](https://hub.docker.com/r/ortussolutions/commandbox/)
 * [Lucee Server](https://www.lucee.org/)
+* [Adobe ColdFusion](https://coldfusion.adobe.com/)
 
 ## Test URLs
 ### JSON

--- a/frameworks/CFML/CFML/cfml-adobe.dockerfile
+++ b/frameworks/CFML/CFML/cfml-adobe.dockerfile
@@ -9,6 +9,8 @@ RUN ${BUILD_DIR}/util/warmup-server.sh
 
 RUN export FINALIZE_STARTUP=true;$BUILD_DIR/run.sh;unset FINALIZE_STARTUP
 
+HEALTHCHECK NONE
+
 EXPOSE 8080
 
 COPY ./src /app/

--- a/frameworks/CFML/coldbox/README.md
+++ b/frameworks/CFML/coldbox/README.md
@@ -1,0 +1,51 @@
+# CFML ColdBox Benchmarking Test
+
+The default test runs on Lucee Server.  The Adobe version runs on Adobe ColdFusion. 
+The code is the same between both CF engines.
+
+### Test Type Implementation Source Code
+
+* [JSON](src/handlers/Main.cfc)
+* [PLAINTEXT](src/handlers/Main.cfc)
+* [DB](src/handlers/Main.cfc)
+* [QUERY](src/handlers/Main.cfc)
+* [CACHED QUERY](src/handlers/Main.cfc)
+* [UPDATE](src/handlers/Main.cfc)
+* [FORTUNES](src/handlers/Main.cfc)
+
+## Important Libraries
+The tests were run with:
+* [CommandBox](https://commandbox.ortusbooks.com/)
+* [ortussolutions/commandbox Docker image](https://hub.docker.com/r/ortussolutions/commandbox/)
+* [Lucee Server](https://www.lucee.org/)
+* [Adobe ColdFusion](https://coldfusion.adobe.com/)
+* [ColdBox MVC](https://www.coldbox.org/)
+
+## Test URLs
+### JSON
+
+http://localhost:8080/index.cfm?event=main.json
+
+### PLAINTEXT
+
+http://localhost:8080/index.cfm?event=main.plaintext
+
+### DB
+
+http://localhost:8080/index.cfm?event=main.db
+
+### QUERY
+
+http://localhost:8080/index.cfm?event=main.query&queries=
+
+### CACHED QUERY
+
+http://localhost:8080/index.cfm?event=main.cached_query&queries=
+
+### UPDATE
+
+http://localhost:8080/index.cfm?event=main.update&queries=
+
+### FORTUNES
+
+http://localhost:8080/index.cfm?event=main.fortunes

--- a/frameworks/CFML/coldbox/benchmark_config.json
+++ b/frameworks/CFML/coldbox/benchmark_config.json
@@ -1,0 +1,53 @@
+{
+  "framework": "coldbox",
+  "tests": [
+    {
+      "default": {
+        "json_url": "/index.cfm?event=main.json",
+        "db_url": "/index.cfm?event=main.db",
+        "query_url":"/index.cfm?event=main.queries&queries=",
+        "fortune_url": "/index.cfm?event=main.fortunes",
+        "plaintext_url": "/index.cfm?event=main.plaintext",
+        "update_url": "/index.cfm?event=main.updates&queries=",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Fullstack",
+        "database": "Postgres",
+        "framework": "ColdBox",
+        "language": "CFML",
+        "flavor": "None",
+        "orm": "raw",
+        "platform": "None",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "coldbox-lucee",
+        "notes": "Coldbox MVC on Lucee Server",
+        "versus": "cfml"
+      },
+      "adobe": {
+        "json_url": "/index.cfm?event=main.json",
+        "db_url": "/index.cfm?event=main.db",
+        "query_url":"/index.cfm?event=main.queries&queries=",
+        "fortune_url": "/index.cfm?event=main.fortunes",
+        "plaintext_url": "/index.cfm?event=main.plaintext",
+        "update_url": "/index.cfm?event=main.updates&queries=",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Fullstack",
+        "database": "Postgres",
+        "framework": "ColdBox",
+        "language": "CFML",
+        "flavor": "None",
+        "orm": "raw",
+        "platform": "None",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "coldbox-adobe",
+        "notes": "Coldbox MVC on Adobe ColdFusion",
+        "versus": "cfml-adobe"
+      }
+    }
+  ]
+}

--- a/frameworks/CFML/coldbox/coldbox-adobe.dockerfile
+++ b/frameworks/CFML/coldbox/coldbox-adobe.dockerfile
@@ -1,9 +1,10 @@
 FROM ortussolutions/commandbox:3.2.1
 
-COPY ./src/server-lucee.json /app/server.json
+COPY ./src/server-adobe.json /app/server.json
 COPY ./src/.cfconfig.json /app/.cfconfig.json
+COPY ./src/box.json /app/box.json
 
-RUN box install commandbox-cfconfig --verbose --force
+RUN box install --verbose --force
 
 RUN ${BUILD_DIR}/util/warmup-server.sh
 

--- a/frameworks/CFML/coldbox/coldbox.dockerfile
+++ b/frameworks/CFML/coldbox/coldbox.dockerfile
@@ -2,8 +2,9 @@ FROM ortussolutions/commandbox:3.2.1
 
 COPY ./src/server-lucee.json /app/server.json
 COPY ./src/.cfconfig.json /app/.cfconfig.json
+COPY ./src/box.json /app/box.json
 
-RUN box install commandbox-cfconfig --verbose --force
+RUN box install --verbose --force
 
 RUN ${BUILD_DIR}/util/warmup-server.sh
 

--- a/frameworks/CFML/coldbox/src/.cfconfig.json
+++ b/frameworks/CFML/coldbox/src/.cfconfig.json
@@ -1,0 +1,14 @@
+{
+    "datasources":{
+        "world":{
+            "database":"hello_world",
+            "dbdriver":"PostgreSQL",
+            "host":"tfb-database",
+            "password":"benchmarkdbpass",
+            "port":"5432",
+            "username":"benchmarkdbuser"
+        }
+    },
+    "inspectTemplate":"never",
+    "maxCFThreads":"512"
+}

--- a/frameworks/CFML/coldbox/src/Application.cfc
+++ b/frameworks/CFML/coldbox/src/Application.cfc
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2005-2007 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+ * www.ortussolutions.com
+ * ---
+ */
+component {
+
+	// Application properties
+	this.name              = 'My App';
+	this.sessionManagement = false;
+	this.clientManagement  = false;
+	this.setClientCookies  = false;
+	this.datasource		   = 'world';
+
+	// COLDBOX STATIC PROPERTY, DO NOT CHANGE UNLESS THIS IS NOT THE ROOT OF YOUR COLDBOX APP
+	COLDBOX_APP_ROOT_PATH = getDirectoryFromPath( getCurrentTemplatePath() );
+	// The web server mapping to this application. Used for remote purposes or static purposes
+	COLDBOX_APP_MAPPING   = "";
+	// COLDBOX PROPERTIES
+	COLDBOX_CONFIG_FILE   = "";
+	// COLDBOX APPLICATION KEY OVERRIDE
+	COLDBOX_APP_KEY       = "";
+
+	// application start
+	public boolean function onApplicationStart() {
+		application.cbBootstrap = new coldbox.system.Bootstrap(
+			COLDBOX_CONFIG_FILE,
+			COLDBOX_APP_ROOT_PATH,
+			COLDBOX_APP_KEY,
+			COLDBOX_APP_MAPPING
+		);
+		application.cbBootstrap.loadColdbox();
+		return true;
+	}
+
+	public boolean function onRequestStart( string targetPage ) {
+		// Process ColdBox Request
+		application.cbBootstrap.onRequestStart( arguments.targetPage );
+
+		return true;
+	}
+
+}

--- a/frameworks/CFML/coldbox/src/box.json
+++ b/frameworks/CFML/coldbox/src/box.json
@@ -1,0 +1,11 @@
+{
+    "name":"My ColdBox App",
+    "version":"1.0.0",
+    "installPaths":{
+        "coldbox":"coldbox/"
+    },
+    "dependencies":{
+        "coldbox":"^6.0.0",
+        "commandbox-cfconfig":"^1.2.1"
+    }
+}

--- a/frameworks/CFML/coldbox/src/config/Coldbox.cfc
+++ b/frameworks/CFML/coldbox/src/config/Coldbox.cfc
@@ -1,0 +1,19 @@
+component {
+
+	function configure() {
+
+		coldbox = {
+			appName                  : "ColdBox MVC",
+			reinitPassword           : "",
+			handlersIndexAutoReload  : false,
+			customErrorTemplate      : "/coldbox/system/exceptions/Whoops.cfm",
+			handlerCaching           : true
+		};
+
+		flash = {
+			scope = "Mock"
+		};
+
+	}
+
+}

--- a/frameworks/CFML/coldbox/src/handlers/Main.cfc
+++ b/frameworks/CFML/coldbox/src/handlers/Main.cfc
@@ -1,0 +1,87 @@
+component extends="coldbox.system.EventHandler" {
+
+	function prehandler( event ) {
+		event.setHTTPHeader( name="Server", value="cfml-coldbox" )
+			.noLayout();
+	}
+
+	function json( event, rc, prc ) {
+		event.renderData( data={ 'message' : 'Hello, World!' }, type="json" );
+	}
+
+	function db( event, rc, prc ) {
+		var qry = queryExecute( '
+			SELECT id, randomNumber
+			FROM World
+			WHERE id = #randRange( 1, 10000 )#
+		');
+		event.renderData( data=qry.getRow( 1 ), type="json" );
+	}
+
+	function queries( event, rc, prc ) {
+				
+		event.paramValue( 'queries', 1 );
+		rc.queries = val( rc.queries );
+		if( rc.queries > 500 ) {
+			rc.queries = 500;
+		} else if( rc.queries < 1 ) {
+			rc.queries = 1;
+		}
+		var results = [];
+		cfloop( from="1", to="#rc.queries#", index="local.i" ) {
+			var qry = queryExecute( '
+				SELECT id, randomNumber
+				FROM World
+				WHERE id = #randRange( 1, 10000 )#
+			');
+			results.append( qry.getRow( 1 ) );
+		}
+
+		event.renderData( data=results, type="json" );		
+	}
+
+	function fortunes( event, rc, prc ) {
+		var qry = queryExecute( '
+			SELECT id, message
+			FROM Fortune
+		');
+		qry.addRow( { 'id' : 0, 'message' : 'Additional fortune added at request time.' } );
+		prc.qry = qry.sort( (a,b)=>compareNoCase(a.message,b.message) );
+		event.setView( "main/fortunes" );
+	}
+
+	function plaintext( event, rc, prc ) {
+		event.renderData( data="Hello, World!", type="plain", contentType="text/plain" );
+	}
+
+	function updates( event, rc, prc ) {
+		event.paramValue( 'queries', 1 );
+		rc.queries = val( rc.queries );
+		if( rc.queries > 500 ) {
+			rc.queries = 500;
+		} else if( rc.queries < 1 ) {
+			rc.queries = 1;
+		}
+		var results = [];
+
+		cfloop( from="1", to="#rc.queries#", index="local.i" ) {
+			var qry = queryExecute( '
+				SELECT id, randomNumber
+				FROM World
+				WHERE id = #randRange( 1, 10000 )#
+			');
+			results.append( { 'id' : qry.id, 'randomNumber' : randRange( 1, 1000 ) } );
+		}
+				
+		cfloop( array="#results#", index="local.i" ) {
+			queryExecute( '
+				update World 
+				SET randomNumber = #val( i.randomNumber )#
+				where id = #val( i.id )#;
+			');
+		}
+
+		event.renderData( data=results, type="json" );
+	}
+
+}

--- a/frameworks/CFML/coldbox/src/index.cfm
+++ b/frameworks/CFML/coldbox/src/index.cfm
@@ -1,0 +1,9 @@
+<cfsetting enablecfoutputonly="yes">
+<!-----------------------------------------------------------------------
+Template :  index.cfm 
+Author 	 :	Luis Majano
+Date     :	October 15, 2005
+Description : 			
+	This is only a place holder since everything occurs in application.cfc now.
+----------------------------------------------------------------------->
+<cfsetting enablecfoutputonly="no">

--- a/frameworks/CFML/coldbox/src/server-adobe.json
+++ b/frameworks/CFML/coldbox/src/server-adobe.json
@@ -1,0 +1,9 @@
+{
+    "profile":"none",
+    "web":{
+        "maxRequests":512
+    },
+    "app":{
+        "cfengine":"adobe@2018"
+    }
+}

--- a/frameworks/CFML/coldbox/src/server-lucee.json
+++ b/frameworks/CFML/coldbox/src/server-lucee.json
@@ -1,0 +1,9 @@
+{
+    "profile":"none",
+    "web":{
+        "maxRequests":512
+    },
+    "app":{
+        "cfengine":"lucee@5.3.8-rc"
+    }
+}

--- a/frameworks/CFML/coldbox/src/views/main/fortunes.cfm
+++ b/frameworks/CFML/coldbox/src/views/main/fortunes.cfm
@@ -1,0 +1,4 @@
+<cfoutput><!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>
+<cfloop query="#prc.qry#"><tr><td>#prc.qry.id#</td><td>#htmlEditFormat( prc.qry.message )#</td></tr></cfloop>
+</table></body></html>
+</cfoutput>


### PR DESCRIPTION
This adds support for the ColdBox MVC framework on the CFML language.  It includes both the Lucee Server and Adobe ColdFusion engines.

I followed the same format as the CFML tests, which is the default test runs Lucee server and the "adobe" version runs the Adobe ColdFusion engine.  Please review the settings in my benchmark config JSON file and let me know if anything is out of place.  

I also tweaked the readme and docker files for the base CFML tests.  (adding some verbiage and turning off a default docker healthcheck)

