### PR TITLE
[mormot]: upgrade to mORMot 2.0.4383 (thread CPU affinity)

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -27,7 +27,7 @@ rm -rf ./libs
 
 # echo "Getting the latest pre-release URL..."
 # USED_TAG=$(wget -qO- https://api.github.com/repos/synopse/mORMot2/releases/latest | jq -r '.tag_name')
-USED_TAG="2.0.4148"
+USED_TAG="2.0.4383"
 
 echo "Used release tag $USED_TAG"
 URL="https://github.com/synopse/mORMot2/releases/download/$USED_TAG/mormot2static.7z"
@@ -40,8 +40,8 @@ echo "Unpacking to ./libs/mORMot/static ..."
 rm -rf ./mormot2static.7z
 
 # uncomment for fixed commit URL
-URL=https://github.com//synopse/mORMot2/tarball/d2a2d829bc539e1410f25c67ada143ba3a3ee2ca
-#URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
+#URL=https://github.com/synopse/mORMot2/tarball/b7422c9af6dbbe7710146164b46e8bff934b9f5a
+URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1
 

--- a/frameworks/Pascal/mormot/src/raw.pas
+++ b/frameworks/Pascal/mormot/src/raw.pas
@@ -156,6 +156,7 @@ begin
     [hsoNoXPoweredHeader, // not needed for a benchmark
      hsoHeadersInterning, // reduce memory contention for /plaintext and /json
      hsoNoStats,          // disable low-level statistic counters
+     hsoThreadCpuAffinity, // to avoid cpu-migrations of threads during high load tests
      {$ifdef WITH_LOGS}
      hsoLogVerbose,
      {$endif WITH_LOGS}
@@ -523,7 +524,7 @@ begin
 
   if (ParamCount <> 1) or
      not TryStrToInt(ParamStr(1), threads) then
-    threads := SystemInfo.dwNumberOfProcessors * 5;
+    threads := SystemInfo.dwNumberOfProcessors * 4;
   if threads < 16 then
     threads := 16
   else if threads > 256 then


### PR DESCRIPTION
upgrade to mORMot 2.0.4383 what sets thread CPU affinity to avoid cpu-migrations of worker threads during high load tests. This should improve all test cases, especially /plaintext and /json