### PR TITLE
Increased number of database connections

### DIFF
--- a/frameworks/CSharp/appmpower/src/Db/PooledConnection.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnection.cs
@@ -9,7 +9,7 @@ namespace appMpower.Db
    public class PooledConnection : IDbConnection
    {
       private bool _isInUse = true;
-      private byte _number = 0;
+      private short _number = 0;
       private OdbcConnection _odbcConnection;
       private ConcurrentDictionary<string, PooledCommand> _pooledCommands;
 
@@ -47,7 +47,7 @@ namespace appMpower.Db
          }
       }
 
-      public byte Number
+      public short Number
       {
          get
          {
@@ -182,11 +182,10 @@ namespace appMpower.Db
          else
          {
             pooledCommand.OdbcCommand = new OdbcCommand(commandText, this.OdbcConnection);
+            pooledCommand.OdbcCommand.Prepare();
             pooledCommand.PooledConnection = this;
-            _pooledCommands.TryAdd(commandText, pooledCommand);
 
             //Console.WriteLine("prepare pool connection: " + this._number + " for command " + _pooledCommands.Count);
-            pooledCommand.OdbcCommand.Prepare();
          }
 
          return pooledCommand;

--- a/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
@@ -8,8 +8,8 @@ namespace appMpower.Db
    public static class PooledConnections
    {
       private static bool _connectionsCreated = false;
-      private static byte _createdConnections = 0;
-      private static byte _maxConnections = 255; //Math.Min((byte)Environment.ProcessorCount, (byte)21);
+      private static short _createdConnections = 0;
+      private static short _maxConnections = 512; //Math.Min((byte)Environment.ProcessorCount, (byte)21);
       private static ConcurrentStack<PooledConnection> _stack = new ConcurrentStack<PooledConnection>();
       private static ConcurrentQueue<TaskCompletionSource<PooledConnection>> _waitingQueue = new ConcurrentQueue<TaskCompletionSource<PooledConnection>>();
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
