### PR TITLE
MySQL update to v8.3

### DIFF
--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.3
 
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=benchmarkdbuser


### PR DESCRIPTION
Released 14 Dec 2023.
https://dev.mysql.com/doc/relnotes/mysql/8.3/en/


After have the new specs, we need to check the config, as in others benchs MySQL is not as slower than Postgre, like in this benchmark.
