### PR TITLE
[hamlet] Update to php 8.1

### DIFF
--- a/frameworks/PHP/hamlet/benchmark_config.json
+++ b/frameworks/PHP/hamlet/benchmark_config.json
@@ -15,7 +15,7 @@
       "database": "mysql",
       "framework": "hamlet",
       "language": "PHP",
-      "flavor": "PHP8",
+      "flavor": "PHP8.1",
       "orm": "micro",
       "platform": "FPM/FastCGI",
       "webserver": "nginx",

--- a/frameworks/PHP/hamlet/hamlet.dockerfile
+++ b/frameworks/PHP/hamlet/hamlet.dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:20.04
 
-ENV PHP_VERSION 8.0
+ENV PHP_VERSION 8.1
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip curl \
-    php${PHP_VERSION}-cli php${PHP_VERSION}-fpm php${PHP_VERSION}-apcu php${PHP_VERSION}-pdo-mysql > /dev/null
+    php${PHP_VERSION}-cli php${PHP_VERSION}-fpm php${PHP_VERSION}-apcu php${PHP_VERSION}-pdo-mysql php${PHP_VERSION}-dev > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 


### PR DESCRIPTION
Ok with `fpm/fastcgi` #6894

With workerman fail PARALLEL:

```
/parallel/src/runtime.c: In function 'zm_startup_PARALLEL_RUNTIME':
hamlet-workerman: /parallel/src/runtime.c:161:42: error: 'zend_class_serialize_deny' undeclared (first use in this function); did you mean 'zend_ce_serializable'?
hamlet-workerman:   161 |     php_parallel_runtime_ce->serialize = zend_class_serialize_deny;
hamlet-workerman:       |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~
hamlet-workerman:       |                                          zend_ce_serializable
hamlet-workerman: /parallel/src/runtime.c:161:42: note: each undeclared identifier is reported only once for each function it appears in
hamlet-workerman: /parallel/src/runtime.c:162:44: error: 'zend_class_unserialize_deny' undeclared (first use in this function); did you mean 'zend_unserialize_data'?                                                                                                                 
hamlet-workerman:   162 |     php_parallel_runtime_ce->unserialize = zend_class_unserialize_deny;                                          
hamlet-workerman:       |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
hamlet-workerman:       |                                            zend_unserialize_data
hamlet-workerman: make: *** [Makefile:213: src/runtime.lo] Error 1

```