### PR TITLE
Revert "Fix use the physical CPU count from NodeJS (#7985)"

### DIFF
--- a/frameworks/JavaScript/nodejs/app.js
+++ b/frameworks/JavaScript/nodejs/app.js
@@ -1,5 +1,5 @@
 const cluster = require('cluster');
-const physicalCpuCount = require('physical-cpu-count')
+const numCPUs = require('os').cpus().length;
 
 process.env.NODE_HANDLER = 'mysql-raw';
 
@@ -17,7 +17,7 @@ if (cluster.isPrimary) {
   console.log(`Primary ${process.pid} is running`);
 
   // Fork workers.
-  for (let i = 0; i < physicalCpuCount; i++) {
+  for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }
 

--- a/frameworks/JavaScript/nodejs/package.json
+++ b/frameworks/JavaScript/nodejs/package.json
@@ -9,12 +9,11 @@
     "mongoose": "5.7.5",
     "mysql": "2.16.0",
     "mysql2": "1.6.5",
-    "node-cache": "4.1.1",
     "parseurl": "1.3.2",
     "pg": "8.5.0",
     "pg-hstore": "2.3.2",
-    "physical-cpu-count": "^2.0.0",
-    "sequelize": "5.15.1"
+    "sequelize": "5.15.1",
+    "node-cache": "4.1.1"
   },
   "main": "app.js"
 }


### PR DESCRIPTION
This reverts commit 1847278bb5fd6e02abe1c09e64bf521c8865e848.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
