### PR TITLE
Bump Finagle and Finatra to latest versions

### DIFF
--- a/frameworks/Scala/finagle/build.sbt
+++ b/frameworks/Scala/finagle/build.sbt
@@ -1,4 +1,4 @@
-lazy val finagleVersion = "21.5.0"
+lazy val finagleVersion = "21.6.0"
 
 name := "finagle-benchmark"
 scalaVersion := "2.12.12"

--- a/frameworks/Scala/finatra/build.sbt
+++ b/frameworks/Scala/finatra/build.sbt
@@ -1,4 +1,4 @@
-lazy val finatraVersion = "21.5.0"
+lazy val finatraVersion = "21.6.0"
 
 name := "techempower-benchmarks-finatra"
 organization := "com.twitter"


### PR DESCRIPTION
This patch bumps Finagle and Finatra to version 21.6.0.