### PR TITLE
Revert to using Ubuntu 18.04 for the wrk image

### DIFF
--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jammy
+FROM buildpack-deps:bionic
 
 RUN apt-get update && apt-get install -yqq libluajit-5.1-dev libssl-dev luajit
 


### PR DESCRIPTION
There has been a significant performance regression after #7783 (e.g. check the composite scores), and this PR is an attempt to figure out where the issue is.

In addition to the `wrk` version update, PR #7783 made the following the changes:
- modified the command used to calculate the maximum number of threads started by `wrk` - I checked the raw data for the `h2o` implementation (which covers all defined tests and has been affected negatively) and there were no differences in the values
- changed the compiler options used to build `wrk` - the new ones do not have any effect in the continuous benchmarking environment (unlike on other platforms)
- updated the base Docker image to Ubuntu 22.04

Concerning the last point, it is possible that the system libraries (e.g. the memory allocator) have received additional security hardening compared to 18.04, which causes the slowdown, so this PR tries to check this theory. Since 18.04 will stop being supported in less than half a year and given that this project is meant to represent a realistic production environment, I expect that we will return to 22.04 eventually, but in the meantime it does not hurt to be aware of any costs.