### PR TITLE
Fix xitca-web test

### DIFF
--- a/frameworks/Rust/xitca-web/Cargo.toml
+++ b/frameworks/Rust/xitca-web/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "065b21b" }
-xitca-web = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "065b21b" }
+xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
+xitca-web = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
 
 ahash = { version = "0.7.4", features = ["compile-time-rng"] }
 atoi = "0.4.0"
@@ -26,6 +26,6 @@ codegen-units = 1
 panic = "abort"
 
 [patch.crates-io]
-xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "065b21b" }
-xitca-server = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "065b21b" }
-xitca-service = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "065b21b" }
+xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
+xitca-server = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
+xitca-service = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }

--- a/frameworks/Rust/xitca-web/Cargo.toml
+++ b/frameworks/Rust/xitca-web/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
-xitca-web = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
+xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "0f4ab88883ac5656403154ab82284117f289d897" }
+xitca-web = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "0f4ab88883ac5656403154ab82284117f289d897" }
 
 ahash = { version = "0.7.4", features = ["compile-time-rng"] }
 atoi = "0.4.0"
@@ -26,6 +26,6 @@ codegen-units = 1
 panic = "abort"
 
 [patch.crates-io]
-xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
-xitca-server = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
-xitca-service = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "ffb3dd1ef154b549be664e37dc2ff5b67681cabe" }
+xitca-http = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "0f4ab88883ac5656403154ab82284117f289d897" }
+xitca-server = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "0f4ab88883ac5656403154ab82284117f289d897" }
+xitca-service = { git = "https://github.com/fakeshadow/xitca-web.git", rev = "0f4ab88883ac5656403154ab82284117f289d897" }

--- a/frameworks/Rust/xitca-web/xitca-web.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web.dockerfile
@@ -6,9 +6,9 @@ ADD ./ /xitca-web
 WORKDIR /xitca-web
 
 RUN cargo clean
+RUN rustup default nightly-2021-07-26
 RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 EXPOSE 8080
 
 CMD ./target/release/xitca-web
-


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Fix build failure caused by nightly Rust regression.