### PR TITLE
[mORMot] use CPU pinning to minimize cpu-migrations

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -35,7 +35,7 @@ echo "Download statics from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot/static
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/08dd4a1898fa2e66b659f0679f7a038b3b2f2c65
+URL=https://github.com/synopse/mORMot2/tarball/f430300300ed51f128b32036423d920032628159
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1


### PR DESCRIPTION
-  use CPU pinning to minimize cpu-migrations
-  upgrade to latest mORMot2
-  added command-line switches for manual testing 