### PR TITLE
[php] Fix #9021 fail to build grpc

### DIFF
--- a/frameworks/PHP/spiral/spiral.dockerfile
+++ b/frameworks/PHP/spiral/spiral.dockerfile
@@ -14,13 +14,13 @@ COPY php/* /usr/local/etc/php/
 RUN chmod +x /usr/local/etc/php/install-composer.sh && /usr/local/etc/php/install-composer.sh
 
 # install dependencies
-RUN apt-get update -yqq > /dev/null && apt-get install -yqq git unzip > /dev/null
-RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev
+RUN apt-get update -yqq > /dev/null && apt-get install -yqq git unzip zlib1g-dev > /dev/null
+RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 # RoadRunner >= 2024.x.x requires protobuf and grpc extensions to be installed
 ARG PROTOBUF_VERSION="4.26.1"
 RUN pecl channel-update pecl.php.net
-RUN MAKEFLAGS="-j $(nproc)" pecl install protobuf-${PROTOBUF_VERSION} grpc
+RUN MAKEFLAGS="-j $(nproc)" pecl install protobuf-${PROTOBUF_VERSION} grpc > /dev/null
 
 # pre-configure
 RUN ./vendor/bin/rr get-binary > /dev/null 2>&1


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
