### PR TITLE
Set backlog for Hummingbird/HummingbirdCore

### DIFF
--- a/frameworks/Swift/hummingbird-core/src/Sources/server/main.swift
+++ b/frameworks/Swift/hummingbird-core/src/Sources/server/main.swift
@@ -48,6 +48,7 @@ func runApp() throws {
     let configuration = HBHTTPServer.Configuration(
         address: .hostname(serverHostName, port: serverPort),
         serverName: "hb-core",
+        backlog: 8192,
         withPipeliningAssistance: false
     )
 

--- a/frameworks/Swift/hummingbird/src/Sources/server/main.swift
+++ b/frameworks/Swift/hummingbird/src/Sources/server/main.swift
@@ -13,6 +13,7 @@ func runApp() throws {
     let configuration = HBApplication.Configuration(
         address: .hostname(serverHostName, port: serverPort),
         serverName: "Hummingbird",
+        backlog: 8192,
         enableHttpPipelining: false
     )
     let app = HBApplication(configuration: configuration)


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
