### PR TITLE
Disable Postgres Pipelining/Batching based tests

### DIFF
--- a/frameworks/C++/ffead-cpp/benchmark_config.json
+++ b/frameworks/C++/ffead-cpp/benchmark_config.json
@@ -95,7 +95,7 @@
 			"display_name": "ffead-cpp [v-prof-b]",
 			"notes": "",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-profiled": {
 			"db_url": "/t3/d",
@@ -137,7 +137,7 @@
 			"display_name": "ffead-cpp [pg-raw-prof-b]",
 			"notes": "memory libpq batch patch profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-async-profiled": {
 			"db_url": "/t4/d",
@@ -219,7 +219,7 @@
 			"display_name": "ffead-cpp [pg-raw-async-prof-b]",
 			"notes": "async memory libpq batch patch profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-async-clibpqb-pool-profiled": {
 			"db_url": "/t4/d",
@@ -240,7 +240,7 @@
 			"display_name": "ffead-cpp [pg-raw-async-prof-b-pool]",
 			"notes": "async memory libpq batch patch profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-async-qw-profiled": {
 			"db_url": "/t5/d",
@@ -282,7 +282,7 @@
 			"display_name": "ffead-cpp [pg-raw-async-qw-prof-b]",
 			"notes": "async memory libpq batch patch profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-async-qw-pool-profiled-m": {
 			"query_url": "/t5/quem?queries=",


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
