### PR TITLE
[ruby/rails] Update trilogy to 2.8.1 and use ssl for connection

### DIFF
--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -2,10 +2,10 @@ ruby '~> 3.2'
 
 source 'https://rubygems.org'
 
-gem 'trilogy', group: :mysql
 gem 'oj', '~> 3.16'
 gem 'pg', '1.5.4', group: :postgresql
 gem 'puma', '~> 6.4'
 gem 'rails', '~> 7.1.3'
 gem 'redis', '~> 5.0'
+gem 'trilogy', '~> 2.8.1', group: :mysql
 gem 'tzinfo-data'

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
-    trilogy (2.6.0)
+    trilogy (2.8.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.5)
@@ -202,7 +202,7 @@ DEPENDENCIES
   puma (~> 6.4)
   rails (~> 7.1.3)
   redis (~> 5.0)
-  trilogy
+  trilogy (~> 2.8.1)
   tzinfo-data
 
 RUBY VERSION

--- a/frameworks/Ruby/rails/config/database.yml
+++ b/frameworks/Ruby/rails/config/database.yml
@@ -16,6 +16,9 @@ test:
 production_mysql:
   <<: *default
   adapter: trilogy
+  ssl: true
+  ssl_mode: 4 <%# Trilogy::SSL_PREFERRED_NOVERIFY %>
+  tls_min_version: 3 <%# Trilogy::TLS_VERSION_12 %>
 
 production_postgresql:
   <<: *default


### PR DESCRIPTION
This fixes connection errors which started occuring with the upgrade to MYSql 8.4

      /usr/local/bundle/gems/activerecord-7.1.3.1/lib/active_record/connection_adapters/trilogy_adapter.rb:61:in
      `rescue in new_client': trilogy_auth_recv: caching_sha2_password
      requires either TCP with TLS or a unix socket: TRILOGY_UNSUPPORTED
      (ActiveRecord::ConnectionNotEstablished)
