### PR TITLE
Reduce the size of the toolset Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bionic
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 # WARNING: DON'T PUT A SPACE AFTER ANY BACKSLASH OR APT WILL BREAK
@@ -13,14 +13,19 @@ RUN apt-get -yqq update && apt-get -yqq install \
       python-dev \
       python-pip \
       siege \
-      software-properties-common
+      software-properties-common && \
+    pip install \
+      colorama==0.3.1 \
+      docker==4.0.2 \
+      MySQL-python \
+      psutil \
+      psycopg2-binary \
+      pymongo \
+      requests && \
+    # Fix for docker-py trying to import one package from the wrong location
+    cp -r /usr/local/lib/python2.7/dist-packages/backports/ssl_match_hostname \
+      /usr/lib/python2.7/dist-packages/backports
 
-RUN pip install colorama==0.3.1 docker==4.0.2 MySQL-python psutil psycopg2-binary pymongo requests
-
-# Fix for docker-py trying to import one package from the wrong location
-RUN cp -r /usr/local/lib/python2.7/dist-packages/backports/ssl_match_hostname /usr/lib/python2.7/dist-packages/backports
-
-ENV PYTHONPATH=/FrameworkBenchmarks
-ENV FWROOT=/FrameworkBenchmarks
+ENV FWROOT=/FrameworkBenchmarks PYTHONPATH=/FrameworkBenchmarks
 
 ENTRYPOINT ["python", "/FrameworkBenchmarks/toolset/run-tests.py"]

--- a/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
+++ b/frameworks/Ruby/h2o_mruby/h2o_mruby.dockerfile
@@ -2,30 +2,39 @@ ARG RUBY_IMAGE_VERSION=3.2
 
 ARG H2O_PREFIX=/opt/h2o
 
-FROM ruby:${RUBY_IMAGE_VERSION} AS compile
+FROM "ruby:${RUBY_IMAGE_VERSION}" AS compile
 
 ARG H2O_VERSION=9ab3feb4d7429ddda52a3cf84bd6da0e890bd52a
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get -yqq update && apt-get -yqq install cmake ninja-build
-WORKDIR h2o-build
-ARG H2O_ARCHIVE="${H2O_VERSION}.tar.gz"
-ADD "https://github.com/h2o/h2o/archive/${H2O_ARCHIVE}" ./
-RUN tar --strip-components=1 -xf "${H2O_ARCHIVE}"
 ARG H2O_PREFIX
-WORKDIR build
-RUN cmake -G Ninja -DCMAKE_C_FLAGS="-flto -march=native -mtune=native" -DWITH_MRUBY=on \
-          -DCMAKE_AR=/usr/bin/gcc-ar -DCMAKE_RANLIB=/usr/bin/gcc-ranlib \
-          -DCMAKE_INSTALL_PREFIX="${H2O_PREFIX}" .. && \
-    cmake --build . -j && \
-    cmake --install .
-WORKDIR /
+WORKDIR /tmp/h2o-build
+RUN apt-get -yqq update && \
+    apt-get -yqq install \
+      cmake \
+      ninja-build && \
+    curl -LSs "https://github.com/h2o/h2o/archive/${H2O_VERSION}.tar.gz" | \
+      tar --strip-components=1 -xz && \
+    cmake \
+      -B build \
+      -DCMAKE_AR=/usr/bin/gcc-ar \
+      -DCMAKE_C_FLAGS="-flto -march=native -mtune=native" \
+      -DCMAKE_INSTALL_PREFIX="${H2O_PREFIX}" \
+      -DCMAKE_RANLIB=/usr/bin/gcc-ranlib \
+      -DWITH_MRUBY=on \
+      -G Ninja \
+      -S . && \
+    cmake --build build -j && \
+    cmake --install build
 
 FROM ruby:${RUBY_IMAGE_VERSION}-slim
 
 ARG H2O_PREFIX
-ADD ./h2o.conf "${H2O_PREFIX}/"
 COPY --from=compile "${H2O_PREFIX}" "${H2O_PREFIX}/"
+COPY h2o.conf "${H2O_PREFIX}/"
 EXPOSE 8080
+ARG BENCHMARK_ENV
+ARG TFB_TEST_DATABASE
+ARG TFB_TEST_NAME
 
 CMD ["/opt/h2o/bin/h2o", "-c", "/opt/h2o/h2o.conf"]

--- a/toolset/databases/mongodb/mongodb.dockerfile
+++ b/toolset/databases/mongodb/mongodb.dockerfile
@@ -1,20 +1,28 @@
-FROM buildpack-deps:jammy
+FROM ubuntu:22.04
 
 ARG MONGODB_VERSION=6.0
 
