### PR TITLE
[symfony-swoole] Add broken tag

### DIFF
--- a/frameworks/PHP/symfony/benchmark_config.json
+++ b/frameworks/PHP/symfony/benchmark_config.json
@@ -65,7 +65,8 @@
       "database_os": "Linux",
       "display_name": "symfony-swoole",
       "notes": "",
-      "versus": "swoole"
+      "versus": "swoole",
+      "tags": ["broken"]
     }
   }]
 }


### PR DESCRIPTION
https://github.com/k911/swoole-bundle
`This repository has been archived by the owner. It is now read-only.`

@jderusse Could you fix it ?
I try my best to fix it.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
