### PR TITLE
racket: bump Racket to 8.6

### DIFF
--- a/frameworks/Racket/racket/app.rkt
+++ b/frameworks/Racket/racket/app.rkt
@@ -226,7 +226,8 @@
      #:tcp@ tcp@
      #:confirmation-channel ch
      #:safety-limits (make-safety-limits
-                      #:max-waiting 4096
+                      #:max-concurrent 1000
+                      #:max-waiting 65535
                       #:request-read-timeout 16
                       #:response-timeout 16
                       #:response-send-timeout 16)))
@@ -236,3 +237,10 @@
     (raise ready-or-exn))
 
   stop)
+
+(module+ main
+  (require net/tcp-unit)
+  (define stop (start "127.0.0.1" 8000 tcp@))
+  (with-handlers ([exn:break? (λ (_) (stop))])
+    (displayln "ready")
+    (sync never-evt)))

--- a/frameworks/Racket/racket/racket.dockerfile
+++ b/frameworks/Racket/racket/racket.dockerfile
@@ -11,7 +11,7 @@ RUN echo 'APT::Get::Install-Recommends "false";' > /etc/apt/apt.conf.d/00-genera
 
 FROM debian AS racket
 
-ARG RACKET_VERSION=8.3
+ARG RACKET_VERSION=8.6
 
 RUN apt-get update -q \
     && apt-get install --no-install-recommends -q -y \
@@ -27,7 +27,6 @@ ENV SSL_CERT_DIR="/etc/ssl/certs"
 
 RUN apt-get update -q \
   && apt-get install --no-install-recommends -q -y redis-server
-
 
 FROM racket AS builder
 


### PR DESCRIPTION
Also tweak parameters and adjust `place-tcp-listener` implementation
for recent web-server changes[1].

[1]: https://github.com/racket/web-server/pull/121

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
