### PR TITLE
Update tfb-startup.sh

### DIFF
--- a/toolset/continuous/tfb-startup.sh
+++ b/toolset/continuous/tfb-startup.sh
@@ -25,6 +25,7 @@ docker build -t techempower/tfb .
 
 echo "running tfb docker image"
 docker run \
+  -e USER_ID=$(id -u) \
   --network=host \
   --mount type=bind,source=$TFB_REPOPARENT/$TFB_REPONAME,target=/FrameworkBenchmarks \
   techempower/tfb \


### PR DESCRIPTION
Startup script missing the USER_ID env var added in https://github.com/TechEmpower/FrameworkBenchmarks/pull/8021 causing service to fail on Citrine

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
