### PR TITLE
drop permissions of container to match host system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ARG USER_ID
+ARG GROUP_ID
 ARG DEBIAN_FRONTEND=noninteractive
 # WARNING: DON'T PUT A SPACE AFTER ANY BACKSLASH OR APT WILL BREAK
 # One -q produces output suitable for logging (mostly hides
@@ -28,5 +30,10 @@ RUN apt-get -yqq update && apt-get -yqq install \
       /usr/lib/python2.7/dist-packages/backports
 
 ENV FWROOT=/FrameworkBenchmarks PYTHONPATH=/FrameworkBenchmarks
+
+# Drop permissions of user to match those of the host system
+RUN addgroup --gid $GROUP_ID user
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
+USER user
 
 ENTRYPOINT ["python", "/FrameworkBenchmarks/toolset/run-tests.py"]

--- a/tfb
+++ b/tfb
@@ -102,5 +102,5 @@ if ! docker network inspect tfb >/dev/null 2>&1; then
 fi
 
 test -t 1 && USE_TTY="-t"
-docker build -t techempower/tfb - < ${SCRIPT_ROOT}/Dockerfile
+docker build -t techempower/tfb --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) - < ${SCRIPT_ROOT}/Dockerfile
 exec docker run -i ${USE_TTY} ${EXTRA_DOCKER_ARGS} --rm --network tfb -v /var/run/docker.sock:/var/run/docker.sock -v ${SCRIPT_ROOT}:/FrameworkBenchmarks techempower/tfb "${@}"


### PR DESCRIPTION
When you run Techempower as a non-elevated user, it will create report files that that the user cannot clean up.

This PR ensures that the Group/User IDs match the host systems.