### PR TITLE
Switch to the wrk package provided by Ubuntu 22.04

### DIFF
--- a/toolset/wrk/wrk.dockerfile
+++ b/toolset/wrk/wrk.dockerfile
@@ -1,33 +1,13 @@
-ARG UBUNTU_VERSION=jammy
-
-FROM "buildpack-deps:${UBUNTU_VERSION}" AS compile
-
-ARG WRK_VERSION=4.2.0
-
-ARG LDFLAGS="-flto -march=native -mtune=native -O3"
-ARG CFLAGS="-I /usr/include/luajit-2.1 ${LDFLAGS}"
-ARG DEBIAN_FRONTEND=noninteractive
-WORKDIR /tmp
-RUN apt-get -yqq update >/dev/null && \
-    apt-get -yqq install >/dev/null \
-      libluajit-5.1-dev \
-      libssl-dev \
-      luajit && \
-    curl -LSs "https://github.com/wg/wrk/archive/${WRK_VERSION}.tar.gz" | \
-      tar --strip-components=1 -xz && \
-    make WITH_LUAJIT=/usr WITH_OPENSSL=/usr -j "$(nproc)"
-
-FROM "ubuntu:${UBUNTU_VERSION}"
+FROM ubuntu:22.04
 
 # Required scripts for benchmarking
 COPY concurrency.sh pipeline.lua pipeline.sh query.sh ./
 
 ARG DEBIAN_FRONTEND=noninteractive
-COPY --from=compile /tmp/wrk /usr/local/bin/
 RUN apt-get -yqq update >/dev/null && \
     apt-get -yqq install >/dev/null \
       curl \
-      libluajit-5.1-2 && \
+      wrk && \
     chmod 777 concurrency.sh pipeline.sh query.sh
 
 # Environment vars required by the wrk scripts with nonsense defaults


### PR DESCRIPTION
Also, make a small change to `h2o_mruby` to test. Note that previously `wrk` was compiled with a lot of optimizations enabled, but since the bottlenecks in the tests are usually elsewhere, I don't expect any significant performance regressions.