### PR TITLE
Disable SSL in .NET Npgsql

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.json
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
+  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
   "Database": "postgresql"
 }

--- a/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.updates.json
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/appsettings.postgresql.updates.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
+  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
   "Database": "postgresql"
 }

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/appsettings.postgresql.json
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/appsettings.postgresql.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
+  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",
   "Database": "postgresql"
 }

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/appsettings.postgresql.updates.json
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/appsettings.postgresql.updates.json
@@ -1,4 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",  
+  "ConnectionString": "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000",  
   "Database": "postgresql"
 }


### PR DESCRIPTION
The recently-released Npgsql 6.0 prefers SSL if the server supports it; this PR disables that.

/cc @sebastienros @vonzshik @NinoFloris