### PR TITLE
Use Cutelyst binary instead of Cutelyst server (for later LTO)

### DIFF
--- a/frameworks/C++/cutelyst/cutelyst-pf-apg-batch.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-pf-apg-batch.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=$(nproc) \

--- a/frameworks/C++/cutelyst/cutelyst-pf-apg.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-pf-apg.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=$(nproc) \

--- a/frameworks/C++/cutelyst/cutelyst-pf-my.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-pf-my.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=$(nproc) \

--- a/frameworks/C++/cutelyst/cutelyst-pf-pg.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-pf-pg.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=$(nproc) \

--- a/frameworks/C++/cutelyst/cutelyst-t-apg-cutelee.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-t-apg-cutelee.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-apg-batch.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-apg-batch.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-apg.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-apg.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-my-cutelee.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-my-cutelee.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-my.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-my.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-pg-cutelee.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-pg-cutelee.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread-pg.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread-pg.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|Driver=.*|Driver=${DRIVER}|g" /cutelyst.ini
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst-thread.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst-thread.dockerfile
@@ -29,7 +29,7 @@ ENV CPU_AFFINITY 1
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=${C_PROCESSES} \

--- a/frameworks/C++/cutelyst/cutelyst.dockerfile
+++ b/frameworks/C++/cutelyst/cutelyst.dockerfile
@@ -29,7 +29,7 @@ ENV CPU_AFFINITY 1
 
 EXPOSE 8080
 
-CMD cutelyst-wsgi2 \
+CMD ${TROOT}/build/cutelyst-benchmarks \
     --ini /cutelyst.ini:uwsgi \
     --application ${CUTELYST_APP} \
     --processes=$(nproc) \


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
