### PR TITLE
[spliffy] Use package-lock.json when installing npm packages

### DIFF
--- a/frameworks/JavaScript/spliffy/spliffy-mongodb.dockerfile
+++ b/frameworks/JavaScript/spliffy/spliffy-mongodb.dockerfile
@@ -1,10 +1,9 @@
 FROM node:14-buster-slim
 
 RUN apt update && apt install -y libpq-dev g++ make git python
-COPY package.json /app/
+COPY . /app
 WORKDIR /app
 RUN npm install
-COPY . /app
 
 ENV DB_HOST=tfb-database
 ENV DATABASE=mongodb

--- a/frameworks/JavaScript/spliffy/spliffy-mysql.dockerfile
+++ b/frameworks/JavaScript/spliffy/spliffy-mysql.dockerfile
@@ -1,10 +1,9 @@
 FROM node:14-buster-slim
 
 RUN apt update && apt install -y libpq-dev g++ make git python
-COPY package.json /app/
+COPY . /app
 WORKDIR /app
 RUN npm install
-COPY . /app
 
 ENV DB_HOST=tfb-database
 ENV DATABASE=mysql

--- a/frameworks/JavaScript/spliffy/spliffy-postgres.dockerfile
+++ b/frameworks/JavaScript/spliffy/spliffy-postgres.dockerfile
@@ -1,10 +1,9 @@
 FROM node:14-buster-slim
 
 RUN apt update && apt install -y libpq-dev g++ make git python
-COPY package.json /app/
+COPY . /app
 WORKDIR /app
 RUN npm install
-COPY . /app
 
 ENV DB_HOST=tfb-database
 ENV DATABASE=postgres

--- a/frameworks/JavaScript/spliffy/spliffy.dockerfile
+++ b/frameworks/JavaScript/spliffy/spliffy.dockerfile
@@ -1,10 +1,9 @@
 FROM node:14-buster-slim
 
 RUN apt update && apt install -y libpq-dev g++ make git python
-COPY package.json /app/
+COPY . /app
 WORKDIR /app
 RUN npm install
-COPY . /app
 
 EXPOSE 1420
 


### PR DESCRIPTION
Spliffy can take 15 minutes to build:
https://tfb-status.techempower.com/unzip/results.2024-06-19-19-20-43-186.zip/results/20240614003233/spliffy/build/spliffy.log
https://tfb-status.techempower.com/unzip/results.2024-06-19-19-20-43-186.zip/results/20240614003233/spliffy-mongodb/build/spliffy-mongodb.log
https://tfb-status.techempower.com/unzip/results.2024-06-19-19-20-43-186.zip/results/20240614003233/spliffy-mysql/build/spliffy-mysql.log
https://tfb-status.techempower.com/unzip/results.2024-06-19-19-20-43-186.zip/results/20240614003233/spliffy-postgres/build/spliffy-postgres.log

By using the package-lock.json ths should be shortend.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
