### PR TITLE
Bump Giraffe version and clear logging providers

### DIFF
--- a/frameworks/FSharp/giraffe/src/App/App.fsproj
+++ b/frameworks/FSharp/giraffe/src/App/App.fsproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Giraffe" Version="6.0.0-alpha-1" />
+    <PackageReference Include="Giraffe" Version="6.0.0-alpha-2" />
     <PackageReference Include="Npgsql" Version="6.0.0" />
   </ItemGroup>
 

--- a/frameworks/FSharp/giraffe/src/App/Program.fs
+++ b/frameworks/FSharp/giraffe/src/App/Program.fs
@@ -117,7 +117,7 @@ module Main =
             | [| "utf8" |]       -> Utf8
             | _                  -> System
 
-        printfn "Running with %A JSON serializer" jsonMode
+        printfn $"Running with %A{jsonMode} JSON serializer"
 
         let jsonSerializer =
             match jsonMode with
@@ -131,27 +131,19 @@ module Main =
                 NewtonsoftJson.Serializer(NewtonsoftJson.Serializer.DefaultSettings)
                 :> Json.ISerializer
 
-        let configureApp (appBuilder : IApplicationBuilder) =
-            appBuilder
-                .UseRouting()
-                .UseGiraffe HttpHandlers.endpoints
-            |> ignore
-
-        let configureServices (services : IServiceCollection) =
-            services
-                .AddRouting()
-                .AddGiraffe()
-                .AddSingleton(jsonSerializer)
-            |> ignore
-
         let builder = WebApplication.CreateBuilder(args)
+
+        builder.Services
+            .AddSingleton(jsonSerializer)
+            .AddGiraffe() |> ignore
+            
         builder.Logging.ClearProviders() |> ignore
-        
-        configureServices builder.Services
 
         let app = builder.Build()
 
-        configureApp app
-        app.Run()
+        app.UseRouting()
+           .UseGiraffe HttpHandlers.endpoints |> ignore
 
+        app.Run()
+        
         0

--- a/frameworks/FSharp/giraffe/src/App/Program.fs
+++ b/frameworks/FSharp/giraffe/src/App/Program.fs
@@ -106,7 +106,8 @@ module Main =
     open Microsoft.Extensions.DependencyInjection
     open Giraffe
     open Giraffe.EndpointRouting
-    open Microsoft.Extensions.Hosting    
+    open Microsoft.Extensions.Hosting
+    open Microsoft.Extensions.Logging
 
     [<EntryPoint>]    
     let main args =
@@ -144,6 +145,8 @@ module Main =
             |> ignore
 
         let builder = WebApplication.CreateBuilder(args)
+        builder.Logging.ClearProviders() |> ignore
+        
         configureServices builder.Services
 
         let app = builder.Build()


### PR DESCRIPTION
Change to mirror the old WebHostBuilder behavior which has no logging by default, this is the likely culprit for our perf drop in https://www.techempower.com/benchmarks/#section=test&runid=939169a8-6a56-44ae-9e50-0e714753c445. 

Testing this locally brings perf back up from 3k rps to 60k which is around what our 5.0 version does for me locally.