### PR TITLE
Fix node cluster for nestjs

### DIFF
--- a/frameworks/TypeScript/nest/package.json
+++ b/frameworks/TypeScript/nest/package.json
@@ -38,7 +38,7 @@
     "@nestjs/cli": "7.5.3",
     "@nestjs/schematics": "7.2.4",
     "@types/express": "4.17.3",
-    "@types/node": "13.7.7",
+    "@types/node": "16.11.46",
     "@typescript-eslint/eslint-plugin": "2.22.0",
     "@typescript-eslint/parser": "2.22.0",
     "eslint": "6.8.0",

--- a/frameworks/TypeScript/nest/src/main.ts
+++ b/frameworks/TypeScript/nest/src/main.ts
@@ -8,7 +8,7 @@ import {
 import { MongoModule } from './mongo/mongo.module';
 import { join } from 'path';
 import { SqlModule } from './sql/sql.module';
-import cluster = require('cluster');
+import cluster from 'cluster'
 import os = require('os');
 
 const port = process.env.PORT || 8080;
@@ -57,7 +57,7 @@ async function bootstrapFastify() {
   await app.listen(8080, '0.0.0.0');
 }
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
   const cpus = os.cpus().length;
   for (let i = 0; i < cpus; i++) {
     cluster.fork();

--- a/frameworks/TypeScript/nest/tsconfig.json
+++ b/frameworks/TypeScript/nest/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
After upgrade the node version to v16, not using all CPU cores.
Because `cluster.isMaster` is deprecated.

`cluster.isMaster` added in NODE version v0.8.1 is deprecated since version 16.0.0. Simply replace deprecated `cluster.isMaster` by `cluster.isPrimary`

Official information are provided by Nodejs here: https://nodejs.org/api/cluster.html#clusterismaster