### PR TITLE
upgrade rust to version 1.58.1 to build may-minihttp

### DIFF
--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.51
+FROM rust:1.58.1
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 


### PR DESCRIPTION
update to use 1.58.1 stable rust to build the may-minihttp
fix the build broken issue