### PR TITLE
[aspnetcore] List should not assume result size

### DIFF
--- a/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
+++ b/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/Providers/RawDbNpgsql.cs
@@ -187,7 +187,7 @@ namespace PlatformBenchmarks
 
         public async Task<List<Fortune>> LoadFortunesRows()
         {
-            var result = new List<Fortune>(20);
+            var result = new List<Fortune>();
 
             using (var db = new NpgsqlConnection(_connectionString))
             {


### PR DESCRIPTION
It's against the rules to initialize the Fortunes collection with prior knowledge of the results size.