### PR TITLE
[toolset] Mysql use the same kernel optimization

### DIFF
--- a/toolset/databases/mysql/60-database-shm.conf
+++ b/toolset/databases/mysql/60-database-shm.conf
@@ -1,0 +1,2 @@
+kernel.shmmax=2147483648
+kernel.shmall=2097152

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -7,3 +7,5 @@ ENV MYSQL_DATABASE=hello_world
 
 COPY my.cnf /etc/mysql/
 COPY create.sql /docker-entrypoint-initdb.d/
+
+COPY 60-database-shm.conf /etc/sysctl.d/60-database-shm.conf


### PR DESCRIPTION
The same than PosgreSQL
The Mysql change, to use the official docker image, have not change the results (like with the PostgreSQL).

For sure than PostgreSQL will be faster.
But still the postgre config is optimized, and the mysql is almost the default. The default config of a database, it is NOT for a benchmark or an Enterprise server.

For now only the Kernel change, to be equal with PostreSQL.
https://github.com/TechEmpower/FrameworkBenchmarks/pull/8003#issuecomment-1467962188
