### PR TITLE
Display startup message for Gin (Go)

### DIFF
--- a/frameworks/Go/gin/gin-std/main.go
+++ b/frameworks/Go/gin/gin-std/main.go
@@ -153,7 +153,7 @@ func main() {
 	r.GET("/fortunes", fortunes)
 	r.GET("/update", update)
 	r.GET("/plaintext", plaintext)
-	log.Print("Listening and serving HTTP\n")
+	fmt.Println("Listening and serving HTTP\n")
 	r.Run(":8080")
 }
 

--- a/frameworks/Go/gin/gin-std/main.go
+++ b/frameworks/Go/gin/gin-std/main.go
@@ -153,7 +153,7 @@ func main() {
 	r.GET("/fortunes", fortunes)
 	r.GET("/update", update)
 	r.GET("/plaintext", plaintext)
-	fmt.Println("Listening and serving HTTP\n")
+	fmt.Println("Listening and serving HTTP")
 	r.Run(":8080")
 }
 


### PR DESCRIPTION
My previous attempt didn't work as it was using logging which is disabled in the scenario. This time I used `fmt.Println` and verified it was correctly outputting the text.

![image](https://user-images.githubusercontent.com/1165805/227381977-11334080-8218-4670-893a-4bdc9e5181fe.png)
