### PR TITLE
[ruby/grape] Use https for Gemfile source

### DIFF
--- a/frameworks/Ruby/grape/Gemfile
+++ b/frameworks/Ruby/grape/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'mysql2', '0.5.4'
 gem 'unicorn', '6.1.0'


### PR DESCRIPTION
`https` is the recommended default for Gemfiles to avoid mitm attacks.
Other frameworks were already using `https`.