### PR TITLE
[ruby/rails] Use 3 threads per worker

### DIFF
--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -5,7 +5,7 @@ default: &default
   password: benchmarkdbpass
   host: tfb-database
   timeout: 5000
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 3 } %>
 
 development:
   <<: *default

--- a/frameworks/Ruby/rails/config/puma.rb
+++ b/frameworks/Ruby/rails/config/puma.rb
@@ -9,7 +9,7 @@ tuned_num_workers, tuned_num_threads = auto_tune
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 3 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
Using 3 threads instead of 5 (as used in master) seems optimal.
Running this locally I got the following results:

```
+---------------------+---------+------+-----+-----+-----+-------+--------------+
|                     |plaintext|update| json|   db|query|fortune|weighted_score|
+---------------------+---------+------+-----+-----+-----+-------+--------------+
| 2 threads per worker|    20870|  9478|66764|16220|11634|  10543|          1042|
| 1 thread  per worker|    20799|  9819|83123|17434|10334|   8653|          1048|
| 4 threads per worker|    29257| 10051|69532|18108|11752|  11132|          1093|
| 5 threads per worker|    33152| 10203|77062|18459|11721|  11711|          1114|
| 3 threads per worker|    25077| 10382|84429|16497|12338|  11246|          1141|
+---------------------+---------+------+-----+-----+-----+-------+--------------+
```