### PR TITLE
[Elide] add elide runtime

### DIFF
--- a/frameworks/JavaScript/elide/README.md
+++ b/frameworks/JavaScript/elide/README.md
@@ -1,0 +1,49 @@
+# [Elide](https://github.com/elide-dev/elide) - A fast polyglot runtime
+
+## Description
+
+Elide is a runtime which can execute **JavaScript**, **Ruby**, **Python**, and others, all in one package.
+
+Elide is powered by [GraalVM](https://graalvm.org), which enables polyglot software design. Code units can interoperate from any supported language.
+
+The test script embedded for this benchmark uses Elide's built-in HTTP intrinsic from JavaScript:
+
+```javascript
+// access the built-in HTTP server engine
+const app = Elide.http;
+
+// register basic handler
+app.router.handle("GET", "/plaintext", (request, response) => {
+  // respond using the captured path variables
+  response.send(200, "Hello, world!");
+});
+
+// register a route handler
+app.router.handle("GET", "/json", (request, response, context) => {
+  // respond using the captured path variables
+  response.send(200, JSON.stringify({ message: "Hello, world!" }));
+});
+
+// configure the server binding options
+app.config.port = 3000;
+
+// receive a callback when the server starts
+app.config.onBind(() => {
+  console.log(`Server listening at "http://localhost:${app.config.port}"! 🚀`);
+});
+
+// start the server
+app.start();
+```
+
+- [Elide Docs](https://docs.elide.dev)
+
+## Test URLs
+
+### Test 1: JSON Encoding
+
+    http://localhost:3000/json
+
+### Test 2: Plaintext
+
+    http://localhost:3000/plaintext

--- a/frameworks/JavaScript/elide/benchmark_config.json
+++ b/frameworks/JavaScript/elide/benchmark_config.json
@@ -1,0 +1,20 @@
+{
+  "framework": "elide",
+  "tests": [{
+    "default": {
+      "json_url": "/json",
+      "plaintext_url": "/plaintext",
+      "port": 3000,
+      "approach": "Realistic",
+      "classification": "Platform",
+      "language": "JavaScript",
+      "flavor": "elide",
+      "platform": "elide",
+      "webserver": "None",
+      "os": "Linux",
+      "database_os": "Linux",
+      "display_name": "elide",
+      "versus": "nodejs"
+    }
+  }]
+}

--- a/frameworks/JavaScript/elide/config.toml
+++ b/frameworks/JavaScript/elide/config.toml
@@ -1,0 +1,15 @@
+[framework]
+name = "elide"
+
+[main]
+urls.plaintext = "/plaintext"
+urls.json = "/json"
+approach = "Realistic"
+classification = "Platform"
+database_os = "Linux"
+database = "None"
+os = "Linux"
+orm = "Raw"
+platform = "elide"
+webserver = "None"
+versus = "nodejs"

--- a/frameworks/JavaScript/elide/elide.dockerfile
+++ b/frameworks/JavaScript/elide/elide.dockerfile
@@ -1,0 +1,11 @@
+FROM --platform=linux/amd64 ghcr.io/elide-dev/bench:1.0-alpha10-bench1-compat@sha256:1e679d95e18f9826c24a74d1709856849f53d3ca20c9bb25b548a8ec62424ad9 AS runtime
+
+EXPOSE 3000
+
+WORKDIR /app
+
+COPY ./src .
+
+ENV NODE_ENV=production
+
+CMD ["elide", "serve", "server.js"]

--- a/frameworks/JavaScript/elide/src/server.js
+++ b/frameworks/JavaScript/elide/src/server.js
@@ -1,0 +1,26 @@
+// access the built-in HTTP server engine
+const app = Elide.http;
+
+// register basic handler
+app.router.handle("GET", "/plaintext", (request, response) => {
+  // respond using the captured path variables
+  response.send(200, "Hello, world!");
+});
+
+// register a route handler
+app.router.handle("GET", "/json", (request, response, context) => {
+  // respond using the captured path variables
+  response.header("Content-Type", "application/json");
+  response.send(200, JSON.stringify({ message: "Hello, world!" }));
+});
+
+// configure the server binding options
+app.config.port = 3000;
+
+// receive a callback when the server starts
+app.config.onBind(() => {
+  console.log(`Server listening at "http://localhost:${app.config.port}"! 🚀`);
+});
+
+// start the server
+app.start();


### PR DESCRIPTION
## Summary

Adds [Elide](https://github.com/elide-dev/elide), a new polyglot runtime built on top of GraalVM. For now, JavaScript server benchmarking is added; Python and Ruby will follow later (Elide runs all three). Elide leverages JVM for networking, specifically via Netty. No build is required to run the server or the benchmarks. Instead, a release image is pulled from `ghcr.io/elide-dev/bench` so that the TechEmpower benchmarks can save some compute.

So far, two benchmarks are implemented (`json` and `plaintext`), with more to come soon.

## Framework README

> The README for the new framework is embedded below because it explains Elide and shows the code sample under bench.

# [Elide](https://github.com/elide-dev/elide) - A fast polyglot runtime

## Description

Elide is a runtime which can execute **JavaScript**, **Ruby**, **Python**, and others, all in one package.

Elide is powered by [GraalVM](https://graalvm.org), which enables polyglot software design. Code units can interoperate from any supported language.

The test script embedded for this benchmark uses Elide's built-in HTTP intrinsic from JavaScript:

```javascript
// access the built-in HTTP server engine
const app = Elide.http;

// register basic handler
app.router.handle("GET", "/plaintext", (request, response) => {
  // respond using the captured path variables
  response.send(200, "Hello, world!");
});

// register a route handler
app.router.handle("GET", "/json", (request, response, context) => {
  // respond using the captured path variables
  response.send(200, JSON.stringify({ message: "Hello, world!" }));
});

// configure the server binding options
app.config.port = 3000;

// receive a callback when the server starts
app.config.onBind(() => {
  console.log(`Server listening at "http://localhost:${app.config.port}"! 🚀`);
});

// start the server
app.start();
```

- [Elide Docs](https://docs.elide.dev)

## Test URLs

### Test 1: JSON Encoding

    http://localhost:3000/json

### Test 2: Plaintext

    http://localhost:3000/plaintext
