### PR TITLE
Fixed runtime errors with Vert.x

### DIFF
--- a/frameworks/Java/vertx/pom.xml
+++ b/frameworks/Java/vertx/pom.xml
@@ -10,9 +10,10 @@
 		<maven.compiler.target>17</maven.compiler.target>
 		<!-- the main class -->
 		<main.class>vertx.App</main.class>
-		<stack.version>4.3.8</stack.version>
-		<jackson.version>2.14.2</jackson.version>
-		<netty.version>4.1.89.Final</netty.version>
+		<stack.version>4.4.2</stack.version>
+		<jackson.version>2.15.0</jackson.version>
+		<netty.version>4.1.92.Final</netty.version>
+		<netty.io_uring.version>0.0.21.Final</netty.io_uring.version>
 	</properties>
 
 	<dependencies>
@@ -131,5 +132,30 @@
 		</plugins>
 
 	</build>
+
+	<profiles>
+		<profile>
+			<id>Linux</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+				<os>
+					<family>unix</family>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.vertx</groupId>
+					<artifactId>vertx-io_uring-incubator</artifactId>
+					<version>${stack.version}</version>
+				</dependency>
+				<dependency>
+					<groupId>io.netty.incubator</groupId>
+					<artifactId>netty-incubator-transport-native-io_uring</artifactId>
+					<version>${netty.io_uring.version}</version>
+					<classifier>linux-x86_64</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 </project>

--- a/frameworks/Java/vertx/src/main/java/vertx/App.java
+++ b/frameworks/Java/vertx/src/main/java/vertx/App.java
@@ -3,6 +3,7 @@ package vertx;
 import com.fizzed.rocker.ContentType;
 import com.fizzed.rocker.RockerOutputFactory;
 import io.netty.util.concurrent.MultithreadEventExecutorGroup;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.pgclient.*;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
@@ -441,6 +442,7 @@ public class App extends AbstractVerticle implements Handler<HttpServerRequest> 
 
   private static void printConfig(Vertx vertx) {
     boolean nativeTransport = vertx.isNativeTransportEnabled();
+    String transport = ((VertxInternal) vertx).transport().getClass().getSimpleName();
     String version = "unknown";
     try {
       InputStream in = Vertx.class.getClassLoader().getResourceAsStream("META-INF/vertx/vertx-version.txt");
@@ -463,5 +465,6 @@ public class App extends AbstractVerticle implements Handler<HttpServerRequest> 
     logger.info("Vertx: " + version);
     logger.info("Event Loop Size: " + ((MultithreadEventExecutorGroup)vertx.nettyEventLoopGroup()).executorCount());
     logger.info("Native transport : " + nativeTransport);
+    logger.info("Transport : " + transport);
   }
 }


### PR DESCRIPTION
Application start can be racy with server start and sometimes the server is up and running before the cached prepared statement are visible to the application leading to runtime errors (NullPointerException). We should start the server after the prepared statement have been created and made visible to the HTTP server threads.