### PR TITLE
Enable Giraffe .NET 6 optimizations

### DIFF
--- a/frameworks/FSharp/giraffe/giraffe-newtonsoft.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-newtonsoft.dockerfile
@@ -5,6 +5,12 @@ RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
+
+# Full PGO
+ENV DOTNET_TieredPGO 1 
+ENV DOTNET_TC_QuickJitForLoops 1 
+ENV DOTNET_ReadyToRun 0
+
 WORKDIR /app
 COPY --from=build /app/out ./
 

--- a/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe-utf8json.dockerfile
@@ -5,6 +5,12 @@ RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
+
+# Full PGO
+ENV DOTNET_TieredPGO 1 
+ENV DOTNET_TC_QuickJitForLoops 1 
+ENV DOTNET_ReadyToRun 0
+
 WORKDIR /app
 COPY --from=build /app/out ./
 

--- a/frameworks/FSharp/giraffe/giraffe.dockerfile
+++ b/frameworks/FSharp/giraffe/giraffe.dockerfile
@@ -5,6 +5,12 @@ RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 ENV ASPNETCORE_URLS http://+:8080
+
+# Full PGO
+ENV DOTNET_TieredPGO 1 
+ENV DOTNET_TC_QuickJitForLoops 1 
+ENV DOTNET_ReadyToRun 0
+
 WORKDIR /app
 COPY --from=build /app/out ./
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

This enables some optimizations that are available in .NET 6 now that we have updated.