### PR TITLE
Use stable toolchain for Actix

### DIFF
--- a/frameworks/Rust/actix/rust-toolchain.toml
+++ b/frameworks/Rust/actix/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"


### PR DESCRIPTION
Fixes #8779

I have no idea how Rust is compiled and why this fixes it, but "nightly" didn't seem right for TFB, and it works, so ...

cc @robjtede


Proof:

```
[17:02:13 INF] Removing intermediate container 4956af1ad71d
[17:02:13 INF]  ---> 70f971b985b7
[17:02:13 INF] Step 7/8 : EXPOSE 8080
[17:02:13 INF]  ---> Running in 10ea344f34f6
[17:02:13 INF] Removing intermediate container 10ea344f34f6
[17:02:13 INF]  ---> bd6769491853
[17:02:13 INF] Step 8/8 : CMD ./target/release/tfb-web
[17:02:13 INF]  ---> Running in 71a0562abcd5
[17:02:13 INF] Removing intermediate container 71a0562abcd5
[17:02:13 INF]  ---> a72da117b2f9
[17:02:13 INF] Successfully built a72da117b2f9
```

On `master`:

```
[17:05:57 INF]    Compiling parking_lot v0.12.1
[17:05:57 INF] error[E0635]: unknown feature `stdsimd`
[17:05:57 INF]   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.3/src/lib.rs:99:42
[17:05:57 INF]    |
[17:05:57 INF] 99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
[17:05:57 INF]    |                                          ^^^^^^^
[17:05:57 INF]
[17:05:57 INF] error[E0635]: unknown feature `stdsimd`
[17:05:57 INF]   --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.7.6/src/lib.rs:33:42
[17:05:57 INF]    |
[17:05:57 INF] 33 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
[17:05:57 INF]    |                                          ^^^^^^^
[17:05:57 INF]
[17:05:57 INF]    Compiling atty v0.2.14
[17:05:57 INF]    Compiling unicode-normalization v0.1.22
[17:05:57 INF]    Compiling rustls-pemfile v1.0.3
[17:05:57 INF]    Compiling rand_chacha v0.3.1
[17:05:57 INF]    Compiling take_mut v0.2.2
[17:05:57 INF]    Compiling termcolor v1.2.0
[17:05:57 INF]    Compiling humantime v2.1.0
[17:05:57 INF]    Compiling bitvec v1.0.1
[17:05:57 INF] For more information about this error, try `rustc --explain E0635`.
[17:05:57 INF] error: could not compile `ahash` (lib) due to 1 previous error
[17:05:57 INF] warning: build failed, waiting for other jobs to finish...
[17:05:57 INF] error: could not compile `ahash` (lib) due to 1 previous error
[17:05:57 INF] error: could not compile `ahash` (lib) due to 1 previous error
[17:06:08 INF] [STDERR] The command '/bin/sh -c RUSTFLAGS="-C target-cpu=native" cargo build --release' returned a non-zero code: 101
```