### PR TITLE
use JSON.generate to generate JSON for JSON benchmark rendering plain…

### DIFF
--- a/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
+++ b/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
@@ -11,7 +11,7 @@ class HelloWorldController < ApplicationController
   end
 
   def json
-    render json: { message: 'Hello, World!' }
+    render json: JSON.generate({message: 'Hello, World!'})
   end
 
   def db


### PR DESCRIPTION
Use faster `JSON.generate()` to generate the JSON object since slower, implicit `to_json` isn't necessary.