### PR TITLE
Revert PHP to ubuntu 20.04

### DIFF
--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
     php8.0-fpm php8.0-mysql php8.0-xml php8.0-mbstring php8.0-intl > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 COPY deploy/conf/* /etc/php/8.0/cli/

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql php8.0-xml php8.0-mbstring php8.0-intl > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/codeigniter/codeigniter.dockerfile
+++ b/frameworks/PHP/codeigniter/codeigniter.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/comet/comet-mysql.dockerfile
+++ b/frameworks/PHP/comet/comet-mysql.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-xml php8.0-mysql  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/comet/comet-mysql.dockerfile
+++ b/frameworks/PHP/comet/comet-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/comet/comet.dockerfile
+++ b/frameworks/PHP/comet/comet.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/comet/comet.dockerfile
+++ b/frameworks/PHP/comet/comet.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/duckphp/duckphp.dockerfile
+++ b/frameworks/PHP/duckphp/duckphp.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
     php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/duckphp/duckphp.dockerfile
+++ b/frameworks/PHP/duckphp/duckphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -14,7 +14,7 @@ WORKDIR /fat-free
 
 ENV F3DIR="/fat-free/src"
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 

--- a/frameworks/PHP/fat-free/fat-free-raw.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /fat-free
 ENV F3DIR="/fat-free/src"
 
 #RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 #RUN git clone -b 3.7.2 --single-branch --depth 1 "https://github.com/bcosca/fatfree-core.git" src

--- a/frameworks/PHP/fat-free/fat-free.dockerfile
+++ b/frameworks/PHP/fat-free/fat-free.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql php8.0-xml php8.0-mbstring php7.0-mcrypt  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/fuel/fuel.dockerfile
+++ b/frameworks/PHP/fuel/fuel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ENV PHP_VERSION 8.0
 ARG DEBIAN_FRONTEND=noninteractive

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip curl \
     php${PHP_VERSION}-cli php${PHP_VERSION}-fpm php${PHP_VERSION}-apcu php${PHP_VERSION}-pdo-mysql > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 ADD ./ /app
 WORKDIR /app

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-mysql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp-workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
+++ b/frameworks/PHP/kumbiaphp/kumbiaphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
     php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 RUN apt-get install -yqq php8.0-mbstring php8.0-xml  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
     php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 RUN apt-get install -yqq php8.0-mbstring php8.0-xml  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/lumen/lumen.dockerfile
+++ b/frameworks/PHP/lumen/lumen.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/mark/mark.dockerfile
+++ b/frameworks/PHP/mark/mark.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/mark/mark.dockerfile
+++ b/frameworks/PHP/mark/mark.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php8.0-dev libevent-dev git > /dev/null
 RUN pecl install event-3.0.2 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
  
 COPY php.ini /etc/php/8.0/cli/php.ini

--- a/frameworks/PHP/mark/mark.dockerfile
+++ b/frameworks/PHP/mark/mark.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
     php7.4-cli php7.4-fpm php7.4-mysql php7.4-mbstring > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/7.4/fpm/
 

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
         php7.4-cli php7.4-fpm php7.4-mysql php7.4-mbstring php7.4-mongodb > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/7.4/fpm/
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
     php7.4-cli php7.4-fpm php7.4-mysql php7.4-mbstring > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/7.4/fpm/
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  php8.0-mbstring > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/php/php-eloquent.dockerfile
+++ b/frameworks/PHP/php/php-eloquent.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-h2o.dockerfile
+++ b/frameworks/PHP/php/php-h2o.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 COPY ./ ./
 

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  php8.0-mbstring > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/php/php-laravel-query-builder.dockerfile
+++ b/frameworks/PHP/php/php-laravel-query-builder.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pgsql-raw.dockerfile
+++ b/frameworks/PHP/php/php-pgsql-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-pools.dockerfile
+++ b/frameworks/PHP/php/php-pools.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php-raw7-tcp.dockerfile
+++ b/frameworks/PHP/php/php-raw7-tcp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/php/php.dockerfile
+++ b/frameworks/PHP/php/php.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/phpixie/phpixie.dockerfile
+++ b/frameworks/PHP/phpixie/phpixie.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/reactphp/reactphp.dockerfile
+++ b/frameworks/PHP/reactphp/reactphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony-raw.dockerfile
+++ b/frameworks/PHP/symfony/symfony-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
@@ -28,7 +28,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx_php7 > /dev/null && \
     make > /dev/null && make install > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer config -g repo.packagist composer https://packagist.phpcomposer.com
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
@@ -28,7 +28,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx_php7 > /dev/null && \
     make > /dev/null && make install > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer config -g repo.packagist composer https://packagist.phpcomposer.com
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
@@ -28,7 +28,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx_php7 > /dev/null && \
     make > /dev/null && make install > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer config -g repo.packagist composer https://packagist.phpcomposer.com
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0 php8.0-common php8.0-cgi php-curl php8.0-mysql > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
@@ -8,7 +8,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0 php8.0-common php8.0-cgi php8.0-pgsql php-curl > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.0-cli php8.0-mongodb php8.0-xml > /dev/null
+    apt-get install -yqq git php8.0-cli php8.0-mongodb php8.0-xml php8.0-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -8,7 +8,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-mongodb php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-mysql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -5,7 +5,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.0-cli php8.0-mysql php8.0-xml > /dev/null
+    apt-get install -yqq git php8.0-cli php8.0-mysql php8.0-xml php8.0-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -8,7 +8,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
+    apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml php8.0-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -8,7 +8,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.5 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -1,5 +1,5 @@
   
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
+    apt-get install -yqq git php8.0-cli php8.0-pgsql php8.0-xml php8.0-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/ubiquity/ubiquity.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/ubiquity/ubiquity.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/webman/webman.dockerfile
+++ b/frameworks/PHP/webman/webman.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/webman/webman.dockerfile
+++ b/frameworks/PHP/webman/webman.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php8.0-dev libevent-dev git > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY php.ini /etc/php/8.0/cli/php.ini

--- a/frameworks/PHP/webman/webman.dockerfile
+++ b/frameworks/PHP/webman/webman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php7.4-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php7.4-dev libevent-dev git > /dev/null
 RUN pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini
 
 COPY php.ini /etc/php/7.4/cli/php.ini

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php7.4-cli php7.4-mysql  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php7.4-dev libevent-dev > /dev/null
 RUN pecl install event > /dev/null && echo "extension=event.so" > /etc/php/7.4/cli/conf.d/event.ini

--- a/frameworks/PHP/workerman/workerman-async.dockerfile
+++ b/frameworks/PHP/workerman/workerman-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php8.0-dev libevent-dev git > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
 
 COPY php.ini /etc/php/8.0/cli/php.ini

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php8.0-dev libevent-dev git > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
  
 COPY php-jit.ini /etc/php/8.0/cli/php.ini

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-pgsql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
+RUN apt-get install -y php-pear php8.0-dev libevent-dev git > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini
  
 COPY php.ini /etc/php/8.0/cli/php.ini

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq php8.0-cli php8.0-mysql php8.0-xml > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php8.0-dev libevent-dev > /dev/null
 RUN pecl install event-3.0.4 > /dev/null && echo "extension=event.so" > /etc/php/8.0/cli/conf.d/event.ini

--- a/frameworks/PHP/yii2/yii2-raw.dockerfile
+++ b/frameworks/PHP/yii2/yii2-raw.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql php8.0-mbstring  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/yii2/yii2-raw.dockerfile
+++ b/frameworks/PHP/yii2/yii2-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php8.0 php8.0-common php8.0-cli php8.0-fpm php8.0-mysql php8.0-mbstring  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/8.0/fpm/
 

--- a/frameworks/PHP/yii2/yii2.dockerfile
+++ b/frameworks/PHP/yii2/yii2.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/frameworks/PHP/zend/zend.dockerfile
+++ b/frameworks/PHP/zend/zend.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip php7.4 php7.4-common php7.4-cli php7.4-fpm php7.4-mysql  > /dev/null
 RUN apt-get install -yqq php7.4-xml php7.4-mbstring  > /dev/null
 
-RUN apt-get install -yqq composer > /dev/null
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 COPY deploy/conf/* /etc/php/7.4/fpm/
 


### PR DESCRIPTION
Till #6591 is fixed.

When fixed, we will try the new kernel.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
