### PR TITLE
More standard connection handling + no custom pooling for ADO

### DIFF
--- a/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
@@ -1,39 +1,39 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS build
 RUN apt-get update
 RUN apt-get -yqq install clang zlib1g-dev libkrb5-dev libtinfo5
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-   libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-   xz-utils tk-dev libffi-dev liblzma-dev pgpool2 vim-tiny
+#RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+#   libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+#   xz-utils tk-dev libffi-dev liblzma-dev pgpool2 vim-tiny
 
-WORKDIR /odbc
+#WORKDIR /odbc
 
 # To compile the latest postgresql odbc driver, postgresql itself needs to be installed
-RUN curl -L -o postgresql-14.1.tar.gz https://ftp.postgresql.org/pub/source/v14.1/postgresql-14.1.tar.gz
-RUN curl -L -o unixODBC-2.3.9.tar.gz ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.9.tar.gz
-RUN curl -L -o psqlodbc-13.02.0000.tar.gz https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-13.02.0000.tar.gz
+#RUN curl -L -o postgresql-14.1.tar.gz https://ftp.postgresql.org/pub/source/v14.1/postgresql-14.1.tar.gz
+#RUN curl -L -o unixODBC-2.3.9.tar.gz ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.9.tar.gz
+#RUN curl -L -o psqlodbc-13.02.0000.tar.gz https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-13.02.0000.tar.gz
 
-RUN tar -xvf postgresql-14.1.tar.gz
-RUN tar -xvf unixODBC-2.3.9.tar.gz
-RUN tar -xvf psqlodbc-13.02.0000.tar.gz
+#RUN tar -xvf postgresql-14.1.tar.gz
+#RUN tar -xvf unixODBC-2.3.9.tar.gz
+#RUN tar -xvf psqlodbc-13.02.0000.tar.gz
 
-WORKDIR /odbc/postgresql-14.1
-RUN ./configure
-RUN make
-RUN make install
+#WORKDIR /odbc/postgresql-14.1
+#RUN ./configure
+#RUN make
+#RUN make install
 
-ENV PATH=/usr/local/pgsql/bin:$PATH
+#ENV PATH=/usr/local/pgsql/bin:$PATH
 
-WORKDIR /odbc/unixODBC-2.3.9
-RUN ./configure --prefix=/usr/local/unixODBC
-RUN make
-RUN make install
+#WORKDIR /odbc/unixODBC-2.3.9
+#RUN ./configure --prefix=/usr/local/unixODBC
+#RUN make
+#RUN make install
 
-ENV PATH=/usr/local/unixODBC/lib:$PATH
+#ENV PATH=/usr/local/unixODBC/lib:$PATH
 
-WORKDIR /odbc/psqlodbc-13.02.0000
-RUN ./configure --with-unixodbc=/usr/local/unixODBC --with-libpq=/usr/local/pgsql --prefix=/usr/local/pgsqlodbc
-RUN make
-RUN make install
+#WORKDIR /odbc/psqlodbc-13.02.0000
+#RUN ./configure --with-unixodbc=/usr/local/unixODBC --with-libpq=/usr/local/pgsql --prefix=/usr/local/pgsqlodbc
+#RUN make
+#RUN make install
 
 WORKDIR /app
 COPY src .
@@ -44,29 +44,29 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0.0 AS runtime
 
 RUN apt-get update
 # The following installs standard versions unixodbc 2.3.6 and pgsqlodbc 11
-#RUN apt-get install -y unixodbc odbc-postgresql
+RUN apt-get install -y unixodbc odbc-postgresql
 # unixodbc still needs to be installed even if compiled locally
-RUN apt-get install -y unixodbc wget curl libpq-dev build-essential
+#RUN apt-get install -y unixodbc wget curl libpq-dev build-essential
 
-WORKDIR /odbc
+#WORKDIR /odbc
 
-RUN curl -L -o pgpool-II-4.2.3.tar.gz https://www.pgpool.net/mediawiki/download.php?f=pgpool-II-4.2.3.tar.gz
-RUN tar -xvf pgpool-II-4.2.3.tar.gz
+#RUN curl -L -o pgpool-II-4.2.3.tar.gz https://www.pgpool.net/mediawiki/download.php?f=pgpool-II-4.2.3.tar.gz
+#RUN tar -xvf pgpool-II-4.2.3.tar.gz
 
-WORKDIR /odbc/pgpool-II-4.2.3
-RUN ./configure
-RUN make
-RUN make install
+#WORKDIR /odbc/pgpool-II-4.2.3
+#RUN ./configure
+#RUN make
+#RUN make install
 
