### PR TITLE
Adding --cpuset-cpus tfb argument to set it on the server container

### DIFF
--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -67,6 +67,11 @@ def main(argv=None):
         ''')
 
     # Suite options
+    # CPU set  options
+    parser.add_argument(
+        '--cpuset-cpus',
+        default=None,
+        help='The cpu set to run framework container on')
     parser.add_argument(
         '--audit',
         action='store_true',

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -52,6 +52,7 @@ class BenchmarkConfig:
         self.database_docker_host = None
         self.client_docker_host = None
         self.network = None
+        self.cpuset_cpus = args.cpuset_cpus
         self.test_container_memory = args.test_container_memory
         self.extra_docker_runtime_args = args.extra_docker_runtime_args
 

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -189,6 +189,13 @@ class DockerHelper:
                 'soft': 99
             }]
 
+            cpuset_cpus = ''
+
+            if self.benchmarker.config.cpuset_cpus is not None:
+                    cpuset_cpus = self.benchmarker.config.cpuset_cpus
+
+            log("Running docker container with cpu set: %s" %cpuset_cpus)
+
             docker_cmd = ''
             if hasattr(test, 'docker_cmd'):
                 docker_cmd = test.docker_cmd
@@ -235,6 +242,7 @@ class DockerHelper:
                 sysctls=sysctl,
                 remove=True,
                 log_config={'type': None},
+                cpuset_cpus=cpuset_cpus,
                 **extra_docker_args
                 )
 


### PR DESCRIPTION
Hi @NateBrady23 I found this option very useful in our lab tests (eg to avoid NUMA effects on our servers): I think the same could be done for the database/client, but given that the concurrency limits kind of mess with the required resources I didn't pushed this further.

I haven't been able to do the same by using the existing extra arguments in the `tfb` command, getting:


```bash
$ ./tfb --mode debug --test quarkus --type plaintext --extra-docker-runtime-args cpuset-cpus:1,3
# ...
# ...
quarkus: Running docker container: quarkus.dockerfile failed
quarkus: Traceback (most recent call last):
quarkus:   File "/FrameworkBenchmarks/toolset/utils/docker_helper.py", line 220, in run
quarkus:     container = self.server.containers.run(
quarkus:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
quarkus:   File "/usr/local/lib/python3.12/dist-packages/docker/models/containers.py", line 873, in run
quarkus:     container = self.create(image=image, command=command,
quarkus:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quarkus:   File "/usr/local/lib/python3.12/dist-packages/docker/models/containers.py", line 931, in create
quarkus:     create_kwargs = _create_container_args(kwargs)
quarkus:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
quarkus:   File "/usr/local/lib/python3.12/dist-packages/docker/models/containers.py", line 1159, in _create_container_args
quarkus:     raise create_unexpected_kwargs_error('run', kwargs)
quarkus: TypeError: run() got an unexpected keyword argument 'cpuset-cpus'

```