-COPY ./ ./
+COPY create.js /tmp/
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-${MONGODB_VERSION}.asc > /etc/apt/keyrings/mongodb-org.asc
-RUN echo "deb [ signed-by=/etc/apt/keyrings/mongodb-org.asc ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/${MONGODB_VERSION} multiverse" > \
-      /etc/apt/sources.list.d/mongodb-org.list
-# Complete and utter hax if works
-RUN ln -s /bin/echo /bin/systemctl
-RUN apt-get -yqq update && apt-get -yqq install mongodb-org
-
-RUN mkdir -p /data/db
-RUN chmod 777 /data/db
-
-RUN mongod --fork --logpath /var/log/mongodb.log --bind_ip_all && sleep 10 && mongosh < create.js && sleep 10
+ADD "https://www.mongodb.org/static/pgp/server-${MONGODB_VERSION}.asc" \
+    /etc/apt/keyrings/mongodb-org.asc
+RUN apt-get -yqq update && \
+    apt-get -yqq install \
+      apt-utils \
+      ca-certificates \
+      lsb-release && \
+    chmod 644 /etc/apt/keyrings/mongodb-org.asc && \
+    echo "deb [ signed-by=/etc/apt/keyrings/mongodb-org.asc ] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/${MONGODB_VERSION} multiverse" > \
+      /etc/apt/sources.list.d/mongodb-org.list && \
+    apt-get -yqq update && \
+    # Complete and utter hax if it works
+    ln -s /bin/echo /bin/systemctl && \
+    apt-get -yqq install mongodb-org && \
+    install -dm777 /data/db && \
+    mongod --fork --logpath /var/log/mongodb.log --bind_ip_all && \
+    sleep 10 && \
+    mongosh < /tmp/create.js && \
+    sleep 10
 
 CMD ["mongod", "--bind_ip_all"]

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -1,55 +1,56 @@
-FROM buildpack-deps:jammy
+FROM ubuntu:22.04
 
 ARG PG_VERSION=15
 
-ADD postgresql.conf postgresql.conf
-ADD pg_hba.conf pg_hba.conf
-ADD 60-postgresql-shm.conf 60-postgresql-shm.conf
-ADD create-postgres-database.sql create-postgres-database.sql
-ADD create-postgres.sql create-postgres.sql
+COPY 60-postgresql-shm.conf pg_hba.conf postgresql.conf ./
+COPY create-postgres.sql create-postgres-database.sql /tmp/
 
-# prepare PostgreSQL APT repository
+# Prepare the PostgreSQL APT repository
 ARG DEBIAN_FRONTEND=noninteractive
-RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc > /etc/apt/keyrings/postgresql.asc
-RUN echo "deb [ signed-by=/etc/apt/keyrings/postgresql.asc ] http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > \
-      /etc/apt/sources.list.d/pgdg.list
-RUN apt-get -yqq update && apt-get -yqq install apt-utils locales
+ADD "https://www.postgresql.org/media/keys/ACCC4CF8.asc" /etc/apt/keyrings/postgresql.asc
+RUN chmod 644 /etc/apt/keyrings/postgresql.asc && \
+    apt-get -yqq update && \
+    apt-get -yqq install \
+      apt-utils \
+      locales \
+      lsb-release && \
+    echo "deb [ signed-by=/etc/apt/keyrings/postgresql.asc ] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > \
+      /etc/apt/sources.list.d/pgdg.list && \
+    locale-gen en_US.UTF-8
 
-RUN locale-gen en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
-# install postgresql on database machine
-RUN apt-get -yqq install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" postgresql-${PG_VERSION} postgresql-contrib-${PG_VERSION}
-
-# Make sure all the configuration files in main belong to postgres
-RUN sed -i "s|PG_VERSION|${PG_VERSION}|g" postgresql.conf
-RUN mv postgresql.conf /etc/postgresql/${PG_VERSION}/main/postgresql.conf
-RUN mv pg_hba.conf /etc/postgresql/${PG_VERSION}/main/pg_hba.conf
-
-RUN chown -Rf postgres:postgres /etc/postgresql/${PG_VERSION}/main
-
-RUN mkdir /ssd
-RUN cp -R -p /var/lib/postgresql/${PG_VERSION}/main /ssd/postgresql
-RUN cp /etc/postgresql/${PG_VERSION}/main/postgresql.conf /ssd/postgresql
-RUN mv 60-postgresql-shm.conf /etc/sysctl.d/60-postgresql-shm.conf
-
-RUN chown -Rf postgres:postgres /var/run/postgresql
-RUN chmod 2777 /var/run/postgresql
-RUN chown postgres:postgres /etc/sysctl.d/60-postgresql-shm.conf
-RUN chown postgres:postgres create-postgres*
-RUN chown -Rf postgres:postgres /ssd
+# Install PostgreSQL on the database machine
+RUN apt-get -yqq update && \
+    apt-get -yqq install \
+      -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+      postgresql-${PG_VERSION} \
+      postgresql-contrib-${PG_VERSION} && \
+    sed -i "s|PG_VERSION|${PG_VERSION}|g" postgresql.conf && \
+    mv pg_hba.conf postgresql.conf /etc/postgresql/${PG_VERSION}/main && \
+    mkdir /ssd && \
+    cp -Rp /var/lib/postgresql/${PG_VERSION}/main /ssd/postgresql && \
+    cp /etc/postgresql/${PG_VERSION}/main/postgresql.conf /ssd/postgresql && \
+    mv 60-postgresql-shm.conf /etc/sysctl.d/60-postgresql-shm.conf && \
+    chown -Rf postgres:postgres \
+      /etc/postgresql/${PG_VERSION}/main \
+      /etc/sysctl.d/60-postgresql-shm.conf \
+      /ssd \
+      /tmp/create-postgres* \
+      /var/run/postgresql && \
+    chmod 2777 /var/run/postgresql
 
 ENV PGDATA=/ssd/postgresql
 
 USER postgres
 
