### PR TITLE
refactor(elixir/phoenix): change to use Config over Mix.Config

### DIFF
--- a/frameworks/Elixir/phoenix/config/config.exs
+++ b/frameworks/Elixir/phoenix/config/config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Config
+import Config
 
 config :phoenix, :json_library, Jason
 

--- a/frameworks/Elixir/phoenix/config/config.exs
+++ b/frameworks/Elixir/phoenix/config/config.exs
@@ -3,7 +3,7 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+use Config
 
 config :phoenix, :json_library, Jason
 

--- a/frameworks/Elixir/phoenix/config/dev.exs
+++ b/frameworks/Elixir/phoenix/config/dev.exs
@@ -1,4 +1,4 @@
-use Config
+import Config
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/frameworks/Elixir/phoenix/config/dev.exs
+++ b/frameworks/Elixir/phoenix/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+use Config
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -1,4 +1,4 @@
-use Config
+import Config
 
 config :hello, HelloWeb.Endpoint,
   url: [host: "0.0.0.0"],

--- a/frameworks/Elixir/phoenix/config/prod.exs
+++ b/frameworks/Elixir/phoenix/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+use Config
 
 config :hello, HelloWeb.Endpoint,
   url: [host: "0.0.0.0"],

--- a/frameworks/Elixir/phoenix/config/test.exs
+++ b/frameworks/Elixir/phoenix/config/test.exs
@@ -1,1 +1,1 @@
-use Config
+import Config

--- a/frameworks/Elixir/phoenix/config/test.exs
+++ b/frameworks/Elixir/phoenix/config/test.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+use Config


### PR DESCRIPTION
Fixes the deprecated warnings to use Config.

See https://hexdocs.pm/mix/1.12/Mix.Config.html
