### PR TITLE
Upgrade to node.js 18.12.1 for nodejs

### DIFF
--- a/frameworks/JavaScript/nodejs/README.md
+++ b/frameworks/JavaScript/nodejs/README.md
@@ -16,7 +16,7 @@ The server is currently in Alpha state, but aims to be a drop-in replacement for
 
 ## Infrastructure Software Versions
 The tests were run with:
-* [Node.js v16.13.0](http://nodejs.org/)
+* [Node.js v18.12.1](http://nodejs.org/)
 
 * [Node MySQL 2.16.0](https://github.com/felixge/node-mysql/)
 * [Sequelize 5.15.1](https://github.com/sequelize/sequelize)

--- a/frameworks/JavaScript/nodejs/nodejs.dockerfile
+++ b/frameworks/JavaScript/nodejs/nodejs.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 ARG TFB_TEST_NAME
 

--- a/frameworks/JavaScript/nodejs/package.json
+++ b/frameworks/JavaScript/nodejs/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "2.5.0",
     "handlebars": "4.3.0",
-    "mongodb": "3.6.4",
+    "mongodb": "3.7.3",
     "mongoose": "5.7.5",
     "mysql": "2.16.0",
     "mysql2": "1.6.5",


### PR DESCRIPTION
Changes the following for Node.js:

- Upgrade node version
- Upgrade  to mongodb 3.7.3