### PR TITLE
[rails] Don't bulk update on MySQL

### DIFF
--- a/frameworks/Ruby/rails/app/models/world.rb
+++ b/frameworks/Ruby/rails/app/models/world.rb
@@ -3,4 +3,14 @@ class World < ApplicationRecord
 
   alias_attribute(:randomNumber, :randomnumber) \
     if connection.adapter_name.downcase.start_with?('postgres')
+
+  if connection.adapter_name.downcase.start_with?('trilogy')
+    def self.upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
+      # On MySQL Batch updates verification isn't supported yet by TechEmpower.
+      # https://github.com/TechEmpower/FrameworkBenchmarks/issues/5983
+      attributes.each do |attrs|
+        where(id: attrs[:id]).update_all(randomNumber: attrs[:randomNumber])
+      end
+    end
+  end
 end


### PR DESCRIPTION
The benchmarks currently don't take into account batch updates in MySQL. This fixes the flaky MySQL updates verification.