-COPY --from=build /usr/local/unixODBC /usr/local/unixODBC
+#COPY --from=build /usr/local/unixODBC /usr/local/unixODBC
 
 # Check unixODBC version by: 
 # 1. Logging into containter: docker run --rm -it --entrypoint=/bin/bash techempower/tfb.test.appmpower
 # 2. odbcinst  --version
 
-ENV PATH=/usr/local/unixODBC/bin:$PATH
+#ENV PATH=/usr/local/unixODBC/bin:$PATH
 
-COPY --from=build /usr/local/pgsqlodbc /usr/local/pgsqlodbc
+#COPY --from=build /usr/local/pgsqlodbc /usr/local/pgsqlodbc
 
 WORKDIR /etc/
 COPY odbcinst.ini .

--- a/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
@@ -1,19 +1,19 @@
 FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS build
 RUN apt-get update
 RUN apt-get -yqq install clang zlib1g-dev libkrb5-dev libtinfo5
-#RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-#   libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-#   xz-utils tk-dev libffi-dev liblzma-dev pgpool2 vim-tiny
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+   libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+   xz-utils tk-dev libffi-dev liblzma-dev pgpool2 vim-tiny
 
-#WORKDIR /odbc
+WORKDIR /odbc
 
 # To compile the latest postgresql odbc driver, postgresql itself needs to be installed
 #RUN curl -L -o postgresql-14.1.tar.gz https://ftp.postgresql.org/pub/source/v14.1/postgresql-14.1.tar.gz
-#RUN curl -L -o unixODBC-2.3.9.tar.gz ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.9.tar.gz
+RUN curl -L -o unixODBC-2.3.9.tar.gz ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-2.3.9.tar.gz
 #RUN curl -L -o psqlodbc-13.02.0000.tar.gz https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-13.02.0000.tar.gz
 
 #RUN tar -xvf postgresql-14.1.tar.gz
-#RUN tar -xvf unixODBC-2.3.9.tar.gz
+RUN tar -xvf unixODBC-2.3.9.tar.gz
 #RUN tar -xvf psqlodbc-13.02.0000.tar.gz
 
 #WORKDIR /odbc/postgresql-14.1
@@ -23,12 +23,12 @@ RUN apt-get -yqq install clang zlib1g-dev libkrb5-dev libtinfo5
 
 #ENV PATH=/usr/local/pgsql/bin:$PATH
 
-#WORKDIR /odbc/unixODBC-2.3.9
-#RUN ./configure --prefix=/usr/local/unixODBC
-#RUN make
-#RUN make install
+WORKDIR /odbc/unixODBC-2.3.9
+RUN ./configure --prefix=/usr/local/unixODBC
+RUN make
+RUN make install
 
-#ENV PATH=/usr/local/unixODBC/lib:$PATH
+ENV PATH=/usr/local/unixODBC/lib:$PATH
 
 #WORKDIR /odbc/psqlodbc-13.02.0000
 #RUN ./configure --with-unixodbc=/usr/local/unixODBC --with-libpq=/usr/local/pgsql --prefix=/usr/local/pgsqlodbc
@@ -48,7 +48,7 @@ RUN apt-get install -y unixodbc odbc-postgresql
 # unixodbc still needs to be installed even if compiled locally
 #RUN apt-get install -y unixodbc wget curl libpq-dev build-essential
 
-#WORKDIR /odbc
+WORKDIR /odbc
 
 #RUN curl -L -o pgpool-II-4.2.3.tar.gz https://www.pgpool.net/mediawiki/download.php?f=pgpool-II-4.2.3.tar.gz
 #RUN tar -xvf pgpool-II-4.2.3.tar.gz
@@ -58,13 +58,13 @@ RUN apt-get install -y unixodbc odbc-postgresql
 #RUN make
 #RUN make install
 
-#COPY --from=build /usr/local/unixODBC /usr/local/unixODBC
+COPY --from=build /usr/local/unixODBC /usr/local/unixODBC
 
 # Check unixODBC version by: 
 # 1. Logging into containter: docker run --rm -it --entrypoint=/bin/bash techempower/tfb.test.appmpower
 # 2. odbcinst  --version
 
-#ENV PATH=/usr/local/unixODBC/bin:$PATH
+ENV PATH=/usr/local/unixODBC/bin:$PATH
 
 #COPY --from=build /usr/local/pgsqlodbc /usr/local/pgsqlodbc
 

--- a/frameworks/CSharp/appmpower/odbcinst.ini
+++ b/frameworks/CSharp/appmpower/odbcinst.ini
@@ -16,8 +16,8 @@ Description=ODBC for PostgreSQL
 ; in version 08.x. Note that the library can also be installed under an other
 ; path than /usr/local/lib/ following your installation.
 ; This is the standard location used by apt-get install -y unixodbc
