### PR TITLE
Do not set  kernel parameters when running in host network mode

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -184,7 +184,11 @@ class DockerHelper:
                 }
                 name = None
 
-            sysctl = {'net.core.somaxconn': 65535}
+            if self.benchmarker.config.network_mode is None:
+                sysctl = {'net.core.somaxconn': 65535}
+            else:
+                # Do not pass `net.*` kernel params when using host network mode
+                sysctl = None
 
             ulimit = [{
                 'name': 'nofile',
@@ -319,10 +323,16 @@ class DockerHelper:
         image_name = "techempower/%s:latest" % database
         log_prefix = image_name + ": "
 
-        sysctl = {
-            'net.core.somaxconn': 65535,
-            'kernel.sem': "250 32000 256 512"
-        }
+        if self.benchmarker.config.network_mode is None:
+            sysctl = {
+                'net.core.somaxconn': 65535,
+                'kernel.sem': "250 32000 256 512"
+            }
+        else:
+            # Do not pass `net.*` kernel params when using host network mode
+            sysctl = {
+                'kernel.sem': "250 32000 256 512"
+            }
 
         ulimit = [{'name': 'nofile', 'hard': 65535, 'soft': 65535}]
 
@@ -401,7 +411,11 @@ class DockerHelper:
                 for line in container.logs(stream=True):
                     log(line, file=benchmark_file)
 
-        sysctl = {'net.core.somaxconn': 65535}
+        if self.benchmarker.config.network_mode is None:
+            sysctl = {'net.core.somaxconn': 65535}
+        else:
+            # Do not pass `net.*` kernel params when using host network mode
+            sysctl = None
 
         ulimit = [{'name': 'nofile', 'hard': 65535, 'soft': 65535}]
 


### PR DESCRIPTION
As mentioned on #6538 :

This change has the potential for impacting results, by changing the kernel params set depending on network type, I wanted to be sure that there were no negative side effects before opening a PR.

I have looked in the contributing docs and the github action for running tests when a PR is opened, but can not see anywhere where host network mode is tested. Are there any tests that run specifically in host network mode, or is running in this mode manually validated?

Any help in validating these changes would be greatly appreciated
