### PR TITLE
Netty 4.1 Optimizations 

### DIFF
--- a/frameworks/Java/netty/netty.dockerfile
+++ b/frameworks/Java/netty/netty.dockerfile
@@ -10,4 +10,4 @@ COPY --from=maven /netty/target/netty-example-0.1-jar-with-dependencies.jar app.
 
 EXPOSE 8080
 
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-jar", "app.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dio.netty.buffer.checkBounds=false", "-Dio.netty.buffer.checkAccessible=false", "-jar", "app.jar"]

--- a/frameworks/Java/netty/pom.xml
+++ b/frameworks/Java/netty/pom.xml
@@ -11,7 +11,8 @@
 	<properties>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
-		<netty.version>4.1.86.Final</netty.version>
+		<netty.version>4.1.89.Final</netty.version>
+		<io_uring.version>0.0.18.Final</io_uring.version>
 	</properties>
 
 	<packaging>jar</packaging>
@@ -41,7 +42,7 @@
 		<dependency>
 			<groupId>io.netty.incubator</groupId>
 			<artifactId>netty-incubator-transport-native-io_uring</artifactId>
-			<version>0.0.15.Final</version>
+			<version>${io_uring.version}</version>
 			<classifier>linux-x86_64</classifier>
 		</dependency>
 

--- a/frameworks/Java/netty/src/main/java/hello/HelloServerInitializer.java
+++ b/frameworks/Java/netty/src/main/java/hello/HelloServerInitializer.java
@@ -4,12 +4,17 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpVersion;
 
 public class HelloServerInitializer extends ChannelInitializer<SocketChannel> {
 
-	private ScheduledExecutorService service;
+	private final ScheduledExecutorService service;
 
 	public HelloServerInitializer(ScheduledExecutorService service) {
 		this.service = service;
@@ -18,8 +23,29 @@ public class HelloServerInitializer extends ChannelInitializer<SocketChannel> {
 	@Override
 	public void initChannel(SocketChannel ch) throws Exception {
 		ch.pipeline()
-                .addLast("encoder", new HttpResponseEncoder())
-                .addLast("decoder", new HttpRequestDecoder(4096, 8192, 8192, false))
+                .addLast("encoder", new HttpResponseEncoder() {
+					@Override
+					public boolean acceptOutboundMessage(final Object msg) throws Exception {
+						if (msg.getClass() == DefaultFullHttpResponse.class) {
+							return true;
+						}
+						return super.acceptOutboundMessage(msg);
+					}
+				})
+                .addLast("decoder", new HttpRequestDecoder(4096, 8192, 8192, false) {
+
+					@Override
+					protected HttpMessage createMessage(final String[] initialLine) throws Exception {
+						return new DefaultHttpRequest(
+								HttpVersion.valueOf(initialLine[2]),
+								HttpMethod.valueOf(initialLine[0]), initialLine[1], validateHeaders);
+					}
+
+					@Override
+					protected boolean isContentAlwaysEmpty(final HttpMessage msg) {
+						return false;
+					}
+				})
                 .addLast("handler", new HelloServerHandler(service));
 	}
 }


### PR DESCRIPTION
These changes are partially related https://redhatperf.github.io/post/type-check-scalability-issue/ and are mostly 
limits of the JDK platform (still to be addressed, see https://bugs.openjdk.org/browse/JDK-8180450).

Said that, luckly, they can be fixed in user code easily and these are the changes addressing both proper scalability issue(s) and inefficient handling of type check (while an interface type is **not** implemented by a concrete type).

The changes are saving:
- DefaultHttpRequest instanceof HttpResponse on HttpObjectDecoder::isContentAlwaysEmpty
- DefaultFullHttpResponse instanceof HttpRequest on HttpResponseEncoder::acceptOutboundMessage
- LastHttpContent.EMPTY_LAST_CONTENT instanceof HttpRequest on HelloServerHandler::channelRead
- DefaultHttpRequest instanceof ReferenceCounted on ReferenceCountUtil.release's (still in HelloServerHandler::channelRead)

While there's another one that cannot be fixed here, but it will be in Netty, directly:
- https://github.com/netty/netty/pull/13225 on Netty 4.1.90.Final 

This PR is bumping to the latest Netty release and its io_uring incubator as well.