### PR TITLE
aiohttp improvements

### DIFF
--- a/frameworks/Python/aiohttp/aiohttp-pg-raw.dockerfile
+++ b/frameworks/Python/aiohttp/aiohttp-pg-raw.dockerfile
@@ -4,7 +4,7 @@ ADD ./ /aiohttp
 
 WORKDIR aiohttp
 
-RUN pip3 install cython==0.29.13 && \
+RUN pip3 install cython==0.29.23 && \
     pip3 install -r /aiohttp/requirements.txt
 
 ENV CONNECTION=RAW

--- a/frameworks/Python/aiohttp/aiohttp.dockerfile
+++ b/frameworks/Python/aiohttp/aiohttp.dockerfile
@@ -4,7 +4,7 @@ ADD ./ /aiohttp
 
 WORKDIR aiohttp
 
-RUN pip3 install cython==0.29.13 && \
+RUN pip3 install cython==0.29.23 && \
     pip3 install -r /aiohttp/requirements.txt
 
 WORKDIR /aiohttp

--- a/frameworks/Python/aiohttp/app/templates/fortune.jinja
+++ b/frameworks/Python/aiohttp/app/templates/fortune.jinja
@@ -1,20 +1,10 @@
 <!DOCTYPE html>
 <html>
-<head>
-<title>Fortunes</title>
-</head>
+<head><title>Fortunes</title></head>
 <body>
 <table>
-<tr>
-<th>id</th>
-<th>message</th>
-</tr>
-{% for fortune in fortunes %}
-<tr>
-<td>{{ fortune.id }}</td>
-<td>{{ fortune.message|escape }}</td>
-</tr>
-{% endfor %}
-</table>
+<tr><th>id</th><th>message</th></tr>
+{% for fortune in fortunes %}<tr><td>{{ fortune.id }}</td><td>{{ fortune.message|escape }}</td></tr>
+{% endfor %}</table>
 </body>
 </html>

--- a/frameworks/Python/aiohttp/app/templates/fortune.jinja
+++ b/frameworks/Python/aiohttp/app/templates/fortune.jinja
@@ -4,7 +4,7 @@
 <body>
 <table>
 <tr><th>id</th><th>message</th></tr>
-{% for fortune in fortunes %}<tr><td>{{ fortune.id }}</td><td>{{ fortune.message|escape }}</td></tr>
+{% for fortune in fortunes %}<tr><td>{{ fortune.id }}</td><td>{{ fortune.message|e }}</td></tr>
 {% endfor %}</table>
 </body>
 </html>

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -128,13 +128,16 @@ async def updates(request):
     Test 5 ORM
     """
     num_queries = get_num_queries(request)
+    ids = [randint(1, 10000) for _ in range(num_queries)]
+    ids.sort()
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['db_session'].begin() as sess:
-        for id_, number in updates:
+        for id_ in ids:
+            rand_new = randint(1, 10000)
             world = await sess.get(World, id_, populate_existing=True)
-            world.randomnumber = number
+            world.randomnumber = rand_new
     return json_response(worlds)
 
 async def updates_raw(request):

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -10,9 +10,17 @@ from sqlalchemy import select
 
 from .models import sa_fortunes, sa_worlds, Fortune, World
 
+ADDITIONAL_FORTUNE_ORM = Fortune(id=0, message='Additional fortune added at request time.')
+ADDITIONAL_FORTUNE_ROW = {'id': 0, 'message': 'Additional fortune added at request time.'}
+READ_ROW_SQL = 'SELECT "randomnumber", "id" FROM "world" WHERE id = $1'
+READ_SELECT_ORM = select(World.randomnumber)
+WRITE_ROW_SQL = 'UPDATE "world" SET "randomnumber"=$1 WHERE id=$2'
+
 json_response = partial(json_response, dumps=ujson.dumps)
 template_path = Path(__file__).parent / 'templates' / 'fortune.jinja'
 template = jinja2.Template(template_path.read_text())
+sort_fortunes_orm = attrgetter('message')
+sort_fortunes_raw = itemgetter('message')
 
 
 def get_num_queries(request):

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -128,19 +128,14 @@ async def updates(request):
     Test 5 ORM
     """
     num_queries = get_num_queries(request)
-    result = []
-
-    ids = [randint(1, 10000) for _ in range(num_queries)]
-    ids.sort()
+    updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
+    worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['db_session'].begin() as sess:
-        for id_ in ids:
-            rand_new = randint(1, 10000)
+        for id_, number in updates:
             world = await sess.get(World, id_, populate_existing=True)
-            world.randomnumber = rand_new
-
-            result.append({'id': id_, 'randomNumber': rand_new})
-    return json_response(result)
+            world.randomnumber = number
+    return json_response(worlds)
 
 async def updates_raw(request):
     """

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -129,7 +129,6 @@ async def updates(request):
     """
     num_queries = get_num_queries(request)
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
-    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['db_session'].begin() as sess:
@@ -144,7 +143,6 @@ async def updates_raw(request):
     """
     num_queries = get_num_queries(request)
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
-    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['pg'].acquire() as conn:

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -117,8 +117,8 @@ async def fortunes_raw(request):
     """
     async with request.app['pg'].acquire() as conn:
         fortunes = await conn.fetch('SELECT * FROM Fortune')
