### PR TITLE
Update Ur/Web version

### DIFF
--- a/frameworks/Ur/urweb/bench.ur
+++ b/frameworks/Ur/urweb/bench.ur
@@ -133,3 +133,9 @@ fun updates s =
 
 fun plaintext () =
   returnText "Hello, World!"
+
+(** * Test type 7: Cached queries *)
+
+val cached_queries = queries
+(* It's really the same code as the uncached queries test!
+ * We just compile with a different flag to enable caching. *)

--- a/frameworks/Ur/urweb/bench.urs
+++ b/frameworks/Ur/urweb/bench.urs
@@ -4,3 +4,4 @@ val queries : string -> transaction page
 val fortunes : unit -> transaction page
 val updates : string -> transaction page
 val plaintext : unit -> transaction page
+val cached_queries : string -> transaction page

--- a/frameworks/Ur/urweb/benchmark_config.json
+++ b/frameworks/Ur/urweb/benchmark_config.json
@@ -1,5 +1,6 @@
 {
   "framework": "urweb",
+  "maintainers": ["achlipala"],
   "tests": [{
     "default": {
       "display_name": "urweb",
@@ -42,7 +43,7 @@
     },
     "cache": {
       "setup_file": "setup-postgresql",
-      "cached_query_url": "/queries/",
+      "cached_query_url": "/cached_queries/",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Fullstack",
@@ -53,12 +54,11 @@
       "platform": "Ur/Web",
       "webserver": "None",
       "os": "Linux",
-      "database_os": "Linux",
-      "tags": ["broken"]
+      "database_os": "Linux"
     },
     "mysql-cache": {
       "setup_file": "setup-mysql",
-      "cached_query_url": "/queries/",
+      "cached_query_url": "/cached_queries/",
       "port": 8080,
       "approach": "Realistic",
       "classification": "Fullstack",
@@ -69,8 +69,7 @@
       "platform": "Ur/Web",
       "webserver": "None",
       "os": "Linux",
-      "database_os": "Linux",
-      "tags": ["broken"]
+      "database_os": "Linux"
     }
   }]
 }

--- a/frameworks/Ur/urweb/config.toml
+++ b/frameworks/Ur/urweb/config.toml
@@ -19,7 +19,7 @@ webserver = "None"
 versus = "None"
 
 [mysql-cache]
-urls.cached_query = "/queries/"
+urls.cached_query = "/cached_queries/"
 approach = "Realistic"
 classification = "Fullstack"
 database = "MySQL"
@@ -31,7 +31,7 @@ webserver = "None"
 versus = "None"
 
 [cache]
-urls.cached_query = "/queries/"
+urls.cached_query = "/cached_queries/"
 approach = "Realistic"
 classification = "Fullstack"
 database = "Postgres"

--- a/frameworks/Ur/urweb/urweb-cache.dockerfile
+++ b/frameworks/Ur/urweb/urweb-cache.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.10
 
 ADD ./ /urweb
 WORKDIR /urweb
 
-RUN apt-get update -yqq && apt-get install -yqq urweb
+RUN apt-get update -yqq && apt-get install -yqq sudo git gcc make autoconf automake libtool mlton libpq-dev libssl-dev uthash-dev libicu-dev && git clone https://github.com/urweb/urweb.git && cd urweb && ./autogen.sh && ./configure && make -j && sudo make install
 
 RUN urweb -sqlcache -db "dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass host=tfb-database" bench
 

--- a/frameworks/Ur/urweb/urweb-mysql-cache.dockerfile
+++ b/frameworks/Ur/urweb/urweb-mysql-cache.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.10
 
 ADD ./ /urweb
 WORKDIR /urweb
 
-RUN apt-get update -yqq && apt-get install -yqq urweb
+RUN apt-get update -yqq && apt-get install -yqq sudo git gcc make autoconf automake libtool mlton libmysqlclient-dev libssl-dev uthash-dev libicu-dev && git clone https://github.com/urweb/urweb.git && cd urweb && ./autogen.sh && ./configure && make -j && sudo make install
 
 RUN urweb -sqlcache -dbms mysql -db "dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass host=tfb-database" bench
 

--- a/frameworks/Ur/urweb/urweb-mysql.dockerfile
+++ b/frameworks/Ur/urweb/urweb-mysql.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.10
 
 ADD ./ /urweb
 WORKDIR /urweb
 
-RUN apt-get update -yqq && apt-get install -yqq urweb
+RUN apt-get update -yqq && apt-get install -yqq sudo git gcc make autoconf automake libtool mlton libmysqlclient-dev libssl-dev uthash-dev libicu-dev && git clone https://github.com/urweb/urweb.git && cd urweb && ./autogen.sh && ./configure && make -j && sudo make install
 
 RUN urweb -dbms mysql -db "dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass host=tfb-database" bench
 

--- a/frameworks/Ur/urweb/urweb.dockerfile
+++ b/frameworks/Ur/urweb/urweb.dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:18.04
+FROM ubuntu:23.10
 
 ADD ./ /urweb
 WORKDIR /urweb
 
-RUN apt-get update -yqq && apt-get install -yqq urweb
+RUN apt-get update -yqq && apt-get install -yqq sudo git gcc make autoconf automake libtool mlton libpq-dev libssl-dev uthash-dev libicu-dev && git clone https://github.com/urweb/urweb.git && cd urweb && ./autogen.sh && ./configure && make -j && sudo make install
 
 RUN urweb -db "dbname=hello_world user=benchmarkdbuser password=benchmarkdbpass host=tfb-database" bench
 


### PR DESCRIPTION
After several years of not paying attention to these benchmarks, I'm here to update the Ur/Web version so that Ur/Web stops looking artificially slow!  Specifically, the compilation options in Debian have been overly conservative in ways that impose big penalties on Ur/Web, so I've switched to building Ur/Web from source.  I also fixed the cached-queries tests (which apparently were only failing because the route string wasn't long enough).