### PR TITLE
[php] Mixphp update to PHP 8.2

### DIFF
--- a/frameworks/PHP/mixphp/mixphp-workerman-pgsql.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp-workerman-pgsql.dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.1-cli php8.1-mbstring php8.1-curl php8.1-xml php8.1-pgsql > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.2-cli php8.2-mbstring php8.2-curl php8.2-xml php8.2-pgsql > /dev/null
 
-RUN apt-get install -y php8.1-dev libevent-dev > /dev/null
+RUN apt-get install -y php8.2-dev libevent-dev > /dev/null
 RUN wget http://pear.php.net/go-pear.phar --quiet && php go-pear.phar
-RUN pecl install event-3.0.8 > /dev/null && echo "extension=event.so" > /etc/php/8.1/cli/conf.d/event.ini
+RUN pecl install event-3.0.8 > /dev/null && echo "extension=event.so" > /etc/php/8.2/cli/conf.d/event.ini
 
-COPY php-jit.ini /etc/php/8.1/cli/php.ini
+COPY php-jit.ini /etc/php/8.2/cli/php.ini
 
 ADD ./ /mixphp
 WORKDIR /mixphp

--- a/frameworks/PHP/mixphp/mixphp.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp.dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential nginx php8.1-fpm php8.1-mysql php8.1-dev > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential nginx php8.2-fpm php8.2-mysql php8.2-dev > /dev/null
 
-COPY deploy/conf/* /etc/php/8.1/fpm/
+COPY deploy/conf/* /etc/php/8.2/fpm/
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.1/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 
 ADD ./ /mixphp
 WORKDIR /mixphp
@@ -22,5 +22,5 @@ RUN chmod -R 777 /mixphp/runtime/logs
 
 EXPOSE 8080
 
-CMD service php8.1-fpm start && \
+CMD service php8.2-fpm start && \
     nginx -c /mixphp/deploy/nginx.conf


### PR DESCRIPTION
And update to Ubuntu 22.04.

#7703


@onanying 
Fail to update with:

-  Swoole
   `Uncaught Error: Creation of dynamic property Swoole\Http\Request::$param is deprecated in /mixphp/vendor/mix/vega/src/Router.php on line 128 in /mixphp/src/Error.php:50`
-  Workerman-Mysql  
   `ERROR  Use of "parent" in callables is deprecated in /mixphp/vendor/mix/database/src/Connection.php on line 53 in /mixphp/src/Error.php on line 50`

