### PR TITLE
[ruby] Remove deprecated --path option from bundle command

### DIFF
--- a/frameworks/Ruby/rack-sequel/rack-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-passenger-mri.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres-passenger-mri.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres-unicorn-mri.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-unicorn-mri.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=mysql
 

--- a/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
-RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile --path=/rack-sequel/rack-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=mysql
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-base.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-base.dockerfile
@@ -5,4 +5,4 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-passenger-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-passenger-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-unicorn-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-unicorn-mri.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV DBTYPE=mysql
 

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
@@ -5,7 +5,7 @@ ENV RUBY_YJIT_ENABLE=1
 ADD ./ /sinatra-sequel
 WORKDIR /sinatra-sequel
 
-RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile --path=/sinatra-sequel/sinatra-sequel/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV DBTYPE=mysql
 

--- a/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-passenger-mri.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-passenger-mri.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 # TODO: https://github.com/phusion/passenger/issues/1916
 ENV _PASSENGER_FORCE_HTTP_SESSION=true

--- a/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-unicorn-mri.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 ENV DBTYPE=postgresql
 

--- a/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-unicorn-mri.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 ENV DBTYPE=mysql
 

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ADD ./ /sinatra
 WORKDIR /sinatra
 
-RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile --path=/sinatra/sinatra/bundle
+RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 ENV DBTYPE=mysql
 


### PR DESCRIPTION
This fixes the following warnings:

    [DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions...
