### PR TITLE
Update Pellet runtime JVM to 22

### DIFF
--- a/frameworks/Kotlin/pellet/pellet.dockerfile
+++ b/frameworks/Kotlin/pellet/pellet.dockerfile
@@ -4,7 +4,7 @@ COPY sample/build.gradle.kts build.gradle.kts
 COPY sample/src src
 RUN gradle clean shadowJar --no-daemon
 
-FROM openjdk:21-jdk-buster
+FROM openjdk:22-jdk-buster
 WORKDIR /sample
 COPY --from=gradle /sample/build/libs/sample-1.0.0-all.jar app.jar
 


### PR DESCRIPTION
Updates Pellet's runtime JVM to 22, which includes Loom improvements for high-concurrency IO.

Verified locally with `./tfb --mode verify --test pellet`. 