### PR TITLE
[ruby/roda] Reduce `random_id` calls in update

### DIFF
--- a/frameworks/Ruby/roda-sequel/boot.rb
+++ b/frameworks/Ruby/roda-sequel/boot.rb
@@ -3,6 +3,8 @@ require "bundler/setup"
 require "time"
 require "oj"
 MAX_PK = 10_000
+QUERY_RANGE = (1..MAX_PK).freeze
+ALL_IDS = QUERY_RANGE.to_a
 QUERIES_MIN = 1
 QUERIES_MAX = 500
 SEQUEL_NO_ASSOCIATIONS = true

--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -37,7 +37,9 @@ class HelloWorld < Roda
     r.is "queries" do
       worlds =
         DB.synchronize do
-          Array.new(bounded_queries) { World.with_pk(rand1).values }
+          ALL_IDS.sample(bounded_queries).map do |id|
+            World.with_pk(id).values
+          end
         end
       worlds.to_json
     end
@@ -58,8 +60,8 @@ class HelloWorld < Roda
     r.is "updates" do
       worlds =
         DB.synchronize do
-          Array.new(bounded_queries) do
-            world = World.with_pk(rand1)
+          ALL_IDS.sample(bounded_queries).map do |id|
+            world = World.with_pk(id)
             new_value = rand1
             new_value = rand1 while new_value == world.randomnumber
             world.update(randomnumber: new_value)


### PR DESCRIPTION
Calling `Array#sample` with a size x is faster than calling `rand` x times.