### PR TITLE
Hummingbird: Fortunes optimisation, plus minor DB optimisations

### DIFF
--- a/frameworks/Swift/hummingbird/src-postgres/Package.swift
+++ b/frameworks/Swift/hummingbird/src-postgres/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", .upToNextMinor(from: "0.13.1")),
-        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird-mustache.git", from: "1.0.1"),
         .package(url: "https://github.com/vapor/postgres-kit.git", from: "2.3.0"),
     ],
     targets: [

--- a/frameworks/Swift/hummingbird/src-postgres/Sources/server/Controllers/FortunesController.swift
+++ b/frameworks/Swift/hummingbird/src-postgres/Sources/server/Controllers/FortunesController.swift
@@ -27,7 +27,7 @@ class FortunesController {
         return request.db.query("SELECT id, message FROM Fortune").map { results in
             var fortunes = results.map {
                 return Fortune(
-                    id: $0.column("id")?.int32 ?? 0,
+                    id: $0.column("id")?.int32,
                     message: $0.column("message")?.string ?? ""
                 )
             }

--- a/frameworks/Swift/hummingbird/src-postgres/Sources/server/Controllers/WorldController.swift
+++ b/frameworks/Swift/hummingbird/src-postgres/Sources/server/Controllers/WorldController.swift
@@ -9,13 +9,14 @@ class WorldController {
     }
 
     func single(request: HBRequest) -> EventLoopFuture<World> {
-        request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
-            PostgresData(int32: .random(in: 1...10_000))
+        let id = Int32.random(in: 1...10_000)
+        return request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
+            PostgresData(int32: id)
         ]).flatMapThrowing { result -> World in
             guard let firstResult = result.first else { throw HBHTTPError(.notFound) }
             return World(
-                id: firstResult.column("id")?.int32 ?? 0,
-                randomNumber: firstResult.column("randomnumber")?.int ?? 0
+                id: id,
+                randomNumber: firstResult.column("randomnumber")?.int32 ?? 0
             )
         }
     }
@@ -23,13 +24,14 @@ class WorldController {
     func multiple(request: HBRequest) -> EventLoopFuture<[World]> {
         let queries = (request.uri.queryParameters.get("queries", as: Int.self) ?? 1).bound(1, 500)
         let futures: [EventLoopFuture<World>] = (0 ..< queries).map { _ -> EventLoopFuture<World> in
-            request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
-                PostgresData(int32: .random(in: 1...10_000))
+            let id = Int32.random(in: 1...10_000)
+            return request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
+                PostgresData(int32: id)
             ]).flatMapThrowing { result -> World in
                 guard let firstResult = result.first else { throw HBHTTPError(.notFound) }
                 return World(
-                    id: firstResult.column("id")?.int32 ?? 0,
-                    randomNumber: firstResult.column("randomnumber")?.int ?? 0
+                    id: id,
+                    randomNumber: firstResult.column("randomnumber")?.int32 ?? 0
                 )
             }
         }
@@ -40,18 +42,17 @@ class WorldController {
         let queries = (request.uri.queryParameters.get("queries", as: Int.self) ?? 1).bound(1, 500)
         let ids = (0 ..< queries).map { _ in Int32.random(in: 1...10_000) }
         let futures: [EventLoopFuture<World>] = ids.map { _ -> EventLoopFuture<World> in
-            request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
-                PostgresData(int32: .random(in: 1...10_000))
+            let id = Int32.random(in: 1...10_000)
+            let randomNumber = Int32.random(in: 1...10_000)
+            return request.db.query("SELECT id, randomnumber FROM World WHERE id = $1", [
+                PostgresData(int32: id)
             ]).flatMap { result in
-                guard let firstResult = result.first else { return request.failure(.notFound) }
-                let id = firstResult.column("id")?.int32 ?? 0
-                let randomNumber = Int32.random(in: 1...10_000)
                 return request.db.query("UPDATE World SET randomnumber = $1 WHERE id = $2", [
                     PostgresData(int32: randomNumber),
                     PostgresData(int32: id)
-                ]).map { ($0, World(id: id, randomNumber: numericCast(randomNumber))) }
-            }.map { (result: PostgresQueryResult, world) in
-                return world
+                ])
+            }.map { _ in
+                return World(id: id, randomNumber: randomNumber)
             }
         }
         return EventLoopFuture.whenAllSucceed(futures, on: request.eventLoop)

--- a/frameworks/Swift/hummingbird/src-postgres/Sources/server/Models/Fortune.swift
+++ b/frameworks/Swift/hummingbird/src-postgres/Sources/server/Models/Fortune.swift
@@ -1,7 +1,21 @@
 import Hummingbird
+import HummingbirdMustache
 
 struct Fortune: HBResponseEncodable {
     var id: Int32?
     var message: String
 }
 
+// avoid using Mirror as it is expensive
+extension Fortune: HBMustacheParent {
+    func child(named: String) -> Any? {
+        switch named {
+        case "id":
+            return id
+        case "message":
+            return message
+        default:
+            return nil
+        }
+    }
+}

--- a/frameworks/Swift/hummingbird/src-postgres/Sources/server/Models/World.swift
+++ b/frameworks/Swift/hummingbird/src-postgres/Sources/server/Models/World.swift
@@ -2,6 +2,6 @@ import Hummingbird
 
 struct World: HBResponseEncodable {
     var id: Int32?
-    var randomNumber: Int
+    var randomNumber: Int32
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Don't rely on `Mirror` to extract data out of `Fortune`