### PR TITLE
Clojure: Bump to Aleph 0.6.1 and latest dependencies

### DIFF
--- a/frameworks/Clojure/aleph/README.md
+++ b/frameworks/Clojure/aleph/README.md
@@ -6,9 +6,9 @@ This is the [Aleph](https://github.com/clj-commons/aleph) portion of a [benchmar
 The dependencies are documented in [project.clj](project.clj),
 but the main ones are:
 
-* [Aleph 0.4.7](https://github.com/clj-commons/aleph)
-* [Clojure 1.11.0](http://clojure.org/)
-* [metosin/jsonista 0.3.5](https://github.com/metosin/jsonista), which in turn uses [Jackson](http://jackson.codehaus.org/)
+* [Aleph 0.6.1](https://github.com/clj-commons/aleph)
+* [Clojure 1.11.1](http://clojure.org/)
+* [metosin/jsonista 0.3.7](https://github.com/metosin/jsonista), which in turn uses [Jackson](http://jackson.codehaus.org/)
 * [hiccup 1.0.5](https://github.com/weavejester/hiccup)
 * [porsas 0.0.1-alpha14](https://github.com/arnaudgeiser/porsas)
 

--- a/frameworks/Clojure/aleph/aleph.dockerfile
+++ b/frameworks/Clojure/aleph/aleph.dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-17-lein-2.9.8
+FROM clojure:temurin-19-lein
 WORKDIR /aleph
 COPY src src
 COPY project.clj project.clj
@@ -14,7 +14,7 @@ EXPOSE 9999
 RUN apt update -y
 RUN apt install perl -y
 
-CMD ["java", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dvertx.disableMetrics=true", "-Dvertx.threadChecks=false", "-Dvertx.disableContextTimings=true", "-Dvertx.disableTCCL=true", "-Djava.net.preferIPv4Stack=true", "-jar", "target/hello-aleph-standalone.jar"]
+CMD ["java", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Djava.net.preferIPv4Stack=true", "-Dio.netty.leakDetection.level=disabled", "-jar", "target/hello-aleph-standalone.jar"]
 
 # To enable JMX and async-profiler
-#CMD ["java", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-Djdk.attach.allowAttachSelf", "-Dcom.sun.management.jmxremote=true", "-Djava.rmi.server.hostname=0.0.0.0","-Dcom.sun.management.jmxremote.rmi.port=9999" ,"-Dcom.sun.management.jmxremote.port=9999", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Dvertx.disableMetrics=true", "-Dvertx.threadChecks=false", "-Dvertx.disableContextTimings=true", "-Dvertx.disableTCCL=true", "-Djava.net.preferIPv4Stack=true", "-jar", "target/hello-aleph-standalone.jar"]
+#CMD ["java", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-Djdk.attach.allowAttachSelf", "-Dcom.sun.management.jmxremote=true", "-Djava.rmi.server.hostname=0.0.0.0","-Dcom.sun.management.jmxremote.rmi.port=9999" ,"-Dcom.sun.management.jmxremote.port=9999", "-Dcom.sun.management.jmxremote.ssl=false", "-Dcom.sun.management.jmxremote.authenticate=false", "-server", "-Xms2G", "-Xmx2G", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Djava.net.preferIPv4Stack=true", "-jar", "target/hello-aleph-standalone.jar"]

--- a/frameworks/Clojure/aleph/project.clj
+++ b/frameworks/Clojure/aleph/project.clj
@@ -1,10 +1,9 @@
 (defproject hello "aleph"
-  :description "JSON/plaintext tests"
-  :dependencies [[org.clojure/clojure "1.11.0"]
-                 [aleph "0.4.7"]
-                 [metosin/jsonista "0.3.5"]
+  :description "Aleph benchmarks"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [aleph "0.6.1"]
+                 [metosin/jsonista "0.3.7"]
                  [hiccup "1.0.5"]
-                 [io.netty/netty-transport-native-epoll "4.1.65.Final" :classifier "linux-x86_64"]
                  [com.github.arnaudgeiser/porsas "0.0.1-alpha14"
                   :exclusions [io.netty/netty-codec-dns
                                io.netty/netty-codec
@@ -18,7 +17,7 @@
                                io.netty/netty-transport
                                io.netty/netty-resolver-dns
                                io.netty/netty-resolver]]
-                 [com.clojure-goes-fast/clj-async-profiler "0.5.1"]]
+                 [com.clojure-goes-fast/clj-async-profiler "1.0.3"]]
   :main hello.handler
   :jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]
   :aot :all)


### PR DESCRIPTION
This :

- Bumps the Aleph dependency to 0.6.1 and the latest dependencies
- Switches from openjdk to temurin
- Adds the JVM property `-Dio.netty.leakDetection.level=disabled` for Netty
- Removes the some unnecessary vertx flags