### PR TITLE
[xitca-web]add epoll bench.

### DIFF
--- a/frameworks/Rust/xitca-web/.cargo/config.toml
+++ b/frameworks/Rust/xitca-web/.cargo/config.toml
@@ -1,3 +1,6 @@
 [build]
-rustflags = ["-Ctarget-cpu=native"]
+rustflags = ["-C", "target-cpu=native"]
 incremental = false
+
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+simd128", "--cfg", "tokio_unstable"]

--- a/frameworks/Rust/xitca-web/Cargo.lock
+++ b/frameworks/Rust/xitca-web/Cargo.lock
@@ -4,13 +4,13 @@ version = 3
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -75,9 +75,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -127,7 +127,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -167,9 +167,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -192,15 +192,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -209,38 +209,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -355,9 +355,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8c7cbf8b89019683667e347572e6d55a7df7ea36b0c4ce69961b0cde67b174"
+checksum = "ef2c45001fb108f37d41bed8efd715769acb14674c1ce3e266ef0e317ef5f877"
 dependencies = [
  "cc",
  "libc",
@@ -399,9 +399,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb174b18635f7561a0c6c9fc2ce57218ac7523cf72c50af80e2d79ab8f3ba1"
+checksum = "92666043c712f7f5c756d07443469ddcda6dd971cc15258bb7f3c3216fd1b7aa"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "0.8.6"
-source = "git+https://github.com/fakeshadow/mio.git?rev=8f9125153aecb37f638a212fe82df8671bc77a1a#8f9125153aecb37f638a212fe82df8671bc77a1a"
+source = "git+https://github.com/fakeshadow/mio.git?rev=4272250caed2f460f7be646d0fd25d53d267eb53#4272250caed2f460f7be646d0fd25d53d267eb53"
 dependencies = [
  "libc",
  "log",
@@ -509,8 +509,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.4"
-source = "git+https://github.com/sfackler/rust-postgres.git?rev=7cd7b187a5cb990ceb0ea9531cd3345b1e2799c3#7cd7b187a5cb990ceb0ea9531cd3345b1e2799c3"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
 dependencies = [
  "base64",
  "byteorder",
@@ -526,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
+checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -550,7 +551,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -567,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -652,7 +653,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.109",
  "toml",
 ]
 
@@ -690,29 +691,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -771,6 +772,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +802,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -820,27 +842,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a12c1b3e0704ae7dfc25562629798b29c72e6b1d0a681b6f29ab4ae5e7f7bf"
+checksum = "6e89f6234aa8fd43779746012fcf53603cdb91fdd8399aa0de868c2d56b6dde1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -855,7 +876,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.5.1",
  "tokio",
  "tokio-util",
 ]
@@ -871,7 +892,7 @@ dependencies = [
  "libc",
  "scoped-tls",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
 ]
 
@@ -926,9 +947,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
@@ -1048,7 +1069,7 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 [[package]]
 name = "xitca-http"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "futures-core",
  "http",
@@ -1056,7 +1077,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.1",
  "tokio",
  "tracing",
  "xitca-io",
@@ -1068,16 +1089,17 @@ dependencies = [
 [[package]]
 name = "xitca-io"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "bytes",
  "tokio",
+ "xitca-unsafe-collection",
 ]
 
 [[package]]
 name = "xitca-postgres"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "fallible-iterator",
  "percent-encoding",
@@ -1093,7 +1115,7 @@ dependencies = [
 [[package]]
 name = "xitca-router"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "xitca-unsafe-collection",
 ]
@@ -1101,9 +1123,9 @@ dependencies = [
 [[package]]
 name = "xitca-server"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
- "socket2",
+ "socket2 0.5.1",
  "tokio",
  "tokio-uring",
  "tracing",
@@ -1115,12 +1137,12 @@ dependencies = [
 [[package]]
 name = "xitca-service"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 
 [[package]]
 name = "xitca-unsafe-collection"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "bytes",
 ]
@@ -1147,13 +1169,13 @@ dependencies = [
  "xitca-server",
  "xitca-service",
  "xitca-unsafe-collection",
- "xitca-web 0.1.0 (git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf)",
+ "xitca-web 0.1.0 (git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2)",
 ]
 
 [[package]]
 name = "xitca-web"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf#c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=d3e9a4fb6b16513ff638f43305c9c96cdb3501b2#d3e9a4fb6b16513ff638f43305c9c96cdb3501b2"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/frameworks/Rust/xitca-web/Cargo.toml
+++ b/frameworks/Rust/xitca-web/Cargo.toml
@@ -19,6 +19,11 @@ path = "./src/main_iou.rs"
 required-features = ["io-uring", "pg", "serde", "template"]
 
 [[bin]]
+name = "xitca-web-epoll"
+path = "./src/main_iou.rs"
+required-features = ["pg", "serde", "template"]
+
+[[bin]]
 name = "xitca-web-wasm"
 path = "./src/main_wasm.rs"
 required-features = ["web"]
@@ -65,7 +70,7 @@ serde_json = { version = "1", optional = true }
 tokio-uring = { version = "0.4", features = ["bytes"], optional = true }
 
 # template optional
-sailfish = { version = "0.6.0", optional = true }
+sailfish = { version = "0.6", optional = true }
 
 # stuff can not be used or not needed in wasi target
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -81,15 +86,13 @@ codegen-units = 1
 panic = "abort"
 
 [patch.crates-io]
-xitca-http = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-io = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-postgres = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-router = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-server = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-service = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-unsafe-collection = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
-xitca-web = { git = "https://github.com/HFQR/xitca-web.git", rev = "c58463d4cd2e58a1fbbe5d15cb4e82c7cd0055bf" }
+xitca-http = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-io = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-postgres = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-router = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-server = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-service = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-unsafe-collection = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
+xitca-web = { git = "https://github.com/HFQR/xitca-web.git", rev = "d3e9a4fb6b16513ff638f43305c9c96cdb3501b2" }
 
-postgres-protocol = { git = "https://github.com/sfackler/rust-postgres.git", rev = "7cd7b187a5cb990ceb0ea9531cd3345b1e2799c3" }
-
-mio = { git = "https://github.com/fakeshadow/mio.git", rev = "8f9125153aecb37f638a212fe82df8671bc77a1a" }
+mio = { git = "https://github.com/fakeshadow/mio.git", rev = "4272250caed2f460f7be646d0fd25d53d267eb53" }

--- a/frameworks/Rust/xitca-web/benchmark_config.json
+++ b/frameworks/Rust/xitca-web/benchmark_config.json
@@ -68,6 +68,28 @@
         "notes": "",
         "versus": ""
       },
+      "epoll": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "db_url": "/db",
+        "fortune_url": "/fortunes",
+        "query_url": "/queries?q=",
+        "update_url": "/updates?q=",
+        "port": 8080,
+        "approach": "Stripped",
+        "classification": "Platform",
+        "database": "Postgres",
+        "framework": "xitca-web",
+        "language": "Rust",
+        "orm": "Raw",
+        "platform": "None",
+        "webserver": "xitca-server",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "xitca-web [epoll]",
+        "notes": "",
+        "versus": ""
+      },
       "wasm": {
         "plaintext_url": "/plaintext",
         "port": 8080,

--- a/frameworks/Rust/xitca-web/rust-toolchain.toml
+++ b/frameworks/Rust/xitca-web/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-03-16"
+channel = "nightly-2023-04-03"

--- a/frameworks/Rust/xitca-web/xitca-web-epoll.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web-epoll.dockerfile
@@ -1,0 +1,10 @@
+FROM rust:latest
+
+ADD ./ /xitca-web
+WORKDIR /xitca-web
+
+RUN cargo build --release --bin xitca-web-epoll --features pg,serde,template
+
+EXPOSE 8080
+
+CMD ./target/release/xitca-web-epoll

--- a/frameworks/Rust/xitca-web/xitca-web-wasm.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web-wasm.dockerfile
@@ -2,7 +2,6 @@ FROM rust:1.67 AS compile
 
 ARG WASMTIME_VERSION=6.0.0
 
-ARG RUSTFLAGS="-C target-feature=+simd128 --cfg tokio_unstable"
 WORKDIR /tmp
 COPY / ./
 RUN curl -LSs "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-$(uname -m)-linux.tar.xz" | \


### PR DESCRIPTION
bench used for a fair comparison(not completely fair but very similar at abstract level) between `tokio` and `tokio-uring` for tcp io.