### PR TITLE
Set new value for update-batch-size in TE environment (Helidon Nima)

### DIFF
--- a/frameworks/Java/helidon/nima/src/main/resources/application.yaml
+++ b/frameworks/Java/helidon/nima/src/main/resources/application.yaml
@@ -44,6 +44,6 @@ sql-pool-size: 1024
 db-repository: "pgclient"     # "pgclient" (default) or "hikari"
 
 # The following for pgclient only
-update-batch-size: 10
+update-batch-size: 5
 update-timeout-millis: 10000
 update-max-retries: 3


### PR DESCRIPTION
Update results seem lower than expected in the TE environment. Trying out a smaller batch size before possible turning off the batch feature altogether.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>

