### PR TITLE
Upgrade to Quarkus 3.2.0.Final and Hibernate Reactive 2.0.2.Final

### DIFF
--- a/frameworks/Java/quarkus/pom.xml
+++ b/frameworks/Java/quarkus/pom.xml
@@ -13,13 +13,15 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.1.1.Final</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+        <quarkus.platform.version>3.2.0.Final</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0</surefire-plugin.version>
         <netty.io_uring.version>0.0.21.Final</netty.io_uring.version>
-        <vertx.version>4.4.2</vertx.version>
+        <vertx.version>4.4.4</vertx.version>
         <rocker.version>1.3.0</rocker.version>
+        <hibernate-orm.version>6.2.6.Final</hibernate-orm.version>
+        <hibernate-reactive.version>2.0.2.Final</hibernate-reactive.version>
     </properties>
 
     <modules>
@@ -34,6 +36,16 @@
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-benchmark-common</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.reactive</groupId>
+                <artifactId>hibernate-reactive-core</artifactId>
+                <version>${hibernate-reactive.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>


### PR DESCRIPTION
This micro update of Quarkus and its dependencies should fix the fact that the "/updates" scenario in Techempower was unable to complete the benchmark successfully when using the reactive stack (with Hibernate Reactive instead of Hibernate ORM).

cc/ @franz1981 