### PR TITLE
Reduce the number of event loop threads for io_uring

### DIFF
--- a/frameworks/Java/netty/src/main/java/hello/HelloWebServer.java
+++ b/frameworks/Java/netty/src/main/java/hello/HelloWebServer.java
@@ -37,7 +37,7 @@ public class HelloWebServer {
 	public void run() throws Exception {
 		// Configure the server.
 		if (IOUring.isAvailable()) {
-			doRun(new IOUringEventLoopGroup(), IOUringServerSocketChannel.class, IoMultiplexer.IO_URING);
+			doRun(new IOUringEventLoopGroup(Runtime.getRuntime().availableProcessors()), IOUringServerSocketChannel.class, IoMultiplexer.IO_URING);
 		} else
 			if (Epoll.isAvailable()) {
 			doRun(new EpollEventLoopGroup(), EpollServerSocketChannel.class, IoMultiplexer.EPOLL);


### PR DESCRIPTION
As per https://github.com/netty/netty-incubator-transport-io_uring/issues/152#issuecomment-1086107530 the number of event loop threads for io_uring can be much less then the default ones used by Netty (2 * cores).