### PR TITLE
[ruby/grape] Upgrade Ruby to 3.3-rc and enable YJIT

### DIFF
--- a/frameworks/Ruby/grape/README.md
+++ b/frameworks/Ruby/grape/README.md
@@ -11,7 +11,7 @@ comparing a variety of web servers.
 ## Infrastructure Software Versions
 The tests were run with:
 
-* [Ruby 3.1](http://www.ruby-lang.org/)
+* [Ruby 3.3-rc1](http://www.ruby-lang.org/)
 * [Grape 1.6.2](http://www.ruby-grape.org/)
 * [Rack 2.2.3.1](https://rack.github.io/)
 * [Unicorn 6.1.0](https://yhbt.net/unicorn/)

--- a/frameworks/Ruby/grape/config.ru
+++ b/frameworks/Ruby/grape/config.ru
@@ -2,6 +2,10 @@ require 'erb'
 require 'active_record'
 require 'yaml'
 
+MAX_PK = 10_000
+QUERIES_MIN = 1
+QUERIES_MAX = 500
+
 Bundler.require :default
 
 db_config = YAML.load(ERB.new(File.read('config/database.yml')).result)[ENV['RACK_ENV']]
@@ -28,38 +32,45 @@ module Acme
   end
 
   class DatabaseQueries < Grape::API
+    helpers do
+      def bounded_queries
+        queries = params[:queries].to_i
+        return QUERIES_MIN if queries < QUERIES_MIN
+        return QUERIES_MAX if queries > QUERIES_MAX
+        queries
+      end
+
+      # Return a random number between 1 and MAX_PK
+      def rand1
+        rand(MAX_PK).succ
+      end
+    end
+
     get '/db' do
       ActiveRecord::Base.connection_pool.with_connection do
-        World.find(Random.rand(10000) + 1)
+        World.find(rand1).attributes
       end
     end
 
     get '/query' do
-      queries = params[:queries].to_i
-      queries = 1 if queries < 1
-      queries = 500 if queries > 500
-
       ActiveRecord::Base.connection_pool.with_connection do
-        (1..queries).map do
-          World.find(Random.rand(10000) + 1)
+        Array.new(bounded_queries) do
+          World.find(rand1)
         end
       end
     end
 
     get '/updates' do
-      queries = params[:queries].to_i
-      queries = 1 if queries < 1
-      queries = 500 if queries > 500
-
-      ActiveRecord::Base.connection_pool.with_connection do
-        worlds = (1..queries).map do
-          world = World.find(Random.rand(10000) + 1)
-          world.randomNumber = Random.rand(10000) + 1
-          World.update(world.id, :randomNumber => world.randomNumber)
-          world
+      worlds =
+        ActiveRecord::Base.connection_pool.with_connection do
+          Array.new(bounded_queries) do
+            world = World.find(rand1)
+            new_value = rand1
+            new_value = rand1 while new_value == world.randomNumber
+            world.update(randomNumber: new_value)
+            world
+          end
         end
-        worlds
-      end
     end
   end
 
@@ -68,7 +79,6 @@ module Acme
       header 'Date', Time.now.httpdate
       header 'Server', 'WebServer'
     end
-    
     content_type :json, 'application/json'
     format :json
 

--- a/frameworks/Ruby/grape/grape-unicorn.dockerfile
+++ b/frameworks/Ruby/grape/grape-unicorn.dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:3.1
+FROM ruby:3.3-rc
+
+ENV RUBY_YJIT_ENABLE=1
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
 

--- a/frameworks/Ruby/grape/grape.dockerfile
+++ b/frameworks/Ruby/grape/grape.dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:3.1
+FROM ruby:3.3-rc
+
+ENV RUBY_YJIT_ENABLE=1
 
 ADD ./ /grape
 


### PR DESCRIPTION
This also removes some warning by copying the database call implementations from sinatra and roda.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
