### PR TITLE
Add --reverse-order option and switch order after each run on citrine

### DIFF
--- a/toolset/benchmark/benchmarker.py
+++ b/toolset/benchmark/benchmarker.py
@@ -29,7 +29,8 @@ class Benchmarker:
 
         # a list of all tests for this run
         self.tests = self.metadata.tests_to_run()
-
+        if self.config.reverse_order:
+            self.tests.reverse()
         self.results = Results(self)
         self.docker_helper = DockerHelper(self)
 

--- a/toolset/continuous/tfb-shutdown.sh
+++ b/toolset/continuous/tfb-shutdown.sh
@@ -30,4 +30,10 @@ ssh techempower@$TFB_DATABASE_HOST "$(typeset -f docker_clean); docker_clean"
 echo "running docker_clean on client host"
 ssh techempower@$TFB_CLIENT_HOST "$(typeset -f docker_clean); docker_clean"
 
+if [ -z "$TFB_RUN_ORDER" ]; then
+  export TFB_RUN_ORDER="reverse"
+else
+  unset TFB_RUN_ORDER
+fi
+
 echo "done with tfb-shutdown script"

--- a/toolset/continuous/tfb-startup.sh
+++ b/toolset/continuous/tfb-startup.sh
@@ -38,6 +38,7 @@ docker run \
   --results-name "$TFB_RUN_NAME" \
   --results-environment "$TFB_ENVIRONMENT" \
   --results-upload-uri "$TFB_UPLOAD_URI" \
+  $(if [ "$TFB_RUN_ORDER" = "reverse" ]; then echo "--reverse-order"; fi) \
   --quiet
 
 echo "zipping the results"

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -85,6 +85,13 @@ def main(argv=None):
         'Only print a limited set of messages to stdout, keep the bulk of messages in log files only'
     )
     parser.add_argument(
+        '--reverse-order',
+        action='store_true',
+        default=False,
+        help=
+        'Run the tests in reverse order, starting with the last test in the list'
+    )
+    parser.add_argument(
         '--results-name',
         help='Gives a name to this set of results, formatted as a date',
         default='(unspecified, datetime = %Y-%m-%d %H:%M:%S)')

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -25,6 +25,7 @@ class BenchmarkConfig:
         self.duration = args.duration
         self.exclude = args.exclude
         self.quiet = args.quiet
+        self.reverse_order = args.reverse_order
         self.server_host = args.server_host
         self.database_host = args.database_host
         self.client_host = args.client_host


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
