### PR TITLE
Raise iosqeAsyncThreshold

### DIFF
--- a/frameworks/Java/netty/netty.dockerfile
+++ b/frameworks/Java/netty/netty.dockerfile
@@ -10,4 +10,4 @@ COPY --from=maven /netty/target/netty-example-0.1-jar-with-dependencies.jar app.
 
 EXPOSE 8080
 
-CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dio.netty.buffer.checkBounds=false", "-Dio.netty.buffer.checkAccessible=false", "-jar", "app.jar"]
+CMD ["java", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-XX:+AggressiveOpts", "-Dio.netty.buffer.checkBounds=false", "-Dio.netty.buffer.checkAccessible=false", "-Dio.netty.iouring.iosqeAsyncThreshold=32000", "-jar", "app.jar"]


### PR DESCRIPTION
plaintext benchmark can cause Netty io_uring to use ASYNC SQEs that are not nicely handled at OS level (creating TONS of kernel threads ie ring size per event loop -> 4096 * 28 ).
Some more info on this behaviour at https://github.com/axboe/liburing/issues/420 and https://blog.cloudflare.com/missing-manuals-io_uring-worker-pool/ as well.
 
In our case, plaintext could use 16384 connections partitioned in 28 event loops = 582 connections per event loop 
which exceed the 25 default ones and can cause ASYNC SQEs to be used
  
This PR fix this behaviour and force SYNC SQEs: see https://github.com/netty/netty-incubator-transport-io_uring/issues/152#issuecomment-1077363041 for more info