### PR TITLE
[yii2] Fix composser allow plugins

### DIFF
--- a/frameworks/PHP/yii2/composer.json
+++ b/frameworks/PHP/yii2/composer.json
@@ -3,5 +3,10 @@
 		"yidas/yii2-composer-bower-skip": "~2.0.13",
 		"yiisoft/yii2": "~2.0.43",
 		"joanhey/adapterman": "dev-master"
-	}
+	},
+	"config": {
+        "allow-plugins": {
+            "yiisoft/*": true
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
