### PR TITLE
[ruby/grape] Fix unicorn config worker_processes

### DIFF
--- a/frameworks/Ruby/grape/config/unicorn.rb
+++ b/frameworks/Ruby/grape/config/unicorn.rb
@@ -1,6 +1,8 @@
 require_relative 'auto_tune'
 
-worker_processes, = auto_tune
+num_workers, = auto_tune
+worker_processes num_workers
+
 listen "/tmp/unicorn.sock", :backlog => 4096
 
 preload_app true


### PR DESCRIPTION
`worker_processes` is a method that accepts an integer, instead of a variable.

## Before:
```
--------------------------------------------------------------------------------
VERIFYING QUERY COUNT FOR http://tfb-server:8080/query?queries=20
--------------------------------------------------------------------------------
...
Transaction rate:	      241.51 trans/sec
```
https://github.com/TechEmpower/FrameworkBenchmarks/actions/runs/6817552651/job/18541298655?pr=8534

## After
```
--------------------------------------------------------------------------------
VERIFYING QUERY COUNT FOR http://tfb-server:8080/query?queries=20
--------------------------------------------------------------------------------
....
Transaction rate:	      538.95 trans/sec
```
https://github.com/TechEmpower/FrameworkBenchmarks/actions/runs/7097772330/job/19318471308?pr=8619