### PR TITLE
Micronaut R2DBC: Set `initialSize` of the pool to 0

### DIFF
--- a/frameworks/Java/micronaut/common/src/main/resources/application-common.yml
+++ b/frameworks/Java/micronaut/common/src/main/resources/application-common.yml
@@ -28,7 +28,7 @@ r2dbc:
       dialect: POSTGRES
       options:
         protocol: postgres
-        initialSize: 48
+        initialSize: 0
         maxSize: 48
 
 mongodb:


### PR DESCRIPTION
It looks like there is a bug in R2DBC Pool that uses one connection when `initialSize` and `maxSize` are equal.

https://github.com/micronaut-projects/micronaut-data/issues/2136