### PR TITLE
Quarkus version upgrade and Type Pollution mitigation

### DIFF
--- a/frameworks/Java/quarkus/pom.xml
+++ b/frameworks/Java/quarkus/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>2.14.0.Final</quarkus.version>
+        <quarkus.version>2.15.0.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
@@ -24,3 +24,5 @@ quarkus.log.level=INFO
 
 quarkus.vertx.prefer-native-transport=true
 
+# Resteasy-reactive config to always send Content-Length on HTTP res and avoid chunked res
+quarkus.resteasy-reactive.output-buffer-size=20480

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/resources/application.properties
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/resources/application.properties
@@ -28,5 +28,7 @@ quarkus.hibernate-orm.second-level-caching-enabled=false
 quarkus.hibernate-orm.database.generation=validate
 quarkus.hibernate-orm.log.sql=false
 
+# Resteasy-reactive config to always send Content-Length on HTTP res and avoid chunked res
+quarkus.resteasy-reactive.output-buffer-size=20480
 
 

--- a/frameworks/Java/quarkus/run_quarkus.sh
+++ b/frameworks/Java/quarkus/run_quarkus.sh
@@ -16,6 +16,7 @@ JAVA_OPTIONS="-server \
   -Dio.netty.buffer.checkBounds=false \
   -Dio.netty.buffer.checkAccessible=false \
   -Djava.util.logging.manager=org.jboss.logmanager.LogManager \
+  -Dquarkus.http.idle-timeout=0 \
   -XX:-UseBiasedLocking \
   -XX:+UseStringDeduplication \
   -XX:+UseNUMA \


### PR DESCRIPTION
As said in the comment messages:
- Upgrade to Quarkus 2.15.0
- Mitigate Type Profiling issues due to VERIFYING QUERY chunked responses
- Shrink Netty's pipeline by removing `IdleStateHandler`