### PR TITLE
PostgreSQL update to v16

### DIFF
--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15-bullseye
+FROM postgres:16-bullseye
 
 ENV POSTGRES_USER=benchmarkdbuser
 ENV POSTGRES_PASSWORD=benchmarkdbpass

--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16-bullseye
+FROM postgres:16-bookworm
 
 ENV POSTGRES_USER=benchmarkdbuser
 ENV POSTGRES_PASSWORD=benchmarkdbpass


### PR DESCRIPTION
Released September 14, 2023.
https://www.postgresql.org/about/news/postgresql-16-released-2715/


After update the Citrine servers, it'll be good to first run with the last commit with full results, to compare the real differences with the new servers.
Or wait to update the databases, after 1-2 full runs in the new servers.

And after check the new specs, we need also to check the database configurations. 