### PR TITLE
[ruby/rails] Enable Rubys MN threads

### DIFF
--- a/frameworks/Ruby/rails/rails-mysql.dockerfile
+++ b/frameworks/Ruby/rails/rails-mysql.dockerfile
@@ -14,6 +14,8 @@ RUN bundle install --jobs=8
 COPY . /rails/
 
 ENV RUBY_YJIT_ENABLE=1
+ENV RUBY_MN_THREADS=1
+
 ENV RAILS_ENV=production_mysql
 ENV PORT=8080
 ENV REDIS_URL=redis://localhost:6379/0

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -14,6 +14,8 @@ RUN bundle install --jobs=8
 COPY . /rails/
 
 ENV RUBY_YJIT_ENABLE=1
+ENV RUBY_MN_THREADS=1
+
 ENV RAILS_ENV=production_postgresql
 ENV PORT=8080
 ENV REDIS_URL=redis://localhost:6379/0


### PR DESCRIPTION
With the M:N thread scheduler thread creation and management cost are reduced.

Waiting for the initial run on the new servers so we can compare if this improves things.