### PR TITLE
Update fastify (node version)

### DIFF
--- a/frameworks/JavaScript/fastify/fastify-mysql.dockerfile
+++ b/frameworks/JavaScript/fastify/fastify-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2
+FROM node:16.14.0
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/fastify/fastify-postgres.dockerfile
+++ b/frameworks/JavaScript/fastify/fastify-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2
+FROM node:16.14.0
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/fastify/fastify.dockerfile
+++ b/frameworks/JavaScript/fastify/fastify.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13.2
+FROM node:16.14.0
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/fastify/package.json
+++ b/frameworks/JavaScript/fastify/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "private": true,
   "dependencies": {
-    "fastify": "3.12.0",
+    "fastify": "3.27.4",
     "handlebars": "4.7.6",
     "knex": "0.21.17",
     "mongodb": "3.5.9",


### PR DESCRIPTION
Changes the following for fastify:

- Update node version for fastify
- Update fastify to v3.27.4