### PR TITLE
Fixed haskell/ihp

### DIFF
--- a/frameworks/Haskell/ihp/benchmark_config.json
+++ b/frameworks/Haskell/ihp/benchmark_config.json
@@ -24,7 +24,7 @@
         "display_name": "Integrated Haskell Platfrom (IHP)",
         "notes": "",
         "versus": "None",
-        "tags": ["broken"]
+        "tags": []
       }
     }
   ]

--- a/frameworks/Haskell/ihp/ihp.dockerfile
+++ b/frameworks/Haskell/ihp/ihp.dockerfile
@@ -4,11 +4,14 @@ COPY ./src /ihp
 WORKDIR /ihp
 
 # Add build dependencies
-RUN nix-env -i git cachix
+RUN nix-env -i cachix
 RUN cachix use digitallyinduced
 
+# Warmup docker build cache
+RUN nix-shell -j auto --cores 0 --command "echo ok"
+
 # Build 
-RUN nix-shell -j auto --cores 0 --command "make build/bin/RunOptimizedProdServer"
+RUN nix-build
 
 # Setup
 ENV DATABASE_URL=postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
@@ -16,4 +19,4 @@ ENV PORT=8080
 EXPOSE 8080
 
 # Run
-CMD nix-shell -j auto --cores 0 --command "./build/bin/RunOptimizedProdServer"
+CMD ./result/bin/RunProdServer +RTS -A32m -N$(nproc) -qn2 -M2G -RTS

--- a/frameworks/Haskell/ihp/src/Config/nix/nixpkgs-config.nix
+++ b/frameworks/Haskell/ihp/src/Config/nix/nixpkgs-config.nix
@@ -1,6 +1,7 @@
 # See https://ihp.digitallyinduced.com/Guide/package-management.html
-{ ihp }:
+{ ihp, additionalNixpkgsOptions, ... }:
 import "${toString ihp}/NixSupport/make-nixpkgs-from-options.nix" {
     ihp = ihp;
     haskellPackagesDir = ./haskell-packages/.;
+    additionalNixpkgsOptions = additionalNixpkgsOptions;
 }

--- a/frameworks/Haskell/ihp/src/default.nix
+++ b/frameworks/Haskell/ihp/src/default.nix
@@ -1,23 +1,21 @@
 let
     ihp = builtins.fetchGit {
         url = "https://github.com/digitallyinduced/ihp.git";
-        ref = "refs/tags/v0.9.0";
+        ref = "refs/tags/v0.20.0";
     };
     haskellEnv = import "${ihp}/NixSupport/default.nix" {
         ihp = ihp;
         haskellDeps = p: with p; [
-            cabal-install
             base
             wai
             text
-            hlint
             p.ihp
         ];
         otherDeps = p: with p; [
-	    git
             # Native dependencies, e.g. imagemagick
         ];
         projectPath = ./.;
+        optimized = true;
     };
 in
     haskellEnv


### PR DESCRIPTION
haskell/ihp was recently marked as broken via https://github.com/TechEmpower/FrameworkBenchmarks/pull/7199. This PR fixes the ihp build and removes the broken tag.

