### PR TITLE
[php] DuckPHP update to PHP 8.2

### DIFF
--- a/frameworks/PHP/duckphp/duckphp.dockerfile
+++ b/frameworks/PHP/duckphp/duckphp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,18 +6,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
-    php8.1-cli php8.1-fpm php8.1-mysql php8.1-dev > /dev/null
+    php8.2-cli php8.2-fpm php8.2-mysql php8.2-dev > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.1/fpm/
+COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /duckphp
 WORKDIR /duckphp
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.1/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
-CMD service php8.1-fpm start && \
+CMD service php8.2-fpm start && \
     nginx -c /duckphp/deploy/nginx.conf


### PR DESCRIPTION
And Ubuntu 22.04

#7703
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
