### PR TITLE
Cutelyst: More picojson usage and a timer instead of a route to updat…

### DIFF
--- a/frameworks/C++/cutelyst/src/CMakeLists.txt
+++ b/frameworks/C++/cutelyst/src/CMakeLists.txt
@@ -5,7 +5,7 @@ project(cutelyst_benchmarks LANGUAGES CXX)
 cmake_policy(SET CMP0069 NEW)
 
 find_package(Qt5 5.6.0 REQUIRED COMPONENTS Core Network Sql)
-find_package(ASqlQt5 0.15.0 REQUIRED)
+find_package(ASqlQt5 0.43.0 REQUIRED)
 find_package(Cutelyst2Qt5 2.12 REQUIRED)
 find_package(Cutelee5 REQUIRED)
 find_package(PostgreSQL REQUIRED)
@@ -18,7 +18,7 @@ set(CMAKE_AUTOMOC ON)
 # to always look for includes there:
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(GLOB_RECURSE TEMPLATES_SRC root/*)

--- a/frameworks/C++/cutelyst/src/singledatabasequerytest.cpp
+++ b/frameworks/C++/cutelyst/src/singledatabasequerytest.cpp
@@ -11,6 +11,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include "picojson.h"
+
 SingleDatabaseQueryTest::SingleDatabaseQueryTest(QObject *parent) : Controller(parent)
 {
 
@@ -26,10 +28,11 @@ void SingleDatabaseQueryTest::dbp(Context *c)
                            {id}, [c, async] (AResult &result) {
         if (Q_LIKELY(!result.error() && result.size())) {
             auto it = result.begin();
-            c->response()->setJsonObjectBody({
-                                                 {QStringLiteral("id"), it[0].toInt()},
-                                                 {QStringLiteral("randomNumber"), it[1].toInt()}
-                                             });
+            c->response()->setJsonBody(QByteArray::fromStdString(
+                            picojson::value(picojson::object({
+                                                {"id", picojson::value(double(it[0].toInt()))},
+                                                {"randomNumber", picojson::value(double(it[1].toInt()))}
+                                            })).serialize()));
             return;
         }
 


### PR DESCRIPTION
…e the date

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
