### PR TITLE
[ruby/padrino] Use https for Gemfile source

### DIFF
--- a/frameworks/Ruby/padrino/Gemfile
+++ b/frameworks/Ruby/padrino/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'mysql2', '~> 0.4'
 gem "unicorn", '~> 6.1'


### PR DESCRIPTION
https is the recommended default for Gemfiles to avoid mitm attacks.