### PR TITLE
Replaced Task.Delay by asynchronous callback

### DIFF
--- a/frameworks/CSharp/appmpower/src/Kestrel/PlainText.cs
+++ b/frameworks/CSharp/appmpower/src/Kestrel/PlainText.cs
@@ -20,7 +20,10 @@ namespace appMpower.Kestrel
          headerDictionary.Add(_headerContentType);
          headerDictionary.Add(new KeyValuePair<string, StringValues>("Content-Length", utf8String.Length.ToString()));
 
-         return await pipeWriter.WriteAsync(utf8String);
+         var result = await pipeWriter.WriteAsync(utf8String);
+         await pipeWriter.FlushAsync();
+
+         return result;
       }
    }
 }


### PR DESCRIPTION
in PooledConnections. This should remove the deadlock situation. 

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
