### PR TITLE
[ruby] Set the MIN_WORKERS to 2, like all other Ruby frameworks.

### DIFF
--- a/frameworks/Ruby/hanami/config/auto_tune.rb
+++ b/frameworks/Ruby/hanami/config/auto_tune.rb
@@ -8,7 +8,7 @@
 require 'etc'
 
 KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (watch smem -k)
-MIN_WORKERS = 15
+MIN_WORKERS = 2
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
 MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)

--- a/frameworks/Ruby/rack/config/auto_tune.rb
+++ b/frameworks/Ruby/rack/config/auto_tune.rb
@@ -8,7 +8,7 @@
 require 'etc'
 
 KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (watch smem -k)
-MIN_WORKERS = 15
+MIN_WORKERS = 2
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
 MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)


### PR DESCRIPTION
This allows better comparison between other frameworks and the Rack baseline.