### PR TITLE
Fixed incorrect benchmark configuration for jooby-pgclient

### DIFF
--- a/frameworks/Java/jooby/benchmark_config.json
+++ b/frameworks/Java/jooby/benchmark_config.json
@@ -104,7 +104,7 @@
       "framework": "Jooby",
       "language": "Java",
       "flavor": "None",
-      "platform": "Undertow",
+      "platform": "Netty",
       "database": "Postgres",
       "database_os": "Linux",
       "orm": "Raw",

--- a/frameworks/Java/jooby/config.toml
+++ b/frameworks/Java/jooby/config.toml
@@ -46,7 +46,7 @@ database = "Postgres"
 database_os = "Linux"
 os = "Linux"
 orm = "Raw"
-platform = "Undertow"
+platform = "Netty"
 webserver = "None"
 versus = "undertow"
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
The `jooby-pgclient` configuration uses Netty as the application server. But the configuration files reflect Undertow as the Platform.

Changed the configuration to set platform as Netty.