### PR TITLE
[ci skip] Fix Fastapi and Silverlining default

### DIFF
--- a/frameworks/Go/silverlining/benchmark_config.json
+++ b/frameworks/Go/silverlining/benchmark_config.json
@@ -1,7 +1,6 @@
 {
   "framework": "silverlining",
-  "tests": [
-    {
+  "tests": [{
       "default": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",
@@ -20,9 +19,7 @@
         "display_name": "silverlining",
         "notes": "",
         "versus": "go"
-      }
-    },
-    {
+      },
       "prefork": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",
@@ -42,6 +39,5 @@
         "notes": "",
         "versus": "go"
       }
-    }
-  ]
+    }]
 }

--- a/frameworks/Python/fastapi/benchmark_config.json
+++ b/frameworks/Python/fastapi/benchmark_config.json
@@ -1,8 +1,7 @@
 {
   "framework": "fastapi",
-  "tests": [
-    {
-      "gunicorn": {
+  "tests": [{
+      "default": {
         "json_url": "/json",
         "fortune_url": "/fortunes",
         "plaintext_url": "/plaintext",
@@ -208,6 +207,5 @@
         "notes": "",
         "versus": "None"
       }
-    }
-  ]
+    }]
 }


### PR DESCRIPTION
in `benchmark_config.json`

Tired of the message:

![image](https://user-images.githubusercontent.com/249085/196150645-ef913f50-75bd-4f13-a5d1-20fa759a8d9d.png)
