### PR TITLE
Fix bracket in ASP.NET Core "display_name"

### DIFF
--- a/frameworks/CSharp/aspnetcore/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore/benchmark_config.json
@@ -169,7 +169,7 @@
       "webserver": "Kestrel",
       "os": "Linux",
       "database_os": "Linux",
-      "display_name": "ASP.NET Core {Middleware, Pg, Dapper]",
+      "display_name": "ASP.NET Core [Middleware, Pg, Dapper]",
       "notes": "",
       "versus": "aspcore-ado-pg"
     },


### PR DESCRIPTION
Fixes bracket in ASP.NET Core display_name: `{` => `[`.