### PR TITLE
Remove lithium tests using pqsql pipelining.

### DIFF
--- a/frameworks/C++/lithium/benchmark_config.json
+++ b/frameworks/C++/lithium/benchmark_config.json
@@ -73,51 +73,7 @@
         "display_name": "Lithium-postgres-beta",
         "notes": "",
         "versus": "None"
-      },
-      "postgres-batch": {
-        "db_url"         : "/db",
-        "query_url"      : "/queries?N=",
-        "fortune_url"    : "/fortunes",
-        "update_url"     : "/updates?N=",
-        "port": 8080,
-        "approach": "Realistic",
-        "classification": "Micro",
-        "database": "Postgres",
-        "framework": "Lithium",
-        "language": "C++",
-        "flavor": "None",
-        "orm": "Full",
-        "platform": "None",
-        "webserver": "None",
-        "os": "Linux",
-        "database_os": "Linux",
-        "display_name": "Lithium-postgres-batch",
-        "notes": "",
-        "versus": "None"
-      },
-
-      "postgres-batch-beta": {
-        "db_url"         : "/db",
-        "query_url"      : "/queries?N=",
-        "fortune_url"    : "/fortunes",
-        "update_url"     : "/updates?N=",
-        "port": 8080,
-        "approach": "Realistic",
-        "classification": "Micro",
-        "database": "Postgres",
-        "framework": "Lithium",
-        "language": "C++",
-        "flavor": "None",
-        "orm": "Full",
-        "platform": "None",
-        "webserver": "None",
-        "os": "Linux",
-        "database_os": "Linux",
-        "display_name": "Lithium-postgres-batch-beta",
-        "notes": "",
-        "versus": "None"
       }
-
     }
   ]
 }


### PR DESCRIPTION
Remove lithium tests using pqsql pipelining to comply with the benchmark rules.
 