### PR TITLE
Add option for extra docker args to tfb script

### DIFF
--- a/tfb
+++ b/tfb
@@ -103,4 +103,4 @@ fi
 
 test -t 1 && USE_TTY="-t"
 docker build -t techempower/tfb - < ${SCRIPT_ROOT}/Dockerfile
-exec docker run -i ${USE_TTY} --rm --network tfb -v /var/run/docker.sock:/var/run/docker.sock -v ${SCRIPT_ROOT}:/FrameworkBenchmarks techempower/tfb "${@}"
+exec docker run -i ${USE_TTY} ${EXTRA_DOCKER_ARGS} --rm --network tfb -v /var/run/docker.sock:/var/run/docker.sock -v ${SCRIPT_ROOT}:/FrameworkBenchmarks techempower/tfb "${@}"


### PR DESCRIPTION
Add the option for extra docker arguments to be added to the docker run command for added user configurability. The user can specify the desired arguments, if any, in an environment variable EXTRA_DOCKER_ARGS before running a test, e.g. `export EXTRA_DOCKER_ARGS="--cpus=2.0 --memory=3G"`.
If no value is specified for EXTRA_DOCKER_ARGS, the existing functionality will not be impacted.