### PR TITLE
[ruby/sinatra] Use Jemalloc for better memory performance

### DIFF
--- a/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 

--- a/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 

--- a/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 

--- a/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+
 ADD ./ /sinatra
 WORKDIR /sinatra
 


### PR DESCRIPTION
Using jemalloc typically reduces memory usage of a Ruby application:
https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html