### PR TITLE
Update to Mysql 8.4 LTS

### DIFF
--- a/toolset/databases/mysql/my.cnf
+++ b/toolset/databases/mysql/my.cnf
@@ -16,6 +16,7 @@ default-character-set=utf8
 # * Basic Settings
 #
 default-storage-engine = innodb
+mysql_native_password = ON
 default_authentication_plugin = mysql_native_password
 
 user            = mysql

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.3
+FROM mysql:8.4
 
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=benchmarkdbuser


### PR DESCRIPTION
And enable `mysql-native-password`

> **MySQL native password authentication changes.**  Beginning with MySQL 8.4.0, the deprecated mysql_native_password authentication plugin is no longer enabled by default. To enable it, start the server with [--mysql-native-password=ON](https://dev.mysql.com/doc/refman/8.4/en/server-options.html#option_mysqld_mysql-native-password) (added in MySQL 8.4.0), or by including mysql_native_password=ON in the [mysqld] section of your MySQL configuration file (added in MySQL 8.4.0).
