### PR TITLE
update erlang runtime and dependencies

### DIFF
--- a/frameworks/Erlang/chicagoboss/chicagoboss.dockerfile
+++ b/frameworks/Erlang/chicagoboss/chicagoboss.dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:18.3.4.8
+FROM erlang:25.1-alpine
 
 ADD ./ /chicagoboss
 WORKDIR /chicagoboss

--- a/frameworks/Erlang/chicagoboss/rebar.config
+++ b/frameworks/Erlang/chicagoboss/rebar.config
@@ -1,5 +1,5 @@
 {deps, [
-  {boss, ".*", {git, "git://github.com/ChicagoBoss/ChicagoBoss.git", {tag, "v0.9.pre-alpha-2"}}}
+  {boss, ".*", {git, "git://github.com/ChicagoBoss/ChicagoBoss.git", {tag, "0.9.0"}}}
 ]}.
 {plugin_dir, ["priv/rebar"]}.
 {plugins, [boss_plugin]}.

--- a/frameworks/Erlang/cowboy/cowboy.dockerfile
+++ b/frameworks/Erlang/cowboy/cowboy.dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:21.1.1
+FROM erlang:25.1
 
 ADD ./ /cowboy
 WORKDIR /cowboy

--- a/frameworks/Erlang/cowboy/rebar.config
+++ b/frameworks/Erlang/cowboy/rebar.config
@@ -1,7 +1,7 @@
 {deps,
  [
-  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.15.2"}}},
+  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "1.1.1"}}},
   {mimetypes, ".*", {git, "http://github.com/spawngrid/mimetypes.git", {branch, master}}},
   {emysql, ".*", {git, "https://github.com/deadtrickster/Emysql.git", "52b802098322aad372198b9f5fa9ae9a4c758ad1"}},
-  {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "2.5.0"}}}
+  {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "2.9.0"}}}
  ]}.

--- a/frameworks/Erlang/cowboy/src/hello_world_app.erl
+++ b/frameworks/Erlang/cowboy/src/hello_world_app.erl
@@ -17,23 +17,23 @@
 
 
 start(_Type, _Args) ->
-        crypto:start(),
-        application:start(emysql),
-        emysql:add_pool(test_pool, 256,
-          "benchmarkdbuser", "benchmarkdbpass", "tfb-database", 3306,
-          "hello_world", utf8),
-	emysql:prepare(db_stmt, <<"SELECT * FROM World where id = ?">>),
-	Dispatch = cowboy_router:compile([
-		{'_', [
-      {"/plaintext", plaintext_handler, []},
-			{"/json", json_handler, []},
-			{"/db", db_handler, []},
-      {"/query", query_handler, []}
-		]}
-	]),
-	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{env => #{dispatch => Dispatch}}
-	),
-	hello_world_sup:start_link().
+    crypto:start(),
+    application:start(emysql),
+    emysql:add_pool(test_pool, 256,
+                    "benchmarkdbuser", "benchmarkdbpass", "tfb-database", 3306,
+                    "hello_world", utf8),
+    emysql:prepare(db_stmt, <<"SELECT * FROM World where id = ?">>),
+    Dispatch = cowboy_router:compile([
+                                      {'_', [
+                                             {"/plaintext", plaintext_handler, []},
+                                             {"/json", json_handler, []},
+                                             {"/db", db_handler, []},
+                                             {"/query", query_handler, []}
+                                            ]}
+                                     ]),
+    {ok, _} = cowboy:start_clear(http, [{port, 8080}], #{env => #{dispatch => Dispatch}}
+                                ),
+    hello_world_sup:start_link().
 
 stop(_State) ->
-	ok.
+    ok.

--- a/frameworks/Erlang/elli/elli.dockerfile
+++ b/frameworks/Erlang/elli/elli.dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:18.3.4.8
+FROM erlang:25.1
 
 WORKDIR /elli
 COPY src src

--- a/frameworks/Erlang/elli/rebar.config
+++ b/frameworks/Erlang/elli/rebar.config
@@ -1,6 +1,6 @@
 {deps,
  [
-  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "0.15.0"}}},
+  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "1.1.1"}}},
   {emysql, ".*", {git, "https://github.com/deadtrickster/Emysql.git", "52b802098322aad372198b9f5fa9ae9a4c758ad1"}},
-  {elli, "", {git, "https://github.com/knutin/elli.git", {tag, "v1.0.5"}}}
+  {elli, ".*", {git, "https://github.com/elli-lib/elli.git", {tag, "3.3.0"}}}
  ]}.

