### PR TITLE
[php] Mark broken PHP frameworks

### DIFF
--- a/frameworks/PHP/comet/benchmark_config.json
+++ b/frameworks/PHP/comet/benchmark_config.json
@@ -22,7 +22,8 @@
       "database_os": "Linux",
       "display_name": "comet",
       "notes": "",
-      "versus": "workerman"
+      "versus": "workerman",
+      "tags": ["broken"]
     },
     "mysql": {
       "db_url": "/db",
@@ -43,7 +44,8 @@
       "database_os": "Linux",
       "display_name": "comet-mysql",
       "notes": "",
-      "versus": "workerman"
+      "versus": "workerman",
+      "tags": ["broken"]
     }
   }]
 }

--- a/frameworks/PHP/phalcon/benchmark_config.json
+++ b/frameworks/PHP/phalcon/benchmark_config.json
@@ -42,7 +42,8 @@
       "database_os": "Linux",
       "display_name": "phalcon-mongodb",
       "notes": "",
-      "versus": "php"
+      "versus": "php",
+      "tags": ["broken"]
     },
     "micro": {
       "plaintext_url": "/plaintext",

--- a/frameworks/PHP/sw-fw-less/benchmark_config.json
+++ b/frameworks/PHP/sw-fw-less/benchmark_config.json
@@ -23,7 +23,8 @@
                 "database_os": "Linux",
                 "display_name": "Sw-Fw-Less",
                 "notes": "",
-                "versus": "swoole"
+                "versus": "swoole",
+                "tags": ["broken"]
             }
         }
     ]

--- a/frameworks/PHP/ubiquity/benchmark_config.json
+++ b/frameworks/PHP/ubiquity/benchmark_config.json
@@ -112,7 +112,8 @@
         "database_os": "Linux",
         "display_name": "ubiquity-roadrunner",
         "notes": "",
-        "versus": "php"
+        "versus": "php",
+        "tags": ["broken"]
       },
       "roadrunner-mysql": {
         "db_url": "/DbMy",
@@ -133,7 +134,8 @@
         "database_os": "Linux",
         "display_name": "ubiquity-roadrunner-mysql",
         "notes": "",
-        "versus": "php"
+        "versus": "php",
+        "tags": ["broken"]
       },
       "workerman-mysql": {
         "db_url": "/DbMy",


### PR DESCRIPTION
Comet need to merge this PR https://github.com/gotzmann/comet/pull/29 to work.
Phalcon Mongodb is using PHP 7.4 EOL.
Sw-fw-less  ~10 months without update and fail with the new Swoole versions.
Ubiquity is failing with Roadrunner.

Without skip tests, to verify that Ubiquity it isn't failing with the new Swoole version.

From #7928

