### PR TITLE
downgrade [xitca-web] to rust 1.53 docker image

### DIFF
--- a/frameworks/Rust/xitca-web/xitca-web-diesel.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web-diesel.dockerfile
@@ -1,6 +1,4 @@
-FROM rust:1.54
-
-RUN apt-get update -yqq && apt-get install -yqq cmake g++
+FROM rust:1.53
 
 ADD ./ /xitca-web
 WORKDIR /xitca-web

--- a/frameworks/Rust/xitca-web/xitca-web.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web.dockerfile
@@ -1,6 +1,4 @@
-FROM rust:1.54
-
-RUN apt-get update -yqq && apt-get install -yqq cmake g++
+FROM rust:1.53
 
 ADD ./ /xitca-web
 WORKDIR /xitca-web


### PR DESCRIPTION
Potential fix for Citrine run.
