### PR TITLE
[ci skip] Revert wrk to version 4.1.0

### DIFF
--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -3,7 +3,7 @@ FROM buildpack-deps:bionic
 RUN apt-get update && apt-get install -yqq libluajit-5.1-dev libssl-dev luajit
 
 WORKDIR /wrk
-RUN curl -sL https://github.com/wg/wrk/archive/4.2.0.tar.gz | tar xz --strip-components=1
+RUN curl -sL https://github.com/wg/wrk/archive/4.1.0.tar.gz | tar xz --strip-components=1
 ENV LDFLAGS="-O3 -march=native -mtune=native -flto"
 ENV CFLAGS="-I /usr/include/luajit-2.1 $LDFLAGS"
 RUN make WITH_LUAJIT=/usr WITH_OPENSSL=/usr -j "$(nproc)"


### PR DESCRIPTION
PR #7832 did not lead to any real differences in the benchmark results (in particular for the fortunes and the JSON serialization tests, which were affected the most, i.e. the maximum score achieved by any framework was reduced), so let's check if the other significant change in #7783 has an impact.