### PR TITLE
⬆️ Build Fiber with Go-1.19 and `GOAMD64=v3`

### DIFF
--- a/frameworks/Go/fiber/fiber-prefork.dockerfile
+++ b/frameworks/Go/fiber/fiber-prefork.dockerfile
@@ -4,9 +4,8 @@ WORKDIR /fiber
 
 COPY ./src /fiber
 
-RUN go get github.com/valyala/quicktemplate/qtc
+RUN go generate -x ./templates
 
-RUN go generate ./templates
 RUN go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080

--- a/frameworks/Go/fiber/fiber-prefork.dockerfile
+++ b/frameworks/Go/fiber/fiber-prefork.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM docker.io/golang:1.19
 
 WORKDIR /fiber
 

--- a/frameworks/Go/fiber/fiber-prefork.dockerfile
+++ b/frameworks/Go/fiber/fiber-prefork.dockerfile
@@ -6,7 +6,7 @@ COPY ./src /fiber
 
 RUN go generate -x ./templates
 
-RUN go build -ldflags="-s -w" -o app .
+RUN GOAMD64=v3 go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080
 

--- a/frameworks/Go/fiber/fiber.dockerfile
+++ b/frameworks/Go/fiber/fiber.dockerfile
@@ -4,6 +4,8 @@ WORKDIR /fiber
 
 COPY ./src /fiber
 
+RUN go mod download
+
 RUN go generate -x ./templates
 
 RUN GOAMD64=v3 go build -ldflags="-s -w" -o app .

--- a/frameworks/Go/fiber/fiber.dockerfile
+++ b/frameworks/Go/fiber/fiber.dockerfile
@@ -4,9 +4,8 @@ WORKDIR /fiber
 
 COPY ./src /fiber
 
-RUN go get github.com/valyala/quicktemplate/qtc
+RUN go generate -x ./templates
 
-RUN go generate ./templates
 RUN go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080

--- a/frameworks/Go/fiber/fiber.dockerfile
+++ b/frameworks/Go/fiber/fiber.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM docker.io/golang:1.19
 
 WORKDIR /fiber
 

--- a/frameworks/Go/fiber/fiber.dockerfile
+++ b/frameworks/Go/fiber/fiber.dockerfile
@@ -6,7 +6,7 @@ COPY ./src /fiber
 
 RUN go generate -x ./templates
 
-RUN gGOAMD64=v3 o build -ldflags="-s -w" -o app .
+RUN GOAMD64=v3 go build -ldflags="-s -w" -o app .
 
 EXPOSE 8080
 

--- a/frameworks/Go/fiber/fiber.dockerfile
+++ b/frameworks/Go/fiber/fiber.dockerfile
@@ -6,7 +6,7 @@ COPY ./src /fiber
 
 RUN go generate -x ./templates
 
-RUN go build -ldflags="-s -w" -o app .
+RUN gGOAMD64=v3 o build -ldflags="-s -w" -o app .
 
 EXPOSE 8080
 

--- a/frameworks/Go/fiber/src/go.mod
+++ b/frameworks/Go/fiber/src/go.mod
@@ -1,6 +1,6 @@
 module fiber/src
 
-go 1.17
+go 1.19
 
 require (
 	github.com/gofiber/fiber/v2 v2.25.0

--- a/frameworks/Go/fiber/src/go.mod
+++ b/frameworks/Go/fiber/src/go.mod
@@ -1,4 +1,4 @@
-module fiber/src
+module fiber/app
 
 go 1.19
 

--- a/frameworks/Go/fiber/src/go.sum
+++ b/frameworks/Go/fiber/src/go.sum
@@ -21,7 +21,6 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -42,7 +41,6 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -158,7 +156,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/frameworks/Go/fiber/src/server.go
+++ b/frameworks/Go/fiber/src/server.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"sync"
 
-	"fiber/src/templates"
+	"fiber/app/templates"
 
 	"github.com/gofiber/fiber/v2"
 	pgx "github.com/jackc/pgx/v4"

--- a/frameworks/Go/fiber/src/templates/fortune.go
+++ b/frameworks/Go/fiber/src/templates/fortune.go
@@ -13,7 +13,7 @@ type Fortunes struct {
 	F []Fortune
 }
 
-//go:generate qtc
+//go:generate go run github.com/valyala/quicktemplate/qtc
 
 var fortunePool = &sync.Pool{
 	New: func() interface{} {


### PR DESCRIPTION
* Bump Go from 1.17 to 1.19: Each Go version improves the performance.
* Set `GOAMD64=v3` to enable the following instructions set: CMPXCHG16B, LAHF, SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3, AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE. The default value is `GOAMD64=v1`. See https://github.com/golang/go/wiki/MinimumRequirements#amd64
* Replace the `RUN go get -u github.com/valyala/quicktemplate/qtc` (Dockerfile) by `//go:generate go run github.com/valyala/quicktemplate/qtc` in the source code. That way Go-1.19 is aware of the dependency on `qtc` and adds automatically it in the `go.mod` with a fixed version to reproduce the same `go generate`.

Note: I insert `docker.io/` in the `FROM docker.io/golang:1.19` statement to allow `podman` and `buildah` to build the container images.