### PR TITLE
Fix use the physical CPU count from NestJS

### DIFF
--- a/frameworks/TypeScript/nest/package.json
+++ b/frameworks/TypeScript/nest/package.json
@@ -28,6 +28,7 @@
     "mongodb": "3.5.4",
     "mysql2": "2.1.0",
     "pg": "8.5.1",
+    "physical-cpu-count": "^2.0.0",
     "point-of-view": "3.7.2",
     "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",

--- a/frameworks/TypeScript/nest/src/main.ts
+++ b/frameworks/TypeScript/nest/src/main.ts
@@ -9,7 +9,7 @@ import { MongoModule } from './mongo/mongo.module';
 import { join } from 'path';
 import { SqlModule } from './sql/sql.module';
 import cluster from 'cluster'
-import os = require('os');
+import physicalCpuCount from 'physical-cpu-count';
 
 const port = process.env.PORT || 8080;
 
@@ -58,8 +58,7 @@ async function bootstrapFastify() {
 }
 
 if (cluster.isPrimary) {
-  const cpus = os.cpus().length;
-  for (let i = 0; i < cpus; i++) {
+  for (let i = 0; i < physicalCpuCount; i++) {
     cluster.fork();
   }
 


### PR DESCRIPTION
Modify to use the number of physical CPUs, not the logical number of CPUs with hyperthreading applied, when using Cluster mode.


```
Working with clusters of Node.js processes it is common to see code using os.cpus().length as the number of child workers to fork.
For some workloads this can negatively impact performance on CPUs that use simultaneous multithreading (SMT).
Latency is doubled because two processes share the same physical CPU core to get their work done.
Additionally there is memory spent for each running worker, as well as time to spawn their processes.
It is better to fork no more child processes than there are physical cores.
```