### PR TITLE
Fix permission issue when using skip-name-resolve, running a local MySQL database server and connecting via TCP

### DIFF
--- a/toolset/databases/mysql/create.sql
+++ b/toolset/databases/mysql/create.sql
@@ -2,6 +2,15 @@
 # http://stackoverflow.com/questions/37719818/the-server-time-zone-value-aest-is-unrecognized-or-represents-more-than-one-ti
 SET GLOBAL time_zone = '+00:00';
 
+CREATE USER 'benchmarkdbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
+CREATE USER 'benchmarkdbuser'@'localhost' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
+
+-- GitHub Actions/CI run the database server on the same system as the benchmarks.
+-- Because we setup MySQL with the skip-name-resolve option, the IP address 127.0.0.1 might not be resolved to localhost
+-- anymore. This does not seem to matter, as long as Unix sockets are being used (e.g. when setting up the docker image),
+-- because the host is set to be localhost implicitly, but it matters for local TCP connections.
+CREATE USER 'benchmarkdbuser'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
+
 # modified from SO answer http://stackoverflow.com/questions/5125096/for-loop-in-mysql
 CREATE DATABASE hello_world;
 USE hello_world;
@@ -12,10 +21,9 @@ CREATE TABLE  world (
   PRIMARY KEY  (id)
 )
 ENGINE=INNODB;
-CREATE USER 'benchmarkdbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
-CREATE USER 'benchmarkdbuser'@'localhost' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
 GRANT ALL PRIVILEGES ON hello_world.world TO 'benchmarkdbuser'@'%';
 GRANT ALL PRIVILEGES ON hello_world.world TO 'benchmarkdbuser'@'localhost';
+GRANT ALL PRIVILEGES ON hello_world.world TO 'benchmarkdbuser'@'127.0.0.1';
 
 DELIMITER #
 CREATE PROCEDURE load_data()
@@ -46,6 +54,7 @@ CREATE TABLE  fortune (
 ENGINE=INNODB;
 GRANT ALL PRIVILEGES ON hello_world.fortune TO 'benchmarkdbuser'@'%';
 GRANT ALL PRIVILEGES ON hello_world.fortune TO 'benchmarkdbuser'@'localhost';
+GRANT ALL PRIVILEGES ON hello_world.fortune TO 'benchmarkdbuser'@'127.0.0.1';
 
 INSERT INTO fortune (message) VALUES ('fortune: No such file or directory');
 INSERT INTO fortune (message) VALUES ('A computer scientist is someone who fixes things that aren''t broken.');


### PR DESCRIPTION
Currently, the MySQL benchmarks can randomly fail when run in CI/GitHub Actions. This happens in CI, but not on Citrine.

The issue seems to be, that the CI runs the database server on the same machine/system as the benchmarks (client) themselves. This means, that the client host is the local machine, usually resolved as `localhost`. But because we do not resolve client hostnames, because we use the `skip-name-resolve` option in the `my.cnf` to avoid the performance overhead name resolution brings, the local IP address `127.0.0.1` might not get resolved to `localhost` at all.

This only happens when using a local TCP connection, because MySQL seems to translate a Unix socket connection to `localhost` implicitly.

The result would be an exception, that the (TCP) connection could not be established to the database server, even though it is up and locally running. For example, this happened randomly on the https://github.com/TechEmpower/FrameworkBenchmarks/pull/6566#issuecomment-850582374 PR.

Typically for MySQL, you would setup users for `localhost` and `%` (any host). For our CI usage here however, we need to explicitly add `127.0.0.1` as a hostname as well, so that non-resolved local TCP connections get mapped to a valid user account.

(Also modernizes the `mysqld` setup code a bit and gracefully shuts it down during the docker image setup. While I am not entirely sure, whether the latter is strictly necessary or not, it is what the official MySQL docker files do.)