### PR TITLE
Update Jester to use latest httpbeast

### DIFF
--- a/frameworks/Nim/jester/techempower.nimble
+++ b/frameworks/Nim/jester/techempower.nimble
@@ -13,5 +13,5 @@ skipExt = @["nim"]
 requires "nim >= 1.0.0"
 
 # We lock dependencies here on purpose.
-requires "httpbeast#v0.2.2"
+requires "httpbeast#v0.4.0"
 requires "jester 0.5.0"


### PR DESCRIPTION
Similar to https://github.com/TechEmpower/FrameworkBenchmarks/pull/6978 but updates Jester's locked versions so it uses the latest httpbeast.