### PR TITLE
[ruby/agoo] Use a connection pool of size 1

### DIFF
--- a/frameworks/Ruby/agoo/app.rb
+++ b/frameworks/Ruby/agoo/app.rb
@@ -6,7 +6,7 @@ require 'oj'
 require 'pg'
 require 'rack'
 
-$pool = ConnectionPool.new(size: 256, timeout: 5) do
+$pool = ConnectionPool.new(size: 1, timeout: 5) do
           PG::Connection.new({
                                  dbname:   'hello_world',
                                  host:     'tfb-database',


### PR DESCRIPTION
As Agoo is currently configured to not use threads, we can use a connection pool of size 1.