### PR TITLE
[ruby/grape] Use auto_tune for connection pool size.

### DIFF
--- a/frameworks/Ruby/grape/config.ru
+++ b/frameworks/Ruby/grape/config.ru
@@ -1,6 +1,7 @@
 require 'erb'
 require 'active_record'
 require 'yaml'
+require_relative 'config/auto_tune'
 
 MAX_PK = 10_000
 QUERIES_MIN = 1

--- a/frameworks/Ruby/grape/config/database.yml
+++ b/frameworks/Ruby/grape/config/database.yml
@@ -5,5 +5,5 @@ production:
   database: hello_world
   username: benchmarkdbuser
   password: benchmarkdbpass
-  pool: 512
+  pool: 2
   timeout: 5000

--- a/frameworks/Ruby/grape/config/puma.rb
+++ b/frameworks/Ruby/grape/config/puma.rb
@@ -4,7 +4,9 @@ require_relative 'auto_tune'
 num_workers, num_threads = auto_tune
 
 workers num_workers
-threads num_threads, num_threads
+
+threads 2, 2
+
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write


### PR DESCRIPTION
I got the following results locally:
```
+--------+---------+------+-----+-----+-----+-------+--------------+
|threads |plaintext|update| json|   db|query|fortune|weighted_score|
+--------+---------+------+-----+-----+-----+-------+--------------+
|master  |    30018|  5669|51864|20665|10083|       |           699|
|5       |    19278|  7043|50914|23169|11094|       |           817|
|3       |    21420|  7287|46779|23205|10921|       |           826|
|2       |    22695|  7981|48680|24954|11535|       |           892|
+--------+---------+------+-----+-----+-----+-------+--------------+
```