### PR TITLE
[mORMot] improved raw fortunes performance; fix potential GPF

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -40,7 +40,7 @@ echo "Unpacking to ./libs/mORMot/static ..."
 rm -rf ./mormot2static.7z
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/ca82bc513fab61c2be8d2abfee2729375cfef6dc
+URL=https://github.com/synopse/mORMot2/tarball/7cc9e10d6dfbe531ded16aa7f9ccd0fb95f8c6dd
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1

--- a/frameworks/Pascal/mormot/src/raw.pas
+++ b/frameworks/Pascal/mormot/src/raw.pas
@@ -373,9 +373,9 @@ var
   conn: TSqlDBConnection;
   stmt: ISQLDBStatement;
   list: TFortunes;
-  f: TFortune;
   arr: TDynArray;
   n: integer;
+  f: ^TFortune;
 begin
   conn := fDbPool.ThreadSafeConnection;
   stmt := conn.NewStatementPrepared(FORTUNES_SQL, true, true);
@@ -383,13 +383,13 @@ begin
   arr.Init(TypeInfo(TFortunes), list, @n);
   while stmt.Step do
   begin
+    f := arr.NewPtr;
     f.id := stmt.ColumnInt(0);
     f.message := stmt.ColumnUtf8(1);
-    arr.Add(f);
   end;
+  f := arr.NewPtr;
   f.id := 0;
   f.message := FORTUNES_MESSAGE;
-  arr.Add(f);
   arr.Sort(FortuneCompareByMessage);
   ctxt.OutContent := fTemplate.RenderDataArray(arr);
   ctxt.OutContentType := HTML_CONTENT_TYPE;


### PR DESCRIPTION
- improved /fortunes  performance in raw mode (~ +4k RPS) by avoid unnecessary record copy
- fixed potential GPF in mORMot async module (found after switch to glibc memory manager) 