### PR TITLE
[ruby/sinatra] Remove torquebox gem from sinatra

### DIFF
--- a/frameworks/Ruby/sinatra/Gemfile
+++ b/frameworks/Ruby/sinatra/Gemfile
@@ -6,7 +6,6 @@ gem 'json', '~> 2.0'
 gem 'passenger', '~> 5.1', :platforms=>[:ruby, :mswin], :require=>false
 gem 'puma', '~> 3.9', :require=>false
 gem 'sinatra', '~> 2.0', :require=>'sinatra/base'
-gem 'torquebox-web', '>= 4.0.0.beta3', '< 5', :platforms=>:jruby, :require=>false
 gem 'unicorn', '~> 5.2', :platforms=>[:ruby, :mswin], :require=>false
 
 group :mysql do

--- a/frameworks/Ruby/sinatra/README.md
+++ b/frameworks/Ruby/sinatra/README.md
@@ -18,7 +18,6 @@ The tests will be run with:
 * [Puma 3](http://puma.io)
 * [Passenger 5](https://www.phusionpassenger.com)
 * [Unicorn 5](https://bogomips.org/unicorn/)
-* [TorqueBox 4.0](http://torquebox.org)\*
 * [Sinatra 2](http://www.sinatrarb.com)
 * [ActiveRecord 5](https://github.com/rails/rails/tree/master/activerecord)
 * [MySQL 5.5](https://www.mysql.com)


### PR DESCRIPTION
Torquebox is no longer maintained, and the gem isn't used.