### PR TITLE
Use Swift 5.9

### DIFF
--- a/frameworks/Swift/hummingbird-core/hummingbird-core.dockerfile
+++ b/frameworks/Swift/hummingbird-core/hummingbird-core.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/hummingbird/hummingbird-postgres.dockerfile
+++ b/frameworks/Swift/hummingbird/hummingbird-postgres.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/hummingbird/hummingbird.dockerfile
+++ b/frameworks/Swift/hummingbird/hummingbird.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/swift-nio/swift-nio.dockerfile
+++ b/frameworks/Swift/swift-nio/swift-nio.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.6-focal as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.6-focal-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Install Swift dependencies

--- a/frameworks/Swift/vapor/vapor-fluent.dockerfile
+++ b/frameworks/Swift/vapor/vapor-fluent.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/vapor/vapor-mongo-fluent.dockerfile
+++ b/frameworks/Swift/vapor/vapor-mongo-fluent.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/vapor/vapor-mongo.dockerfile
+++ b/frameworks/Swift/vapor/vapor-mongo.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -18,7 +18,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 RUN apt update

--- a/frameworks/Swift/vapor/vapor-postgres.dockerfile
+++ b/frameworks/Swift/vapor/vapor-postgres.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/vapor/vapor-sql-kit.dockerfile
+++ b/frameworks/Swift/vapor/vapor-sql-kit.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts

--- a/frameworks/Swift/vapor/vapor.dockerfile
+++ b/frameworks/Swift/vapor/vapor.dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.7 as build
+FROM swift:5.9 as build
 WORKDIR /build
 
 # Copy entire repo into container
@@ -15,7 +15,7 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM swift:5.7-slim
+FROM swift:5.9-slim
 WORKDIR /run
 
 # Copy build artifacts


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Update Swift frameworks to use Swift 5.9

@0xTim