### PR TITLE
[PHP, Spiral/RoadRunner]: update `Dockerfile` to address RR `v2024.x.x` requirements

### DIFF
--- a/frameworks/PHP/spiral/spiral.dockerfile
+++ b/frameworks/PHP/spiral/spiral.dockerfile
@@ -17,6 +17,11 @@ RUN chmod +x /usr/local/etc/php/install-composer.sh && /usr/local/etc/php/instal
 RUN apt-get update -yqq > /dev/null && apt-get install -yqq git unzip > /dev/null
 RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev
 
+# RoadRunner >= 2024.x.x requires protobuf and grpc extensions to be installed
+ARG PROTOBUF_VERSION="4.26.1"
+RUN pecl channel-update pecl.php.net
+RUN MAKEFLAGS="-j $(nproc)" pecl install protobuf-${PROTOBUF_VERSION} grpc
+
 # pre-configure
 RUN ./vendor/bin/rr get-binary > /dev/null 2>&1
 RUN php app.php configure > /dev/null 2>&1


### PR DESCRIPTION
Starting from the RR `v2024.1.0` it requires `protobuf` and `grpc` extension installed. They used to improve the performance of parsing proto-requests.
