### PR TITLE
bump alpine & OCaml version in use for httpaf framework

### DIFF
--- a/frameworks/OCaml/httpaf/httpaf.dockerfile
+++ b/frameworks/OCaml/httpaf/httpaf.dockerfile
@@ -1,17 +1,42 @@
 # -*- mode: dockerfile -*-
 
-FROM ocurrent/opam:alpine-3.12-ocaml-4.11
+FROM alpine:3.15
 
+# https://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html
+# https://linux.die.net/man/1/ocamlrun
+# https://blog.janestreet.com/memory-allocator-showdown/
+ENV OCAMLRUNPARAM a=2,o=240
+
+RUN apk add --no-cache \
+    bash\
+    bubblewrap\
+    coreutils\
+    gcc\
+    git\
+    libev-dev\
+    libffi-dev\
+    linux-headers\
+    m4\
+    make\
+    musl-dev\
+    opam\
+    postgresql-dev
+
+RUN opam init\
+    --disable-sandboxing\
+    --auto-setup\
+    --compiler ocaml-base-compiler.4.13.1
+
+RUN opam install -y opam-depext
 RUN \
-  opam depext dune conf-libev httpaf httpaf-lwt-unix lwt yojson && \
-  opam install dune conf-libev httpaf httpaf-lwt-unix lwt yojson
+  opam depext -y dune conf-libev httpaf httpaf-lwt-unix lwt yojson && \
+  opam install -y dune conf-libev httpaf httpaf-lwt-unix lwt yojson
 
 COPY . /app
 
 WORKDIR /app
 
 RUN \
-  sudo chown -R opam: . && \
   eval $(opam env) && \
   dune build --release httpaf_unix.exe
 


### PR DESCRIPTION
* Bumps alpine from 3.12 to 3.15
* Bumps OCaml from 4.11 to 4.13.1
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
