### PR TITLE
use db.getSiblingDB in mongo create.js

### DIFF
--- a/toolset/databases/mongodb/create.js
+++ b/toolset/databases/mongodb/create.js
@@ -1,4 +1,4 @@
-use hello_world
+db = db.getSiblingDB('hello_world')
 db.world.drop()
 for (var i = 1; i <= 10000; i++) {
   db.world.save( { _id: i, id: i, randomNumber: Math.min(Math.floor(Math.random() * 10000) + 1, 10000) })


### PR DESCRIPTION
When running mongodb.dockerfile locally on windows, I noticed that it was creating a database named test instead of hello_world which caused all of the validations to fail when run.

I changed the create.js script to use db.getSiblingDb("hello_world") instead of use hello_world and that resolved the issue. This should work identically in all cases where it was already working.

https://docs.mongodb.com/manual/reference/method/db.getSiblingDB/