### PR TITLE
feat(zio-http): add plaintext and json benchmarks for zio-http

### DIFF
--- a/frameworks/Scala/ZIO-Http/build.sbt
+++ b/frameworks/Scala/ZIO-Http/build.sbt
@@ -1,0 +1,13 @@
+scalaVersion := "2.13.3"
+lazy val root = (project in file("."))
+  .settings(
+    name := "helloExample",
+    libraryDependencies ++= Seq(
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.6.4",
+      // Use the "provided" scope instead when the "compile-internal" scope is not supported
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.6.4" % "compile-internal",
+      "io.d11" % "zhttp" % "1.0.0-RC1"
+
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )

--- a/frameworks/Scala/ZIO-Http/project/build.properties
+++ b/frameworks/Scala/ZIO-Http/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.4.7

--- a/frameworks/Scala/ZIO-Http/src/main/scala/Main.scala
+++ b/frameworks/Scala/ZIO-Http/src/main/scala/Main.scala
@@ -1,0 +1,24 @@
+import zhttp.http._
+import zhttp.service.Server
+import zio.{App, ExitCode, URIO}
+
+object WebApp extends App {
+
+  val message: String = "Hello, World!"
+
+  import com.github.plokhotnyuk.jsoniter_scala.macros._
+  import com.github.plokhotnyuk.jsoniter_scala.core._
+
+  case class Message(message: String)
+  implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make
+
+  val jsonstr = new String(writeToArray(Message(message)))
+
+  val app = Http.collect[Request] {
+    case Method.GET -> Root / "plaintext" => Response.text(message)
+    case Method.GET -> Root / "json" => Response.jsonString(jsonstr)
+  }
+
+  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = Server.start(8080, app).exitCode
+
+}


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
