### PR TITLE
[rust] Fix Roa

### DIFF
--- a/frameworks/Rust/roa/roa-core.dockerfile
+++ b/frameworks/Rust/roa/roa-core.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-diesel.dockerfile
+++ b/frameworks/Rust/roa/roa-diesel.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-pg.dockerfile
+++ b/frameworks/Rust/roa/roa-pg.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-sqlx.dockerfile
+++ b/frameworks/Rust/roa/roa-sqlx.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa-tokio.dockerfile
+++ b/frameworks/Rust/roa/roa-tokio.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/roa/roa.dockerfile
+++ b/frameworks/Rust/roa/roa.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59.0
+FROM rust:1.73
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 


### PR DESCRIPTION
Update Rustc to v1.73.

Actually fail to start.
![image](https://github.com/TechEmpower/FrameworkBenchmarks/assets/249085/e4ab988b-39dd-46bd-8c32-52981e59c405)


And before failed the same tests, than now with this PR:

![image](https://github.com/TechEmpower/FrameworkBenchmarks/assets/249085/0794156e-42b7-4b33-b121-33c6103676ce)
