### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       #
       # We need to fetch more than one commit to be able to access HEAD^2 in case
       # of a pull request
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10
       # In case of a push event, the commit we care about is simply HEAD.
@@ -110,10 +110,10 @@ jobs:
       PREVIOUS_COMMIT: ${{ needs.setup.outputs.previous_commit }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request'
         with:
           name: pr
@@ -46,7 +46,7 @@ jobs:
           echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           echo "PREVIOUS_COMMIT=$(git log --format=%H -n 1 HEAD^2~1)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'

--- a/.github/workflows/get-maintainers.yml
+++ b/.github/workflows/get-maintainers.yml
@@ -8,7 +8,7 @@ jobs:
   get_maintainers:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 10
       - name: Get commit branch and commit message from PR
@@ -19,7 +19,7 @@ jobs:
           echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
           echo "PREVIOUS_COMMIT=$(git log --format=%H -n 1 HEAD^2~1)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'
@@ -31,7 +31,7 @@ jobs:
         run: |
           python ./toolset/github_actions/get_maintainers.py > ./maintainers/maintainers.md
       - name: Save Maintainers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: maintainers
           path: maintainers/

--- a/.github/workflows/label-failing-pr.yml
+++ b/.github/workflows/label-failing-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           # scripts lightly modified from https://securitylab.github.com/research/github-actions-preventing-pwn-requests
           script: |
@@ -32,7 +32,7 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
       - run: unzip pr.zip
       - name: Label PR
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ping-maintainers.yml
+++ b/.github/workflows/ping-maintainers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'Download maintainers artifact'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -32,7 +32,7 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/maintainers.zip', Buffer.from(download.data));
       - run: unzip maintainers.zip
       - name: Ping maintainers
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Deprecated actions changed. Listed in the summary GH Actions workflows.

![image](https://github.com/TechEmpower/FrameworkBenchmarks/assets/249085/9b5f3c84-eff3-45d1-9add-efde9696ee97)

Still no fix for `mattes/cached-docker-build-action@v1`