### PR TITLE
[ruby/sinatra] Use `update_columns` instead of `update`

### DIFF
--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -92,7 +92,7 @@ class HelloWorld < Sinatra::Base
           world = World.find(rand1)
           new_value = rand1
           new_value = rand1 while new_value == world.randomnumber
-          world.update(randomnumber: new_value)
+          world.update_columns(randomnumber: new_value)
           world
         end
       end


### PR DESCRIPTION
Unlike `update_columns`, `update` runs in a transaction and runs callbacks. Transactions aren't a requirement, so we can just call `update_columns` for improved performance.