### PR TITLE
Added NoResetOnClose to ADO conn + remove recreation of InternalConnection

### DIFF
--- a/frameworks/CSharp/appmpower/src/Db/DataProvider.cs
+++ b/frameworks/CSharp/appmpower/src/Db/DataProvider.cs
@@ -5,8 +5,8 @@ namespace appMpower.Db
 #if MYSQL
       public const string ConnectionString = "Driver={MariaDB};Server=tfb-database;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;Pooling=false;OPTIONS=67108864;FLAG_FORWARD_CURSOR=1"; 
 #elif ADO
-      public const string ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
-      //public const string ConnectionString = "Server=localhost;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000";
+      public const string ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000"; 
+      //public const string ConnectionString = "Server=localhost;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;SSL Mode=Disable;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000"; 
 #else
       public const string ConnectionString = "Driver={PostgreSQL};Server=tfb-database;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;UseServerSidePrepare=1;Pooling=false";
       //public const string ConnectionString = "Driver={PostgreSQL};Server=localhost;Database=hello_world;Uid=benchmarkdbuser;Pwd=benchmarkdbpass;UseServerSidePrepare=1;Pooling=false";

--- a/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
+++ b/frameworks/CSharp/appmpower/src/Db/PooledConnections.cs
@@ -55,17 +55,6 @@ namespace appMpower.Db
          return taskCompletionSource.Task;
       }
 
-      public static void Dispose(PooledConnection pooledConnection)
-      {
-         InternalConnection internalConnection = new InternalConnection();
-
-         internalConnection.DbConnection = pooledConnection.DbConnection;
-         internalConnection.Number = pooledConnection.Number;
-         internalConnection.PooledCommands = pooledConnection.PooledCommands;
-
-         Release(internalConnection);
-      }
-
       public static void Release(InternalConnection internalConnection)
       {
          TaskCompletionSource<InternalConnection> taskCompletionSource;


### PR DESCRIPTION
…Connecton objects

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
