### PR TITLE
[ruby/rack] Enable Rubys M:N thread scheduler for Puma

### DIFF
--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:3.4-rc
 
 ENV RUBY_YJIT_ENABLE=1
+ENV RUBY_MN_THREADS=1
 
 # Use Jemalloc
 RUN apt-get update && \


### PR DESCRIPTION
With the M:N thread scheduler thread creation and management cost are reduced.
