### PR TITLE
[ruby/sinatra] Fix clear_active_connections! deprecation

### DIFF
--- a/frameworks/Ruby/sinatra/boot.rb
+++ b/frameworks/Ruby/sinatra/boot.rb
@@ -61,4 +61,4 @@ class Fortune < ActiveRecord::Base
   self.table_name = name
 end
 
-ActiveRecord::Base.clear_active_connections!
+ActiveRecord::Base.connection_handler.clear_active_connections!

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -40,7 +40,7 @@ class HelloWorld < Sinatra::Base
   end if SERVER_STRING
 
   after do
-    ActiveRecord::Base.clear_active_connections!
+    ActiveRecord::Base.connection_handler.clear_active_connections!
   end
 
   # Test type 1: JSON serialization


### PR DESCRIPTION
Fixes the following warning:

     DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections! is deprecated. Please
     call the method directly on the connection handler; for example:
     `ActiveRecord::Base.connection_handler.clear_active_connections!`.
     (called from block in <class:HelloWorld> at /sinatra/hello_world.rb:43)
