### PR TITLE
Update requirements on `uvicorn`

### DIFF
--- a/frameworks/Python/uvicorn/requirements.txt
+++ b/frameworks/Python/uvicorn/requirements.txt
@@ -2,5 +2,6 @@ asyncpg==0.21.0
 gunicorn==20.0.4
 Jinja2==3.0.3
 ujson==5.4.0
-uvloop==0.14.0
-uvicorn==0.11.7
+uvloop==0.17.0
+uvicorn==0.20.0
+httptools==0.5.0


### PR DESCRIPTION
`uvicorn` automatically uses `httptools` when installed in the virtual environment.

Disclaimer: I'm a maintainer of `uvicorn`.