### PR TITLE
Don't reuse shared message instance

### DIFF
--- a/frameworks/Java/redkale/src/main/java/org/redkalex/benchmark/Message.java
+++ b/frameworks/Java/redkale/src/main/java/org/redkalex/benchmark/Message.java
@@ -27,7 +27,7 @@ public final class Message {
     }
 
     public static Message create(String str) {
-        Message instance = new Message(str)
+        Message instance = new Message(str);
         return instance;
     }
 

--- a/frameworks/Java/redkale/src/main/java/org/redkalex/benchmark/Message.java
+++ b/frameworks/Java/redkale/src/main/java/org/redkalex/benchmark/Message.java
@@ -16,8 +16,6 @@ import org.redkale.util.Bean;
 @Bean
 public final class Message {
 
-    private static final Message instance = new Message();
-
     @ConvertSmallString
     private String message;
 
@@ -29,7 +27,7 @@ public final class Message {
     }
 
     public static Message create(String str) {
-        instance.message = str;
+        Message instance = new Message(str)
         return instance;
     }
 


### PR DESCRIPTION
I believe the specs forbid reusing the same instance for json serialization. It's also wrong code-wise since concurrent requests could assign different strings to the same instance.
