### PR TITLE
[CSharp] AOT compile for modern CPUs

### DIFF
--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -12,6 +12,7 @@
     <StripSymbols>true</StripSymbols>
     <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
     <IlcPgoOptimize>true</IlcPgoOptimize>
+    <IlcInstructionSet>x86-x64-v3</IlcInstructionSet>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
x86-x64-v3 corresponds to ~Skylake that is 5 years old at this point.

