### PR TITLE
update spider-gazelle version and replaced orm with pg-orm

### DIFF
--- a/frameworks/Crystal/spider-gazelle/shard.yml
+++ b/frameworks/Crystal/spider-gazelle/shard.yml
@@ -4,26 +4,16 @@ version: 1.0.0
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
-    version: "1.4.2"
+    version: "5.6.0"
 
-  granite:
-    github: amberframework/granite
-    version: "0.15.0"
+  pg-orm:
+    github: spider-gazelle/pg-orm
 
   # https://github.com/jeromegn/kilt
   # Generic template interface for Crystal
   kilt:
     github: jeromegn/kilt
-    version: "0.4.0"
-
-  pg:
-    github: will/crystal-pg
-    version: "0.15.0"
-
-development_dependencies:
-  ameba:
-    github: veelenga/ameba
-    version: "0.8.1"
+    version: "0.6.1"
 
 # compile target
 targets:

--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -1,4 +1,6 @@
-FROM placeos/crystal
+FROM 84codes/crystal:1.7.2-alpine
+RUN apk add --update --no-cache gmp-dev
+
 WORKDIR /usr/src/app
 
 COPY shard.yml ./

--- a/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
+++ b/frameworks/Crystal/spider-gazelle/spider-gazelle.dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM placeos/crystal
 WORKDIR /usr/src/app
 
 COPY shard.yml ./
@@ -7,9 +7,12 @@ COPY src src
 # Build App
 RUN shards build --release --no-debug
 
-ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world?initial_pool_size=56&max_pool_size=56&max_idle_pool_size=56
+ENV DATABASE_URL postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
+
 ENV SG_ENV production
 
 # Run the app binding on port 8080
 EXPOSE 8080
+ENTRYPOINT []
+
 CMD bin/app -w $(nproc) -b 0.0.0.0 -p 8080

--- a/frameworks/Crystal/spider-gazelle/src/config.cr
+++ b/frameworks/Crystal/spider-gazelle/src/config.cr
@@ -1,9 +1,6 @@
 # Application dependencies
 require "action-controller"
-
-require "granite/adapter/pg"
-Granite.settings.logger = Logger.new(nil)
-Granite::Adapters << Granite::Adapter::Pg.new({name: "pg", url: ENV["DATABASE_URL"]})
+require "pg-orm"
 
 # Application code
 require "./controllers/application"
@@ -12,6 +9,9 @@ require "./models/*"
 
 # Server required after application controllers
 require "action-controller/server"
+
+# Configure PG Database connection
+PgORM::Database.parse(ENV["DATABASE_URL"])
 
 # Configure session cookies
 # NOTE:: Change these from defaults

--- a/frameworks/Crystal/spider-gazelle/src/controllers/application.cr
+++ b/frameworks/Crystal/spider-gazelle/src/controllers/application.cr
@@ -6,6 +6,6 @@ abstract class Application < ActionController::Base
 
   def set_date_header
     response.headers["Server"] = "Spider-Gazelle"
-    response.headers["Date"] = HTTP.format_time(Time.now)
+    response.headers["Date"] = HTTP.format_time(Time.local)
   end
 end

--- a/frameworks/Crystal/spider-gazelle/src/controllers/benchmark.cr
+++ b/frameworks/Crystal/spider-gazelle/src/controllers/benchmark.cr
@@ -21,33 +21,31 @@ class Benchmark < Application
 
   # Postgres Test 2: Single database query
   get "/db", :db do
-    results = {} of Symbol => Int32
-    if world = World.find(Random.rand(ID_MAXIMUM).succ)
-      results = {id: world.id, randomNumber: world.randomnumber}
-    end
-
+    world = World.find(Random.rand(1..ID_MAXIMUM))
+    results = {id: world.id, randomNumber: world.randomnumber}
     render json: results
   end
 
   # Postgres Test 3: Multiple database query
   get "/queries", :queries do
     results = (1..get_query_count).map do
-      if world = World.find(Random.rand(ID_MAXIMUM).succ)
-        {id: world.id, randomNumber: world.randomnumber}
-      end
+      world = World.find(Random.rand(1..ID_MAXIMUM))
+      {id: world.id, randomNumber: world.randomnumber}
     end
-
     render json: results
   end
 
   # Postgres Test 5: Database Updates
   get "/updates", :updates do
     results = (1..get_query_count).map do
-      if world = World.find(Random.rand(ID_MAXIMUM).succ)
-        world.randomnumber = Random.rand(ID_MAXIMUM).succ
-        world.save
-        {id: world.id, randomNumber: world.randomnumber}
+      world = World.find(Random.rand(1..ID_MAXIMUM))
+      random_number = Random.rand(1..ID_MAXIMUM)
+      while random_number == world.randomnumber
+        random_number = Random.rand(1..ID_MAXIMUM)
       end
+      world.randomnumber = random_number
+      world.save!
+      {id: world.id, randomNumber: random_number}
     end
 
     render json: results
@@ -55,16 +53,12 @@ class Benchmark < Application
 
   # Postgres Test 4: Fortunes
   FORTUNE_MESSAGE = "Additional fortune added at request time."
-  FORTUNE_CTYPE = "text/html; charset=UTF-8"
+  FORTUNE_CTYPE   = "text/html; charset=UTF-8"
 
   get "/fortunes", :fortunes do
-    fortune = Fortune.new
-    fortune.id = 0
-    fortune.message = FORTUNE_MESSAGE
-
-    fortunes = Fortune.all
-    fortunes << fortune
-    fortunes.sort_by! { |fortune| fortune.message || "" }
+    fortunes = Fortune.all.to_a
+    fortunes << Fortune.new(id: 0, message: FORTUNE_MESSAGE)
+    fortunes.sort_by!(&.message)
 
     # by default this would have been returned as text/html
     response.content_type = FORTUNE_CTYPE

--- a/frameworks/Crystal/spider-gazelle/src/models/fortune.cr
+++ b/frameworks/Crystal/spider-gazelle/src/models/fortune.cr
@@ -1,9 +1,6 @@
-require "granite/adapter/pg"
+require "pg-orm"
 
-class Fortune < Granite::Base
-  adapter pg
-
-  table_name fortune
-  primary id : Int32
-  field message : String
+class Fortune < PgORM::Base
+  attribute id : Int32, primary_key: true
+  attribute message : String
 end

--- a/frameworks/Crystal/spider-gazelle/src/models/world.cr
+++ b/frameworks/Crystal/spider-gazelle/src/models/world.cr
@@ -1,9 +1,6 @@
-require "granite/adapter/pg"
+require "pg-orm"
 
-class World < Granite::Base
-  adapter pg
-
-  table_name world
-  primary id : Int32
-  field randomnumber : Int32
+class World < PgORM::Base
+  attribute id : Int32, primary_key: true
+  attribute randomnumber : Int32
 end


### PR DESCRIPTION
This PR contains the following updates to `spider-gazelle`:

* Update dependencies to latest version
* Removed dependency on `granite` ORM
* Added `pg-orm` as a replacement ORM

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
