### PR TITLE
[php] Ngx-php update to Nginx/1.26.0

### DIFF
--- a/frameworks/PHP/php-ngx/benchmark_config.json
+++ b/frameworks/PHP/php-ngx/benchmark_config.json
@@ -81,7 +81,8 @@
       "database_os": "Linux",
       "display_name": "ngx-php async",
       "notes": "ngx_php async",
-      "versus": "php"
+      "versus": "php",
+      "tags": ["broken"]
     }
   }]
 }

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,12 +9,12 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
 
-ADD . .
+COPY --link . .
 
-ENV NGINX_VERSION 1.25.4
+ENV NGINX_VERSION 1.26.0
 
 RUN git clone -b v0.0.29 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -12,8 +12,6 @@ RUN apt-get update -yqq > /dev/null && \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
 
-COPY --link . .
-
 ENV NGINX_VERSION 1.26.0
 
 RUN git clone -b v0.0.29 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
@@ -29,6 +27,8 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
 RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
+
+COPY --link . .
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-async.dockerfile
@@ -26,6 +26,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php/third_party/ngx_devel_kit \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
+
 RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 
 COPY --link . .

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -27,10 +27,12 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
 
-RUN export WORKERS=$(( 4 * $(nproc) )) && \
-    sed -i "s/worker_processes  auto/worker_processes $WORKERS/g" /deploy/nginx.conf
+RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 
 COPY --link . .
+
+RUN export WORKERS=$(( 4 * $(nproc) )) && \
+    sed -i "s/worker_processes  auto/worker_processes $WORKERS/g" /deploy/nginx.conf
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,11 +9,11 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
-ADD . .
+COPY --link . .
 
-ENV NGINX_VERSION 1.25.4
+ENV NGINX_VERSION 1.26.0
 
 RUN git clone -b v0.0.29 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-mysql.dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
-COPY --link . .
 
 ENV NGINX_VERSION 1.26.0
 
@@ -30,6 +29,8 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
 
 RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s/worker_processes  auto/worker_processes $WORKERS/g" /deploy/nginx.conf
+
+COPY --link . .
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-pgsql > /dev/null
-COPY --link . .
 
 ENV NGINX_VERSION 1.26.0
 
@@ -33,6 +32,9 @@ RUN sed -i "s|app.php|app-pg.php|g" /deploy/nginx.conf
 RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s|worker_processes  auto|worker_processes $WORKERS|g" /deploy/nginx.conf
 RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
+
+COPY --link . .
+
 EXPOSE 8080
 
 CMD /nginx/sbin/nginx -c /deploy/nginx.conf

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,11 +9,11 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-pgsql > /dev/null
-ADD . .
+COPY --link . .
 
-ENV NGINX_VERSION 1.25.4
+ENV NGINX_VERSION 1.26.0
 
 RUN git clone -b v0.0.29 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx-pgsql.dockerfile
@@ -27,13 +27,14 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
 
+RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
+
+COPY --link . .
+
 RUN sed -i "s|app.php|app-pg.php|g" /deploy/nginx.conf
 
 RUN export WORKERS=$(( 4 * $(nproc) )) && \
     sed -i "s|worker_processes  auto|worker_processes $WORKERS|g" /deploy/nginx.conf
-RUN sed -i "s|opcache.jit=off|opcache.jit=function|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
-
-COPY --link . .
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
                     zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
-COPY --link . .
 
 ENV NGINX_VERSION 1.26.0
 
@@ -28,6 +27,8 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
 RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
+
+COPY --link . .
 
 EXPOSE 8080
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,11 +9,11 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git libxml2-dev systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-mysql > /dev/null
-ADD . .
+COPY --link . .
 
-ENV NGINX_VERSION 1.25.4
+ENV NGINX_VERSION 1.26.0
 
 RUN git clone -b v0.0.29 --single-branch --depth 1 https://github.com/rryqszq4/ngx-php.git > /dev/null
 

--- a/frameworks/PHP/php-ngx/php-ngx.dockerfile
+++ b/frameworks/PHP/php-ngx/php-ngx.dockerfile
@@ -26,6 +26,7 @@ RUN wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
             --add-module=/ngx-php/third_party/ngx_devel_kit \
             --add-module=/ngx-php > /dev/null && \
     make > /dev/null && make install > /dev/null
+
 RUN sed -i "s|opcache.jit=off|;opcache.jit=off|g" /etc/php/8.3/embed/conf.d/10-opcache.ini
 
 COPY --link . .


### PR DESCRIPTION
And Ubuntu 24.04.

Mark MySQL async as broken, til we fix it. Fail with Mysql 8.4, with 8.3 was OK.

Move `COPY` at bottom in Dockerfiles, for faster local builds when only change the code.