### PR TITLE
Downgrade the version of the PG shard

### DIFF
--- a/frameworks/Crystal/grip/shard.yml
+++ b/frameworks/Crystal/grip/shard.yml
@@ -4,11 +4,11 @@ version: 0.2.0
 dependencies:
   grip:
     github: grip-framework/grip
-    version: 2.0.0
+    version: 2.0.2
 
   pg:
     github: will/crystal-pg
-    version: 0.26.0
+    version: 0.20.0
 targets:
   grip:
     main: grip.cr

--- a/frameworks/Crystal/grip/shard.yml
+++ b/frameworks/Crystal/grip/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.0
 dependencies:
   grip:
     github: grip-framework/grip
-    version: 2.0.2
+    version: 2.0.0
 
   pg:
     github: will/crystal-pg


### PR DESCRIPTION
Fails to build on 0.26.0 and seems to build on 0.20.0