### PR TITLE
Bump Finagle benchmarks

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,4 +1,4 @@
-lazy val finagleVersion = "21.4.0"
+lazy val finagleVersion = "21.5.0"
 
 name := "finagle-benchmark"
 scalaVersion := "2.12.12"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,4 +1,4 @@
-lazy val finatraVersion = "21.4.0"
+lazy val finatraVersion = "21.5.0"
 
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"


### PR DESCRIPTION
We've released the latest releases of twitter/finagle and twitter/finatra. We'd like to bump each to their latest revision.

- Finagle to 21.5.0
- Finatra to 21.5.0