### PR TITLE
[amp] Fix and update

### DIFF
--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -1,24 +1,29 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip php7.4 php7.4-common php7.4-cli php7.4-dev php7.4-mbstring composer curl build-essential > /dev/null
+    apt-get install -yqq git unzip wget curl build-essential \
+    php8.0-cli php8.0-mbstring php8.0-dev php8.0-xml php8.0-curl > /dev/null
 
 # An extension is required!
 # We deal with concurrencies over 1k, which stream_select doesn't support.
-
-RUN apt-get install -y php-pear php-dev libuv1-dev libuv1 > /dev/null
-RUN pecl install uv-0.2.4 > /dev/null
+RUN wget http://pear.php.net/go-pear.phar --quiet && php go-pear.phar
+#RUN apt-get install -y libuv1-dev > /dev/null
+RUN apt-get install -y libevent-dev > /dev/null
+#RUN pecl install uv-0.2.4 > /dev/null && echo "extension=uv.so" > /etc/php/8.0/cli/conf.d/uv.ini
+RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 ADD ./ /amp
 WORKDIR /amp
 
-COPY deploy/conf/* /etc/php/7.4/cli/conf.d/
+COPY deploy/conf/* /etc/php/8.0/cli/conf.d/
 
-RUN composer install --prefer-dist --optimize-autoloader --no-dev
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+RUN composer install --prefer-dist --optimize-autoloader --no-dev --quiet
 
 EXPOSE 8080
 

--- a/frameworks/PHP/amp/benchmark_config.json
+++ b/frameworks/PHP/amp/benchmark_config.json
@@ -4,7 +4,7 @@
     "default": {
       "json_url": "/json",
       "db_url": "/db",
-      "query_url": "/queries?queries=",
+      "query_url": "/queries?q=",
       "fortune_url": "/fortunes",
       "plaintext_url": "/plaintext",
       "port": 8080,

--- a/frameworks/PHP/amp/deploy/conf/php.ini
+++ b/frameworks/PHP/amp/deploy/conf/php.ini
@@ -1,6 +1,16 @@
-# Enable OPcache also for CLI scripts
-opcache.enable_cli = On
-
 # Disable assertions, because Amp uses them for debugging code
 zend.assertions = -1
-extension=uv.so
+
+opcache.enable=1
+opcache.enable_cli=1
+opcache.validate_timestamps=0
+opcache.save_comments=0
+opcache.enable_file_override=1
+opcache.huge_code_pages=1
+
+mysqlnd.collect_statistics = Off
+
+memory_limit = 512M
+
+opcache.jit_buffer_size=128M
+opcache.jit=tracing

--- a/frameworks/PHP/amp/fortunes.php
+++ b/frameworks/PHP/amp/fortunes.php
@@ -1,4 +1,4 @@
 <!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>
 <?php foreach ($items as $id => $fortune): ?>
-<tr><td><?php echo $id ?></td><td><?php echo \htmlspecialchars($fortune, ENT_QUOTES, 'UTF-8') ?></td></tr>
+<tr><td><?= $id ?></td><td><?= \htmlspecialchars($fortune, ENT_QUOTES, 'UTF-8') ?></td></tr>
 <?php endforeach ?></table></body></html>

--- a/frameworks/PHP/amp/server.php
+++ b/frameworks/PHP/amp/server.php
@@ -90,7 +90,7 @@ Amp\Loop::run(function () {
             $query = $request->getUri()->getQuery();
             \parse_str($query, $queryParams);
 
-            $queries = (int) ($queryParams['queries'] ?? 1);
+            $queries = (int) ($queryParams['q'] ?? 1);
             if ($queries < 1) {
                 $queries = 1;
             } elseif ($queries > 500) {
@@ -157,12 +157,6 @@ Amp\Loop::run(function () {
             ], \ob_get_clean());
         }
 
-        private function execute($statement) {
-            $result = yield $statement->execute([mt_rand(1, 10000)]);
-            yield $result->advance();
-
-            return $result->getCurrent();
-        }
     });
 
     // Case 6 - Plaintext


### PR DESCRIPTION
Fix as was broken.

Change event-loop from libuv to libevent 3.0.4 as in workerman.
Update to PHP8 JIT, libuv extension is not ready for PHP8.

In a future PR, I'll try to add variants with event libev and libuv.
