### PR TITLE
Fix use the physical CPU count from Express

### DIFF
--- a/frameworks/JavaScript/express/app.js
+++ b/frameworks/JavaScript/express/app.js
@@ -4,7 +4,7 @@
  */
 
 const cluster = require('cluster'),
-  numCPUs = require('os').cpus().length,
+  physicalCpuCount = require('physical-cpu-count'),
   express = require('express');
 
 const bodyParser = require('body-parser');
@@ -13,7 +13,7 @@ if (cluster.isPrimary) {
   console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.
-  for (let i = 0; i < numCPUs; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 
@@ -41,5 +41,7 @@ if (cluster.isPrimary) {
   app.get('/plaintext', (req, res) =>
     res.header('Content-Type', 'text/plain').send('Hello, World!'));
 
-  app.listen(8080);
+  app.listen(8080, () => {
+    console.log('listening on port 8080');
+  });
 }

--- a/frameworks/JavaScript/express/mongodb-app.js
+++ b/frameworks/JavaScript/express/mongodb-app.js
@@ -4,7 +4,7 @@
  */
 
 const cluster = require('cluster'),
-  numCPUs = require('os').cpus().length,
+  physicalCpuCount = require('physical-cpu-count'),
   express = require('express'),
   mongoose = require('mongoose'),
   conn = mongoose.connect('mongodb://tfb-database/hello_world');
@@ -33,7 +33,7 @@ const FortuneSchema = new mongoose.Schema({
 
 if (cluster.isPrimary) {
   // Fork workers.
-  for (let i = 0; i < numCPUs; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 
@@ -101,5 +101,7 @@ if (cluster.isPrimary) {
     res.send(results);
   });
 
-  app.listen(8080);
+  app.listen(8080, () => {
+    console.log('listening on port 8080');
+  });
 }

--- a/frameworks/JavaScript/express/mysql-app.js
+++ b/frameworks/JavaScript/express/mysql-app.js
@@ -4,7 +4,7 @@
  */
 
 const cluster = require('cluster'),
-  numCPUs = require('os').cpus().length,
+  physicalCpuCount = require('physical-cpu-count'),
   express = require('express'),
   Sequelize = require('sequelize');
 
@@ -45,7 +45,7 @@ const Fortune = sequelize.define('Fortune', {
 
 if (cluster.isPrimary) {
   // Fork workers.
-  for (let i = 0; i < numCPUs; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 
@@ -127,5 +127,7 @@ if (cluster.isPrimary) {
     res.send(results);
   });
 
-  app.listen(8080);
+  app.listen(8080, () => {
+    console.log('listening on port 8080');
+  });
 }

--- a/frameworks/JavaScript/express/package.json
+++ b/frameworks/JavaScript/express/package.json
@@ -11,6 +11,7 @@
     "mysql2": "2.2.5",
     "pg": "8.5.0",
     "pg-promise": "10.7.3",
+    "physical-cpu-count": "^2.0.0",
     "pug": "2.0.1",
     "sequelize": "5.15.1"
   }

--- a/frameworks/JavaScript/express/postgresql-app.js
+++ b/frameworks/JavaScript/express/postgresql-app.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 const cluster = require('cluster'),
-  numCPUs = require('os').cpus().length,
+  physicalCpuCount = require('physical-cpu-count'),
   express = require('express'),
   helper = require('./helper');
 
@@ -51,7 +51,7 @@ const randomWorldPromise = () => {
 
 if (cluster.isPrimary) {
   // Fork workers.
-  for (let i = 0; i < numCPUs; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 


### PR DESCRIPTION
Modify to use the number of physical CPUs, not the logical number of CPUs with hyperthreading applied, when using Cluster mode.


```
Working with clusters of Node.js processes it is common to see code using os.cpus().length as the number of child workers to fork.
For some workloads this can negatively impact performance on CPUs that use simultaneous multithreading (SMT).
Latency is doubled because two processes share the same physical CPU core to get their work done.
Additionally there is memory spent for each running worker, as well as time to spawn their processes.
It is better to fork no more child processes than there are physical cores.
```