### PR TITLE
Ping maintainers on framework update

### DIFF
--- a/.github/workflows/ping_maintainers.yml
+++ b/.github/workflows/ping_maintainers.yml
@@ -1,0 +1,42 @@
+name: Ping maintainers
+on: 
+  pull_request:
+    types: [opened, reopened]
+permissions:
+  pull-requests: write
+jobs:
+  ping_maintainers:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+      - name: Get commit branch and commit message from PR
+        run: |
+          echo "BRANCH_NAME=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+          echo "TARGET_BRANCH_NAME=$(echo ${GITHUB_BASE_REF##*/})" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
+          echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo "PREVIOUS_COMMIT=$(git log --format=%H -n 1 HEAD^2~1)" >> $GITHUB_ENV
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+      - name: Get Maintainers
+        run: |
+          echo "MAINTAINERS_COMMENT<<EOF" >> $GITHUB_ENV
+          echo "$(./toolset/github_actions/get_maintainers.py)" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Ping maintainers
+        if: env.MAINTAINERS_COMMENT
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.MAINTAINERS_COMMENT
+            });

--- a/frameworks/Java/gemini/benchmark_config.json
+++ b/frameworks/Java/gemini/benchmark_config.json
@@ -1,5 +1,6 @@
 {
   "framework": "gemini",
+  "maintainers": ["ecruz-te"],
   "tests": [
     {
       "default": {

--- a/toolset/github_actions/get_maintainers.py
+++ b/toolset/github_actions/get_maintainers.py
@@ -6,8 +6,6 @@
 # @description: This script is only for use within Github Actions. It is meant
 # to get a list of maintainers to ping for a PR whenever their framework
 # is updated.
-# This script is meant to be used in conjunction with the github_actions_diff.py
-# to determine which frameworks have been updated.
 
 import os
 import json

--- a/toolset/github_actions/get_maintainers.py
+++ b/toolset/github_actions/get_maintainers.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# @file:        toolset/github_actions/get_maintainers.py
+# @author:      Elwyn Cruz (ecruz-te)
+#
+# @description: This script is only for use within Github Actions. It is meant
+# to get a list of maintainers to ping for a PR whenever their framework
+# is updated.
+# This script is meant to be used in conjunction with the github_actions_diff.py
+# to determine which frameworks have been updated.
+
+import os
+import json
+import re
+import subprocess
+
+diff_target = os.getenv("TARGET_BRANCH_NAME") 
+
+def fw_found_in_changes(test, changes_output):
+    return re.search(
+        r"frameworks/" + re.escape(test) + "/",
+        changes_output, re.M)
+
+def clean_output(output):
+    return os.linesep.join([s for s in output.splitlines() if s])
+
+curr_branch = "HEAD"
+# Also fetch master to compare against
+subprocess.check_output(['bash', '-c', 'git fetch origin {0}:{0}'
+                        .format(diff_target)])
+
+changes = clean_output(
+    subprocess.check_output([
+        'bash', '-c',
+        'git --no-pager diff --name-only {0} $(git merge-base {0} {1})'
+            .format(curr_branch, diff_target)
+    ], text=True))
+
+def get_frameworks(test_lang):
+    dir = "frameworks/" + test_lang + "/"
+    return [test_lang + "/" + x for x in [x for x in os.listdir(dir) if os.path.isdir(dir + x)]]
+
+test_dirs = []
+for frameworks in map(get_frameworks, os.listdir("frameworks")):
+    for framework in frameworks:
+        test_dirs.append(framework)
+affected_frameworks = [fw for fw in test_dirs if fw_found_in_changes(fw, changes)]
+
+maintained_frameworks = {}
+
+for framework in affected_frameworks:
+    _, name = framework.split("/")
+    try:
+        with open("frameworks/" + framework + "/benchmark_config.json", "r") as framework_config:
+            config = json.load(framework_config)
+    except FileNotFoundError:
+        continue
+    framework_maintainers = config.get("maintainers", None)
+    if framework_maintainers is not None:
+        maintained_frameworks[name] = framework_maintainers
+
+if maintained_frameworks:
+    print("The following frameworks were updated, pinging maintainers:")
+    for framework, maintainers in maintained_frameworks.items():
+        print("`%s`: @%s" % (framework, ", @".join(maintainers)))
+exit(0)


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Adds a github action to ping maintainers when a file is changed in their framework directory.
- maintainers can be added in the `benchmark_config.json` file, like so:

```
{
  "framework": "gemini",
  "maintainers": ["ecruz-te"],
  ...
}
```