### PR TITLE
Upgrade to node.js 18.12.1 for hapi

### DIFF
--- a/frameworks/JavaScript/hapi/hapi-mysql.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/hapi/hapi-nginx.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-nginx.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:18.12.1-slim
 
 RUN apt-get update
 RUN apt-get install nginx -y

--- a/frameworks/JavaScript/hapi/hapi-postgres.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/hapi/hapi.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 


### PR DESCRIPTION
Changes the following for hapi:

- Upgrade node version