### PR TITLE
Update php to Ubuntu 21.04

### DIFF
--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/comet/comet-mysql.dockerfile
+++ b/frameworks/PHP/comet/comet-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/comet/comet.dockerfile
+++ b/frameworks/PHP/comet/comet.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/duckphp/duckphp.dockerfile
+++ b/frameworks/PHP/duckphp/duckphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ENV PHP_VERSION 8.0
 ARG DEBIAN_FRONTEND=noninteractive

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/mark/mark.dockerfile
+++ b/frameworks/PHP/mark/mark.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 COPY ./ ./
 

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/reactphp/reactphp.dockerfile
+++ b/frameworks/PHP/reactphp/reactphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/webman/webman.dockerfile
+++ b/frameworks/PHP/webman/webman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/yii2/yii2-raw.dockerfile
+++ b/frameworks/PHP/yii2/yii2-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:21.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Ubuntu 20.10 EOL

And actually Odrej  automated PHP builds, don't support EOL versions.
The last 3 runs in Citrine failed almost all PHP frameworks for that.

We can use the 20.04 LTS.
But we will test the new kernel 5.11 in Ubuntu 21.04, with the FSGSBASE support to improve context switch performance on x86 processors.
That theoretically will help Intel/AMD CPU performance that had been hurt badly by Spectre/Meltdown and other CPU vulnerability mitigations largely on the Intel side.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
