### PR TITLE
[Rust] update may_minihttp dependency

### DIFF
--- a/frameworks/Rust/may-minihttp/Cargo.toml
+++ b/frameworks/Rust/may-minihttp/Cargo.toml
@@ -18,7 +18,7 @@ yarte = { version = "0.15", features = ["bytes-buf", "json"] }
 buf-min = { version = "0.7", features = ["bytes"] }
 
 may = { version = "0.3", default-features = false }
-may_minihttp = { git = "https://github.com/Xudong-Huang/may_minihttp.git", rev = "f8241e7", default-features = false }
+may_minihttp = { version = "0.1", default-features = false }
 may_postgres = { git = "https://github.com/Xudong-Huang/may_postgres.git", rev = "bf1d86e", default-features = false }
 
 [profile.release]

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.72
+FROM rust:latest
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
+++ b/frameworks/Rust/may-minihttp/may-minihttp.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:1.77
 
 RUN apt-get update -yqq && apt-get install -yqq cmake g++
 

--- a/frameworks/Rust/may-minihttp/src/main.rs
+++ b/frameworks/Rust/may-minihttp/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use may_minihttp::{HttpService, HttpServiceFactory, Request, Response};
-use may_postgres::{self, types::ToSql, Client, Statement};
+use may_postgres::{types::ToSql, Client, Statement};
 use nanorand::{Rng, WyRand};
 use smallvec::SmallVec;
 use yarte::{ywrite_html, Serialize};


### PR DESCRIPTION
* update may_minihttp dependency to 0.1 from crates.io
* update to use latest rust toolchain
