### PR TITLE
[php] Update ngx-php to PHP 8.3

### DIFF
--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,13 +10,13 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php8.2-cli php8.2-dev libphp8.2-embed php8.2-mysql > /dev/null
+                    php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
 
 ADD . .
 
 ENV NGINX_VERSION 1.24.0
 
-RUN git clone -b v0.0.27 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
@@ -28,7 +28,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx_php7/third_party/ngx_devel_kit \
             --add-module=/ngx_php7 > /dev/null && \
     make > /dev/null && make install > /dev/null
-RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.2/embed/conf.d/10-opcache.ini
+RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -yqq > /dev/null && \
 
 ADD . .
 
-ENV NGINX_VERSION 1.24.0
+ENV NGINX_VERSION 1.25.3
 
 RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -16,7 +16,7 @@ ADD . .
 
 ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
+RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,12 +10,12 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php8.2-cli php8.2-dev libphp8.2-embed php8.2-mysql > /dev/null
+                    php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
 ADD . .
 
 ENV NGINX_VERSION 1.24.0
 
-RUN git clone -b v0.0.27 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -15,7 +15,7 @@ ADD . .
 
 ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -yqq > /dev/null && \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
 ADD . .
 
-ENV NGINX_VERSION 1.24.0
+ENV NGINX_VERSION 1.25.3
 
 RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -15,7 +15,7 @@ ADD . .
 
 ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,12 +10,12 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php8.2-cli php8.2-dev libphp8.2-embed php8.2-pgsql > /dev/null
+                    php8.3-cli php8.3-dev libphp8.3-embed php8.3-pgsql > /dev/null
 ADD . .
 
-ENV NGINX_VERSION 1.24.0
+ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b v0.0.27 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
@@ -32,7 +32,7 @@ RUN sed -i "s|app.php|app-pg.php|g" /deploy/nginx.conf
 
 RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s|worker_processes  auto|worker_processes $WORKERS|g" /deploy/nginx.conf
-RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.2/embed/conf.d/10-opcache.ini
+RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 EXPOSE 8080
 
 CMD /nginx/sbin/nginx -c /deploy/nginx.conf

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,12 +10,12 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
-                    php8.2-cli php8.2-dev libphp8.2-embed php8.2-mysql
+                    php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql
 ADD . .
 
-ENV NGINX_VERSION 1.24.0
+ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b v0.0.27 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \
@@ -27,7 +27,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php/third_party/ngx_devel_kit \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
-RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.2/embed/conf.d/10-opcache.ini
+RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -15,7 +15,7 @@ ADD . .
 
 ENV NGINX_VERSION 1.25.3
 
-RUN git clone -b next --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
+RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 
 RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
     tar -zxf nginx-${NGINX_VERSION}.tar.gz && \


### PR DESCRIPTION
Update also to Ubuntu 22.04 and the last Nginx 1.25.3 (that support http3).

~Using the branch `next` till the new release.~
Using the new version tag.

- #8579
- https://github.com/rryqszq4/ngx-php/pull/178