### PR TITLE
Improved odbc settings and number of connections

### DIFF
--- a/frameworks/CSharp/appmpower/odbcinst.ini
+++ b/frameworks/CSharp/appmpower/odbcinst.ini
@@ -14,4 +14,6 @@ Description=ODBC for PostgreSQL
 ; WARNING: The old psql odbc driver psqlodbc.so is now renamed psqlodbcw.so
 ; in version 08.x. Note that the library can also be installed under an other
 ; path than /usr/local/lib/ following your installation.
-Driver=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
+Driver = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
+Threading = 1
+CPTimeout = 0

--- a/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
@@ -9,7 +9,7 @@ namespace appMpower.Db
    {
       private static bool _connectionsCreated = false;
       private static byte _createdConnections = 0;
-      private static byte _maxConnections = Math.Min((byte)Environment.ProcessorCount, (byte)21);
+      private static byte _maxConnections = 144; //Math.Min((byte)Environment.ProcessorCount, (byte)21);
       private static ConcurrentStack<PooledConnection> _stack = new ConcurrentStack<PooledConnection>();
       private static ConcurrentQueue<TaskCompletionSource<PooledConnection>> _waitingQueue = new ConcurrentQueue<TaskCompletionSource<PooledConnection>>();
 

--- a/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
@@ -9,7 +9,7 @@ namespace appMpower.Db
    {
       private static bool _connectionsCreated = false;
       private static byte _createdConnections = 0;
-      private static byte _maxConnections = 144; //Math.Min((byte)Environment.ProcessorCount, (byte)21);
+      private static byte _maxConnections = 255; //Math.Min((byte)Environment.ProcessorCount, (byte)21);
       private static ConcurrentStack<PooledConnection> _stack = new ConcurrentStack<PooledConnection>();
       private static ConcurrentQueue<TaskCompletionSource<PooledConnection>> _waitingQueue = new ConcurrentQueue<TaskCompletionSource<PooledConnection>>();
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
