### PR TITLE
[Python] uWSGI: fix max connections

### DIFF
--- a/frameworks/Python/uwsgi/nginx.conf
+++ b/frameworks/Python/uwsgi/nginx.conf
@@ -6,7 +6,7 @@ error_log stderr error;
 events {
     # This needed to be increased because the nginx error log said so.
     # http://nginx.org/en/docs/ngx_core_module.html#worker_connections
-    worker_connections  65535;
+    worker_connections  4095;
     multi_accept on;
 }
 

--- a/frameworks/Python/uwsgi/uwsgi.ini
+++ b/frameworks/Python/uwsgi/uwsgi.ini
@@ -2,7 +2,7 @@
 master
 ; Increase listen queue used for nginx connecting to uWSGI. This matches
 ; net.ipv4.tcp_max_syn_backlog and net.core.somaxconn.
-listen = 16384
+listen = 4096
 ; for performance
 disable-logging
 ; use UNIX sockets instead of TCP loopback for performance


### PR DESCRIPTION
In a production system, for some reason, the kernel uses a parameter `net.core.somaxconn` with a lower value.
On the CI system, there is no such problem.

[LOG](https://tfb-status.techempower.com/unzip/results.2023-04-13-01-30-40-927.zip/results/20230406155252/uwsgi-nginx-uwsgi/run/uwsgi-nginx-uwsgi.log) from production system.