### PR TITLE
Bump dependency versions to the latest and the JDK version to 17, and use `PgConnection` instead of `PgPool` in the benchmark portion "vertx-web-scala"

### DIFF
--- a/frameworks/Scala/vertx-web-scala/.gitignore
+++ b/frameworks/Scala/vertx-web-scala/.gitignore
@@ -183,3 +183,5 @@ nbdist/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.bsp

--- a/frameworks/Scala/vertx-web-scala/README.md
+++ b/frameworks/Scala/vertx-web-scala/README.md
@@ -13,8 +13,8 @@ This is the Vert.x Web Scala portion of a [benchmarking test suite](../) compari
 
 ## Versions
 
-* [Java OpenJDK 11](https://openjdk.java.net/)
-* [Vert.x 3.7](https://vertx.io/)
+* [Java OpenJDK 17](https://openjdk.java.net/)
+* [Vert.x 3.9](https://vertx.io/)
 
 ## Test URLs
 

--- a/frameworks/Scala/vertx-web-scala/build.sbt
+++ b/frameworks/Scala/vertx-web-scala/build.sbt
@@ -2,22 +2,26 @@ name := "vertx-web-scala"
 
 version := "1"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.17"
 
 lazy val root = (project in file(".")).enablePlugins(SbtTwirl)
 
-libraryDependencies += "io.vertx" %% "vertx-lang-scala" % "3.7.1"
-libraryDependencies += "io.vertx" %% "vertx-web-scala" % "3.7.1"
-libraryDependencies += "io.vertx" % "vertx-codegen" % "3.7.1"
-libraryDependencies += "io.netty" % "netty-transport-native-kqueue" % "4.1.36.Final" classifier "osx-x86_64"
-libraryDependencies += "io.netty" % "netty-transport-native-epoll" % "4.1.36.Final" classifier "linux-x86_64"
-libraryDependencies += "io.reactiverse" % "reactive-pg-client" % "0.11.3"
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+val vertxScalaVersion = "3.9.1"
+val vertxVersion = "3.9.15"
+val nettyVersion = "4.1.89.Final"
 
-mainClass in Compile := Some("vertx.App")
+libraryDependencies += "io.vertx" %% "vertx-lang-scala" % vertxScalaVersion
+libraryDependencies += "io.vertx" %% "vertx-web-scala" % vertxScalaVersion
+libraryDependencies += "io.vertx" % "vertx-codegen" % vertxVersion
+libraryDependencies += "io.vertx" % "vertx-pg-client" % vertxVersion
+libraryDependencies += "io.netty" % "netty-transport-native-kqueue" % nettyVersion classifier "osx-x86_64"
+libraryDependencies += "io.netty" % "netty-transport-native-epoll" % nettyVersion classifier "linux-x86_64"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.5"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
 
-assemblyMergeStrategy in assembly := {
+Compile / mainClass := Some("vertx.App")
+
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-  case _ => MergeStrategy.first
+  case _                                   => MergeStrategy.first
 }

--- a/frameworks/Scala/vertx-web-scala/project/build.properties
+++ b/frameworks/Scala/vertx-web-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.8.2

--- a/frameworks/Scala/vertx-web-scala/project/plugins.sbt
+++ b/frameworks/Scala/vertx-web-scala/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.typesafe.play" % "sbt-twirl" % "1.5.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")

--- a/frameworks/Scala/vertx-web-scala/src/main/scala/vertx/App.scala
+++ b/frameworks/Scala/vertx-web-scala/src/main/scala/vertx/App.scala
@@ -7,15 +7,16 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.ThreadLocalRandom
 
 import com.typesafe.scalalogging.Logger
-import io.reactiverse.pgclient._
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpHeaders
 import io.vertx.core.json.{JsonArray, JsonObject}
 import io.vertx.core.{AsyncResult, VertxOptions => JVertxOptions}
 import io.vertx.lang.scala.{ScalaVerticle, VertxExecutionContext}
+import io.vertx.pgclient._
 import io.vertx.scala.core.http.{HttpServer, HttpServerRequest, HttpServerResponse}
 import io.vertx.scala.core.{VertxOptions, _}
 import io.vertx.scala.ext.web.Router
+import io.vertx.sqlclient._
 import vertx.model.{Fortune, Message, World}
 
 import scala.collection.JavaConverters._
@@ -26,7 +27,7 @@ case class Header(name: CharSequence, value: String)
 class App extends ScalaVerticle {
 
   private val HELLO_WORLD = "Hello, world!"
-  private val HELLO_WORLD_BUFFER = Buffer.factory.directBuffer(HELLO_WORLD, "UTF-8")
+  private val HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD, "UTF-8")
   private val SERVER = "vert.x"
 
   private val contentTypeJson = Header(HttpHeaders.CONTENT_TYPE, "application/json")
@@ -36,7 +37,7 @@ class App extends ScalaVerticle {
   private var dateString: String = ""
 
   private var server: HttpServer = _
-  private var client: PgClient = _
+  private var client: PgPool = _
   private var pool: PgPool = _
 
   private def refreshDateHeader(): Unit = dateString = App.createDateHeader()
@@ -45,7 +46,7 @@ class App extends ScalaVerticle {
     refreshDateHeader()
     vertx.setPeriodic(1000, (_: Long) => refreshDateHeader())
 
-    val options = new PgPoolOptions()
+    val pgConnectOptions = new PgConnectOptions()
       .setDatabase(config.getString("database"))
       .setHost(config.getString("host"))
       .setPort(config.getInteger("port", 5432))
@@ -54,8 +55,8 @@ class App extends ScalaVerticle {
       .setCachePreparedStatements(true)
 
     val jVertx = vertx.asJava.asInstanceOf[io.vertx.core.Vertx]
-    client = PgClient.pool(jVertx, new PgPoolOptions(options).setMaxSize(1))
-    pool = PgClient.pool(jVertx, new PgPoolOptions(options).setMaxSize(4))
+    client = PgPool.pool(jVertx, pgConnectOptions, new PoolOptions().setMaxSize(1))
+    pool = PgPool.pool(jVertx, pgConnectOptions, new PoolOptions().setMaxSize(4))
 
     val router = Router.router(vertx)
     router.get("/plaintext").handler(context => handlePlainText(context.request()))
@@ -87,25 +88,26 @@ class App extends ScalaVerticle {
       .end(Message("Hello, World!").toBuffer)
 
   private def handleDb(request: HttpServerRequest): Unit =
-    client.preparedQuery(
-      "SELECT id, randomnumber from WORLD where id=$1",
-      Tuple.of(App.randomWorld(), Nil: _*),
-      (ar: AsyncResult[PgRowSet]) => {
-        if (ar.succeeded) {
-          val resultSet = ar.result.iterator
-          if (!resultSet.hasNext) {
-            request.response.setStatusCode(404).end()
+    client
+      .preparedQuery("SELECT id, randomnumber from WORLD where id=$1")
+      .execute(
+        Tuple.of(App.randomWorld(), Nil: _*),
+        (ar: AsyncResult[RowSet[Row]]) => {
+          if (ar.succeeded) {
+            val resultSet = ar.result.iterator
+            if (!resultSet.hasNext) {
+              request.response.setStatusCode(404).end()
+            } else {
+              val row = resultSet.next
+              responseWithHeaders(request.response, contentTypeJson)
+                .end(World(row.getInteger(0), row.getInteger(1)).encode())
+            }
           } else {
-            val row = resultSet.next
-            responseWithHeaders(request.response, contentTypeJson)
-              .end(World(row.getInteger(0), row.getInteger(1)).encode())
+            App.logger.error("Failed to handle request", ar.cause())
+            request.response.setStatusCode(500).end(ar.cause.getMessage)
           }
-        } else {
-          App.logger.error("Failed to handle request", ar.cause())
-          request.response.setStatusCode(500).end(ar.cause.getMessage)
         }
-      }
-    )
+      )
 
   private def handleQueries(request: HttpServerRequest): Unit = {
     val queries = App.getQueries(request)
@@ -113,26 +115,27 @@ class App extends ScalaVerticle {
     var i = 0
     var failed = false
     while (i < queries) {
-      client.preparedQuery(
-        "SELECT id, randomnumber from WORLD where id=$1",
-        Tuple.of(App.randomWorld(), Nil: _*),
-        (ar: AsyncResult[PgRowSet]) => {
-          if (!failed) {
-            if (ar.failed) {
-              failed = true
-              request.response.setStatusCode(500).end(ar.cause.getMessage)
-              return
-            }
-            // we need a final reference
-            val row = ar.result.iterator.next
+      client
+        .preparedQuery("SELECT id, randomnumber from WORLD where id=$1")
+        .execute(
+          Tuple.of(App.randomWorld(), Nil: _*),
+          (ar: AsyncResult[RowSet[Row]]) => {
+            if (!failed) {
+              if (ar.failed) {
+                failed = true
+                request.response.setStatusCode(500).end(ar.cause.getMessage)
+                return
+              }
+              // we need a final reference
+              val row = ar.result.iterator.next
 
-            worlds.add(World(row.getInteger(0), row.getInteger(1)))
-            if (worlds.size == queries)
-              responseWithHeaders(request.response, contentTypeJson)
-                .end(worlds.encode)
+              worlds.add(World(row.getInteger(0), row.getInteger(1)))
+              if (worlds.size == queries)
+                responseWithHeaders(request.response, contentTypeJson)
+                  .end(worlds.encode)
+            }
           }
-        }
-      )
+        )
 
       i += 1
     }
@@ -144,24 +147,25 @@ class App extends ScalaVerticle {
       request.response.setStatusCode(500).end(err.getMessage)
     }
 
-    def handleUpdates(conn: PgConnection, worlds: Array[World]): Unit = {
+    def handleUpdates(conn: SqlConnection, worlds: Array[World]): Unit = {
       Sorting.quickSort(worlds)
 
       val batch = worlds.map(world => Tuple.of(world.randomNumber, world.id)).toList.asJava
-      conn.preparedBatch(
-        "UPDATE world SET randomnumber=$1 WHERE id=$2",
-        batch,
-        (ar: AsyncResult[PgRowSet]) => {
-          conn.close()
-          if (ar.failed) {
-            sendError(ar.cause)
-            return
-          }
+      conn
+        .preparedQuery("UPDATE world SET randomnumber=$1 WHERE id=$2")
+        .executeBatch(
+          batch,
+          (ar: AsyncResult[RowSet[Row]]) => {
+            conn.close()
+            if (ar.failed) {
+              sendError(ar.cause)
+              return
+            }
 
-          responseWithHeaders(request.response, contentTypeJson)
-            .end(new JsonArray(worlds.toList.asJava).toBuffer)
-        }
-      )
+            responseWithHeaders(request.response, contentTypeJson)
+              .end(new JsonArray(worlds.toList.asJava).toBuffer)
+          }
+        )
     }
 
     val queries = App.getQueries(request)
@@ -169,7 +173,7 @@ class App extends ScalaVerticle {
     var failed = false
     var queryCount = 0
 
-    pool.getConnection((ar1: AsyncResult[PgConnection]) => {
+    pool.getConnection((ar1: AsyncResult[SqlConnection]) => {
       if (ar1.failed) {
         failed = true
         sendError(ar1.cause)
@@ -180,23 +184,24 @@ class App extends ScalaVerticle {
       while (i < worlds.length) {
         val id = App.randomWorld()
         val index = i
-        conn.preparedQuery(
-          "SELECT id, randomnumber from WORLD where id=$1",
-          Tuple.of(id, Nil: _*),
-          (ar2: AsyncResult[PgRowSet]) => {
-            if (!failed) {
-              if (ar2.failed) {
-                conn.close()
-                failed = true
-                sendError(ar2.cause)
-                return
+        conn
+          .preparedQuery("SELECT id, randomnumber from WORLD where id=$1")
+          .execute(
+            Tuple.of(id, Nil: _*),
+            (ar2: AsyncResult[RowSet[Row]]) => {
+              if (!failed) {
+                if (ar2.failed) {
+                  conn.close()
+                  failed = true
+                  sendError(ar2.cause)
+                  return
+                }
+                worlds(index) = World(ar2.result.iterator.next.getInteger(0), App.randomWorld())
+                queryCount += 1
+                if (queryCount == worlds.length) handleUpdates(conn, worlds)
               }
-              worlds(index) = World(ar2.result.iterator.next.getInteger(0), App.randomWorld())
-              queryCount += 1
-              if (queryCount == worlds.length) handleUpdates(conn, worlds)
             }
-          }
-        )
+          )
 
         i += 1
       }
@@ -205,29 +210,30 @@ class App extends ScalaVerticle {
   }
 
   private def handleFortunes(request: HttpServerRequest): Unit =
-    client.preparedQuery(
-      "SELECT id, message from FORTUNE",
-      (ar: AsyncResult[PgRowSet]) => {
-        val response = request.response
-        if (ar.succeeded) {
-          val resultSet = ar.result.iterator
-          if (!resultSet.hasNext) {
-            response.setStatusCode(404).end("No results")
-            return
+    client
+      .preparedQuery("SELECT id, message from FORTUNE")
+      .execute(
+        (ar: AsyncResult[RowSet[Row]]) => {
+          val response = request.response
+          if (ar.succeeded) {
+            val resultSet = ar.result.iterator
+            if (!resultSet.hasNext) {
+              response.setStatusCode(404).end("No results")
+              return
+            }
+            val fortunes = (resultSet.asScala
+              .map(row => Fortune(row.getInteger(0), row.getString(1))) ++
+              Seq(Fortune(0, "Additional fortune added at request time."))).toArray
+            Sorting.quickSort(fortunes)
+            responseWithHeaders(request.response, contentTypeHtml)
+              .end(html.fortune(fortunes).body)
+          } else {
+            val err = ar.cause
+            App.logger.error("", err)
+            response.setStatusCode(500).end(err.getMessage)
           }
-          val fortunes = (resultSet.asScala
-            .map(row => Fortune(row.getInteger(0), row.getString(1))) ++
-            Seq(Fortune(0, "Additional fortune added at request time."))).toArray
-          Sorting.quickSort(fortunes)
-          responseWithHeaders(request.response, contentTypeHtml)
-            .end(html.fortune(fortunes).body)
-        } else {
-          val err = ar.cause
-          App.logger.error("", err)
-          response.setStatusCode(500).end(err.getMessage)
         }
-      }
-    )
+      )
 
 }
 

--- a/frameworks/Scala/vertx-web-scala/vertx-web-scala.dockerfile
+++ b/frameworks/Scala/vertx-web-scala/vertx-web-scala.dockerfile
@@ -1,13 +1,6 @@
-FROM openjdk:11-jdk
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.5_8_1.8.2_2.12.17
 
-ARG SBT_VERSION=1.2.8
-
-# Install sbt
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
-RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list
-RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
-RUN apt-get update -yqq
-RUN apt-get install -yqq sbt
+ARG SBT_VERSION=1.8.2
 
 WORKDIR /vertx
 COPY src src


### PR DESCRIPTION
Bump the dependency versions to the latest supported by Scala and Vert.x as tested manually (Scala 2.12.17, SBT 1.8.2, Vert.x 3.9.15, Vert.x Scala libraries 3.9.1), upgrade the JDK version to 17, and use `PgConnection` instead of `PgPool`.

While bumping the dependency versions, [the Reactive Postgres Client with the package name `io.reactiverse`](https://github.com/vietj/reactive-pg-client) is replaced with its new replacement the Vert.x Reactive PostgreSQL Client ([site](https://vertx.io/docs/vertx-pg-client/java/), [repo](https://github.com/eclipse-vertx/vertx-sql-client)). However, doing this solely degrades the benchmark's performance. By using `PgConnection` instead of `PgPool`, the performance is brought back to an almost identical level. Due to this reason and also the API changes, the second commit depends on the first one, and both are combined in this one PR.

This is part of an effort to ensure fairer comparison among all the benchmark portions using Vert.x, which are written in different languages and depending on different utility libraries. Also see #7932 and #7933.