### PR TITLE
Mongodb update to v7.0

### DIFF
--- a/toolset/databases/mongodb/mongodb.dockerfile
+++ b/toolset/databases/mongodb/mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:6.0
+FROM mongo:7.0
 
 ENV MONGO_INITDB_DATABASE=hello_world
 


### PR DESCRIPTION
Released 01 Aug 2023.
https://www.mongodb.com/docs/manual/release-notes/7.0/

Exist new versions (7.1 and 7.2) but they are rapid releases.

![image](https://github.com/TechEmpower/FrameworkBenchmarks/assets/249085/ade54bff-0d23-4a1c-84cf-349950bbca16)


Some frameworks need to update the drivers, as are showing deprecation errors. But pass the tests.
The deprecations were in nodejs-mongodb, that I used to test locally the new version. But possibly it'll happen with others.

PD: it's better to update the databases, after 1-2 full runs with the new servers.