### PR TITLE
Add missing space in ASP.NET Core "display_name"

### DIFF
--- a/frameworks/CSharp/aspnetcore/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore/benchmark_config.json
@@ -55,7 +55,7 @@
       "webserver": "Kestrel",
       "os": "Linux",
       "database_os": "Linux",
-      "display_name": "ASP.NET Core [Platform,Pg]",
+      "display_name": "ASP.NET Core [Platform, Pg]",
       "notes": "",
       "versus": "aspcore-ado-pg-up"
     },


### PR DESCRIPTION
Add space after comma in ASP.NET Core `display_name`.