### PR TITLE
Fix node cluster for fastify

### DIFF
--- a/frameworks/JavaScript/fastify/app.js
+++ b/frameworks/JavaScript/fastify/app.js
@@ -1,16 +1,16 @@
 const cluster = require("cluster");
 const numCPUs = require("os").cpus().length;
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
+
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }
 
-  console.log("Master starting " + new Date().toISOString());
-
-  cluster.on("exit", () => {
-    process.exit(1);
+  cluster.on('exit', (worker, code, signal) => {
+    console.log(`worker ${worker.process.pid} died`);
   });
 } else {
   // worker task


### PR DESCRIPTION
After upgrade the node version to v16, not using all CPU cores.
Because `cluster.isMaster` is deprecated.

`cluster.isMaster` added in NODE version v0.8.1 is deprecated since version 16.0.0. Simply replace deprecated `cluster.isMaster` by `cluster.isPrimary`

Official information are provided by Nodejs here: https://nodejs.org/api/cluster.html#clusterismaster