### PR TITLE
Update Clojure/Aleph

### DIFF
--- a/frameworks/Clojure/aleph/README.md
+++ b/frameworks/Clojure/aleph/README.md
@@ -1,18 +1,18 @@
 # Compojure Benchmarking Test
 
-This is the [Aleph](https://github.com/ztellman/aleph) portion of a [benchmarking test suite](../) comparing a variety of web development platforms.
+This is the [Aleph](https://github.com/clj-commons/aleph) portion of a [benchmarking test suite](../) comparing a variety of web development platforms.
 
 ### JSON Encoding Test
 
-* [JSON test source](hello/src/hello/handler.clj)
+* [JSON test source](src/hello/handler.clj)
 
 ## Infrastructure Software Versions
-The dependencies are documented in [project.clj](hello/project.clj),
+The dependencies are documented in [project.clj](project.clj),
 but the main ones are:
 
-* [Aleph 0.4.5-alpha6](https://github.com/ztellman/aleph)
-* [Clojure 1.9.0](http://clojure.org/)
-* [metosin/jsonista 0.2.0](https://github.com/metosin/jsonista), which in turn uses [Jackson](http://jackson.codehaus.org/)
+* [Aleph 0.4.7](https://github.com/clj-commons/aleph)
+* [Clojure 1.11.0](http://clojure.org/)
+* [metosin/jsonista 0.3.5](https://github.com/metosin/jsonista), which in turn uses [Jackson](http://jackson.codehaus.org/)
 
 ## Test URLs
 ### JSON Encoding Test

--- a/frameworks/Clojure/aleph/aleph.dockerfile
+++ b/frameworks/Clojure/aleph/aleph.dockerfile
@@ -6,4 +6,4 @@ RUN lein uberjar
 
 EXPOSE 8080
 
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "target/hello-aleph-standalone.jar"]
+CMD ["java", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+UseStringDeduplication", "-Djava.net.preferIPv4Stack=true", "-jar", "target/hello-aleph-standalone.jar"]

--- a/frameworks/Clojure/aleph/aleph.dockerfile
+++ b/frameworks/Clojure/aleph/aleph.dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-2.8.1
+FROM clojure:openjdk-17-lein-2.9.8
 WORKDIR /aleph
 COPY src src
 COPY project.clj project.clj
@@ -6,4 +6,4 @@ RUN lein uberjar
 
 EXPOSE 8080
 
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "target/hello-aleph-standalone.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-jar", "target/hello-aleph-standalone.jar"]

--- a/frameworks/Clojure/aleph/project.clj
+++ b/frameworks/Clojure/aleph/project.clj
@@ -1,10 +1,9 @@
 (defproject hello "aleph"
   :description "JSON/plaintext tests"
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [clj-tuple "0.2.2"]
+  :dependencies [[org.clojure/clojure "1.11.0"]
                  [org.clojure/tools.cli "0.3.7"]
-                 [aleph "0.4.5-alpha6"]
-                 [javax.xml.bind/jaxb-api "2.3.0"]
-                 [metosin/jsonista "0.2.0"]]
+                 [aleph "0.4.7"]
+                 [metosin/jsonista "0.3.5"]]
+  :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]
   :main hello.handler
   :aot :all)

--- a/frameworks/Clojure/aleph/src/hello/handler.clj
+++ b/frameworks/Clojure/aleph/src/hello/handler.clj
@@ -1,29 +1,27 @@
 (ns hello.handler
   (:require
-    [byte-streams :as bs]
-    [clojure.tools.cli :as cli]
-    [aleph.http :as http]
-    [jsonista.core :as json]
-    [clj-tuple :as t])
+   [aleph.http        :as http]
+   [aleph.netty       :as netty]
+   [byte-streams      :as bs]
+   [clojure.tools.cli :as cli]
+   [jsonista.core     :as json])
   (:gen-class))
 
 (def plaintext-response
-  (t/hash-map
-    :status 200
-    :headers (t/hash-map "content-type" "text/plain; charset=utf-8")
-    :body (bs/to-byte-array "Hello, World!")))
+  {:status 200
+   :headers {"Content-Type" "text/plain"}
+   :body (bs/to-byte-array "Hello, World!")})
 
 (def json-response
-  (t/hash-map
-    :status 200
-    :headers (t/hash-map "content-type" "application/json")))
+  {:status 200
+   :headers {"Content-Type" "application/json"}})
 
 (defn handler [req]
   (let [uri (:uri req)]
     (cond
       (.equals "/plaintext" uri) plaintext-response
-      (.equals "/json" uri) (assoc json-response
-                              :body (json/write-value-as-bytes (t/hash-map :message "Hello, World!")))
+      (.equals "/json" uri)      (assoc json-response
+                                        :body (json/write-value-as-bytes {:message "Hello, World!"}))
       :else {:status 404})))
 
 ;;;
@@ -41,5 +39,5 @@
       (println banner)
       (System/exit 0))
 
-    (aleph.netty/leak-detector-level! :disabled)
+    (netty/leak-detector-level! :disabled)
     (http/start-server handler {:port port, :executor :none})))


### PR DESCRIPTION
## Description

This PR introduces a couple of changes but is mostly about bumping `aleph`, `clojure` and removing `clj-tuple` which is not used.

Here are the list of the relevant changes:
- Aleph bumped to 0.4.7 from 0.4.5-alpha5
- Clojure bumped to 1.11.0 from 1.9.0
- jsonista bumped to 0.3.5 from 0.2.0 
- clj-tuple has been removed
- JVM bumped to Java 17
- JVM flags have been adapted to match the ones from [reitit](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Clojure/reitit/reitit.dockerfile#L6)
- Links inside this repository have been fixed
- Links to `Aleph` have been changed to reflect its new home