### PR TITLE
H2O: Fix a compatibility issue with Docker

### DIFF
--- a/frameworks/C/h2o/src/thread.c
+++ b/frameworks/C/h2o/src/thread.c
@@ -74,14 +74,16 @@ static void set_thread_memory_allocation_policy(void)
 	memset(nodemask, 0, sizeof(nodemask));
 	nodemask[memory_node / (sizeof(*nodemask) * CHAR_BIT)] |=
 		1UL << (memory_node % (sizeof(*nodemask) * CHAR_BIT));
-	CHECK_ERRNO(mbind,
-	            stack_addr,
-	            stack_size,
-	            MPOL_PREFERRED,
-	            nodemask,
-	            memory_node + 1,
-	            MPOL_MF_MOVE | MPOL_MF_STRICT);
-	CHECK_ERRNO(set_mempolicy, MPOL_PREFERRED, NULL, 0);
+
+	if (mbind(stack_addr,
+	          stack_size,
+	          MPOL_PREFERRED,
+	          nodemask,
+	          memory_node + 1,
+	          MPOL_MF_MOVE | MPOL_MF_STRICT))
+		STANDARD_ERROR("mbind");
+	else if (set_mempolicy(MPOL_PREFERRED, NULL, 0))
+		STANDARD_ERROR("set_mempolicy");
 }
 
 void free_thread_context(thread_context_t *ctx)


### PR DESCRIPTION
Docker may block execution of the `mbind()` and the `set_mempolicy()` system calls. Since we use them just as a performance optimization (without any effect on correctness), we change the application to handle their failure more gracefully, i.e. without aborting.