### PR TITLE
[rails] Upgrade redis and tzinfo-data gems

### DIFF
--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -8,5 +8,5 @@ gem 'oj', '~> 3.16'
 gem 'pg', '1.5.4', group: :postgresql
 gem 'puma', '~> 6.4'
 gem 'rails', '7.1.0.beta1'
-gem 'redis', '~> 4.0'
-gem 'tzinfo-data', '1.2021.5'
+gem 'redis', '~> 5.0'
+gem 'tzinfo-data'

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -177,7 +177,10 @@ GEM
       ffi (~> 1.0)
     rdoc (6.5.0)
       psych (>= 4.0.0)
-    redis (4.5.1)
+    redis (5.0.7)
+      redis-client (>= 0.9.0)
+    redis-client (0.17.0)
+      connection_pool
     reline (0.3.8)
       io-console (~> 0.5)
     ruby2_keywords (0.0.5)
@@ -206,8 +209,8 @@ DEPENDENCIES
   pg (= 1.5.4)
   puma (~> 6.4)
   rails (= 7.1.0.beta1)
-  redis (~> 4.0)
-  tzinfo-data (= 1.2021.5)
+  redis (~> 5.0)
+  tzinfo-data
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/frameworks/Ruby/rails/rails-mysql.dockerfile
+++ b/frameworks/Ruby/rails/rails-mysql.dockerfile
@@ -16,5 +16,5 @@ COPY . /rails/
 ENV RUBY_YJIT_ENABLE=1
 ENV RAILS_ENV=production_mysql
 ENV PORT=8080
-ENV REDIS_URL=redis://localhost:6379/0/cache
+ENV REDIS_URL=redis://localhost:6379/0
 CMD ./run-with-redis.sh

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -16,5 +16,5 @@ COPY . /rails/
 ENV RUBY_YJIT_ENABLE=1
 ENV RAILS_ENV=production_postgresql
 ENV PORT=8080
-ENV REDIS_URL=redis://localhost:6379/0/cache
+ENV REDIS_URL=redis://localhost:6379/0
 CMD ./run-with-redis.sh


### PR DESCRIPTION
The redis URL needed to be updated as the newer gem is more strict in allowed values and raises:

      <ArgumentError: invalid value for Integer(): "0/cache">
