### PR TITLE
[ruby] Use relative path to jemalloc

### DIFF
--- a/frameworks/Ruby/agoo/agoo.dockerfile
+++ b/frameworks/Ruby/agoo/agoo.dockerfile
@@ -11,7 +11,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 

--- a/frameworks/Ruby/grape/grape-unicorn.dockerfile
+++ b/frameworks/Ruby/grape/grape-unicorn.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 RUN apt-get update -yqq && apt-get install -yqq nginx
 
 ADD ./ /grape

--- a/frameworks/Ruby/grape/grape.dockerfile
+++ b/frameworks/Ruby/grape/grape.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /grape
 
 WORKDIR /grape

--- a/frameworks/Ruby/hanami/hanami.dockerfile
+++ b/frameworks/Ruby/hanami/hanami.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /hanami
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-passenger-mri.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres-passenger-mri.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres-unicorn-mri.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-unicorn-mri.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 

--- a/frameworks/Ruby/rack/rack-falcon.dockerfile
+++ b/frameworks/Ruby/rack/rack-falcon.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 

--- a/frameworks/Ruby/rack/rack-unicorn.dockerfile
+++ b/frameworks/Ruby/rack/rack-unicorn.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 

--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -1,12 +1,17 @@
 FROM ruby:3.4-rc
 
-ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 ENV RUBY_YJIT_ENABLE=1
+
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
 COPY Gemfile  ./
 
+ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set without 'development test'
 RUN bundle install --jobs=8
 

--- a/frameworks/Ruby/rails/rails-mysql.dockerfile
+++ b/frameworks/Ruby/rails/rails-mysql.dockerfile
@@ -10,7 +10,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 COPY ./Gemfile* /rails/
 

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -9,7 +9,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 COPY ./Gemfile* /rails/
 

--- a/frameworks/Ruby/roda-sequel/roda-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-passenger-mri.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-passenger-mri.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-unicorn-mri.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/roda-sequel/roda-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-unicorn-mri.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -8,7 +8,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-base.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-base.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.4-rc
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-passenger-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-passenger-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-unicorn-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.4-rc
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.3
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-unicorn-mri.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.4-rc
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
@@ -2,6 +2,11 @@ FROM ruby:3.4-rc
 
 ENV RUBY_YJIT_ENABLE=1
 
+# Use Jemalloc
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libjemalloc2
+ENV LD_PRELOAD=libjemalloc.so.2
+
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 

--- a/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra

--- a/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra

--- a/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra

--- a/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV LD_PRELOAD=libjemalloc.so.2
 
 ADD ./ /sinatra
 WORKDIR /sinatra


### PR DESCRIPTION
Linux is capable of resolving the path to the library.
This makes sure it works on m1/m2 architecture as well.