### PR TITLE
Hummingbird2 updates

### DIFF
--- a/frameworks/Swift/hummingbird2/src-postgres/Sources/server/main.swift
+++ b/frameworks/Swift/hummingbird2/src-postgres/Sources/server/main.swift
@@ -39,7 +39,7 @@ func runApp() async throws {
         database: "hello_world", 
         tls: .disable
     )
-    postgresConfiguration.options.maximumConnections = 1900
+    postgresConfiguration.options.maximumConnections = 100
     let postgresClient = PostgresClient(
         configuration: postgresConfiguration, 
         eventLoopGroup: MultiThreadedEventLoopGroup.singleton


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
- Use one connection for multiple, update queries
- Use prepared statements for DB calls
- Reduce size of connection pool