### PR TITLE
[php] Update Slim to 3.12.4

### DIFF
--- a/frameworks/PHP/slim/benchmark_config.json
+++ b/frameworks/PHP/slim/benchmark_config.json
@@ -14,7 +14,7 @@
       "database": "MySQL",
       "framework": "slim",
       "language": "PHP",
-      "flavor": "PHP7",
+      "flavor": "PHP8",
       "orm": "Raw",
       "platform": "FPM/FastCGI",
       "webserver": "nginx",

--- a/frameworks/PHP/slim/composer.json
+++ b/frameworks/PHP/slim/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "slim/slim": "3.8.1",
-        "slim/php-view": "2.2.0"
+        "slim/slim": "3.12.4",
+        "slim/php-view": "3.2.0"
     }
 }

--- a/frameworks/PHP/slim/deploy/conf/php.ini
+++ b/frameworks/PHP/slim/deploy/conf/php.ini
@@ -1909,6 +1909,10 @@ opcache.huge_code_pages=1
 ; SSL stream context option.
 ;openssl.capath=
 
+
+opcache.jit_buffer_size = 128M
+opcache.jit = tracing
+
 ; Local Variables:
 ; tab-width: 4
 ; End:

--- a/frameworks/PHP/slim/slim.dockerfile
+++ b/frameworks/PHP/slim/slim.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Update slim to 3.12.4 and views to 3.2
Update dockerfile with ubuntu 22.04 
Add JIT

To work with PHP 8.1, we need to update to v4 and change the code.