### PR TITLE
Spiral: Add Cycle ORM config

### DIFF
--- a/frameworks/PHP/spiral/app/config/cycle.php
+++ b/frameworks/PHP/spiral/app/config/cycle.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Cycle\ORM\SchemaInterface;
+
+return [
+    'schema' => [
+        /**
+         * true (Default) - Schema will be stored in a cache after compilation.
+         * It won't be changed after entity modification. Use `php app.php cycle` to update schema.
+         *
+         * false - Schema won't be stored in a cache after compilation.
+         * It will be automatically changed after entity modification. (Development mode)
+         */
+        'cache' => true,
+
+        /**
+         * The CycleORM provides the ability to manage default settings for
+         * every schema with not defined segments
+         */
+        'defaults' => [
+            SchemaInterface::MAPPER => \Cycle\ORM\Mapper\Mapper::class,
+            SchemaInterface::REPOSITORY => \Cycle\ORM\Select\Repository::class,
+            SchemaInterface::SCOPE => null,
+            SchemaInterface::TYPECAST_HANDLER => [
+                \Cycle\ORM\Parser\Typecast::class
+            ],
+        ],
+
+        'collections' => [
+            'default' => 'array',
+            'factories' => [
+                'array' => new \Cycle\ORM\Collection\ArrayCollectionFactory(),
+                // 'doctrine' => new \Cycle\ORM\Collection\DoctrineCollectionFactory(),
+                // 'illuminate' => new \Cycle\ORM\Collection\IlluminateCollectionFactory(),
+            ],
+        ],
+
+        /**
+         * Schema generators (Optional)
+         * null (default) - Will be used schema generators defined in bootloaders
+         */
+        'generators' => null,
+    ],
+
+    /**
+     * Prepare all internal ORM services (mappers, repositories, typecasters...)
+     */
+    'warmup' => true,
+];


### PR DESCRIPTION
## What was changed:

Added Cycle ORM config with `cache=true`

## Why?

https://github.com/TechEmpower/FrameworkBenchmarks/pull/9021#issuecomment-2116174844

I suppose that unnecessary requests arise because each of the RoadRunner workers synchronizes the ORM schema with the database.
Enabling cache might help avoid the issue.

