### PR TITLE
Update Maven Dependencies in Microhttp Java Test

### DIFF
--- a/frameworks/Java/microhttp/README.md
+++ b/frameworks/Java/microhttp/README.md
@@ -9,7 +9,7 @@
 
 The tests were run with:
 * [OpenJDK 17.0.2](http://openjdk.java.net/)
-* [Microhttp 0.6](https://github.com/ebarlas/microhttp)
+* [Microhttp 0.7](https://github.com/ebarlas/microhttp)
 * [Jackson 2.13.2](https://github.com/FasterXML/jackson)
 
 ## Test URLs

--- a/frameworks/Java/microhttp/README.md
+++ b/frameworks/Java/microhttp/README.md
@@ -9,8 +9,8 @@
 
 The tests were run with:
 * [OpenJDK 17.0.2](http://openjdk.java.net/)
-* [Microhttp 0.3](https://github.com/ebarlas/microhttp)
-* [Jackson 2.13.1](https://github.com/FasterXML/jackson)
+* [Microhttp 0.6](https://github.com/ebarlas/microhttp)
+* [Jackson 2.13.2](https://github.com/FasterXML/jackson)
 
 ## Test URLs
 ### JSON

--- a/frameworks/Java/microhttp/pom.xml
+++ b/frameworks/Java/microhttp/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.microhttp</groupId>
             <artifactId>microhttp</artifactId>
-            <version>0.6</version>
+            <version>0.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/frameworks/Java/microhttp/pom.xml
+++ b/frameworks/Java/microhttp/pom.xml
@@ -11,9 +11,6 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <microhttp.version>0.4</microhttp.version>
-        <jackson.version>2.13.2</jackson.version>
-        <junit.version>5.8.2</junit.version>
     </properties>
 
     <packaging>jar</packaging>
@@ -22,23 +19,23 @@
         <dependency>
             <groupId>org.microhttp</groupId>
             <artifactId>microhttp</artifactId>
-            <version>${microhttp.version}</version>
+            <version>0.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.13.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.2</version>
-            <scope>${junit.version}</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/frameworks/Java/microhttp/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/microhttp/src/main/java/hello/HelloWebServer.java
@@ -51,7 +51,7 @@ public class HelloWebServer {
                 .withMaxRequestSize(1_024 * 1_024)
                 .withReadBufferSize(1_024 * 64)
                 .withResolution(Duration.ofMillis(1_000))
-                .withSocketTimeout(Duration.ofSeconds(90));
+                .withRequestTimeout(Duration.ofSeconds(90));
         EventLoop eventLoop = new EventLoop(options, new DisabledLogger(), this::handle);
         eventLoop.start();
     }
@@ -95,7 +95,7 @@ public class HelloWebServer {
         }
     }
 
-    byte[] jsonBody() {
+    static byte[] jsonBody() {
         try {
             return OBJECT_MAPPER.writeValueAsBytes(new JsonMessage(MESSAGE));
         } catch (IOException e) {


### PR DESCRIPTION
The PR includes dependency updates for the Microhttp Java test.

It also changes the way dependency versions are organized. Dependency versions are now configured inline rather than with Maven properties.

Dependabot isn't able to reason about versions managed via Maven properties.

See https://github.com/TechEmpower/FrameworkBenchmarks/issues/7282