### PR TITLE
[ruby/roda] Use Ruby 3.3-rc

### DIFF
--- a/frameworks/Ruby/roda-sequel/roda-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-passenger-mri.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-passenger-mri.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-unicorn-mri.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel

--- a/frameworks/Ruby/roda-sequel/roda-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-unicorn-mri.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2
+FROM ruby:3.3-rc
 
 ADD ./ /roda-sequel
 WORKDIR /roda-sequel


### PR DESCRIPTION
After this all Ruby frameworks run on Ruby 3.3-rc, except Padrino which doesn't run on 3.3 yet.