### PR TITLE
⬆️ Bump Go 1.19 + `evio` 1.0.8 + set `GOAMD64=v3`

### DIFF
--- a/frameworks/Go/evio/evio-stdlib.dockerfile
+++ b/frameworks/Go/evio/evio-stdlib.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM docker.io/golang:1.19
 
 ENV GO111MODULE on
 WORKDIR /evio

--- a/frameworks/Go/evio/evio-stdlib.dockerfile
+++ b/frameworks/Go/evio/evio-stdlib.dockerfile
@@ -1,13 +1,10 @@
 FROM docker.io/golang:1.19
 
-ENV GO111MODULE on
 WORKDIR /evio
 
 COPY ./src /evio
 
-RUN go mod download
-
-RUN go build -ldflags="-s -w" -o app .
+RUN GOAMD64=v3 go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080
 

--- a/frameworks/Go/evio/evio.dockerfile
+++ b/frameworks/Go/evio/evio.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM docker.io/golang:1.19
 
 ENV GO111MODULE on
 WORKDIR /evio

--- a/frameworks/Go/evio/evio.dockerfile
+++ b/frameworks/Go/evio/evio.dockerfile
@@ -1,13 +1,10 @@
 FROM docker.io/golang:1.19
 
-ENV GO111MODULE on
 WORKDIR /evio
 
 COPY ./src /evio
 
-RUN go mod download
-
-RUN go build -ldflags="-s -w" -o app .
+RUN GOAMD64=v3 go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080
 

--- a/frameworks/Go/evio/src/go.mod
+++ b/frameworks/Go/evio/src/go.mod
@@ -1,6 +1,7 @@
 module evio
 
-require (
-	github.com/kavu/go_reuseport v1.4.0 // indirect
-	github.com/tidwall/evio v1.0.2
-)
+go 1.19
+
+require github.com/tidwall/evio v1.0.8
+
+require github.com/kavu/go_reuseport v1.5.0 // indirect

--- a/frameworks/Go/evio/src/go.mod
+++ b/frameworks/Go/evio/src/go.mod
@@ -1,4 +1,4 @@
-module evio
+module evio/app
 
 go 1.19
 

--- a/frameworks/Go/evio/src/go.sum
+++ b/frameworks/Go/evio/src/go.sum
@@ -1,4 +1,4 @@
-github.com/kavu/go_reuseport v1.4.0 h1:YIp/96RZ3sJfn0LN+FFkkXIq3H3dfVOdRUtNejhDcxc=
-github.com/kavu/go_reuseport v1.4.0/go.mod h1:CG8Ee7ceMFSMnx/xr25Vm0qXaj2Z4i5PWoUx+JZ5/CU=
-github.com/tidwall/evio v1.0.2 h1:vhPp5nVS5PZfR0CfV5ixqDEf+BKQFcaR1W1XeLLkvRE=
-github.com/tidwall/evio v1.0.2/go.mod h1:cYtY49LddNrlpsOmW7qJnqM8B2gOjrFrzT8+Fnb/GKs=
+github.com/kavu/go_reuseport v1.5.0 h1:UNuiY2OblcqAtVDE8Gsg1kZz8zbBWg907sP1ceBV+bk=
+github.com/kavu/go_reuseport v1.5.0/go.mod h1:CG8Ee7ceMFSMnx/xr25Vm0qXaj2Z4i5PWoUx+JZ5/CU=
+github.com/tidwall/evio v1.0.8 h1:+M7lh83rL4KwEObDGtXP3J1wE5utH80LeaAhrKCGVfE=
+github.com/tidwall/evio v1.0.8/go.mod h1:MJhRp4iVVqx/n/5mJk77oKmSABVhC7yYykcJiKaFYYw=


### PR DESCRIPTION
* Bump `evio` from v1.0.2 to v1.0.8.
* Bump Go from 1.12 to 1.19: Each Go version improves the performance. I expect some little gains since Go-1.12.
* Set `GOAMD64=v3` to enable the following instructions set: CMPXCHG16B, LAHF, SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3, AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE. The default value is `GOAMD64=v1`. See https://github.com/golang/go/wiki/MinimumRequirements#amd64

Note: I insert `docker.io/` in the `FROM docker.io/golang:1.19` statement to allow `podman` and `buildah` to build the container images:

    cd FrameworkBenchmarks/frameworks/Go/evio
    docker  build -f evio.dockerfile .
    podman  build -f evio.dockerfile .
    buildah build -f evio.dockerfile .