### PR TITLE
Bumping up number of workers

### DIFF
--- a/frameworks/Prolog/SWI-Prolog/app/server.pl
+++ b/frameworks/Prolog/SWI-Prolog/app/server.pl
@@ -14,7 +14,7 @@
 server(Port) :-
     odbc_set_option(connection_pooling(true)),
     current_prolog_flag(cpu_count, Cores),
-    Workers is 8 * Cores,
+    Workers is 256 * Cores,
     http_server(http_dispatch, [workers(Workers), port(Port), timeout(30)]).
 
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
