### PR TITLE
Fix build Python/aioworkers with PyYAML==6.0

### DIFF
--- a/frameworks/Python/aioworkers/requirements.txt
+++ b/frameworks/Python/aioworkers/requirements.txt
@@ -1,3 +1,3 @@
 aioworkers==0.24.1
 httptools==0.6.0
-PyYAML==6.0
+PyYAML==6.0.1


### PR DESCRIPTION
Docker image build fail with PyYAML==6.0

up to PyYAML==6.0.1