### PR TITLE
Upgrade Microdot tests to Python 3.11

### DIFF
--- a/frameworks/Python/microdot/app_async.py
+++ b/frameworks/Python/microdot/app_async.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from datetime import datetime
 import os
-from random import randint
+from random import randint, sample
 
 from alchemical.aio import Alchemical
 import sqlalchemy as sqla
@@ -52,10 +52,7 @@ def get_num_queries(request, name="queries"):
 
 
 def generate_ids(num_queries):
-    ids = {randint(1, 10000) for _ in range(num_queries)}
-    while len(ids) < num_queries:
-        ids.add(randint(1, 10000))
-    return list(ids)
+    return sample(range(1, 10001), num_queries)
 
 
 @app.route("/json")

--- a/frameworks/Python/microdot/app_async_raw.py
+++ b/frameworks/Python/microdot/app_async_raw.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from datetime import datetime
 import os
-from random import randint
+from random import randint, sample
 
 import asyncpg
 from asyncache import cached
@@ -45,10 +45,7 @@ def get_num_queries(request, name="queries"):
 
 
 def generate_ids(num_queries):
-    ids = {randint(1, 10000) for _ in range(num_queries)}
-    while len(ids) < num_queries:
-        ids.add(randint(1, 10000))
-    return list(ids)
+    return sample(range(1, 10001), num_queries)
 
 
 @app.route("/json")

--- a/frameworks/Python/microdot/app_sync.py
+++ b/frameworks/Python/microdot/app_sync.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from functools import lru_cache
 import os
-from random import randint
+from random import randint, sample
 
 from alchemical import Alchemical
 import sqlalchemy as sqla
@@ -53,10 +53,7 @@ def get_num_queries(request, name="queries"):
 
 
 def generate_ids(num_queries):
-    ids = {randint(1, 10000) for _ in range(num_queries)}
-    while len(ids) < num_queries:
-        ids.add(randint(1, 10000))
-    return list(ids)
+    return sample(range(1, 10001), num_queries)
 
 
 @app.route("/json")

--- a/frameworks/Python/microdot/app_sync_raw.py
+++ b/frameworks/Python/microdot/app_sync_raw.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from functools import lru_cache
 import os
-from random import randint
+from random import randint, sample
 
 from microdot_wsgi import Microdot
 from microdot_jinja import render_template
@@ -36,10 +36,7 @@ def get_num_queries(request, name="queries"):
 
 
 def generate_ids(num_queries):
-    ids = {randint(1, 10000) for _ in range(num_queries)}
-    while len(ids) < num_queries:
-        ids.add(randint(1, 10000))
-    return list(ids)
+    return sample(range(1, 10001), num_queries)
 
 
 @app.route("/json")

--- a/frameworks/Python/microdot/microdot-async-raw.dockerfile
+++ b/frameworks/Python/microdot/microdot-async-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.11
 
 RUN apt-get update
 RUN apt-get install libpq-dev python3-dev -y

--- a/frameworks/Python/microdot/microdot-async.dockerfile
+++ b/frameworks/Python/microdot/microdot-async.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.11
 
 RUN apt-get update
 RUN apt-get install libpq-dev python3-dev -y

--- a/frameworks/Python/microdot/microdot-raw.dockerfile
+++ b/frameworks/Python/microdot/microdot-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.11
 
 RUN apt-get update
 RUN apt-get install libpq-dev python3-dev -y

--- a/frameworks/Python/microdot/microdot.dockerfile
+++ b/frameworks/Python/microdot/microdot.dockerfile
@@ -1,5 +1,4 @@
-FROM python:3.8-buster
-
+FROM python:3.11
 
 RUN apt-get update
 RUN apt-get install libpq-dev python3-dev -y

--- a/frameworks/Python/microdot/requirements.txt
+++ b/frameworks/Python/microdot/requirements.txt
@@ -7,6 +7,6 @@ cachetools
 asyncache
 
 alchemical
-microdot
+microdot<2
 gunicorn
-uvicorn
+uvicorn[standard]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Update all tests to use Python 3.11, plus a couple minor performance related updates.