### PR TITLE
[rails] Set connection pool to 5

### DIFF
--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   password: benchmarkdbpass
   host: tfb-database
   timeout: 5000
-  pool: <%= require_relative 'auto_tune'; auto_tune.reduce(:*) %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default


### PR DESCRIPTION
The connection pool size should be set to the number of threads per worker. This was previously correct.

This partially reverts commit 43761fca4aa920e78b5ea6a13c690da1d2b75565, which made things slower:

Before 43761fca4aa920e78b5ea6a13c690da1d2b75565
```
---------------------------------------------------------
 Queries: 15 for update
---------------------------------------------------------
  Latency Distribution
     50%   58.73ms
     75%  483.00ms
     90%  860.02ms
     99%    1.04s 
Requests/sec:   3465.84
Transfer/sec:      2.63MB
---------------------------------------------------------
 Queries: 20 for update
---------------------------------------------------------
  Latency Distribution
     50%   73.98ms
     75%  598.22ms
     90%    1.09s 
     99%    1.32s 
Requests/sec:   2729.54
Transfer/sec:      2.49MB
```
https://tfb-status.techempower.com/unzip/results.2023-10-24-06-36-44-054.zip/results/20231017225516/rails/update/raw.txt

After 43761fca4aa920e78b5ea6a13c690da1d2b75565, which made things slower.
```
---------------------------------------------------------
 Queries: 15 for update
---------------------------------------------------------
  Latency Distribution
     50%   78.31ms
     75%  668.30ms
     90%    1.28s 
     99%    1.53s 
Requests/sec:   2374.23
Transfer/sec:      1.80MB
---------------------------------------------------------
 Queries: 20 for update
---------------------------------------------------------
  Latency Distribution
     50%   99.43ms
     75%  851.43ms
     90%    1.64s 
     99%    1.98s 
Requests/sec:   1842.55
Transfer/sec:      1.68MB
```
https://tfb-status.techempower.com/unzip/results.2023-11-19-14-13-11-885.zip/results/20231113064027/rails/update/raw.txt