### PR TITLE
[ci skip] Fix Robyn benchmark_config.json

### DIFF
--- a/frameworks/Python/robyn/benchmark_config.json
+++ b/frameworks/Python/robyn/benchmark_config.json
@@ -17,9 +17,7 @@
         "display_name": "Robyn",
         "notes": "",
         "versus": "None"
-      }
-    },
-    {
+      },
       "const": {
         "plaintext_url": "/plaintext",
         "port": 8080,


### PR DESCRIPTION
Fix 
`Framework robyn does not define a default test in benchmark_config.json`
