### PR TITLE
Fix dependabot permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,9 @@ jobs:
   dependabot:
     needs: verify
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
Attempts to address the dependabot issue by adding permissions to the GitHub Actions job for dependabot.