### PR TITLE
Shorter db loop cycle (0.001 millisecond) + plaintext correction

### DIFF
--- a/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
@@ -7,52 +7,38 @@ namespace appMpower.Db
 {
    public static class PooledConnections
    {
-      private static int _maxLoops = 999;
+      private static bool _connectionsCreated = false;
       private static byte _createdConnections = 0;
       private static byte _maxConnections = Math.Min((byte)Environment.ProcessorCount, (byte)21);
       private static ConcurrentStack<PooledConnection> _stack = new ConcurrentStack<PooledConnection>();
+      private static TimeSpan _timeSpan = new TimeSpan(10); // 10 = 0.001 millisecond
 
       public static async Task<PooledConnection> GetConnection(string connectionString)
       {
-         int i = 0;
-         PooledConnection pooledConnection;
+         PooledConnection pooledConnection = null;
 
-         if (_createdConnections < _maxConnections)
+         if (_connectionsCreated)
          {
-            pooledConnection = new PooledConnection();
-            pooledConnection.OdbcConnection = new OdbcConnection(connectionString);
-            _createdConnections++;
-            pooledConnection.Number = _createdConnections;
-            pooledConnection.PooledCommands = new ConcurrentDictionary<string, PooledCommand>();
-            //Console.WriteLine("opened connection number: " + pooledConnection.Number);
+            while (!_stack.TryPop(out pooledConnection))
+            {
+               await Task.Delay(_timeSpan);
+            }
 
             return pooledConnection;
          }
          else
          {
-            while (!_stack.TryPop(out pooledConnection) && i < _maxLoops)
-            {
-               if (i < 5) await Task.Delay(1);
-               else if (i < 10) await Task.Delay(2);
-               else if (i < 25) await Task.Delay(3);
-               else if (i < 50) await Task.Delay(4);
-               else if (i < 100) await Task.Delay(5);
-               else if (i < 500) await Task.Delay(10);
-               else await Task.Delay(20);
+            pooledConnection = new PooledConnection();
+            pooledConnection.OdbcConnection = new OdbcConnection(connectionString);
+            _createdConnections++;
 
-               i++;
-               //Console.WriteLine("waiting: " + i);
-            }
+            if (_createdConnections == _maxConnections) _connectionsCreated = true;
 
-            if (i < _maxLoops)
-            {
-               //Console.WriteLine("opened connection number: " + pooledConnection.Number);
-               return pooledConnection;
-            }
-            else
-            {
-               throw new Exception("No connections are available");
-            }
+            pooledConnection.Number = _createdConnections;
+            pooledConnection.PooledCommands = new ConcurrentDictionary<string, PooledCommand>();
+            //Console.WriteLine("opened connection number: " + pooledConnection.Number);
+
+            return pooledConnection;
          }
       }
 

--- a/frameworks/CSharp/appmpower/src/HttpApplication.cs
+++ b/frameworks/CSharp/appmpower/src/HttpApplication.cs
@@ -1,16 +1,16 @@
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using appMpower.Kestrel;
-using PlatformBenchmarks;
 
 namespace appMpower
 {
    public class HttpApplication : IHttpApplication<IFeatureCollection>
    {
-      private readonly static AsciiString _plainText = "Hello, World!";
+      public static readonly byte[] _plainText = Encoding.UTF8.GetBytes("Hello, World!");
       private readonly static JsonMessageSerializer _jsonMessageSerializer = new JsonMessageSerializer();
       private readonly static WorldSerializer _worldSerializer = new WorldSerializer();
 
@@ -34,7 +34,7 @@ namespace appMpower
 
             if (pathStringLength == 10 && pathStringStart == "p")
             {
-               PlainText.Render(httpResponse.Headers, httpResponseBody.Writer, _plainText);
+               await PlainText.RenderAsync(httpResponse.Headers, httpResponseBody.Writer, _plainText);
                return;
             }
             else if (pathStringLength == 5 && pathStringStart == "j")

--- a/frameworks/CSharp/appmpower/src/Kestrel/PlainText.cs
+++ b/frameworks/CSharp/appmpower/src/Kestrel/PlainText.cs
@@ -1,8 +1,9 @@
+using System;
+using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using PlatformBenchmarks;
 
 namespace appMpower.Kestrel
 {
@@ -13,15 +14,13 @@ namespace appMpower.Kestrel
       private readonly static KeyValuePair<string, StringValues> _headerContentType =
          new KeyValuePair<string, StringValues>("Content-Type", new StringValues("text/plain"));
 
-      public static void Render(IHeaderDictionary headerDictionary, PipeWriter pipeWriter, AsciiString utf8String)
+      public static async Task<FlushResult> RenderAsync(IHeaderDictionary headerDictionary, PipeWriter pipeWriter, ReadOnlyMemory<byte> utf8String)
       {
          headerDictionary.Add(_headerServer);
          headerDictionary.Add(_headerContentType);
          headerDictionary.Add(new KeyValuePair<string, StringValues>("Content-Length", utf8String.Length.ToString()));
 
-         var bufferWriter = new BufferWriter<WriterAdapter>(new WriterAdapter(pipeWriter), 208);
-         bufferWriter.Write(utf8String);
-         bufferWriter.Commit();
+         return await pipeWriter.WriteAsync(utf8String);
       }
    }
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
