### PR TITLE
[may_minihttp] fix plaintext and update toolchain

### DIFF
--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -18,7 +18,7 @@ yarte = { version = "0.15", features = ["bytes-buf", "json"] }
 buf-min = { version = "0.7", features = ["bytes"] }
 
 may = { version = "0.3", default-features = false }
-may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp.git", rev = "bbcd7f7", default-features = false }
+may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp.git", rev = "b3080c0", default-features = false }
 may_postgres = { git = "https://github.com/Xudong-Huang/may_postgres.git", rev = "bf1d86e", default-features = false }
 
 [profile.release]

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68
+FROM rust:1.72
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 


### PR DESCRIPTION
1.  update may_minihttp dependency to fix plaintext
2.  update rust toolchain
