### PR TITLE
Update requirements on fastapi-uvicorn

### DIFF
--- a/frameworks/Python/fastapi/requirements-uvicorn.txt
+++ b/frameworks/Python/fastapi/requirements-uvicorn.txt
@@ -1,1 +1,3 @@
-uvicorn==0.18.3
+uvicorn==0.20.0
+uvloop==0.17.0
+httptools==0.5.0


### PR DESCRIPTION
Those were removed on https://github.com/TechEmpower/FrameworkBenchmarks/pull/7613 by mistake.

They should be included.

Disclaimer: I'm a maintainer of `uvicorn`.