### PR TITLE
[gin] Output message when gin-std server is ready

### DIFF
--- a/frameworks/Go/gin/gin-std/main.go
+++ b/frameworks/Go/gin/gin-std/main.go
@@ -153,6 +153,7 @@ func main() {
 	r.GET("/fortunes", fortunes)
 	r.GET("/update", update)
 	r.GET("/plaintext", plaintext)
+	log.Print("Listening and serving HTTP\n")
 	r.Run(":8080")
 }
 


### PR DESCRIPTION
I could use this to detect when the application has started before sending some request. Currently nothing is displayed at all.

@0uep is there a better way to do this?
