### PR TITLE
[F#/Oxpecker] Got rid of SpanJson as bringning no benefit. Disabled ReadyToRun

### DIFF
--- a/frameworks/FSharp/oxpecker/README.md
+++ b/frameworks/FSharp/oxpecker/README.md
@@ -19,7 +19,6 @@ This includes tests for plaintext, json, and fortunes HTML serialization.
 
 * [Oxpecker](https://github.com/Lanayx/Oxpecker)
 * [Dapper](https://github.com/DapperLib/Dapper)
-* [SpanJson](https://github.com/Tornhoof/SpanJson)
 * ASP.NET Core
 
 ## Paths & Source for Tests

--- a/frameworks/FSharp/oxpecker/oxpecker.dockerfile
+++ b/frameworks/FSharp/oxpecker/oxpecker.dockerfile
@@ -4,6 +4,9 @@ COPY src/App .
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+ENV DOTNET_ReadyToRun 0
+
 ENV URLS http://+:8080
 
 WORKDIR /app

--- a/frameworks/FSharp/oxpecker/src/App/App.fsproj
+++ b/frameworks/FSharp/oxpecker/src/App/App.fsproj
@@ -14,6 +14,5 @@
     <PackageReference Include="Dapper" Version="2.1.44" />
     <PackageReference Include="Oxpecker" Version="0.10.1" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="SpanJson" Version="4.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
