### PR TITLE
[ruby] Reduce `random_id` calls in queries and update

### DIFF
--- a/frameworks/Ruby/grape/config.ru
+++ b/frameworks/Ruby/grape/config.ru
@@ -4,6 +4,8 @@ require 'yaml'
 require_relative 'config/auto_tune'
 
 MAX_PK = 10_000
+ID_RANGE = (1..MAX_PK).freeze
+ALL_IDS = ID_RANGE.to_a
 QUERIES_MIN = 1
 QUERIES_MAX = 500
 
@@ -53,8 +55,8 @@ module Acme
 
     get '/query' do
       ActiveRecord::Base.connection_pool.with_connection do
-        Array.new(bounded_queries) do
-          World.find(rand1)
+        ALL_IDS.sample(bounded_queries).map do |id|
+          World.find(id)
         end
       end
     end
@@ -62,8 +64,8 @@ module Acme
     get '/updates' do
       worlds =
         ActiveRecord::Base.connection_pool.with_connection do
-          Array.new(bounded_queries) do
-            world = World.find(rand1)
+          ALL_IDS.sample(bounded_queries).map do |id|
+            world = World.find(id)
             new_value = rand1
             new_value = rand1 while new_value == world.randomNumber
             world.update_columns(randomNumber: new_value)

--- a/frameworks/Ruby/rack-sequel/boot.rb
+++ b/frameworks/Ruby/rack-sequel/boot.rb
@@ -3,6 +3,8 @@ require 'bundler/setup'
 require 'time'
 
 MAX_PK = 10_000
+ID_RANGE = (1..10_000).freeze
+ALL_IDS = ID_RANGE.to_a
 QUERIES_MIN = 1
 QUERIES_MAX = 500
 SEQUEL_NO_ASSOCIATIONS = true

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -29,8 +29,8 @@ class HelloWorld
 
   def queries(env)
     DB.synchronize do
-      Array.new(bounded_queries(env)) do
-        WORLD_BY_ID.(:id=>rand1)
+      ALL_IDS.sample(bounded_queries(env)).map do |id|
+        WORLD_BY_ID.(id: id)
       end
     end
   end
@@ -78,9 +78,9 @@ class HelloWorld
 
   def updates(env)
     DB.synchronize do
-      Array.new(bounded_queries(env)) do
-        world = WORLD_BY_ID.(:id=>rand1)
-        WORLD_UPDATE.(:id=>world[:id], :randomnumber=>(world[:randomnumber] = rand1))
+      ALL_IDS.sample(bounded_queries(env)).map do |id|
+        world = WORLD_BY_ID.(id: id)
+        WORLD_UPDATE.(id: world[:id], randomnumber: (world[:randomnumber] = rand1))
         world
       end
     end

--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -2,10 +2,10 @@ ruby '~> 3.2'
 
 source 'https://rubygems.org'
 
-gem 'trilogy', group: :mysql
 gem 'oj', '~> 3.16'
 gem 'pg', '1.5.4', group: :postgresql
 gem 'puma', '~> 6.4'
 gem 'rails', '~> 7.1.3'
 gem 'redis', '~> 5.0'
+gem 'trilogy', '~> 2.8.1', group: :mysql
 gem 'tzinfo-data'

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
-    trilogy (2.6.0)
+    trilogy (2.8.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.5)
@@ -202,7 +202,7 @@ DEPENDENCIES
   puma (~> 6.4)
   rails (~> 7.1.3)
   redis (~> 5.0)
-  trilogy
+  trilogy (~> 2.8.1)
   tzinfo-data
 
 RUBY VERSION

--- a/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
+++ b/frameworks/Ruby/rails/app/controllers/hello_world_controller.rb
@@ -7,7 +7,7 @@ class HelloWorldController < ApplicationController
   MAX_QUERIES = 500          # max number of records that can be retrieved
 
   def db
-    render json: World.find(random_id)
+    render json: World.find(random_id).attributes
   end
 
   def query

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -16,6 +16,9 @@ test:
 production_mysql:
   <<: *default
   adapter: trilogy
+  ssl: true
+  ssl_mode: 4 <%# Trilogy::SSL_PREFERRED_NOVERIFY %>
+  tls_min_version: 3 <%# Trilogy::TLS_VERSION_12 %>
 
 production_postgresql:
   <<: *default

--- a/frameworks/Ruby/sinatra-sequel/boot.rb
+++ b/frameworks/Ruby/sinatra-sequel/boot.rb
@@ -3,6 +3,8 @@ require 'bundler/setup'
 require 'time'
 
 MAX_PK = 10_000
+ID_RANGE = (1..MAX_PK).freeze
+ALL_IDS = ID_RANGE.to_a
 QUERIES_MIN = 1
 QUERIES_MAX = 500
 SEQUEL_NO_ASSOCIATIONS = true

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -56,8 +56,8 @@ class HelloWorld < Sinatra::Base
   get '/queries' do
     worlds =
       DB.synchronize do
-        Array.new(bounded_queries) do
-          World.with_pk(rand1)
+        ALL_IDS.sample(bounded_queries).map do |id|
+          World.with_pk(id)
         end
       end
 
@@ -80,8 +80,8 @@ class HelloWorld < Sinatra::Base
   get '/updates' do
     worlds =
       DB.synchronize do
-        Array.new(bounded_queries) do
-          world = World.with_pk(rand1)
+        ALL_IDS.sample(bounded_queries).map do |id|
+          world = World.with_pk(id)
           new_value = rand1
           new_value = rand1 while new_value == world.randomnumber
           world.update(randomnumber: new_value)

--- a/frameworks/Ruby/sinatra/boot.rb
+++ b/frameworks/Ruby/sinatra/boot.rb
@@ -3,6 +3,8 @@ require 'bundler/setup'
 require 'time'
 
 MAX_PK = 10_000
+ID_RANGE = (1..MAX_PK).freeze
+ALL_IDS = ID_RANGE.to_a
 QUERIES_MIN = 1
 QUERIES_MAX = 500
 

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -62,12 +62,12 @@ class HelloWorld < Sinatra::Base
   get '/queries' do
     worlds =
       ActiveRecord::Base.connection_pool.with_connection do
-        Array.new(bounded_queries) do
-          World.find(rand1)
+        ALL_IDS.sample(bounded_queries).map do |id|
+          World.find(id).attributes
         end
       end
 
-    json worlds.map!(&:attributes)
+    json worlds
   end
 
   # Test type 4: Fortunes
@@ -88,16 +88,16 @@ class HelloWorld < Sinatra::Base
   get '/updates' do
     worlds =
       ActiveRecord::Base.connection_pool.with_connection do
-        Array.new(bounded_queries) do
-          world = World.find(rand1)
+        ALL_IDS.sample(bounded_queries).map do |id|
+          world = World.find(id)
           new_value = rand1
           new_value = rand1 while new_value == world.randomnumber
           world.update_columns(randomnumber: new_value)
-          world
+          world.attributes
         end
       end
 
-    json worlds.map!(&:attributes)
+    json worlds
   end
 
   # Test type 6: Plaintext


### PR DESCRIPTION
Calling `Array#sample` with a size x is faster than calling `rand` x times.
Depends on: #9027