-;Driver = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
-Driver =/usr/local/pgsqlodbc/lib/psqlodbcw.so
+Driver = /usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so
+;Driver =/usr/local/pgsqlodbc/lib/psqlodbcw.so
 Threading = 0
 CPTimeout = 0
 

--- a/frameworks/CSharp/appmpower/src/Db/DataProvider.cs
+++ b/frameworks/CSharp/appmpower/src/Db/DataProvider.cs
@@ -5,8 +5,8 @@ namespace appMpower.Db
 #if MYSQL
       public const string ConnectionString = "Driver={MariaDB};Server=tfb-database;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;Pooling=false;OPTIONS=67108864;FLAG_FORWARD_CURSOR=1"; 
 #elif ADO
-      public const string ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=8;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
-      //public const string ConnectionString = "Server=localhost;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=9;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
+      public const string ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
+      //public const string ConnectionString = "Server=localhost;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
 #else
       public const string ConnectionString = "Driver={PostgreSQL};Server=tfb-database;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;UseServerSidePrepare=1;Pooling=false";
       //public const string ConnectionString = "Driver={PostgreSQL};Server=localhost;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;UseServerSidePrepare=1;Pooling=false";

--- a/frameworks/CSharp/appmpower/src/Db/InternalConnection.cs
+++ b/frameworks/CSharp/appmpower/src/Db/InternalConnection.cs
@@ -1,0 +1,16 @@
+using System.Collections.Concurrent;
+using System.Data;
+
+namespace appMpower.Db
+{
+   public class InternalConnection : System.IDisposable
+   {
+      public short Number { get; set; }
+      public IDbConnection DbConnection { get; set; }
+      public ConcurrentDictionary<string, PooledCommand> PooledCommands { get; set; }
+
+      public void Dispose()
+      {
+      }
+   }
+}

--- a/frameworks/CSharp/appmpower/src/Db/PooledCommand.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledCommand.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace appMpower.Db
@@ -17,7 +16,12 @@ namespace appMpower.Db
 
       public PooledCommand(string commandText, PooledConnection pooledConnection)
       {
-         pooledConnection.GetCommand(commandText, this);
+         pooledConnection.GetCommand(commandText, CommandType.Text, this);
+      }
+
+      public PooledCommand(string commandText, CommandType commandType, PooledConnection pooledConnection)
+      {
+         pooledConnection.GetCommand(commandText, commandType, this);
       }
 
       internal PooledCommand(IDbCommand dbCommand, PooledConnection pooledConnection)
@@ -143,6 +147,11 @@ namespace appMpower.Db
          return _dbCommand.CreateParameter();
       }
 
+      public IDbDataParameter CreateParameter(string name, object value)
+      {
+         return CreateParameter(name, DbType.String, value);
+      }
+
       public IDbDataParameter CreateParameter(string name, DbType dbType, object value)
       {
          IDbDataParameter dbDataParameter = null;
@@ -177,12 +186,12 @@ namespace appMpower.Db
 
       public async Task<int> ExecuteNonQueryAsync()
       {
-         return await (_dbCommand as DbCommand).ExecuteNonQueryAsync();
+         return await (_dbCommand as System.Data.Common.DbCommand).ExecuteNonQueryAsync();
       }
 
-      public async Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+      public async Task<System.Data.Common.DbDataReader> ExecuteReaderAsync(CommandBehavior behavior)
       {
-         return await (_dbCommand as DbCommand).ExecuteReaderAsync(behavior);
+         return await (_dbCommand as System.Data.Common.DbCommand).ExecuteReaderAsync(behavior);
       }
 
       public IDataReader ExecuteReader(CommandBehavior behavior)
@@ -197,14 +206,16 @@ namespace appMpower.Db
       }
 #nullable disable
 
+#nullable enable
+      public async Task<object?> ExecuteScalarAsync()
+      {
+         return await ((System.Data.Common.DbCommand)_dbCommand).ExecuteScalarAsync();
+      }
+#nullable disable
+
       public void Prepare()
       {
          _dbCommand.Prepare();
-      }
-
-      public void Release()
-      {
-         _pooledConnection.ReleaseCommand(this);
       }
 
       public void Dispose()

--- a/frameworks/CSharp/appmpower/src/appMpower.ado
+++ b/frameworks/CSharp/appmpower/src/appMpower.ado
@@ -17,7 +17,7 @@
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Npgsql" Version="6.0.3" />
+      <PackageReference Include="Npgsql" Version="6.0.2" />
       <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
    </ItemGroup>
 

--- a/frameworks/CSharp/appmpower/src/appMpower.ado
+++ b/frameworks/CSharp/appmpower/src/appMpower.ado
@@ -17,7 +17,7 @@
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Npgsql" Version="6.0.2" />
+      <PackageReference Include="Npgsql" Version="6.0.3" />
       <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
    </ItemGroup>
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
