### PR TITLE
Don't return HashMap for JSON serialization in Spring

### DIFF
--- a/frameworks/Java/spring/src/main/java/hello/controller/HelloController.java
+++ b/frameworks/Java/spring/src/main/java/hello/controller/HelloController.java
@@ -31,8 +31,8 @@ public final class HelloController {
 
   @RequestMapping("/json")
   @ResponseBody
-  Map<String, String> json() {
-    return Map.of("message", "Hello, World!");
+  Message json() {
+    return new Message("Hello, World!");
   }
 
   @RequestMapping("/db")
@@ -112,4 +112,15 @@ public final class HelloController {
     return Math.min(500, Math.max(1, parsedValue));
   }
 
+  static class Message {
+    private final String message;
+
+    public Message(String message) {
+      this.message = message;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
 }


### PR DESCRIPTION
It is much cheaper to construct a simple data carrier object as opposed to a `HashMap` instance.

