### PR TITLE
[xitca-web] update toolchain.

### DIFF
--- a/frameworks/Rust/xitca-web/rust-toolchain.toml
+++ b/frameworks/Rust/xitca-web/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-09-13"
+channel = "nightly-2023-09-26"


### PR DESCRIPTION
fix rustc warning and slow compile time of `xitca-web-wasm`.
