### PR TITLE
[Crystal] Optimize JSON responses

### DIFF
--- a/frameworks/Crystal/crystal/server.cr
+++ b/frameworks/Crystal/crystal/server.cr
@@ -20,7 +20,8 @@ server = HTTP::Server.new do |context|
   when "/json"
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_JSON
-    {message: "Hello, World!"}.to_json(response)
+    json = {message: "Hello, World!"}.to_json
+    response.print(json)
   when "/plaintext"
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_TEXT
@@ -28,13 +29,14 @@ server = HTTP::Server.new do |context|
   when "/db"
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_JSON
-    find_world(rand(1..ID_MAXIMUM)).to_json(response)
+    json = find_world(rand(1..ID_MAXIMUM)).to_json
+    response.print(json)
   when "/queries"
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_JSON
 
     worlds = (1..sanitized_query_count(request)).map { find_world(rand(1..ID_MAXIMUM)) }
-    worlds.to_json(response)
+    response.print(worlds.to_json)
   when "/fortunes"
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_HTML
@@ -62,7 +64,7 @@ server = HTTP::Server.new do |context|
       APPDB.exec("UPDATE world SET randomNumber = $1 WHERE id = $2", random_number, world[:id])
       {id: world[:id], randomNumber: random_number}
     end
-    worlds.to_json(response)
+    response.print(worlds.to_json)
   else
     response.status_code = 404
   end

--- a/frameworks/Crystal/crystal/server_radix.cr
+++ b/frameworks/Crystal/crystal/server_radix.cr
@@ -22,7 +22,8 @@ json_handler = ->(context : HTTP::Server::Context) do
   context.response.tap do |response|
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_JSON
-    {message: "Hello, World!"}.to_json(response)
+    json = {message: "Hello, World!"}.to_json
+    response.print(json)
   end
 end
 
@@ -30,7 +31,8 @@ db_handler = ->(context : HTTP::Server::Context) do
   context.response.tap do |response|
     response.status_code = 200
     response.headers["Content-Type"] = CONTENT_JSON
-    find_world(rand(1..ID_MAXIMUM)).to_json(response)
+    json = find_world(rand(1..ID_MAXIMUM)).to_json
+    response.print(json)
   end
 end
 
@@ -41,7 +43,7 @@ queries_handler = ->(context : HTTP::Server::Context) do
     response.headers["Content-Type"] = CONTENT_JSON
 
     worlds = (1..sanitized_query_count(request)).map { find_world(rand(1..ID_MAXIMUM)) }
-    worlds.to_json(response)
+    response.print(worlds.to_json)
   end
 end
 
@@ -78,7 +80,7 @@ updates_handler = ->(context : HTTP::Server::Context) do
       APPDB.exec("UPDATE world SET randomNumber = $1 WHERE id = $2", random_number, world[:id])
       {id: world[:id], randomNumber: random_number}
     end
-    worlds.to_json(response)
+    response.print(worlds.to_json)
   end
 end
 


### PR DESCRIPTION
`response.print(...)` is WAY faster than `.to_json(response)` for some reason. Local test on /json went from 80k per second to 220k per second.