### PR TITLE
[mORMot] improved `/updates` performance

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -40,7 +40,7 @@ echo "Unpacking to ./libs/mORMot/static ..."
 rm -rf ./mormot2static.7z
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/5439a291fbb43bb8b5804982c5f843420ce932e1
+URL=https://github.com/synopse/mORMot2/tarball/dbe44a75014ac01f3afb4fbf1880dbfd18ae0d2c
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1

--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -40,7 +40,7 @@ echo "Unpacking to ./libs/mORMot/static ..."
 rm -rf ./mormot2static.7z
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/2a29d80e352f04570f5cfba61bda8b862415cd4c
+URL=https://github.com/synopse/mORMot2/tarball/5439a291fbb43bb8b5804982c5f843420ce932e1
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1

--- a/frameworks/Pascal/mormot/src/raw.pas
+++ b/frameworks/Pascal/mormot/src/raw.pas
@@ -113,7 +113,7 @@ const
 
   WORLD_READ_SQL = 'select id, randomNumber from World where id=?';
   WORLD_UPDATE_SQLN ='update World as t set randomNumber = v.r from ' +
-    '(SELECT unnest(?::NUMERIC[]), unnest(?::NUMERIC[])) as v(id, r)' +
+    '(SELECT unnest(?::NUMERIC[]), unnest(?::NUMERIC[]) order by 2) as v(id, r)' +
     ' where t.id = v.id';
   FORTUNES_SQL = 'select id, message from Fortune';
 
@@ -511,7 +511,7 @@ begin
       servers := 1;
     end;
   end;
-  //if servers = 1 then
+  if servers = 1 then
     include(flags, hsoThreadSmooting); // 30% better /plaintext e.g. on i5 7300U
 
   // start the server instance(s), in hsoReusePort mode


### PR DESCRIPTION
In this PR:
 - for batch update use `order by ID` for unnested arrays - this should minimize table locking on big concurrency 
 - optimized per-thread connection retrieving by using a threadvar for O(1) lookup
 - change ThreadPollingWakeup algorithm to *NOT* focus the process on the first threads of the pool (removed hsoThreadSmooting option)
 - HTTP headers parser optimizations
 