### PR TITLE
Improve LoadMultipleUpdatesRows performance.

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
@@ -54,23 +54,19 @@ namespace Benchmarks.Data
         public async Task<World[]> LoadMultipleUpdatesRows(int count)
         {
             var results = new World[count];
-            int currentValue, newValue;
-
-            var ids = Enumerable.Range(1, 10000).Select(x => _random.Next(1, 10001)).Distinct().Take(count).ToArray();
-
+            var usedIds = new HashSet<int>(count);
+            
             for (var i = 0; i < count; i++)
             {
-                results[i] = await _firstWorldTrackedQuery(_dbContext, ids[i]);
-
-                currentValue = results[i].RandomNumber;
-
+                int id;
                 do
                 {
-                    newValue = _random.Next(1, 10001);
-                }
-                while (newValue == currentValue);
+                    id = _random.Next(1, 10001);
+                } while (!usedIds.Add(id));
+                
+                results[i] = await _firstWorldTrackedQuery(_dbContext, id);
 
-                results[i].RandomNumber = newValue;
+                results[i].RandomNumber = _random.Next(1, 10001);
 
                 _dbContext.Entry(results[i]).State = EntityState.Modified;
             }


### PR DESCRIPTION
This PR reverts some of the changes made in #5933. It improves performance and reduces the amount of memory allocations in number and size.
It increases the throughput of the `LoadMultipleUpdatesRows()` method on my local machine running the vagrant VM (altered to use 6 CPU cores and 20 GB of RAM) by up to 2%.

---

The main issue for EF Core here is of course, that while we could retrieve two untracked entities with the same ID (which could happen by shear coincidence through the (pseudo) random number generator), we can only effectively update one of those entities within one `SaveChanges()` call.

The implementation of this PR uses an explicit `HashSet<>` to ensure, that no duplicate random ID numbers are being used for querying. The advantage over the previous algorithm is, that it is faster than the LINQ query and it does not unnecessarily allocate an array (as the previous algorithm did at the end with `ToArray()`). While the `HashSet<>` implementation uses 56 bytes and the internal `Set<>` implementation used by `Distinct()` (part of the previous algorithm) uses only 24 bytes, we should still allocate fewer bytes over all with explicitly using `HashSet<>`. Also, we can set the capacity in advance this way.

There are two possible variations of this for possible future optimizations:

One is to keep using the old algorithm for this part, just drop the `ToArray()` call and use the returned enumerator when in need for a distinct ID later. This should save additional memory (the difference between the `HashSet<>` and the `Set` implementation in bytes) at the cost of CPU cycles.
This is slower than this PR on my local rig.
If anybody wants to test this variation, it's available through a feature branch of my fork: https://github.com/lauxjpn/FrameworkBenchmarks/tree/test/aspnetcore_ef_update_2

The other is to not use any explicit set at all and just trade memory for CPU cycles in general, by iterating over the already queried `results[]` array for duplicate ID detection (which could be worth it, since the number of array items is pretty small).
This slower than the previous variation on my local rig.
If anybody wants to test this variation, it's available through a feature branch of my fork: https://github.com/lauxjpn/FrameworkBenchmarks/tree/test/aspnetcore_ef_update_3

---

Since #6566, I am now unsure what the correct process for this PR is, since it is targeting ASP.NET.

@roji Is the special standard of #6566 only meant for the ASP.NET Core _platform_ benchmarks and does therefore not apply to the normal ASP.NET Core benchmarks like this one, or does it apply to _all_ ASP.NET Core benchmarks, or only to specific files (e.g. those that could affect Npgsql/PostgreSQL benchmarks)?