### PR TITLE
Fix setup for the Python framework fastapi

### DIFF
--- a/frameworks/Python/fastapi/app.py
+++ b/frameworks/Python/fastapi/app.py
@@ -3,7 +3,7 @@ import asyncpg
 import os
 import jinja2
 from fastapi import FastAPI
-from starlette.responses import HTMLResponse, UJSONResponse, PlainTextResponse
+from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
 from random import randint
 from operator import itemgetter
 from urllib.parse import parse_qs
@@ -13,6 +13,19 @@ READ_ROW_SQL = 'SELECT "randomnumber", "id" FROM "world" WHERE id = $1'
 WRITE_ROW_SQL = 'UPDATE "world" SET "randomnumber"=$1 WHERE id=$2'
 ADDITIONAL_ROW = [0, 'Additional fortune added at request time.']
 
+
+# https://www.starlette.io/responses/#custom-json-serialization
+try:
+    import orjson
+
+    class CustomJSONResponse(JSONResponse):
+        def render(self, content):
+            return orjson.dumps(content)
+
+except ImportError:
+
+    class CustomJSONResponse(JSONResponse):
+        pass
 
 
 async def setup_database():
@@ -58,7 +71,7 @@ app = FastAPI()
 
 @app.get('/json')
 async def json_serialization():
-    return UJSONResponse({'message': 'Hello, world!'})
+    return CustomJSONResponse({'message': 'Hello, world!'})
 
 
 @app.get('/db')
@@ -68,7 +81,7 @@ async def single_database_query():
     async with connection_pool.acquire() as connection:
         number = await connection.fetchval(READ_ROW_SQL, row_id)
 
-    return UJSONResponse({'id': row_id, 'randomNumber': number})
+    return CustomJSONResponse({'id': row_id, 'randomNumber': number})
 
 
 @app.get('/queries')
@@ -84,7 +97,7 @@ async def multiple_database_queries(queries = None):
             number = await statement.fetchval(row_id)
             worlds.append({'id': row_id, 'randomNumber': number})
 
-    return UJSONResponse(worlds)
+    return CustomJSONResponse(worlds)
 
 
 @app.get('/fortunes')
@@ -110,7 +123,7 @@ async def database_updates(queries = None):
             await statement.fetchval(row_id)
         await connection.executemany(WRITE_ROW_SQL, updates)
 
-    return UJSONResponse(worlds)
+    return CustomJSONResponse(worlds)
 
 
 @app.get('/plaintext')

--- a/frameworks/Python/fastapi/requirements-orjson.txt
+++ b/frameworks/Python/fastapi/requirements-orjson.txt
@@ -1,6 +1,7 @@
 asyncpg==0.21.0
 gunicorn==20.0.4
 Jinja2==2.11.3
+markupsafe==2.0.1
 fastapi==0.65.2
 orjson==2.6.5
 uvicorn==0.11.3

--- a/frameworks/Python/fastapi/requirements.txt
+++ b/frameworks/Python/fastapi/requirements.txt
@@ -1,6 +1,7 @@
 asyncpg==0.21.0
 gunicorn==20.0.4
 Jinja2==2.11.3
+markupsafe==2.0.1
 ujson==2.0.3
 uvloop==0.14.0
 uvicorn==0.11.3


### PR DESCRIPTION
## Issue 1

https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

```
fastapi: [2022-03-05 14:12:53 +0000] [11] [ERROR] Exception in worker process
fastapi: Traceback (most recent call last):
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
fastapi:     worker.init_process()
fastapi:   File "/usr/local/lib/python3.8/site-packages/uvicorn/workers.py", line 57, in init_process
fastapi:     super(UvicornWorker, self).init_process()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 119, in init_process
fastapi:     self.load_wsgi()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi
fastapi:     self.wsgi = self.app.wsgi()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
fastapi:     self.callable = self.load()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
fastapi:     return self.load_wsgiapp()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
fastapi:     return util.import_app(self.app_uri)
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/util.py", line 358, in import_app
fastapi:     mod = importlib.import_module(module)
fastapi:   File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
fastapi:     return _bootstrap._gcd_import(name[level:], package, level)
fastapi:   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
fastapi:   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
fastapi:   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
fastapi:   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
fastapi:   File "<frozen importlib._bootstrap_external>", line 843, in exec_module
fastapi:   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
fastapi:   File "/fastapi/app.py", line 4, in <module>
fastapi:     import jinja2
fastapi:   File "/usr/local/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
fastapi:     from .environment import Environment
fastapi:   File "/usr/local/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
fastapi:     from .defaults import BLOCK_END_STRING
fastapi:   File "/usr/local/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
fastapi:     from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
fastapi:   File "/usr/local/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
fastapi:     from markupsafe import soft_unicode
fastapi: ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.8/site-packages/markupsafe/__init__.py)
fastapi: ERROR: Framework is not accepting requests from client machine
fastapi: Total test time: 16s
tfb: Total time building so far: 0s
tfb: Total time verifying so far: 0s
tfb: Total execution time so far: 21s
```

-----

## Issue 2

https://github.com/encode/starlette/blob/master/docs/release-notes.md#0141

```
fastapi: [2022-03-05 14:25:31 +0000] [16] [ERROR] Exception in worker process
fastapi: Traceback (most recent call last):
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
fastapi:     worker.init_process()
fastapi:   File "/usr/local/lib/python3.8/site-packages/uvicorn/workers.py", line 57, in init_process
fastapi:     super(UvicornWorker, self).init_process()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 119, in init_process
fastapi:     self.load_wsgi()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/workers/base.py", line 144, in load_wsgi
fastapi:     self.wsgi = self.app.wsgi()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/base.py", line 67, in wsgi
fastapi:     self.callable = self.load()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 49, in load
fastapi:     return self.load_wsgiapp()
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/app/wsgiapp.py", line 39, in load_wsgiapp
fastapi:     return util.import_app(self.app_uri)
fastapi:   File "/usr/local/lib/python3.8/site-packages/gunicorn/util.py", line 358, in import_app
fastapi:     mod = importlib.import_module(module)
fastapi:   File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
fastapi:     return _bootstrap._gcd_import(name[level:], package, level)
fastapi:   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
fastapi:   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
fastapi:   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
fastapi:   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
fastapi:   File "<frozen importlib._bootstrap_external>", line 843, in exec_module
fastapi:   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
fastapi:   File "/fastapi/app.py", line 6, in <module>
fastapi:     from starlette.responses import HTMLResponse, UJSONResponse, PlainTextResponse
fastapi: ImportError: cannot import name 'UJSONResponse' from 'starlette.responses' (/usr/local/lib/python3.8/site-packages/starlette/responses.py)
fastapi: ERROR: Framework is not accepting requests from client machine
fastapi: Total test time: 1m 30s
tfb: Total time building so far: 1m 14s
tfb: Total time verifying so far: 0s
tfb: Total execution time so far: 1m 35s
```