### PR TITLE
Add Pellet framework

### DIFF
--- a/frameworks/Kotlin/pellet/README.md
+++ b/frameworks/Kotlin/pellet/README.md
@@ -1,0 +1,19 @@
+# Pellet
+
+[Pellet](https://www.pellet.dev) is an opinionated, Kotlin-first web framework that helps you write fast, concise, and correct backend services 🚀.
+
+This is a simple set of benchmarks as part of the TechEmpower Web Framework Benchmarks suite.
+
+Currently the suite only includes plaintext and JSON serialization benchmarks.
+
+All routes are contained within the [Benchmark.kt](sample/src/main/kotlin/benchmark/Benchmark.kt) file.
+
+## Test URLs
+
+### JSON
+
+http://localhost:8080/json
+
+### Plaintext
+
+http://localhost:8080/plaintext

--- a/frameworks/Kotlin/pellet/benchmark_config.json
+++ b/frameworks/Kotlin/pellet/benchmark_config.json
@@ -1,0 +1,26 @@
+{
+  "framework": "pellet",
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "None",
+        "framework": "Pellet",
+        "language": "Kotlin",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "None",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Pellet",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/Kotlin/pellet/pellet.dockerfile
+++ b/frameworks/Kotlin/pellet/pellet.dockerfile
@@ -1,0 +1,13 @@
+FROM gradle:jdk18 as gradle
+WORKDIR /sample
+COPY sample/build.gradle.kts build.gradle.kts
+COPY sample/src src
+RUN gradle clean shadowJar --no-daemon
+
+FROM openjdk:18-jdk-buster
+WORKDIR /sample
+COPY --from=gradle /sample/build/libs/sample-1.0.0-all.jar app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-server", "-jar", "app.jar"]

--- a/frameworks/Kotlin/pellet/sample/build.gradle.kts
+++ b/frameworks/Kotlin/pellet/sample/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    application
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+    kotlin("jvm") version "1.6.21"
+    kotlin("plugin.serialization") version "1.6.21"
+}
+
+group = "benchmark"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("dev.pellet:pellet-server:0.0.7")
+    implementation("dev.pellet:pellet-logging:0.0.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    implementation(platform(kotlin("bom")))
+    implementation(kotlin("stdlib-jdk8"))
+    implementation(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.1"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+}
+
+java {
+    toolchain {
+        sourceCompatibility = JavaVersion.VERSION_18
+        targetCompatibility = JavaVersion.VERSION_18
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.jvmTarget = "18"
+}
+
+application {
+    mainClass.set("benchmark.BenchmarkKt")
+}

--- a/frameworks/Kotlin/pellet/sample/src/main/kotlin/benchmark/Benchmark.kt
+++ b/frameworks/Kotlin/pellet/sample/src/main/kotlin/benchmark/Benchmark.kt
@@ -1,0 +1,69 @@
+package benchmark
+
+import dev.pellet.logging.pelletLogger
+import dev.pellet.server.PelletBuilder.httpRouter
+import dev.pellet.server.PelletBuilder.pelletServer
+import dev.pellet.server.PelletConnector
+import dev.pellet.server.codec.mime.MediaType
+import dev.pellet.server.responder.http.PelletHTTPRouteContext
+import dev.pellet.server.routing.http.HTTPRouteResponse
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+object Benchmark
+
+val logger = pelletLogger<Benchmark>()
+
+fun main() = runBlocking {
+    val sharedRouter = httpRouter {
+        get("/plaintext", ::handlePlain)
+        get("/json", ::handleJson)
+    }
+    val pellet = pelletServer {
+        logRequests = false
+        httpConnector {
+            endpoint = PelletConnector.Endpoint(
+                hostname = "0.0.0.0",
+                port = 8080
+            )
+            router = sharedRouter
+        }
+    }
+    pellet.start().join()
+}
+
+val dateFormatter = DateTimeFormatter
+    .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH)
+    .withZone(ZoneId.of("GMT"))
+
+private suspend fun handlePlain(
+    context: PelletHTTPRouteContext
+): HTTPRouteResponse {
+    return HTTPRouteResponse.Builder()
+        .statusCode(200)
+        .entity("Hello, World!", MediaType("text", "plain"))
+        .header("Server", "pellet")
+        .header("Date", dateFormatter.format(Instant.now()))
+        .build()
+}
+
+@kotlinx.serialization.Serializable
+data class ResponseBody(
+    val message: String
+)
+
+private suspend fun handleJson(
+    context: PelletHTTPRouteContext
+): HTTPRouteResponse {
+    val responseBody = ResponseBody(message = "Hello, World!")
+    return HTTPRouteResponse.Builder()
+        .statusCode(200)
+        .jsonEntity(Json, responseBody)
+        .header("Server", "pellet")
+        .header("Date", dateFormatter.format(Instant.now()))
+        .build()
+}


### PR DESCRIPTION
Adds `plaintext` and `json` benchmarks for the [Pellet](https://www.pellet.dev) framework, using `./tfb --new`.

Verification passes on my fork: https://github.com/CarrotCodes/FrameworkBenchmarks/actions/runs/2286170377

Please let me know if there's anything else you need 😄 