### PR TITLE
[php] Phalcon update to PHP 8.2

### DIFF
--- a/frameworks/PHP/phalcon/app/config/config-mongo.php
+++ b/frameworks/PHP/phalcon/app/config/config-mongo.php
@@ -1,6 +1,6 @@
 <?php
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 
 return new Config([
     'database'     => [

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
+RUN apt-get install -y php-pear php8.2-dev > /dev/null
+RUN mkdir -p /etc/php/8.2/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
+
 RUN apt-get install -yqq nginx git unzip \
     php8.2-cli php8.2-fpm php8.2-mysql php8.2-mbstring php8.2-xml > /dev/null
 
@@ -15,9 +19,6 @@ COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
-
-RUN apt-get install -y php-pear php8.2-dev > /dev/null
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
 
 RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 

--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -7,19 +7,19 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.1-cli php8.1-fpm php8.1-mysql php8.1-mbstring php8.1-xml > /dev/null
+    php8.2-cli php8.2-fpm php8.2-mysql php8.2-mbstring php8.2-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.1/fpm/
+COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt-get install -y php-pear php8.1-dev > /dev/null
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.1/fpm/conf.d/phalcon.ini
+RUN apt-get install -y php-pear php8.2-dev > /dev/null
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.1/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --ignore-platform-reqs
 
@@ -29,5 +29,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php8.1-fpm start && \
+CMD service php8.2-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,19 +6,21 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
+RUN apt-get install -y php-pear php8.2-dev > /dev/null
+RUN mkdir -p /etc/php/8.2/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
+
 RUN apt-get install -yqq nginx git unzip \
-    php7.4-cli php7.4-fpm php7.4-mysql php7.4-mbstring php7.4-mongodb > /dev/null
+    php8.2-cli php8.2-fpm php8.2-mbstring php8.2-xml php8.2-mongodb > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/7.4/fpm/
+COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/7.4/fpm/php-fpm.conf ; fi;
-
-RUN apt-get install -yqq php7.4-psr php7.4-phalcon  > /dev/null
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet --ignore-platform-reqs
 
@@ -28,5 +30,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php7.4-fpm start && \
+CMD service php8.2-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
+RUN apt-get install -y php-pear php8.2-dev > /dev/null
+RUN mkdir -p /etc/php/8.2/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
+
 RUN apt-get install -yqq nginx git unzip \
     php8.2-cli php8.2-fpm php8.2-mysql php8.2-mbstring php8.2-xml > /dev/null
 
@@ -15,9 +19,6 @@ COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
-
-RUN apt-get install -y php-pear php8.2-dev > /dev/null
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
 
 RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -7,19 +7,19 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.1-cli php8.1-fpm php8.1-mysql php8.1-mbstring php8.1-xml > /dev/null
+    php8.2-cli php8.2-fpm php8.2-mysql php8.2-mbstring php8.2-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.1/fpm/
+COPY deploy/conf/* /etc/php/8.2/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN apt-get install -y php-pear php8.1-dev > /dev/null
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.1/fpm/conf.d/phalcon.ini
+RUN apt-get install -y php-pear php8.2-dev > /dev/null
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.2/fpm/conf.d/phalcon.ini
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.1/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.2/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --ignore-platform-reqs
 
@@ -27,5 +27,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php8.1-fpm start && \
+CMD service php8.2-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/public/index-mongo.php
+++ b/frameworks/PHP/phalcon/public/index-mongo.php
@@ -3,10 +3,9 @@
 use MongoDB\Client;
 use Phalcon\Db\Adapter\Pdo\Mysql;
 use Phalcon\DI\FactoryDefault;
-use Phalcon\Exception as PhalconException;
 use Phalcon\Http\Request;
 use Phalcon\Incubator\MongoDB\Mvc\Collection\Manager as MongoDBCollectionManager;
-use Phalcon\Loader;
+use Phalcon\Autoload\Loader;
 use Phalcon\Mvc\Application;
 use Phalcon\Mvc\Model\MetaData\Apc;
 use Phalcon\Mvc\Model\MetaData\Memory;
@@ -22,7 +21,7 @@ try {
 
     // Register an autoloader
     $loader = new Loader();
-    $loader->registerDirs([
+    $loader->setDirectories([
         $config->application->controllersDir,
         $config->application->modelsDir,
         $config->application->collectionsDir,


### PR DESCRIPTION
Using the last Pecl extension 5.2.1 (2023-02-28) that is working with php 8.2. https://pecl.php.net/package/phalcon

Move Phalcon Pecl install up, to use docker cache, as this layer is very time consuming.

Mongodb variant, still don't work with php 8.x, but updated all the files. 
