### PR TITLE
Quarkus: fix and refactoring for Fortunes benchmark

### DIFF
--- a/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -47,7 +47,6 @@ public class WorldRepository {
         }
     }
 
-    @Transactional
     public void updateAll(Collection<World> worlds) {
         try (Session s = sf.openSession()) {
             s.setJdbcBatchSize(worlds.size());

--- a/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/resource/DbResource.java
+++ b/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/resource/DbResource.java
@@ -30,9 +30,7 @@ public class DbResource {
     @GET
     @Path("/db")
     public World db() {
-        World world = randomWorldForRead();
-        if (world==null) throw new IllegalStateException( "No data found in DB. Did you seed the database? Make sure to invoke /createdata once." );
-        return world;
+        return worldRepository.findSingleAndStateless(randomWorldNumber());
     }
 
     @GET
@@ -70,10 +68,6 @@ public class DbResource {
     public String createData() {
         worldRepository.createData();
         return "OK";
-    }
-
-    private World randomWorldForRead() {
-        return worldRepository.findSingleAndStateless(randomWorldNumber());
     }
 
     private Collection<World> randomWorldForRead(int count) {

--- a/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/resource/FortuneResource.java
+++ b/frameworks/Java/quarkus/resteasy-hibernate/src/main/java/io/quarkus/benchmark/resource/FortuneResource.java
@@ -1,6 +1,5 @@
 package io.quarkus.benchmark.resource;
 
-import com.fizzed.rocker.BindableRockerModel;
 import com.fizzed.rocker.Rocker;
 import com.fizzed.rocker.RockerOutput;
 import io.quarkus.benchmark.model.Fortune;

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/FortuneRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/FortuneRepository.java
@@ -18,4 +18,5 @@ public class FortuneRepository extends BaseRepository {
                 session -> session.createQuery("SELECT F FROM Fortune F", Fortune.class).getResultList()
         );
     }
+
 }

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/FortuneRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/FortuneRepository.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
@@ -21,11 +18,7 @@ public class FortuneRepository {
 
     public List<Fortune> findAllStateless() {
         try (StatelessSession s = sf.openStatelessSession()) {
-            CriteriaBuilder criteriaBuilder = sf.getCriteriaBuilder();
-            CriteriaQuery<Fortune> fortuneQuery = criteriaBuilder.createQuery(Fortune.class);
-            Root<Fortune> from = fortuneQuery.from(Fortune.class);
-            fortuneQuery.select(from);
-            return s.createQuery(fortuneQuery).getResultList();
+            return s.createQuery("SELECT F FROM Fortune F", Fortune.class).getResultList();
         }
     }
 }

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/resource/FortuneResource.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/resource/FortuneResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -34,7 +33,7 @@ public class FortuneResource {
     @GET
     @Path("/fortunes")
     public String fortunes() {
-        List<Fortune> fortunes = new ArrayList<>(repository.findAllStateless());
+        List<Fortune> fortunes = repository.findAllStateless();
         fortunes.add(new Fortune(0, "Additional fortune added at request time."));
         fortunes.sort(fortuneComparator);
 

--- a/frameworks/Java/quarkus/run_quarkus.sh
+++ b/frameworks/Java/quarkus/run_quarkus.sh
@@ -10,6 +10,11 @@
 # Consider using -Dquarkus.http.io-threads=$((`grep --count ^processor /proc/cpuinfo`)) \
 
 JAVA_OPTIONS="-server \
+  -Dquarkus.http.io-threads=$((`grep --count ^processor /proc/cpuinfo`)) \
+  -Dquarkus.vertx.event-loops-pool-size=$((`grep --count ^processor /proc/cpuinfo`)) \
+  -XX:InitialRAMPercentage=50 \
+  -XX:MaxRAMPercentage=50 \
+  -XX:+AlwaysPreTouch \
   -Dquarkus.vertx.prefer-native-transport=true  \
   -XX:-StackTraceInThrowable \
   -Dquarkus.http.accept-backlog=-1 \


### PR DESCRIPTION
Did some cleanup of the Quarkus benchmark code; the persistence layer is now better organized and separated from the webserver layer.

In particular the benchmark for `/fortunes` was doing some dump stuff compared to the benchmark we had for Quarkus 1.1, so fixed a regression there.

Finally, some additional touches to JVM tuning.