-    fortunes.append(dict(id=0, message='Additional fortune added at request time.'))
-    fortunes.sort(key=itemgetter('message'))
+    fortunes.append(ADDITIONAL_FORTUNE_ROW)
+    fortunes.sort(key=sort_fortunes_raw)
     content = template.render(fortunes=fortunes)
     return Response(text=content, content_type='text/html')
 

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -86,11 +86,10 @@ async def multiple_database_queries_raw(request):
     num_queries = get_num_queries(request)
 
     ids = [randint(1, 10000) for _ in range(num_queries)]
-    ids.sort()
 
     result = []
     async with request.app['pg'].acquire() as conn:
-        stmt = await conn.prepare('SELECT id,randomnumber FROM world WHERE id = $1')
+        stmt = await conn.prepare(READ_ROW_SQL)
         for id_ in ids:
             result.append({
                 'id': id_,

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -14,7 +14,7 @@ ADDITIONAL_FORTUNE_ORM = Fortune(id=0, message='Additional fortune added at requ
 ADDITIONAL_FORTUNE_ROW = {'id': 0, 'message': 'Additional fortune added at request time.'}
 READ_ROW_SQL = 'SELECT "randomnumber", "id" FROM "world" WHERE id = $1'
 READ_SELECT_ORM = select(World.randomnumber)
-WRITE_ROW_SQL = 'UPDATE "world" SET "randomnumber"=$1 WHERE id=$2'
+WRITE_ROW_SQL = 'UPDATE "world" SET "randomnumber"=$2 WHERE id=$1'
 
 json_response = partial(json_response, dumps=ujson.dumps)
 template_path = Path(__file__).parent / 'templates' / 'fortune.jinja'
@@ -129,6 +129,7 @@ async def updates(request):
     """
     num_queries = get_num_queries(request)
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
+    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['db_session'].begin() as sess:
@@ -143,6 +144,7 @@ async def updates_raw(request):
     """
     num_queries = get_num_queries(request)
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
+    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['pg'].acquire() as conn:

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -70,7 +70,6 @@ async def multiple_database_queries_orm(request):
     num_queries = get_num_queries(request)
 
     ids = [randint(1, 10000) for _ in range(num_queries)]
-    ids.sort()
 
     result = []
     async with request.app['db_session']() as sess:

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -129,7 +129,6 @@ async def updates(request):
     """
     num_queries = get_num_queries(request)
     ids = [randint(1, 10000) for _ in range(num_queries)]
-    ids.sort()
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -144,6 +144,7 @@ async def updates_raw(request):
     """
     num_queries = get_num_queries(request)
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
+    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['pg'].acquire() as conn:

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -128,15 +128,14 @@ async def updates(request):
     Test 5 ORM
     """
     num_queries = get_num_queries(request)
-    ids = [randint(1, 10000) for _ in range(num_queries)]
     updates = [(randint(1, 10000), randint(1, 10000)) for _ in range(num_queries)]
+    updates.sort()
     worlds = [{'id': row_id, 'randomNumber': number} for row_id, number in updates]
 
     async with request.app['db_session'].begin() as sess:
-        for id_ in ids:
-            rand_new = randint(1, 10000)
+        for id_, number in updates:
             world = await sess.get(World, id_, populate_existing=True)
-            world.randomnumber = rand_new
+            world.randomnumber = number
     return json_response(worlds)
 
 async def updates_raw(request):

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -106,7 +106,7 @@ async def fortunes(request):
         ret = await sess.execute(select(Fortune.id, Fortune.message))
         fortunes = ret.all()
     fortunes.append(ADDITIONAL_FORTUNE_ORM)
-    fortunes.sort(key=attrgetter('message'))
+    fortunes.sort(key=sort_fortunes_orm)
     content = template.render(fortunes=fortunes)
     return Response(text=content, content_type='text/html')
 

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -74,7 +74,7 @@ async def multiple_database_queries_orm(request):
     result = []
     async with request.app['db_session']() as sess:
         for id_ in ids:
-            num = await sess.scalar(select(World.randomnumber).filter_by(id=id_))
+            num = await sess.scalar(READ_SELECT_ORM.filter_by(id=id_))
             result.append({'id': id_, 'randomNumber': num})
     return json_response(result)
 

--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -105,7 +105,7 @@ async def fortunes(request):
     async with request.app['db_session']() as sess:
         ret = await sess.execute(select(Fortune.id, Fortune.message))
         fortunes = ret.all()
-    fortunes.append(Fortune(id=0, message='Additional fortune added at request time.'))
+    fortunes.append(ADDITIONAL_FORTUNE_ORM)
     fortunes.sort(key=attrgetter('message'))
     content = template.render(fortunes=fortunes)
     return Response(text=content, content_type='text/html')

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -1,9 +1,9 @@
 aiohttp==3.7.4
-asyncpg==0.22.0
+asyncpg==0.23.0
 cchardet==2.1.7
-gunicorn==20.0.4
-jinja2==2.11.3
+gunicorn==20.1
+jinja2==3.0.1
 psycopg2==2.8.6
-SQLAlchemy==1.4.0b3
-ujson==2.0.3
-uvloop==0.14.0
+SQLAlchemy==1.4.18
+ujson==4.0.2
+uvloop==0.15.2


### PR DESCRIPTION
These changes just get the code to match exactly what fastapi is doing, minimising any differences in the code.

For some reason, we need to do `updates.sort()`, otherwise there are deadlock errors. I can't see any reason that fastapi would not have these deadlock errors, given the code is exactly the same, even using the same library for postgres.