### PR TITLE
[php] Enable JIT

### DIFF
--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -32,7 +32,7 @@ RUN sed -i "s|app.php|app-pg.php|g" /deploy/nginx.conf
 
 RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s|worker_processes  auto|worker_processes $WORKERS|g" /deploy/nginx.conf
-
+RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.1/embed/conf.d/10-opcache.ini
 EXPOSE 8080
 
 CMD /nginx/sbin/nginx -c /deploy/nginx.conf

--- a/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-php8-jit.dockerfile
@@ -20,6 +20,7 @@ WORKDIR /workerman
 
 RUN sed -i "s|'/app.php|'/app-pg.php|g" server.php
 RUN sed -i "s|init()|DbRaw::init()|g" server.php
+RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.2/cli/conf.d/10-opcache.ini
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 


### PR DESCRIPTION
PHP JIT is not enabled.

By default the `ppa:ondrej/php`, have disabled JIT. Even when you enable it, in your `php.ini`. I found it when creating tests for ngx-php, and later checking the benchmark, are also disabled.
Because some code have segfaults. I'll create an Issue in Odrej repo, because it's OK to be disabled by default, but we need to enable it, in dockerfile without a `sed`, for frameworks/apps that work without problems.

So I tested in benchmark mode first in local now, and I'll enable selectively in some fws.
Using function mode, not tracing.
Now only `Workerman-jit` and `php-ngx-pgsql`, to check the difference.
