### PR TITLE
[mORMot] bind query params as binary; use 'unnest' pattern for updates with count > 15

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -35,7 +35,7 @@ echo "Download statics from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot/static
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/46f5360a668ccf7a7c4d538fb319b449da8a232f
+URL=https://github.com/synopse/mORMot2/tarball/c57d48846f050f4f68856758d28cf76450addaf2
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1


### PR DESCRIPTION
- for /updates with count <=15 using 'case .. when .. then' pattern, for count > 15 - 'unnest' pattern
- using binary parameter binding format for Int4/Int8 parameter types - should be faster than textual