--- a/frameworks/Erlang/mochiweb/mochiweb.dockerfile
+++ b/frameworks/Erlang/mochiweb/mochiweb.dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:18.3.4.8
+FROM erlang:23
 
 ADD ./ /mochiweb
 WORKDIR /mochiweb

--- a/frameworks/Erlang/mochiweb/rebar.config
+++ b/frameworks/Erlang/mochiweb/rebar.config
@@ -1,9 +1,9 @@
 %% -*- erlang -*-
 {deps, [
-  {mochiweb, "2.9.0", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.9.0"}}},
-  {jsonx, ".*", {git, "https://github.com/iskra/jsonx.git", "9c95948c6835827ed61a9506ae4a9aba61acf335"}},
+  {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.20.1"}}},
+  {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {tag, "1.1.1"}}},
   {emysql, ".*", {git, "https://github.com/deadtrickster/Emysql.git"}},
-  {erlydtl, "0.11.1", {git, "https://github.com/erlydtl/erlydtl.git", {tag, "0.11.1"}}}
+  {erlydtl, ".*", {git, "https://github.com/erlydtl/erlydtl.git", {tag, "0.14.0"}}}
 ]}.
 {erlydtl_opts, [
     {doc_root,   "priv/templates"},

--- a/frameworks/Erlang/mochiweb/src/erl_bench.erl
+++ b/frameworks/Erlang/mochiweb/src/erl_bench.erl
@@ -2,22 +2,20 @@
 -export([hello_json/0, hello_plain/0, random_json/0, randoms_json/1, update_randoms_json/1, fortunes_html/0]).
 
 hello_json() ->
-    jsonx:encode([{<<"message">>, <<"Hello, World!">>}]).
+    {[{<<"message">>, <<"Hello, World!">>}]}.
 
 hello_plain() ->
     <<"Hello, world!">>.
 
 random_json() ->
     RandomId = randoms:random_id(),
-    jsonx:encode(find(RandomId)).
+    find(RandomId).
 
 randoms_json(Count) ->
-    Json = [find(Id) || Id <- randoms:random_ids(Count)],
-    jsonx:encode(Json).
+    [find(Id) || Id <- randoms:random_ids(Count)].
 
 update_randoms_json(Count) ->
-    Json = [update(Id) || Id <- randoms:random_ids(Count)],
-    jsonx:encode(Json).
+    [update(Id) || Id <- randoms:random_ids(Count)].
 
 fortunes_html() ->
     Props = [[{message, Message}, {id, Id}] || {Message, Id} <- fortunes:all()],
@@ -28,8 +26,8 @@ fortunes_html() ->
 
 find(Id) ->
     {Id, RandomNumber} = randoms:find(Id),
-    [{<<"id">>, Id}, {<<"randomNumber">>, RandomNumber}].
+    {[{<<"id">>, Id}, {<<"randomNumber">>, RandomNumber}]}.
 
 update(Id) ->
     {Id, RandomNumber} = randoms:update(Id),
-    [{<<"id">>, Id}, {<<"randomNumber">>, RandomNumber}].
+    {[{<<"id">>, Id}, {<<"randomNumber">>, RandomNumber}]}.

--- a/frameworks/Erlang/mochiweb/src/randoms.erl
+++ b/frameworks/Erlang/mochiweb/src/randoms.erl
@@ -4,11 +4,10 @@
 -define(world_max_records, 10000).
 
 init() ->
-    random:seed(erlang:now()),
     emysql:prepare(find_random, <<"SELECT id, randomNumber FROM World WHERE id = ? LIMIT 1;">>),
     emysql:prepare(update_random, <<"UPDATE World SET randomNumber = ? WHERE id = ? LIMIT 1;">>).
 
-random_id() -> random:uniform(?world_max_records).
+random_id() -> rand:uniform(?world_max_records).
 
 random_ids(Times) -> random_ids(Times, []).
 
@@ -20,7 +19,7 @@ find(Id) ->
     {Id, RandomNumber}.
 
 update(Id) ->
-    NewRandomNumber = random:uniform(10000),
+    NewRandomNumber = rand:uniform(10000),
     emysql:execute(db_pool, update_random, [NewRandomNumber, Id]),
     {Id, NewRandomNumber}.
 


### PR DESCRIPTION
Updated Erlang to 25.1 except for mochiweb.  Mochiweb has a dependency that doesn't support higher than 23.  Also bumped cowboy, ellli, mochiweb, and jiffy to latest.