### PR TITLE
[C#][aspnetcore] - mark all classes sealed

### DIFF
--- a/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/AppSettings.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/AppSettings.cs
@@ -3,7 +3,7 @@
 
 namespace Benchmarks.Configuration;
 
-public class AppSettings
+public sealed class AppSettings
 {
     public string ConnectionString { get; set; }
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/ConsoleArgs.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/ConsoleArgs.cs
@@ -3,7 +3,7 @@
 
 namespace Benchmarks.Configuration;
 
-public class ConsoleArgs
+public sealed class ConsoleArgs
 {
     public ConsoleArgs(string[] args)
     {

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/ConsoleHostScenariosConfiguration.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/ConsoleHostScenariosConfiguration.cs
@@ -3,7 +3,7 @@
 
 namespace Benchmarks.Configuration;
 
-public class ConsoleHostScenariosConfiguration : IScenariosConfiguration
+public sealed class ConsoleHostScenariosConfiguration : IScenariosConfiguration
 {
     private readonly string[] _args;
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/EnabledScenario.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/EnabledScenario.cs
@@ -3,7 +3,7 @@
 
 namespace Benchmarks.Configuration;
 
-public class EnabledScenario
+public sealed class EnabledScenario
 {
     public EnabledScenario(string name, IEnumerable<string> paths)
     {

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/Scenarios.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Configuration/Scenarios.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Benchmarks.Configuration;
 
-public class Scenarios
+public sealed class Scenarios
 {
     public Scenarios(IScenariosConfiguration scenariosConfiguration)
     {

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/FortunesController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/FortunesController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Benchmarks.Controllers;
 
 [Route("mvc/fortunes")]
-public class FortunesController : Controller
+public sealed class FortunesController : Controller
 {
     [HttpGet("raw")]
     public async Task<IActionResult> Raw()

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/HomeController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/HomeController.cs
@@ -28,7 +28,7 @@ public sealed class HomeController : Controller
         return View();
     }
 
-    private class PlainTextActionResult : IActionResult
+    private sealed class PlainTextActionResult : IActionResult
     {
         private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("Hello, World!");
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/HomeController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/HomeController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Benchmarks.Controllers;
 
 [Route("mvc")]
-public class HomeController : Controller
+public sealed class HomeController : Controller
 {
     [HttpGet("plaintext")]
     public IActionResult Plaintext()

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/MultipleQueriesController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/MultipleQueriesController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Benchmarks.Controllers;
 
 [Route("mvc/queries")]
-public class MultipleQueriesController : Controller
+public sealed class MultipleQueriesController : Controller
 {
     [HttpGet("raw")]
     [Produces("application/json")]

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/MultipleUpdatesController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/MultipleUpdatesController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Benchmarks.Controllers;
 
 [Route("mvc/updates")]
-public class MultipleUpdatesController : Controller
+public sealed class MultipleUpdatesController : Controller
 {
     [HttpGet("raw")]
     [Produces("application/json")]

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/SingleQueryController.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Controllers/SingleQueryController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Benchmarks.Controllers;
 
 [Route("mvc/db")]
-public class SingleQueryController : Controller
+public sealed class SingleQueryController : Controller
 {
     [HttpGet("raw")]
     [Produces("application/json")]

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/BatchUpdateString.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/BatchUpdateString.cs
@@ -5,7 +5,7 @@ using Benchmarks.Configuration;
 
 namespace Benchmarks.Data;
 
-internal class BatchUpdateString
+internal sealed class BatchUpdateString
 {
     private const int MaxBatch = 500;
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/DapperDb.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data;
 
-public class DapperDb : IDb
+public sealed class DapperDb : IDb
 {
     private static readonly Comparison<World> WorldSortComparison = (a, b) => a.Id.CompareTo(b.Id);
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/EfDb.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data;
 
-public class EfDb : IDb
+public sealed class EfDb : IDb
 {
     private readonly IRandom _random;
     private readonly ApplicationDbContext _dbContext;

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/Fortune.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/Fortune.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace Benchmarks.Data;
 
 [Table("fortune")]
-public class Fortune : IComparable<Fortune>, IComparable
+public sealed class Fortune : IComparable<Fortune>, IComparable
 {
     [Column("id")]
     public int Id { get; set; }

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/Random.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/Random.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace Benchmarks.Data;
 
-public class DefaultRandom : IRandom
+public sealed class DefaultRandom : IRandom
 {
     private static int nextSeed = 0;
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/RawDb.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data;
 
-public class RawDb : IDb
+public sealed class RawDb : IDb
 {
     private static readonly Comparison<World> WorldSortComparison = (a, b) => a.Id.CompareTo(b.Id);
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Data/World.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Data/World.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace Benchmarks.Data;
 
 [Table("world")]
-public class World
+public sealed class World
 {
     [Column("id")]
     public int Id { get; set; }

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesDapperMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesDapperMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class FortunesDapperMiddleware
+public sealed class FortunesDapperMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbFortunesDapper));
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesEfMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesEfMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class FortunesEfMiddleware
+public sealed class FortunesEfMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbFortunesEf));
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesRawMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/FortunesRawMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class FortunesRawMiddleware
+public sealed class FortunesRawMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbFortunesRaw));
 

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/JsonMiddleware.cs
@@ -6,7 +6,7 @@ using Benchmarks.Configuration;
 
 namespace Benchmarks.Middleware;
 
-public class JsonMiddleware
+public sealed class JsonMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.Json));
     private const int _bufferSize = 27;

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesDapperMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesDapperMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleQueriesDapperMiddleware
+public sealed class MultipleQueriesDapperMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiQueryDapper));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesEfMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesEfMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleQueriesEfMiddleware
+public sealed class MultipleQueriesEfMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiQueryEf));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesRawMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleQueriesRawMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleQueriesRawMiddleware
+public sealed class MultipleQueriesRawMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiQueryRaw));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesDapperMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesDapperMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleUpdatesDapperMiddleware
+public sealed class MultipleUpdatesDapperMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiUpdateDapper));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesEfMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesEfMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleUpdatesEfMiddleware
+public sealed class MultipleUpdatesEfMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiUpdateEf));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesRawMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/MultipleUpdatesRawMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class MultipleUpdatesRawMiddleware
+public sealed class MultipleUpdatesRawMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbMultiUpdateRaw));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/PlaintextMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/PlaintextMiddleware.cs
@@ -6,7 +6,7 @@ using Benchmarks.Configuration;
 
 namespace Benchmarks.Middleware;
 
-public class PlaintextMiddleware
+public sealed class PlaintextMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.Plaintext));
     private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("Hello, World!");

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryDapperMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryDapperMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class SingleQueryDapperMiddleware
+public sealed class SingleQueryDapperMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbSingleQueryDapper));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryEfMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryEfMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class SingleQueryEfMiddleware
+public sealed class SingleQueryEfMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbSingleQueryEf));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryRawMiddleware.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Middleware/SingleQueryRawMiddleware.cs
@@ -7,7 +7,7 @@ using Benchmarks.Data;
 
 namespace Benchmarks.Middleware;
 
