### PR TITLE
[ruby/grape] Use `update_columns` instead of `update`

### DIFF
--- a/frameworks/Ruby/grape/config.ru
+++ b/frameworks/Ruby/grape/config.ru
@@ -66,7 +66,7 @@ module Acme
             world = World.find(rand1)
             new_value = rand1
             new_value = rand1 while new_value == world.randomNumber
-            world.update(randomNumber: new_value)
+            world.update_columns(randomNumber: new_value)
             world
           end
         end


### PR DESCRIPTION
Unlike `update_columns`, `update` runs in a transaction and runs callbacks. Transactions aren't a requirement, so we can just call `update_columns` for improved performance.