### PR TITLE
Fix node cluster for nodejs

### DIFF
--- a/frameworks/JavaScript/nodejs/app.js
+++ b/frameworks/JavaScript/nodejs/app.js
@@ -13,16 +13,16 @@ if (process.env.TFB_TEST_NAME === 'nodejs-mongodb') {
   process.env.NODE_HANDLER = 'sequelize-postgres';
 }
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
+  console.log(`Primary ${process.pid} is running`);
+
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }
 
   cluster.on('exit', (worker, code, signal) => {
-  	console.log([
-  	  'A process exit was triggered, most likely due to a failed database action',
-  	  'NodeJS test server shutting down now'].join('\n'));
+    console.log(`worker ${worker.process.pid} died`);
     process.exit(1);
   });
 } else {


### PR DESCRIPTION
After upgrade the node version to v16, not using all CPU cores.
Because `cluster.isMaster` is deprecated.

`cluster.isMaster` added in NODE version v0.8.1 is deprecated since version 16.0.0. Simply replace deprecated `cluster.isMaster` by `cluster.isPrimary`

Official information are provided by Nodejs here: https://nodejs.org/api/cluster.html#clusterismaster