### PR TITLE
A few changes to the test runner when used with --debug option

### DIFF
--- a/frameworks/Lisp/woo/benchmark_config.json
+++ b/frameworks/Lisp/woo/benchmark_config.json
@@ -10,6 +10,7 @@
                 "query_url": "/queries?queries=",
                 "update_url": "/updates?queries=",
                 "port": 8080,
+                "debug_port": 4005,
                 "approach": "Stripped",
                 "classification": "Micro",
                 "database": "Postgres",

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -197,8 +197,16 @@ class DockerHelper:
 
             # Expose ports in debugging mode
             ports = {}
+            environment = {}
+
             if self.benchmarker.config.mode == "debug":
+                environment['DEBUG'] = 'true'
                 ports = {test.port: test.port}
+
+                # This allows to expose a debugger port to attach
+                # to the webserver from IDE
+                if hasattr(test, 'debug_port'):
+                    ports[test.debug_port] = test.debug_port
 
             container = self.server.containers.run(
                 "techempower/tfb.test.%s" % test.name,
@@ -207,6 +215,7 @@ class DockerHelper:
                 network=self.benchmarker.config.network,
                 network_mode=self.benchmarker.config.network_mode,
                 ports=ports,
+                environment=environment,
                 stderr=True,
                 detach=True,
                 init=True,


### PR DESCRIPTION
- when you pass `--debug` option, `DEBUG=true` environment variable is passed into the docker image. This way benchmark author can enable logging or open a debugger port when running the test in the debug mode.
- also, now you can specify `debug_port` option in the `benchmark_config.json` file. If you do so, then this port will be exposed from docker container if test was started with `--debug` option. I use this feature to connect to the Lisp process inside docker from Emacs and to play with the code in interactive mode.