### PR TITLE
Upgrade to node.js 18.12.1 for nestjs

### DIFF
--- a/frameworks/TypeScript/nest/nestjs-fastify-mongo.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify-mongo.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-fastify-mysql.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-fastify.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-mongo.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-mongo.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-mysql.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.0-slim
+FROM node:18.12.1-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/package.json
+++ b/frameworks/TypeScript/nest/package.json
@@ -37,8 +37,9 @@
   "devDependencies": {
     "@nestjs/cli": "7.5.3",
     "@nestjs/schematics": "7.2.4",
-    "@types/express": "4.17.3",
-    "@types/node": "16.11.46",
+    "@types/express": "4.17.4",
+    "@types/express-serve-static-core": "4.17.30",
+    "@types/node": "18.11.9",
     "@typescript-eslint/eslint-plugin": "2.22.0",
     "@typescript-eslint/parser": "2.22.0",
     "eslint": "6.8.0",


### PR DESCRIPTION
Changes the following for NestJS:

- Upgrade node version
- Upgrade devDependencies