### PR TITLE
Fix use the physical CPU count from NodeJS

### DIFF
--- a/frameworks/JavaScript/nodejs/app.js
+++ b/frameworks/JavaScript/nodejs/app.js
@@ -1,5 +1,5 @@
 const cluster = require('cluster');
-const numCPUs = require('os').cpus().length;
+const physicalCpuCount = require('physical-cpu-count')
 
 process.env.NODE_HANDLER = 'mysql-raw';
 
@@ -17,7 +17,7 @@ if (cluster.isPrimary) {
   console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.
-  for (let i = 0; i < numCPUs; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 

--- a/frameworks/JavaScript/nodejs/package.json
+++ b/frameworks/JavaScript/nodejs/package.json
@@ -9,11 +9,12 @@
     "mongoose": "5.7.5",
     "mysql": "2.16.0",
     "mysql2": "1.6.5",
+    "node-cache": "4.1.1",
     "parseurl": "1.3.2",
     "pg": "8.5.0",
     "pg-hstore": "2.3.2",
-    "sequelize": "5.15.1",
-    "node-cache": "4.1.1"
+    "physical-cpu-count": "^2.0.0",
+    "sequelize": "5.15.1"
   },
   "main": "app.js"
 }


### PR DESCRIPTION
Modify to use the number of physical CPUs, not the logical number of CPUs with hyperthreading applied, when using Cluster mode.


```
Working with clusters of Node.js processes it is common to see code using os.cpus().length as the number of child workers to fork.
For some workloads this can negatively impact performance on CPUs that use simultaneous multithreading (SMT).
Latency is doubled because two processes share the same physical CPU core to get their work done.
Additionally there is memory spent for each running worker, as well as time to spawn their processes.
It is better to fork no more child processes than there are physical cores.
```