### PR TITLE
Switch aspnetcore and easyrpc from MemoryCache to FastCache.Cached fo…

### DIFF
--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbMySqlConnector.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbMySqlConnector.cs
@@ -85,7 +85,7 @@ namespace PlatformBenchmarks
 
             return Task.FromResult(result);
 
-            static async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
+            async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
             {
                 using (var db = new MySqlConnection(rawdb._connectionString))
                 {

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using FastCache;
+using FastCache.Extensions;
 using Microsoft.Extensions.Caching.Memory;
 using Npgsql;
 
@@ -19,11 +21,6 @@ namespace PlatformBenchmarks
     {
         private readonly ConcurrentRandom _random;
         private readonly string _connectionString;
-        private readonly MemoryCache _cache = new(
-            new MemoryCacheOptions
-            {
-                ExpirationScanFrequency = TimeSpan.FromMinutes(60)
-            });
 
         public RawDb(ConcurrentRandom random, AppSettings appSettings)
         {
@@ -71,15 +68,14 @@ namespace PlatformBenchmarks
         {
             var result = new CachedWorld[count];
             var cacheKeys = _cacheKeys;
-            var cache = _cache;
             var random = _random;
             for (var i = 0; i < result.Length; i++)
             {
                 var id = random.Next(1, 10001);
                 var key = cacheKeys[id];
-                if (cache.TryGetValue(key, out object cached))
+                if (Cached<CachedWorld>.TryGet(key, out var cached))
                 {
-                    result[i] = (CachedWorld)cached;
+                    result[i] = cached.Value;
                 }
                 else
                 {
@@ -98,10 +94,7 @@ namespace PlatformBenchmarks
                     var (cmd, idParameter) = rawdb.CreateReadCommand(db);
                     using (cmd)
                     {
-                        Func<ICacheEntry, Task<CachedWorld>> create = async _ =>
-                        {
-                            return await rawdb.ReadSingleRow(cmd);
-                        };
+                        async Task<CachedWorld> create(int key) => await ReadSingleRow(cmd);
 
                         var cacheKeys = _cacheKeys;
                         var key = cacheKeys[id];
@@ -110,7 +103,7 @@ namespace PlatformBenchmarks
 
                         for (; i < result.Length; i++)
                         {
-                            result[i] = await rawdb._cache.GetOrCreateAsync(key, create);
+                            result[i] = await Cached.GetOrCompute(key, create, TimeSpan.FromMinutes(60));
 
                             id = rawdb._random.Next(1, 10001);
                             idParameter.TypedValue = id;
@@ -133,11 +126,10 @@ namespace PlatformBenchmarks
                 using (cmd)
                 {
                     var cacheKeys = _cacheKeys;
-                    var cache = _cache;
                     for (var i = 1; i < 10001; i++)
                     {
                         idParameter.TypedValue = i;
-                        cache.Set<CachedWorld>(cacheKeys[i], await ReadSingleRow(cmd));
+                        await ReadSingleRow(cmd).Cache(cacheKeys[i], TimeSpan.FromMinutes(60));
                     }
                 }
             }
@@ -238,27 +230,7 @@ namespace PlatformBenchmarks
             }
         }
 
-        private static readonly object[] _cacheKeys = Enumerable.Range(0, 10001).Select(i => new CacheKey(i)).ToArray();
-
-        public sealed class CacheKey : IEquatable<CacheKey>
-        {
-            private readonly int _value;
-
-            public CacheKey(int value)
-                => _value = value;
-
-            public bool Equals(CacheKey key)
-                => key._value == _value;
-
-            public override bool Equals(object obj)
-                => ReferenceEquals(obj, this);
-
-            public override int GetHashCode()
-                => _value;
-
-            public override string ToString()
-                => _value.ToString();
-        }
+        private static readonly int[] _cacheKeys = Enumerable.Range(0, 10001).ToArray();
     }
 }
 

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
@@ -85,7 +85,7 @@ namespace PlatformBenchmarks
 
             return Task.FromResult(result);
 
-            static async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
+            async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
             {
                 using (var db = new NpgsqlConnection(rawdb._connectionString))
                 {

--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="FastCache.Cached" Version="1.4.0" />
     <PackageReference Condition=" '$(DatabaseProvider)' == 'Npgsql' " Include="Npgsql" Version="6.0.0" />
     <PackageReference Condition=" '$(DatabaseProvider)' == 'MySqlConnector' " Include="MySqlConnector" Version="2.0.0" />
   </ItemGroup>

--- a/frameworks/CSharp/easyrpc/Benchmarks/Benchmarks.csproj
+++ b/frameworks/CSharp/easyrpc/Benchmarks/Benchmarks.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="EasyRpc.AspNetCore" Version="5.0.0" />
     <PackageReference Include="EasyRpc.AspNetCore.Utf8Json" Version="5.0.0" />
     <PackageReference Include="EasyRpc.AspNetCore.Views" Version="5.0.0" />
+    <PackageReference Include="FastCache.Cached" Version="1.4.0" />
     <PackageReference Include="Npgsql" Version="5.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change switches `cached-worlds` `aspnetcore` and `easyrpc` workloads from `MemoryCache` to `FastCache.Cached`.

The main reason for this change is that `FastCache.Cached` is much more performant in high-throughput and/or multi-threaded scenarios. This is achieved via several factors:
- Providing a more limited feature set when compared to `MemoryCache` like per-entry callbacks, multiple expiration modes supported simultaneously, etc.
- Using `Environment.TickCount64` instead of `DateTime.UtcNow` as a timestamp source which has significantly lower overhead
- Reducing memory indirection cost by using `readonly struct`-based cache entries - both timestamp and entry values are fetched in a single cache line load (when not crossing cache line boundary) and then are passed in CPU registers (struct enregistration)
- Using static dispatch to a static cache store instance (caches are separated per key-value types combinations, e.g. `int + CachedWorld`, `(string, bool) + OtherType`, etc.)
- Having read and write paths lock-free and wait-free (for the most part thanks to https://github.com/VSadov/NonBlocking) provides better scaling per thread
- `MemoryCache` uses keys boxed into `object` which may allocate on every read and cannot take advantage of specialized lookup implementations available for number-based keys
- Even regardless of other techniques, the implementation itself being more limited when compared to `MemoryCache` means that CPU has to execute much less code and cache entries being much smaller (min size is only 40B for node in ConcurrentDictionary that nests 16B+ sized `CachedInner`) allows for higher read and write throughput per same amount of memory traffic

Any feedback on further possible improvements or potential issues will be much appreciated.

Also attaching TL;DR comparison of latency and throughput vs MemoryCache in a standalone benchmark suite (string-based keys, for int-based keys the difference in perf will be much higher)
|            Library | Lowest read latency | Read throughput (M/1s) | Lowest write latency | Write throughput (M/1s) | Cost per item | Cost per 10M items |
| ------------------ | ------------------- | ---------------------- | -------------------- | ----------------------- | ------------- | ------------------ |
|   **FastCache.Cached** |            **15.63 ns** | **114-288M MT / 9-72M ST** |             **33.75 ns** |    **39-81M MT / 6-31M ST** |          **40 B** |             **381 MB** |
|        MemoryCache |            56.93 ns |   41-46M MT / 4-10M ST |            203.32 ns |    11-26M MT /  2-6M ST |         224 B |           2,136 MB |

*`NonBlocking.ConcurrentDictionary` has specialized implementations for number-based keys. See diff in https://github.com/neon-sunset/fast-cache/blob/main/docs/performance/defaults-net7-win-x64.md
**As of now, the library is incompatible with AOT. Once this is fixed, I will update (here or separate PR) `CoreRT` and `Mono` workloads accordingly. See https://github.com/VSadov/NonBlocking/pull/13#issuecomment-1153598339