### PR TITLE
Updating Node/MongoDB Handlers to Use Default _id Index

### DIFF
--- a/frameworks/JavaScript/express/helper.js
+++ b/frameworks/JavaScript/express/helper.js
@@ -1,8 +1,7 @@
 module.exports = {
 
     sanititizeTotal : (total) => {
-
-        var totalIterations;
+        let totalIterations;
         if (!total || typeof(total) != 'number') {
             totalIterations = 1;
         } else if(total < 501 && total > 0) {
@@ -16,7 +15,6 @@ module.exports = {
     },
 
     randomizeNum : () => {
-
         return Math.floor(Math.random() * 10000) + 1
     }
 }

--- a/frameworks/JavaScript/express/mongodb-app.js
+++ b/frameworks/JavaScript/express/mongodb-app.js
@@ -1,35 +1,37 @@
-
 /**
  * Module dependencies.
  */
 
-const cluster = require('cluster'),
-  numCPUs = require('os').cpus().length,
-  express = require('express'),
-  mongoose = require('mongoose'),
-  conn = mongoose.connect('mongodb://tfb-database/hello_world');
+const cluster = require('cluster');
+const numCPUs = require('os').cpus().length;
+const express = require('express');
+const mongoose = require('mongoose');
+const conn = mongoose.connect('mongodb://tfb-database/hello_world');
 
 // Middleware
 const bodyParser = require('body-parser');
 
-const Schema = mongoose.Schema,
-  ObjectId = Schema.ObjectId;
-
+/**
+ * Note! The benchmarks say we should use "id" as a property name.
+ * However, Mongo provides a default index on "_id", so to be equivalent to the other tests, we use
+ * the same, default index provided by the database.
+ *
+ */
 const WorldSchema = new mongoose.Schema({
-  id: Number,
+  _id: Number,
   randomNumber: Number
 }, {
-    collection: 'world'
-  }),
-  MWorld = mongoose.model('world', WorldSchema);
+  collection: 'world'
+});
+const MWorld = mongoose.model('world', WorldSchema);
 
 const FortuneSchema = new mongoose.Schema({
-  id: Number,
+  _id: Number,
   message: String
 }, {
-    collection: 'fortune'
-  }),
-  MFortune = mongoose.model('fortune', FortuneSchema);
+  collection: 'fortune'
+});
+const MFortune = mongoose.model('fortune', FortuneSchema);
 
 if (cluster.isPrimary) {
   // Fork workers.
@@ -37,13 +39,21 @@ if (cluster.isPrimary) {
     cluster.fork();
   }
 
-  cluster.on('exit', (worker, code, signal) =>
-    console.log('worker ' + worker.pid + ' died'));
+  cluster.on('exit', (worker, code, signal) => console.log('worker ' + worker.pid + ' died'));
 } else {
   const app = module.exports = express();
 
+  const randomTfbNumber = () => Math.floor(Math.random() * 10000) + 1;
+  const toClientWorld = (world) => {
+    if (world) {
+      world.id = world._id;
+      delete world._id;
+    }
+    return world;
+  };
+
   // Configuration
-  app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(bodyParser.urlencoded({extended: true}));
 
   // Set headers for all routes
   app.use((req, res, next) => {
@@ -54,51 +64,57 @@ if (cluster.isPrimary) {
   app.set('view engine', 'pug');
   app.set('views', __dirname + '/views');
 
+  async function getRandomWorld() {
+    return toClientWorld(await MWorld.findOne({_id: randomTfbNumber()}).lean().exec());
+  }
+
   // Routes
   app.get('/mongooseq', async (req, res) => {
-    const queries = Math.min(parseInt(req.query.queries) || 1, 500),
-      results = [];
+    const queryCount = Math.min(parseInt(req.query.queries) || 1, 500);
+    const promises = [];
 
-    for (let i = 1; i <= queries; i++) {
-      results.push(await MWorld.findOne({ id: (Math.floor(Math.random() * 10000) + 1) }));
+    for (let i = 1; i <= queryCount; i++) {
+      promises.push(getRandomWorld());
     }
 
-    res.send(results);
+    res.send(await Promise.all(promises));
   });
 
   app.get('/mongoose', async (req, res) => {
-    let results = await MWorld.findOne({ id: (Math.floor(Math.random() * 10000) + 1) });
+    const result = await MWorld.findOne({_id: randomTfbNumber()}).lean().exec();
 
-    res.send(results);
+    res.send(toClientWorld(result));
   });
 
-  app.get('/mongoose-fortune', (req, res) => {
-    MFortune.find({}, (err, fortunes) => {
-      const newFortune = { id: 0, message: "Additional fortune added at request time." };
-      fortunes.push(newFortune);
-      fortunes.sort((a, b) => (a.message < b.message) ? -1 : 1);
+  app.get('/mongoose-fortune', async (req, res) => {
+    const fortunes = (await MFortune.find({}).lean().exec()).map(toClientWorld);
+    const newFortune = {id: 0, message: "Additional fortune added at request time."};
+    fortunes.push(newFortune);
+    fortunes.sort((a, b) => (a.message < b.message) ? -1 : 1);
 
-      res.render('fortunes/index', { fortunes: fortunes });
+    res.render('fortunes/index', {fortunes});
+  });
+
+  async function getUpdateRandomWorld() {
+    const world = await MWorld.findOne({_id: randomTfbNumber()}).lean().exec();
+    world.randomNumber = randomTfbNumber();
+    await MWorld.update({
+      _id: world._id
+    }, {
+      randomNumber: world.randomNumber
     });
-  });
+    return toClientWorld(world);
+  }
 
   app.get('/mongoose-update', async (req, res) => {
-    const results = [],
-      queries = Math.min(parseInt(req.query.queries) || 1, 500);
+    const queryCount = Math.min(parseInt(req.query.queries, 10) || 1, 500);
+    const promises = [];
 
-    for (let i = 1; i <= queries; i++) {
-      const world = await MWorld.findOne({ id: (Math.floor(Math.random() * 10000) + 1) });
-      world.randomNumber = ~~(Math.random() * 10000) + 1;
-      await MWorld.update({
-        id: world.id
-      }, {
-          randomNumber: world.randomNumber
-        });
-
-      results.push(world);
+    for (let i = 1; i <= queryCount; i++) {
+      promises.push(getUpdateRandomWorld());
     }
 
-    res.send(results);
+    res.send(await Promise.all(promises));
   });
 
   app.listen(8080);

--- a/frameworks/JavaScript/express/mongodb-app.js
+++ b/frameworks/JavaScript/express/mongodb-app.js
@@ -96,11 +96,17 @@ if (cluster.isPrimary) {
   });
 
   async function getUpdateRandomWorld() {
-    return toClientWorld(await MWorld.findOneAndUpdate({_id: randomTfbNumber()}, {
-      randomNumber: randomTfbNumber()
+    // it would be nice to use findOneAndUpdate here, but for some reason the test fails with it.
+    const world = await MWorld.findOne({_id: randomTfbNumber()}).lean().exec();
+    world.randomNumber = randomTfbNumber();
+    await MWorld.updateOne({
+      _id: world._id
     }, {
-      new: true
-    }).lean().exec());
+      $set: {
+        randomNumber: world.randomNumber
+      }
+    }).exec();
+    return toClientWorld(world);
   }
 
   app.get('/mongoose-update', async (req, res) => {

--- a/frameworks/JavaScript/express/mongodb-app.js
+++ b/frameworks/JavaScript/express/mongodb-app.js
@@ -96,14 +96,11 @@ if (cluster.isPrimary) {
   });
 
   async function getUpdateRandomWorld() {
-    const world = await MWorld.findOne({_id: randomTfbNumber()}).lean().exec();
-    world.randomNumber = randomTfbNumber();
-    await MWorld.update({
-      _id: world._id
+    return toClientWorld(await MWorld.findOneAndUpdate({_id: randomTfbNumber()}, {
+      randomNumber: randomTfbNumber()
     }, {
-      randomNumber: world.randomNumber
-    });
-    return toClientWorld(world);
+      new: true
+    }).lean().exec());
   }
 
   app.get('/mongoose-update', async (req, res) => {

--- a/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
+++ b/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
@@ -19,9 +19,8 @@ MongoClient.connect(mongoUrl, (err, database) => {
 
 const mongodbRandomWorld = (callback) => {
   collections.World.findOne({
-    id: h.randomTfbNumber()
+    _id: h.randomTfbNumber()
   }, (err, world) => {
-    world._id = undefined; // remove _id from query response
     callback(err, world);
   });
 };
@@ -33,10 +32,10 @@ const mongodbGetAllFortunes = (callback) => {
 };
 
 const mongodbDriverUpdateQuery = (callback) => {
-  collections.World.findOne({ id: h.randomTfbNumber() }, (err, world) => {
+  collections.World.findOne({ _id: h.randomTfbNumber() }, (err, world) => {
     world.randomNumber = h.randomTfbNumber();
-    collections.World.update({ id: world.id }, world, (err, updated) => {
-      callback(err, { id: world.id, randomNumber: world.randomNumber });
+    collections.World.update({ _id: world._id }, world, (err, updated) => {
+      callback(err, { _id: world._id, randomNumber: world.randomNumber });
     });
   });
 };

--- a/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
+++ b/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
@@ -1,92 +1,94 @@
 const h = require('../helper');
-const async = require('async');
 const MongoClient = require('mongodb').MongoClient;
-const collections = {
-  World: null,
-  Fortune: null
-};
+let collections = null, connecting = false, connectionCallbacks = [];
 
 const mongoUrl = 'mongodb://tfb-database:27017';
 const dbName = 'hello_world';
 
-MongoClient.connect(mongoUrl, (err, database) => {
-  // do nothing if there is err connecting to db
-
-  collections.World = database.db(dbName).collection('world');
-  collections.Fortune = database.db(dbName).collection('fortune');
-});
-
-
-const mongodbRandomWorld = (callback) => {
-  collections.World.findOne({
-    _id: h.randomTfbNumber()
-  }, (err, world) => {
-    callback(err, world);
-  });
-};
-
-const mongodbGetAllFortunes = (callback) => {
-  collections.Fortune.find().toArray((err, fortunes) => {
-    callback(err, fortunes);
-  })
-};
-
-const mongodbDriverUpdateQuery = (callback) => {
-  collections.World.findOne({ _id: h.randomTfbNumber() }, (err, world) => {
-    world.randomNumber = h.randomTfbNumber();
-    collections.World.update({ _id: world._id }, world, (err, updated) => {
-      callback(err, { _id: world._id, randomNumber: world.randomNumber });
+const getCollections = async () => {
+  // mongoose creates a queue of requests during connection, so we don't have to wait.
+  // however, with the raw driver we need to connect first, or sometimes the test will fail randomly
+  if (collections) {
+    return collections;
+  }
+  if (connecting) {
+    const promise = new Promise((resolve) => {
+      connectionCallbacks.push(resolve);
     });
+    return await promise;
+  }
+  connecting = true;
+  const client = await MongoClient.connect(mongoUrl);
+  collections = {
+    World: null,
+    Fortune: null
+  };
+  collections.World = client.db(dbName).collection('world');
+  collections.Fortune = client.db(dbName).collection('fortune');
+  return collections;
+}
+
+
+const mongodbRandomWorld = async () => {
+  const collections = await getCollections();
+  const world = collections.World.findOne({
+    _id: h.randomTfbNumber()
   });
+  world._id = undefined; // remove _id from query response
+  return world;
+};
+
+const mongodbGetAllFortunes = async () => {
+  const collections = await getCollections();
+  return await collections.Fortune.find().lean().toArray();
+};
+
+const mongodbDriverUpdateQuery = async () => {
+  const world = await collections.World.findOne({_id: h.randomTfbNumber()}).lean().exec();
+  world.randomNumber = h.randomTfbNumber();
+  await collections.World.updateOne({_id: world._id}, {
+    $set: {
+      randomNumber: world.randomNumber
+    }
+  });
+  return world;
 };
 
 
 module.exports = {
 
-  SingleQuery: (req, res) => {
-    mongodbRandomWorld((err, result) => {
-      if (err) { return process.exit(1) }
-
-      h.addTfbHeaders(res, 'json');
-      res.end(JSON.stringify(result));
-    });
+  SingleQuery: async (req, res) => {
+    const result = await mongodbRandomWorld();
+    h.addTfbHeaders(res, 'json');
+    res.end(JSON.stringify(result));
   },
 
-  MultipleQueries: (queries, req, res) => {
-    const queryFunctions = h.fillArray(mongodbRandomWorld, queries);
+  MultipleQueries: async (queryCount, req, res) => {
+    const queryFunctions = h.fillArray(mongodbRandomWorld, queryCount);
+    const results = await Promise.all(queryFunctions);
 
-    async.parallel(queryFunctions, (err, results) => {
-      if (err) { return process.exit(1) }
-
-      h.addTfbHeaders(res, 'json');
-      res.end(JSON.stringify(results));
-    });
+    h.addTfbHeaders(res, 'json');
+    res.end(JSON.stringify(results));
   },
 
-  Fortunes: (req, res) => {
-    mongodbGetAllFortunes((err, fortunes) => {
-      if (err) { return process.exit(1) }
-
-      fortunes.push(h.additionalFortune());
-      fortunes.sort(function (a, b) {
-        return a.message.localeCompare(b.message);
-      });
-      h.addTfbHeaders(res, 'html');
-      res.end(h.fortunesTemplate({
-        fortunes: fortunes
-      }));
+  Fortunes: async (req, res) => {
+    const fortunes = await mongodbGetAllFortunes();
+    fortunes.push(h.additionalFortune());
+    fortunes.sort(function (a, b) {
+      return a.message.localeCompare(b.message);
     });
+    h.addTfbHeaders(res, 'html');
+    res.end(h.fortunesTemplate({
+      fortunes: fortunes
+    }));
   },
 
-  Updates: (queries, req, res) => {
-    const queryFunctions = h.fillArray(mongodbDriverUpdateQuery, queries);
+  Updates: async (queryCount, req, res) => {
+    const queryFunctions = h.fillArray(mongodbDriverUpdateQuery, queryCount);
+    const results = await Promise.all(queryFunctions);
 
-    async.parallel(queryFunctions, (err, results) => {
-      if (err) { return process.exit(1) }
-
-      h.addTfbHeaders(res, 'json');
-      res.end(JSON.stringify(results));
-    });
+    h.addTfbHeaders(res, 'json');
+    res.end(JSON.stringify(results));
   }
 
 };

--- a/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
+++ b/frameworks/JavaScript/nodejs/handlers/mongodb-raw.js
@@ -40,11 +40,11 @@ const mongodbRandomWorld = async () => {
 
 const mongodbGetAllFortunes = async () => {
   const collections = await getCollections();
-  return await collections.Fortune.find().lean().toArray();
+  return await collections.Fortune.find().toArray();
 };
 
 const mongodbDriverUpdateQuery = async () => {
-  const world = await collections.World.findOne({_id: h.randomTfbNumber()}).lean().exec();
+  const world = await collections.World.findOne({_id: h.randomTfbNumber()}).exec();
   world.randomNumber = h.randomTfbNumber();
   await collections.World.updateOne({_id: world._id}, {
     $set: {

--- a/frameworks/JavaScript/nodejs/handlers/mongoose.js
+++ b/frameworks/JavaScript/nodejs/handlers/mongoose.js
@@ -5,13 +5,13 @@ const connection = Mongoose.createConnection('mongodb://tfb-database/hello_world
 
 // Mongoose Setup
 const WorldSchema = new Mongoose.Schema({
-  id: Number,
+  _id: Number,
   randomNumber: Number
 }, {
     collection: 'world'
   });
 const FortuneSchema = new Mongoose.Schema({
-  id: Number,
+  _id: Number,
   message: String
 }, {
     collection: 'fortune'
@@ -22,7 +22,7 @@ const Fortunes = connection.model('Fortune', FortuneSchema);
 
 const mongooseRandomWorld = (callback) => {
   Worlds.findOne({
-    id: h.randomTfbNumber()
+    _id: h.randomTfbNumber()
   }).exec(callback);
 };
 
@@ -81,7 +81,7 @@ module.exports = {
           updateFunctions.push((callback) => {
             worlds[i].randomNumber = h.randomTfbNumber();
             Worlds.update({
-              id: worlds[i].id
+              _id: worlds[i]._id
             }, {
                 randomNumber: worlds[i].randomNumber
               }, callback);

--- a/frameworks/JavaScript/nodejs/helper.js
+++ b/frameworks/JavaScript/nodejs/helper.js
@@ -2,6 +2,12 @@ const Handlebars = require('handlebars');
 
 const GREETING = "Hello, World!";
 
+const headerTypes = {
+  plain: 'text/plain',
+  json:  'application/json',
+  html:  'text/html; charset=UTF-8'
+};
+
 const self = module.exports = {
 
   additionalFortune: () => ({
@@ -41,12 +47,6 @@ const self = module.exports = {
   },
 
   addTfbHeaders: (res, headerType) => {
-    const headerTypes = {
-      plain: 'text/plain',
-      json:  'application/json',
-      html:  'text/html; charset=UTF-8'
-    };
-    
     res.setHeader('Server', 'Node');
     res.setHeader('Content-Type', headerTypes[headerType]);
 },

--- a/frameworks/JavaScript/nodejs/routing.js
+++ b/frameworks/JavaScript/nodejs/routing.js
@@ -1,4 +1,4 @@
-// Intialized database connections, one for each db config
+// Initialized database connections, one for each db config
 // * Mongoose is a popular Node/MongoDB driver
 // * Sequelize is a popular Node/SQL driver
 


### PR DESCRIPTION
The current benchmarks for Node/Mongo do not use an index for queries. I'm not sure how much data we're storing in here yet, but the other tests are using default indexes (like default primary key index in PG), so this seems appropriate.

### Explanation

When you use `id` instead of `_id` you are not using an index, since you're creating a new field, without an index. We could explicitly create an index in the code, however it's fine to just use `_id` as a `Number` and use the default btree index that you get along with that.

- Moved from "id" to "_id" to use default btree like postgres/mysql tests.
- Refactored callback based code to use async/await - how most NodeJS code is written today. Performance is about the same.
- Fixed connection related race conditions in the native mongodb driver benchmark.
- Added additional parallelism in some places using promises and `Promise.all`.
- ~~Replaced multiple sequential queries with findOneAndUpdate which also returns the new version.~~
