### PR TITLE
[mORMot] improved HTTP server performance

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -35,7 +35,7 @@ echo "Download statics from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot/static
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/c9cefa05e892763ff66a9a51a659b937def36195
+URL=https://github.com/synopse/mORMot2/tarball/c68d24054ffd3e5d63ecb33a2eea49055948e816
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1

--- a/frameworks/Pascal/mormot/src/raw.pas
+++ b/frameworks/Pascal/mormot/src/raw.pas
@@ -201,10 +201,11 @@ begin
      hsoNoStats,           // disable low-level statistic counters
      //hsoThreadCpuAffinity, // worse scaling on multi-servers
      hsoThreadSmooting,    // seems a good option, even if not magical
+     hsoEnablePipelining,  // as expected by /plaintext
      {$ifdef WITH_LOGS}
      hsoLogVerbose,
      {$endif WITH_LOGS}
-     hsoIncludeDateHeader  // required by TPW General Test Requirements #5
+     hsoIncludeDateHeader  // required by TFB General Test Requirements #5
     ] + flags);
   if pin2Core <> -1 then
     fHttpServer.Async.SetCpuAffinity(pin2Core);


### PR DESCRIPTION
Update to mORMot 2023-12-02:
- improved HTTP server performance
- HTTP pipeline is disabled by default in mORMot (for security reasons) - enable it only for TFB