### PR TITLE
Adding framework name as per issue 6466

### DIFF
--- a/frameworks/CSharp/appmpower/benchmark_config.json
+++ b/frameworks/CSharp/appmpower/benchmark_config.json
@@ -1,5 +1,5 @@
 {
-  "framework": "appmpower",
+  "framework": "appMpower",
   "tests": [
     {
       "default": {
@@ -9,7 +9,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "None",
-        "framework": "ASP.NET Core",
+        "framework": "appMpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",
@@ -31,7 +31,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "Postgres",
-        "framework": "ASP.NET Core",
+        "framework": "appMpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",
@@ -53,7 +53,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "MySQL",
-        "framework": "ASP.NET Core",
+        "framework": "appMpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",

--- a/frameworks/CSharp/appmpower/benchmark_config.json
+++ b/frameworks/CSharp/appmpower/benchmark_config.json
@@ -1,5 +1,5 @@
 {
-  "framework": "appMpower",
+  "framework": "appmpower",
   "tests": [
     {
       "default": {
@@ -9,7 +9,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "None",
-        "framework": "appMpower",
+        "framework": "appmpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",
@@ -31,7 +31,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "Postgres",
-        "framework": "appMpower",
+        "framework": "appmpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",
@@ -53,7 +53,7 @@
         "approach": "Realistic",
         "classification": "Platform",
         "database": "MySQL",
-        "framework": "appMpower",
+        "framework": "appmpower",
         "language": "C#",
         "orm": "Raw",
         "platform": ".NET",


### PR DESCRIPTION
According to issue #6466, the framework name should be unique to show up in the composite scores

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
