### PR TITLE
[ruby/rails] Reduce `random_id` calls in update

### DIFF
--- a/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
+++ b/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
@@ -33,8 +33,8 @@ class HelloWorldController < ApplicationController
   end
 
   def update
-    worlds = Array.new(query_count) do
-      world = World.find(random_id)
+    worlds = ALL_IDS.sample(query_count).map do |id|
+      world = World.find(id)
       new_value = random_id
       new_value = random_id until new_value != world.randomNumber
       world.update_columns(randomNumber: new_value)


### PR DESCRIPTION
Calling `Array#sample` with a size x is faster than calling `rand` x times.