### PR TITLE
[ruby/padrino] Use `update_columns` instead of `update`

### DIFF
--- a/frameworks/Ruby/padrino/app/controllers.rb
+++ b/frameworks/Ruby/padrino/app/controllers.rb
@@ -45,7 +45,7 @@ HelloWorld::App.controllers  do
       # get a random row from the database, which we know has 10000
       # rows with ids 1 - 10000
       world = World.get(Random.rand(MAX_PK) + 1)
-      world.update(randomNumber: Random.rand(MAX_PK) + 1)
+      world.update_columns(randomNumber: Random.rand(MAX_PK) + 1)
       world.attributes
     end
 


### PR DESCRIPTION
Unlike `update_columns`, `update` runs in a transaction and runs callbacks. Transactions aren't a requirement, so we can just call `update_columns` for improved performance.