### PR TITLE
New parent images in Helidon docker files

### DIFF
--- a/frameworks/Java/helidon/helidon-nima.dockerfile
+++ b/frameworks/Java/helidon/helidon-nima.dockerfile
@@ -1,20 +1,4 @@
-FROM openjdk:19-jdk-slim as maven
-
-RUN apt-get update \
-  && apt-get install -y curl procps \
-  && rm -rf /var/lib/apt/lists/*
-ARG MAVEN_VERSION=3.8.6
-ARG USER_HOME_DIR="/root"
-ARG SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+FROM docker.io/maven:3.8.6-eclipse-temurin-19
 
 WORKDIR /helidon
 COPY nima/src src

--- a/frameworks/Java/helidon/helidon-nima.dockerfile
+++ b/frameworks/Java/helidon/helidon-nima.dockerfile
@@ -1,5 +1,4 @@
-FROM docker.io/maven:3.8.6-eclipse-temurin-19
-
+FROM docker.io/maven:3.8.6-eclipse-temurin-19 as maven
 WORKDIR /helidon
 COPY nima/src src
 COPY nima/pom.xml pom.xml

--- a/frameworks/Java/helidon/helidon.dockerfile
+++ b/frameworks/Java/helidon/helidon.dockerfile
@@ -1,5 +1,4 @@
-FROM docker.io/maven:3.8.6-eclipse-temurin-19
-
+FROM docker.io/maven:3.8.6-eclipse-temurin-19 as maven
 WORKDIR /helidon
 COPY reactive/src src
 COPY reactive/pom.xml pom.xml

--- a/frameworks/Java/helidon/helidon.dockerfile
+++ b/frameworks/Java/helidon/helidon.dockerfile
@@ -1,20 +1,4 @@
-FROM openjdk:19-jdk-slim as maven
-
-RUN apt-get update \
-  && apt-get install -y curl procps \
-  && rm -rf /var/lib/apt/lists/*
-ARG MAVEN_VERSION=3.8.6
-ARG USER_HOME_DIR="/root"
-ARG SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+FROM docker.io/maven:3.8.6-eclipse-temurin-19
 
 WORKDIR /helidon
 COPY reactive/src src

--- a/frameworks/Java/helidon/nima/src/main/resources/application.yaml
+++ b/frameworks/Java/helidon/nima/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ host: "tfb-database"
 db: "hello_world"
 username: benchmarkdbuser
 password: benchmarkdbpass
-sql-pool-size: 256
+sql-pool-size: 1024
 db-repository: "pgclient"     # "pgclient" (default) or "hikari"
 
 # The following for pgclient only


### PR DESCRIPTION
New parent images for Helidon docker files that do not require installation of Maven. Current images are failing while attempting to access host `apache.osuosl.org` in the TE environment. These new docker files avoid that problem by using a different parent image that already includes Maven.

Piggybacking a small config change related to SQL pools as well.
