### PR TITLE
Fix link in to Baratine

### DIFF
--- a/frameworks/Java/baratine/README.md
+++ b/frameworks/Java/baratine/README.md
@@ -13,7 +13,7 @@ This is the Baratine portion of a [benchmarking test suite](../) comparing a var
 ## Software Versions
 
 * [Java OpenJDK 1.8](http://openjdk.java.net/)
-* [Baratine 0.11.0](http://baratine.io/)
+* [Baratine 0.11.0](https://github.com/baratine/baratine)
 
 ## Test URLs
 


### PR DESCRIPTION
baratine.io no longer hosts the framework.

maybe it should be deleted instead as there hasn’t been a commit in 8 years. 