### PR TITLE
summary: Add plaintext table parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ Results of continuous benchmarking runs are available in real time [here](https:
 
 If you have a `results.json` file that you would like to visualize, you can [do that here](https://tfb-status.techempower.com/share). You can also attach a `runid` parameter to that url where `runid` is a run listed on [tfb-status](https://tfb-status.techempower.com) like so: https://www.techempower.com/benchmarks/#section=test&runid=fd07b64e-47ce-411e-8b9b-b13368e988c6
 
+Also, you could run a plaintext result parser on your bash:
+```
+ python3 prettytable_result_parser.py --files  results.json baseline.json --data latencyAvg latencyMax
+ --data slects interested data for you
+ --files is the results.json file used as input
+ 
+ Example output
+ +---------------------------------------------------------------------------------+
+|                         Type: query, Result: latencyAvg                         |
++----------------+------------------------------+---------------------------------+
+| queryIntervals |      spring-baseline.json     |      spring-optimized.json      |
++----------------+------------------------------+---------------------------------+
+|       1        |           33.34ms            |             33.08ms             |
+|       5        |           259.89ms           |             99.70ms             |
+|       10       |           156.09ms           |             185.85ms            |
+|       15       |           165.22ms           |             267.43ms            |
+|       20       |           216.60ms           |             351.01ms            |
++----------------+------------------------------+---------------------------------+
+```
+
 ## Contributing
 
 The community has consistently helped in making these tests better, and we welcome any and all changes. Reviewing our contribution practices and guidelines will help to keep us all on the same page. The [contribution guide](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Development-Contributing-Guide) can be found in the [TFB documentation](https://github.com/TechEmpower/FrameworkBenchmarks/wiki).

--- a/prettytable_result_parser.py
+++ b/prettytable_result_parser.py
@@ -1,0 +1,105 @@
+# -*- coding: UTF-8 -*-
+import json as js
+import os, getopt, argparse
+from prettytable import PrettyTable
+
+workload_lists = ["fortune", "plaintext", "db", "update", "json", "query"]
+result_dict = {}
+# result_dict[workload][test_name + file_name]
+# result_dict[update][netty-20220409082258/results.json] = [ {'latencyAvg': '90.89us', 'latencyMax': '9.24ms'}, ... ]
+connection_level = []
+pipeline = []
+queryIntervals = []
+
+
+def parse_argument():
+    parser = argparse.ArgumentParser(
+        description="Analyse json resluts from FrameWork BenchMark.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        '--files',
+        default=[],
+        nargs='+',
+        help='json result files'
+    )
+    parser.add_argument(
+        '--datas',
+        default=['latencyAvg'],
+        nargs='+',
+        help='interested datas'
+    )
+    args = parser.parse_args()
+    return args
+
+
+def read_files(args):
+    global connection_level
+    global queryIntervals
+    global pipeline
+    for f in args.files:
+        result = open(f)
+        json_text = result.read()
+        json_obj = js.loads(json_text)
+        raw_data = json_obj["rawData"]
+        connection_level = json_obj["concurrencyLevels"]
+        queryIntervals = json_obj["queryIntervals"]
+        pipeline = json_obj["pipelineConcurrencyLevels"]
+        for workload in workload_lists:
+            if (raw_data[workload]):
+                for test_name, test_result in raw_data[workload].items():
+                    update_result(test_name, f, workload, test_result);
+
+
+def update_result(test_name, file_name, workload, test_result):
+    name = test_name + '-' + file_name
+    if workload not in result_dict:
+        result_dict[workload] = {}
+    if name not in result_dict[workload]:
+        result_dict[workload][name] = test_result
+
+
+def print_table(args):
+    for interested_data in args.datas:
+        for k, workload_results in result_dict.items():
+            pt = PrettyTable()
+            pt.title = "Type: " + k + ", Result: " + interested_data
+            pt.field_names = [map_workload_to_field(k)] + list(result_dict[k].keys())
+            for i in range(len(workload_results[next(iter(workload_results))])):
+                data_row = [v[i].get(interested_data) for v in workload_results.values()]
+                pt.add_row([map_workload_to_value(k)[i]] + data_row)
+            print(pt)
+
+def map_workload_to_field(workload):
+    if (workload == 'query'):
+        return 'queryIntervals'
+    elif (workload == 'plaintext'):
+        return 'pipeline'
+    else:
+        return 'concurrencyLevel'
+
+
+def map_workload_to_value(workload):
+    if (workload == 'query'):
+        return queryIntervals
+    elif (workload == 'plaintext'):
+        return pipeline
+    else:
+        return connection_level
+
+
+def toms(s):
+    if s is None:
+        return '0';
+    elif s.find('ms') != -1:
+        return str(s.replace('ms', ''))
+    elif s.find('us') != -1:
+        return str(float(s.replace('us', '')) / 1000)
+    elif s.find('s') != -1:
+        return str(float(s.replace('s', "")) * 1000)
+
+
+if __name__ == "__main__":
+    args = parse_argument()
+    read_files(args)
+    print_table(args)


### PR DESCRIPTION
install: pip3 install prettytable
usage: prettytable_result_parser.py [-h] [--files FILES [FILES ...]]
                                    [--datas DATAS [DATAS ...]]

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
