### PR TITLE
Revert "Fix use the physical CPU count from NestJS (#7987)"

### DIFF
--- a/frameworks/TypeScript/nest/package.json
+++ b/frameworks/TypeScript/nest/package.json
@@ -28,7 +28,6 @@
     "mongodb": "3.5.4",
     "mysql2": "2.1.0",
     "pg": "8.5.1",
-    "physical-cpu-count": "^2.0.0",
     "point-of-view": "3.7.2",
     "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",

--- a/frameworks/TypeScript/nest/src/main.ts
+++ b/frameworks/TypeScript/nest/src/main.ts
@@ -9,7 +9,7 @@ import { MongoModule } from './mongo/mongo.module';
 import { join } from 'path';
 import { SqlModule } from './sql/sql.module';
 import cluster from 'cluster'
-import physicalCpuCount from 'physical-cpu-count';
+import os = require('os');
 
 const port = process.env.PORT || 8080;
 
@@ -58,7 +58,8 @@ async function bootstrapFastify() {
 }
 
 if (cluster.isPrimary) {
-  for (let i = 0; i < physicalCpuCount; i++) {
+  const cpus = os.cpus().length;
+  for (let i = 0; i < cpus; i++) {
     cluster.fork();
   }
 


### PR DESCRIPTION
This reverts commit e0fa21156973165d78e791049e5a8a71155cb901.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
