### PR TITLE
⬆️ Run `martini` with Go-1.19, Go modules and `GOAMD64=v3`

### DIFF
--- a/frameworks/Go/martini/go.mod
+++ b/frameworks/Go/martini/go.mod
@@ -1,0 +1,10 @@
+module martini
+
+go 1.19
+
+require (
+	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
+	github.com/lib/pq v1.10.7
+)
+
+require github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect

--- a/frameworks/Go/martini/go.sum
+++ b/frameworks/Go/martini/go.sum
@@ -1,0 +1,6 @@
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
+github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
+github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/frameworks/Go/martini/martini.dockerfile
+++ b/frameworks/Go/martini/martini.dockerfile
@@ -7,4 +7,4 @@ RUN go mod download
 
 EXPOSE 8080
 
-CMD go run .
+CMD GOAMD64=v3 go run .

--- a/frameworks/Go/martini/martini.dockerfile
+++ b/frameworks/Go/martini/martini.dockerfile
@@ -3,13 +3,8 @@ FROM docker.io/golang:1.19-alpine
 WORKDIR /home
 COPY . .
 
-RUN mkdir -p bin
-ENV GOPATH /home
-ENV path ${GOPATH}/bin:${PATH}
-
-RUN go get github.com/go-martini/martini
-RUN go get github.com/lib/pq
+RUN go mod download
 
 EXPOSE 8080
 
-CMD go run randomNumber.go sanitizeQueries.go main.go
+CMD go run .

--- a/frameworks/Go/martini/martini.dockerfile
+++ b/frameworks/Go/martini/martini.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM docker.io/golang:1.19-alpine
 
 WORKDIR /home
 COPY . .

--- a/frameworks/Go/martini/martini.dockerfile
+++ b/frameworks/Go/martini/martini.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.19-alpine
+FROM docker.io/golang:1.19
 
 WORKDIR /home
 COPY . .


### PR DESCRIPTION
* Use the **Go modules**.
* Bump Go from 1.14 to 1.19.
* Set `GOAMD64=v3` to enable the following instructions set: CMPXCHG16B, LAHF, SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3, AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE. The default value is `GOAMD64=v1`. See https://github.com/golang/go/wiki/MinimumRequirements#amd64

Note: I insert `docker.io/` in the `FROM docker.io/golang:1.19` statement to allow `podman` and `buildah` to also build the container images.