### PR TITLE
pull in a newer base image & compiler for httpaf

### DIFF
--- a/frameworks/OCaml/httpaf/httpaf.dockerfile
+++ b/frameworks/OCaml/httpaf/httpaf.dockerfile
@@ -1,36 +1,13 @@
 # -*- mode: dockerfile -*-
 
-FROM alpine:3.15
+# https://github.com/rbjorklin/techempower-ocaml-image
+# Use pre-built image with all dependencies for faster test times
+FROM rbjorklin/techempower-ocaml-image:4.14.1-4bf86567
 
 # https://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html
 # https://linux.die.net/man/1/ocamlrun
 # https://blog.janestreet.com/memory-allocator-showdown/
 ENV OCAMLRUNPARAM a=2,o=240
-
-RUN apk add --no-cache \
-    bash\
-    bubblewrap\
-    coreutils\
-    gcc\
-    git\
-    libev-dev\
-    libffi-dev\
-    linux-headers\
-    m4\
-    make\
-    musl-dev\
-    opam\
-    postgresql-dev
-
-RUN opam init\
-    --disable-sandboxing\
-    --auto-setup\
-    --compiler ocaml-base-compiler.4.13.1
-
-RUN opam install -y opam-depext
-RUN \
-  opam depext -y dune conf-libev httpaf httpaf-lwt-unix lwt yojson && \
-  opam install -y dune conf-libev httpaf httpaf-lwt-unix lwt yojson
 
 COPY . /app
 


### PR DESCRIPTION
This PR is related to #7822 where a shared pre-built image is being used for the compiler. This change should shave a few minutes off the build process.