### PR TITLE
[Ubiquity] Fix roadrunner images

### DIFF
--- a/frameworks/PHP/ubiquity/README.md
+++ b/frameworks/PHP/ubiquity/README.md
@@ -49,9 +49,9 @@ The tests are separated into controllers:
 
 ## Important Libraries
 The tests were run with:
-* [Ubiquity 2.3.*](https://ubiquity.kobject.net/)
-* [PHP Version 7.4.*](http://www.php.net/) with FPM
-* [nginx 1.14](http://nginx.org/)
+* [Ubiquity 2.4.*](https://ubiquity.kobject.net/)
+* [PHP Version 8.0.*](http://www.php.net/) with FPM
+* [nginx](http://nginx.org/)
 * [Swoole](https://www.swoole.com/), [Ubiquity-swoole](https://github.com/phpMv/ubiquity-swoole)
 * [Workerman](https://github.com/walkor/Workerman), [Ubiquity-workerman](https://github.com/phpMv/ubiquity-workerman)
 * [Roadrunner](https://github.com/spiral/roadrunner), [Roadrunner-ubiquity](https://github.com/Lapinskas/roadrunner-ubiquity)

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.8
+ENV NGINX_VERSION=1.21.0
 
 RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 ADD ./ ./
 
-ENV NGINX_VERSION=1.19.8
+ENV NGINX_VERSION=1.21.0
 
 RUN git clone -b v0.0.25 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
@@ -25,7 +25,7 @@ RUN deploy/run/install-composer.sh
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git unzip > /dev/null
 
-RUN php composer.phar require lapinskas/roadrunner-ubiquity:dev-master --quiet
+RUN php composer.phar require lapinskas/roadrunner-ubiquity:1.1.1 --quiet
 
 RUN vendor/bin/rr get
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
@@ -27,7 +27,7 @@ RUN deploy/run/install-composer.sh
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git unzip > /dev/null
 
-RUN php composer.phar require lapinskas/roadrunner-ubiquity:dev-master --quiet
+RUN php composer.phar require lapinskas/roadrunner-ubiquity:1.1.1 --quiet
 
 RUN vendor/bin/rr get
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -yqq > /dev/null && \
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
-RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY deploy/conf/php-async.ini /etc/php/8.0/cli/php.ini
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -yqq > /dev/null && \
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
-RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY deploy/conf/php-async.ini /etc/php/8.0/cli/php.ini
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -yqq > /dev/null && \
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
-RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY deploy/conf/php-async.ini /etc/php/8.0/cli/php.ini
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -yqq > /dev/null && \
 RUN apt-get install -yqq composer > /dev/null
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
-RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
+RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY deploy/conf/php-async.ini /etc/php/8.0/cli/php.ini
 


### PR DESCRIPTION
### Updated
- Fix `ubiquity-roadrunner` (revert to roadrunner 1 with Roadrunner-ubiquity 1.1.1) see https://github.com/Lapinskas/roadrunner-ubiquity/issues/28
- Update event to 3.0.5 for Workerman versions
- Update nginx to 1.21.0 for ngx versions
