### PR TITLE
[rails] Increase connection pool to total of threads

### DIFF
--- a/frameworks/Ruby/rails/config/auto_tune.rb
+++ b/frameworks/Ruby/rails/config/auto_tune.rb
@@ -6,7 +6,7 @@
 require 'etc'
 
 KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (watch smem -k)
-MIN_WORKERS = 15
+MIN_WORKERS = 2
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
 MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   password: benchmarkdbpass
   host: tfb-database
   timeout: 5000
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= require_relative 'auto_tune'; auto_tune.reduce(:*) %>
 
 development:
   <<: *default


### PR DESCRIPTION
Currently the connection pool size is set to the number of threads per
worker: `5`. The database connection pool size should equal:

    number_of_workers * threads_per_worker

We can use the autotune script to get these values.

See also: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#database-connections

Also set the MIN_WORKERS to 2, like all other Ruby frameworks.
Now when verifying only 3 workers get started instead of 15.

Before:
```
rails: Build time: 2m 51s
rails: Time starting database: 3s
rails: Time until accepting requests: 5s
rails: Verify time: 1m 18s
rails: Total test time: 4m 23s
```

After:
```
rails: Build time: 2m 46s
rails: Time starting database: 3s
rails: Time until accepting requests: 3s
rails: Verify time: 1m 9s
rails: Total test time: 4m 7s
```

This also reduces the longest transaction and increases the Transaction Rate.
For example for the db call:
Before:
```
Transactions:		         512 hits
Availability:		      100.00 %
Elapsed time:		        5.21 secs
Data transferred:	        0.02 MB
Response time:		        3.62 secs
Transaction rate:	       98.27 trans/sec
Throughput:		        0.00 MB/sec
Concurrency:		      355.49
Successful transactions:         512
Failed transactions:	           0
Longest transaction:	        5.19
Shortest transaction:	        0.25
```

After:
```
Transactions:		         512 hits
Availability:		      100.00 %
Elapsed time:		        1.39 secs
Data transferred:	        0.02 MB
Response time:		        0.96 secs
Transaction rate:	      368.35 trans/sec
Throughput:		        0.01 MB/sec
Concurrency:		      353.88
Successful transactions:         512
Failed transactions:	           0
Longest transaction:	        1.35
Shortest transaction:	        0.05
```