-# We have to wait for postgres to start before we can use the cli
+# We have to wait for PostgreSQL to start before we can use the CLI
 RUN service postgresql start && \
     until psql -c "\q"; do sleep 1; done && \
-    psql < create-postgres-database.sql && \
-    psql -a hello_world < create-postgres.sql && \
+    psql < /tmp/create-postgres-database.sql && \
+    psql -a hello_world < /tmp/create-postgres.sql && \
     service postgresql stop
 
 ENV PATH=${PATH}:/usr/lib/postgresql/${PG_VERSION}/bin

--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,30 +1,41 @@
-FROM buildpack-deps:jammy
+ARG UBUNTU_VERSION=jammy
+
+FROM "buildpack-deps:${UBUNTU_VERSION}" AS compile
+
+ARG WRK_VERSION=4.2.0
+
+ARG LDFLAGS="-flto -march=native -mtune=native -O3"
+ARG CFLAGS="-I /usr/include/luajit-2.1 ${LDFLAGS}"
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /tmp
+RUN apt-get -yqq update && \
+    apt-get -yqq install \
+      libluajit-5.1-dev \
+      libssl-dev \
+      luajit && \
+    curl -LSs "https://github.com/wg/wrk/archive/${WRK_VERSION}.tar.gz" | \
+      tar --strip-components=1 -xz && \
+    make WITH_LUAJIT=/usr WITH_OPENSSL=/usr -j "$(nproc)"
+
+FROM "ubuntu:${UBUNTU_VERSION}"
+
+# Required scripts for benchmarking
+COPY concurrency.sh pipeline.lua pipeline.sh query.sh ./
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get -yqq update && apt-get -yqq install libluajit-5.1-dev libssl-dev luajit
-
-WORKDIR /wrk
-RUN curl -sL https://github.com/wg/wrk/archive/4.2.0.tar.gz | tar xz --strip-components=1
-ARG LDFLAGS="-O3 -march=native -mtune=native -flto"
-ARG CFLAGS="-I /usr/include/luajit-2.1 ${LDFLAGS}"
-RUN make WITH_LUAJIT=/usr WITH_OPENSSL=/usr -j "$(nproc)"
-RUN cp wrk /usr/local/bin
-
-WORKDIR /
-# Required scripts for benchmarking
-COPY pipeline.lua pipeline.lua
-COPY concurrency.sh concurrency.sh
-COPY pipeline.sh pipeline.sh
-COPY query.sh query.sh
-
-RUN chmod 777 pipeline.lua concurrency.sh pipeline.sh query.sh
+COPY --from=compile /tmp/wrk /usr/local/bin/
+RUN apt-get -yqq update && \
+    apt-get -yqq install \
+      curl \
+      libluajit-5.1-2 && \
+    chmod 777 concurrency.sh pipeline.sh query.sh
 
 # Environment vars required by the wrk scripts with nonsense defaults
-ENV name=name
-ENV server_host=server_host
-ENV levels=levels
-ENV duration=duration
-ENV max_concurrency=max_concurrency
-ENV max_threads=max_threads
-ENV pipeline=pipeline
-ENV accept=accept
+ENV accept=accept \
+    duration=duration \
+    levels=levels \
+    max_concurrency=max_concurrency \
+    max_threads=max_threads \
+    name=name \
+    pipeline=pipeline \
+    server_host=server_host


### PR DESCRIPTION
The toolset Dockerfiles were using variants of `buildpack-deps` as their base images, but this is not really necessary because we do not compile anything (except in the wrk case); switch to the underlying `ubuntu` images instead. Also, try to reduce the number of layers in the images by following best practices.