### PR TITLE
[python] Api_hour variants mark as broken

### DIFF
--- a/frameworks/Python/api_hour/benchmark_config.json
+++ b/frameworks/Python/api_hour/benchmark_config.json
@@ -60,7 +60,8 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "API-Hour-yocto",
-      "notes": "Python 3 + API-Hour + AsyncIO"
+      "notes": "Python 3 + API-Hour + AsyncIO",
+      "tags": ["broken"]
     },
     "dbs": {
       "db_url": "/db",
@@ -79,7 +80,8 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "API-Hour-yocto",
-      "notes": "Python 3 + API-Hour + AsyncIO"
+      "notes": "Python 3 + API-Hour + AsyncIO",
+      "tags": ["broken"]
     },
     "plaintext": {
       "plaintext_url": "/plaintext",
@@ -96,7 +98,8 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "API-Hour-yocto",
-      "notes": "Python 3 + API-Hour + AsyncIO"
+      "notes": "Python 3 + API-Hour + AsyncIO",
+      "tags": ["broken"]
     }
   }]
 }


### PR DESCRIPTION
Add the variants as broken, that fail.

They use still Debian Stretch EOL. If we update the version, fail to build.
