### PR TITLE
Fix and update blaze

### DIFF
--- a/frameworks/Scala/blaze/README.md
+++ b/frameworks/Scala/blaze/README.md
@@ -1,11 +1,5 @@
 #blaze Benchmarking Test
 
-## Infrastructure Software Versions
-The tests were run with:
-
-* [Java Oracle 1.8.0](http://www.oracle.com/technetwork/java/javase)
-* [blaze 0.14.0-M3](https://github.com/http4s/blaze/)
-
 ## Test URLs
 ### JSON Encoding Test
 

--- a/frameworks/Scala/blaze/blaze.dockerfile
+++ b/frameworks/Scala/blaze/blaze.dockerfile
@@ -1,12 +1,11 @@
-FROM adoptopenjdk/openjdk11:x86_64-alpine-jre-11.0.3_7
-RUN apk add bash
+FROM openjdk:15
 WORKDIR /blaze
 COPY project project
 COPY src src
 COPY build.sbt build.sbt
 COPY sbt sbt
 RUN ./sbt assembly -batch && \
-    mv target/scala-2.12/blaze-assembly-1.0.jar . && \
+    mv target/blaze-assembly-1.0.jar . && \
     rm -Rf target && \
     rm -Rf project/target && \
     rm -Rf ~/.sbt && \

--- a/frameworks/Scala/blaze/build.sbt
+++ b/frameworks/Scala/blaze/build.sbt
@@ -2,10 +2,12 @@ name := "blaze"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.5"
 
 libraryDependencies ++= Seq(
-	"org.http4s" %% "http4s-blaze-core" % "0.20.3",
-	"com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "0.51.3",
+	"org.http4s" %% "blaze-http" % "0.14.16",
+	"com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.7.3",
 	"ch.qos.logback" % "logback-classic" % "1.2.3"
 )
+
+crossPaths := false

--- a/frameworks/Scala/blaze/project/build.properties
+++ b/frameworks/Scala/blaze/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.5.1

--- a/frameworks/Scala/blaze/sbt
+++ b/frameworks/Scala/blaze/sbt
@@ -18,10 +18,10 @@ declare -r latest_28="2.8.2"
 
 declare -r buildProps="project/build.properties"
 
-declare -r sbt_launch_ivy_release_repo="http://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="http://repo.scala-sbt.org/scalasbt/maven-releases"
-declare -r sbt_launch_mvn_snapshot_repo="http://repo.scala-sbt.org/scalasbt/maven-snapshots"
+declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
 declare -r default_jvm_opts_common="-Xms512m -Xss2m"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
@@ -133,6 +133,7 @@ make_url () {
       0.10.* ) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
     0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
           0.*) echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+        1.5.*) echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch-$version.jar" ;;
             *) echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
   esac
 }

--- a/frameworks/Scala/blaze/src/main/scala/Main.scala
+++ b/frameworks/Scala/blaze/src/main/scala/Main.scala
@@ -23,7 +23,7 @@ object Main {
   private val jsonHeaders = Seq("server" -> "blaze", "content-type" -> "application/json")
   private val plaintextHeaders = Seq("server" -> "blaze", "content-type" -> "text/plain")
 
-  private implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make[Message](CodecMakerConfig())
+  private implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make[Message](CodecMakerConfig)
 
   def serve(request: HttpRequest): Future[RouteAction] = Future.successful {
     request.url match {
@@ -37,7 +37,7 @@ object Main {
     Future.successful(LeafBuilder(new Http1ServerStage(serve, config)))
 
   def main(args: Array[String]): Unit =
-    NIO1SocketServerGroup.fixedGroup()
+    NIO1SocketServerGroup.fixed()
       .bind(new InetSocketAddress(8080), connect)
       .getOrElse(sys.error("Failed to start server."))
       .join()


### PR DESCRIPTION
Currently blaze is failing to build because it uses an outdated URL to download sbt. 

This PR fixes the issue and updates blaze, it's dependencies, build system and runtime.