### PR TITLE
Fix node cluster for express

### DIFF
--- a/frameworks/JavaScript/express/app.js
+++ b/frameworks/JavaScript/express/app.js
@@ -9,14 +9,17 @@ const cluster = require('cluster'),
 
 const bodyParser = require('body-parser');
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
+
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }
 
-  cluster.on('exit', (worker, code, signal) =>
-    console.log('worker ' + worker.pid + ' died'));
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`worker ${worker.process.pid} died`);
+  });
 } else {
   const app = module.exports = express();
 


### PR DESCRIPTION
After upgrade the node version to v16, not using all CPU cores.
Because `cluster.isMaster` is deprecated.

`cluster.isMaster` added in NODE version v0.8.1 is deprecated since version 16.0.0. Simply replace deprecated `cluster.isMaster` by `cluster.isPrimary`

Official information are provided by Nodejs here: https://nodejs.org/api/cluster.html#clusterismaster