### PR TITLE
[lapis] Fix json route and update openresty to v1.19.9.1

### DIFF
--- a/frameworks/Lua/lapis/benchmark_config.json
+++ b/frameworks/Lua/lapis/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "lapis",
   "tests": [{
     "default": {
-      "json_url": "/",
+      "json_url": "/json",
       "db_url": "/db",
       "query_url": "/queries?queries=",
       "fortune_url": "/fortunes",

--- a/frameworks/Lua/lapis/lapis.dockerfile
+++ b/frameworks/Lua/lapis/lapis.dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial
+FROM buildpack-deps:focal
 
 ENV LUA_VERSION="5.1"
 ENV LUA_MICRO="5"
@@ -33,7 +33,7 @@ RUN cd $LUAROCKS && \
     ./configure --prefix=$LUA_HOME --with-lua=$LUA_HOME && \
     make --quiet bootstrap
 
-ENV OPENRESTY_VERSION="1.11.2.1"
+ENV OPENRESTY_VERSION="1.19.9.1"
 ENV OPENRESTY=/openresty
 ENV OPENRESTY_HOME=$OPENRESTY-$OPENRESTY_VERSION
 

--- a/frameworks/Lua/lapis/web.lua
+++ b/frameworks/Lua/lapis/web.lua
@@ -97,7 +97,7 @@ local Benchmark
 do
   local _parent_0 = lapis.Application
   local _base_0 = {
-    ["/"] = function(self)
+    ["/json"] = function(self)
       return {
         json = {
           message = "Hello, World!"


### PR DESCRIPTION
Fix:
`Route for json must be at least 5 characters, found '/' instead`

And update to Ubuntu focal and Openresty to last version.