-public class SingleQueryRawMiddleware
+public sealed class SingleQueryRawMiddleware
 {
     private static readonly PathString _path = new(Scenarios.GetPath(s => s.DbSingleQueryRaw));
     private static readonly JsonSerializerOptions _serializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };

--- a/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
+++ b/frameworks/CSharp/aspnetcore/Benchmarks/Startup.cs
@@ -14,7 +14,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Benchmarks;
 
-public class Startup
+public sealed class Startup
 {
     public Startup(IWebHostEnvironment hostingEnv, Scenarios scenarios)
     {

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Configuration/AppSettings.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Configuration/AppSettings.cs
@@ -3,7 +3,7 @@
 
 namespace PlatformBenchmarks;
 
-public class AppSettings
+public sealed class AppSettings
 {
     public string ConnectionString { get; set; }
 

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/BatchUpdateString.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/BatchUpdateString.cs
@@ -3,7 +3,7 @@
 
 namespace PlatformBenchmarks;
 
-internal class BatchUpdateString
+internal sealed class BatchUpdateString
 {
     private const int MaxBatch = 500;
 

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbMySqlConnector.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbMySqlConnector.cs
@@ -15,7 +15,7 @@ namespace PlatformBenchmarks
 {
     // Is semantically identical to RawDbNpgsql.cs.
     // If you are changing RawDbMySqlConnector.cs, also consider changing RawDbNpgsql.cs.
-    public class RawDb
+    public sealed class RawDb
     {
         private readonly ConcurrentRandom _random;
         private readonly string _connectionString;

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
@@ -15,7 +15,7 @@ namespace PlatformBenchmarks
 {
     // Is semantically identical to RawDbMySqlConnector.cs.
     // If you are changing RawDbNpgsql.cs, also consider changing RawDbMySqlConnector.cs.
-    public class RawDb
+    public sealed class RawDb
     {
         private readonly ConcurrentRandom _random;
         private readonly string _connectionString;

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Random.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Random.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace PlatformBenchmarks;
 
-public class ConcurrentRandom
+public sealed class ConcurrentRandom
 {
     private static int nextSeed = 0;
 

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/HttpApplication.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/HttpApplication.cs
@@ -14,7 +14,7 @@ public static class HttpApplicationConnectionBuilderExtensions
     }
 }
 
-public class HttpApplication<TConnection> where TConnection : IHttpConnection, new()
+public sealed class HttpApplication<TConnection> where TConnection : IHttpConnection, new()
 {
     public Task ExecuteAsync(ConnectionContext connection)
     {

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Program.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Program.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace PlatformBenchmarks;
 
-public class Program
+public sealed class Program
 {
     public static string[] Args;
 

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Startup.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Startup.cs
@@ -3,7 +3,7 @@
 
 namespace PlatformBenchmarks;
 
-public class Startup
+public sealed class Startup
 {
     public void Configure(IApplicationBuilder app)
     {


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

That's a tiny improvement which might help for runtime to devirtualize class. 

I would better quote Stephen Toub from [this topic](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-6/#peanut-butter).

> If the runtime can see that a given instance on which a virtual call is being made is actually sealed, then it knows for certain what the actual target of the call will be, and it can invoke that target directly rather than doing a virtual dispatch operation. Better yet, once the call is devirtualized, it might be inlineable, and then if it’s inlined, all the previously discussed benefits around optimizing the caller+callee combined kick in.