### PR TITLE
Upgrade Grape benchmark package versions

### DIFF
--- a/frameworks/Ruby/grape/Gemfile
+++ b/frameworks/Ruby/grape/Gemfile
@@ -1,10 +1,10 @@
 source 'http://rubygems.org'
 
-gem 'mysql2', '0.4.10'
-gem 'unicorn', '5.3.0'
-gem 'puma', '3.12.6'
-gem 'activerecord', '5.1.5', :require => 'active_record'
-gem 'activerecord-import', "~> 0.18.1"
-gem 'grape', '1.1.0'
-gem 'rack', '1.6.12'
-gem 'json', '2.1.0'
+gem 'mysql2', '0.5.4'
+gem 'unicorn', '6.1.0'
+gem 'puma', '5.6.4'
+gem 'activerecord', '7.0.3', :require => 'active_record'
+gem 'activerecord-import', '1.4.0'
+gem 'grape', '1.6.2'
+gem 'rack', '2.2.3.1'
+gem 'json', '2.6.2'

--- a/frameworks/Ruby/grape/README.md
+++ b/frameworks/Ruby/grape/README.md
@@ -6,20 +6,16 @@ For further guidance, review the
 Also note the additional information provided in the [Ruby README](../).
 
 This is the Ruby Grape portion of a [benchmarking test suite](../../)
-comparing a variety of web servers along with JRuby/MRI.
+comparing a variety of web servers.
 
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Ruby 2.0.0-p0](http://www.ruby-lang.org/)
-* [JRuby 1.7.8](http://jruby.org/)
-* [Rubinius 2.2.10](http://rubini.us/)
-* [Grape 0.8.0](http://intridea.github.io/grape/)
-* [Rack 1.5.2](http://rack.github.com/)
-* [Unicorn 4.8.3](http://unicorn.bogomips.org/)
-* [TorqBox 0.1.7](http://torquebox.org/torqbox/)
-* [Puma 3.9](http://puma.io/)
-* [Thin 1.6.2](http://code.macournoyer.com/thin/)
+* [Ruby 3.1](http://www.ruby-lang.org/)
+* [Grape 1.6.2](http://www.ruby-grape.org/)
+* [Rack 2.2.3.1](https://rack.github.io/)
+* [Unicorn 6.1.0](https://yhbt.net/unicorn/)
+* [Puma 5.6.4](https://puma.io/)
 
 ## Paths & Source for Tests
 
@@ -42,4 +38,4 @@ _No experts listed, yet. If you're an expert, add yourself!_
 
 ### Resources
 
-* [Grape Micro-framework Source Code](https://github.com/intridea/grape)
+* [Grape Micro-framework Source Code](https://github.com/ruby-grape/grape)

--- a/frameworks/Ruby/grape/grape-unicorn.dockerfile
+++ b/frameworks/Ruby/grape/grape-unicorn.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:3.1
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
 

--- a/frameworks/Ruby/grape/grape.dockerfile
+++ b/frameworks/Ruby/grape/grape.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:3.1
 
 ADD ./ /grape
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

This updates the Ruby Grape dependencies and Ruby version. I've also updated the README to the current versions and fixed outdated links. 

To test, I've run these locally successfully and posted results here: 

- MRI: https://www.techempower.com/benchmarks/#section=test&shareid=8c24b657-bb6f-4bc2-bbda-099ef8161af8&hw=ph&test=update&a=2
- Unicorn: https://www.techempower.com/benchmarks/#section=test&shareid=78cde7c7-16be-4f0b-b8a4-a2014665b439