### PR TITLE
[rails] Revert to mysql2 for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -2,7 +2,7 @@ ruby '~> 3.2'
 
 source 'https://rubygems.org'
 
-gem 'trilogy', group: :mysql
+gem 'mysql2', '0.5.6', group: :mysql
 gem 'oj', '~> 3.16'
 gem 'pg', '1.5.4', group: :postgresql
 gem 'puma', '~> 6.4'

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.2)
     mutex_m (0.2.0)
+    mysql2 (0.5.6)
     net-imap (0.4.10)
       date
       net-protocol
@@ -180,7 +181,6 @@ GEM
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
-    trilogy (2.6.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.5)
@@ -197,12 +197,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  mysql2 (= 0.5.6)
   oj (~> 3.16)
   pg (= 1.5.4)
   puma (~> 6.4)
   rails (~> 7.1.3)
   redis (~> 5.0)
-  trilogy
   tzinfo-data
 
 RUBY VERSION

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -15,7 +15,7 @@ test:
 
 production_mysql:
   <<: *default
-  adapter: trilogy
+  adapter: mysql2
 
 production_postgresql:
   <<: *default

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -14,7 +14,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 COPY ./Gemfile* /rails/
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
-ENV BUNDLE_WITHOUT=trilogy
+ENV BUNDLE_WITHOUT=mysql
 RUN bundle install --jobs=8
 
 COPY . /rails/


### PR DESCRIPTION
The trilogy adapter currently doesn't support caching_sha2_password authentication:

          /usr/local/bundle/gems/activerecord-7.1.3.1/lib/active_record/connection_adapters/trilogy_adapter.rb:61:in
          `rescue in new_client': trilogy_auth_recv: caching_sha2_password
          requires either TCP with TLS or a unix socket: TRILOGY_UNSUPPORTED
          (ActiveRecord::ConnectionNotEstablished)

See: https://github.com/trilogy-libraries/trilogy/issues/26