### PR TITLE
`--extra-docker-runtime-args` should split on first colon only

### DIFF
--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -215,7 +215,7 @@ class DockerHelper:
             # Convert extra docker runtime args to a dictionary
             extra_docker_args = {}
             if self.benchmarker.config.extra_docker_runtime_args is not None:
-                extra_docker_args = {key: int(value) if value.isdigit() else value for key, value in (pair.split(":") for pair in self.benchmarker.config.extra_docker_runtime_args)}
+                extra_docker_args = {key: int(value) if value.isdigit() else value for key, value in (pair.split(":", 1) for pair in self.benchmarker.config.extra_docker_runtime_args)}
 
             container = self.server.containers.run(
                 "techempower/tfb.test.%s" % test.name,


### PR DESCRIPTION
If the value has colon as well it should be preserved.

Currently:

```
>>> extra_docker_args = {key: int(value) if value.isdigit() else value for key, value in (pair.split(":") for pair in ["cpu_period:10000", "cpu_quota:50000", "volumne:/host:/container"])}; print(extra_docker_args)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <dictcomp>
ValueError: too many values to unpack (expected 2)
```

Fixed with this pull request:
```
>>> extra_docker_args = {key: int(value) if value.isdigit() else value for key, value in (pair.split(":", 1) for pair in ["cpu_period:10000", "cpu_quota:50000", "volumne:/host:/container"])}; print(extra_docker_args)
{'cpu_period': 10000, 'cpu_quota': 50000, 'volumne': '/host:/container'}
```

See https://stackoverflow.com/a/6903597/810109

Code was introduced in #8329