### PR TITLE
Perl: Fix non-functional benchmarks

### DIFF
--- a/frameworks/Perl/dancer/README.md
+++ b/frameworks/Perl/dancer/README.md
@@ -8,7 +8,7 @@
 
 * Dancer
 * Dancer::Plugin::Database
-* DBD::mysql
+* DBD::MariaDB
 * Starman (if using Starman as web server)
 * Plack (for plackup)
 * nginx (if you want to front Dancer with nginx, nginx.conf provided)
@@ -22,3 +22,4 @@ Something along the lines of
 if you want to front it with nginx, otherwise
 
     plackup -E production -s Starman --port=8080 --workers=2 -a ./app.pl
+

--- a/frameworks/Perl/dancer/app.pl
+++ b/frameworks/Perl/dancer/app.pl
@@ -8,8 +8,8 @@ use JSON::XS;  # Ensure that the fast implementation of the serializer is instal
 
 set serializer => 'JSON';
 
-my $dsn = "dbi:mysql:database=hello_world;host=tfb-database;port=3306";
-my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass', { mysql_auto_reconnect=>1 } );
+my $dsn = "dbi:MariaDB:database=hello_world;host=tfb-database;port=3306";
+my $dbh = DBI->connect( $dsn, 'benchmarkdbuser', 'benchmarkdbpass' );
 my $sth = $dbh->prepare("SELECT * FROM World where id = ?");
 
 get '/json' => sub {
@@ -20,7 +20,7 @@ get '/dbquery' => sub {
     my $queries = params->{queries} || 1;
     $queries = 1 if ( $queries !~ /^\d+$/ || $queries < 1 );
     $queries = 500 if $queries > 500;
-    
+
     my @response;
     for ( 1 .. $queries ) {
         my $id = int rand 10000 + 1;
@@ -42,3 +42,4 @@ get '/db' => sub {
 };
 
 Dancer->dance;
+

--- a/frameworks/Perl/dancer/benchmark_config.json
+++ b/frameworks/Perl/dancer/benchmark_config.json
@@ -19,7 +19,8 @@
       "display_name": "dancer",
       "notes": "",
       "versus": "",
-      "tags": ["broken"]
+      "tags": []
     }
   }]
 }
+

--- a/frameworks/Perl/dancer/dancer.dockerfile
+++ b/frameworks/Perl/dancer/dancer.dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.26
+FROM perl:5.40
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
 
@@ -10,7 +10,7 @@ RUN cpanm --notest --no-man-page \
       Dancer@1.3134 \
       Dancer::Plugin::Database@2.10 \
       DBI@1.633 \
-      DBD::mysql@4.033 \
+      DBD::MariaDB@1.23 \
       JSON::XS@3.01 \
       Plack@1.0034 \
       Starman@0.4011
@@ -19,3 +19,4 @@ EXPOSE 8080
 
 CMD nginx -c /dancer/nginx.conf && \
     plackup -E production -s Starman --workers=$(nproc) --max-requests=100000 -l /tmp/perl-dancer.sock -a ./app.pl
+

--- a/frameworks/Perl/dancer/dancer.dockerfile
+++ b/frameworks/Perl/dancer/dancer.dockerfile
@@ -18,4 +18,4 @@ RUN cpanm --notest --no-man-page \
 EXPOSE 8080
 
 CMD nginx -c /dancer/nginx.conf && \
-    plackup -E production -s Starman --workers=$(nproc) -l /tmp/perl-dancer.sock -a ./app.pl
+    plackup -E production -s Starman --workers=$(nproc) --max-requests=100000 -l /tmp/perl-dancer.sock -a ./app.pl

--- a/frameworks/Perl/kelp/benchmark_config.json
+++ b/frameworks/Perl/kelp/benchmark_config.json
@@ -1,7 +1,7 @@
 {
   "framework": "kelp",
   "tests": [{
-    "gazelle-mysql": {
+    "default": {
       "dockerfile": "kelp.dockerfile",
       "plaintext_url": "/plaintext",
       "json_url": "/json",

--- a/frameworks/Perl/kelp/run.pl
+++ b/frameworks/Perl/kelp/run.pl
@@ -62,6 +62,10 @@ my %runner_map = (
 	],
 );
 
+# default is gazelle-mysql (techempower will warn if there is no default)
+$test_name = 'kelp-gazelle-mysql'
+	if $test_name eq 'kelp';
+
 die "invalid test name $test_name"
 	unless $test_name =~ m{^kelp-(\w+)-(\w+)$};
 

--- a/frameworks/Perl/mojolicious/app.pl
+++ b/frameworks/Perl/mojolicious/app.pl
@@ -13,17 +13,12 @@ use constant MAX_DB_CONCURRENCY => 50;
   my $nproc = `nproc`;
   app->config(hypnotoad => {
     accepts => 100000,
-    clients => 50,
+    clients => MAX_DB_CONCURRENCY,
     graceful_timeout => 1,
     requests => 10000,
     workers => $nproc,
     backlog => 256
   });
-}
-
-{
-  my $db_host = 'tfb-database';
-  helper pg => sub { state $pg = Mojo::Pg->new('postgresql://benchmarkdbuser:benchmarkdbpass@' . $db_host . '/hello_world')->max_connections(MAX_DB_CONCURRENCY + 1) };
 }
 
 # Routes
@@ -59,6 +54,12 @@ get '/updates' => sub ($c) {
 get '/plaintext' => { text => 'Hello, World!', format => 'txt' };
 
 # Additional helpers (shared code)
+
+helper pg => sub {
+  state $pg = Mojo::Pg
+    ->new('postgresql://benchmarkdbuser:benchmarkdbpass@tfb-database/hello_world')
+    ->max_connections(MAX_DB_CONCURRENCY + 1);
+};
 
 helper 'render_query' => sub ($self, $q, $args = {}) {
   $self->render_later;

--- a/frameworks/Perl/mojolicious/app.pl
+++ b/frameworks/Perl/mojolicious/app.pl
@@ -11,7 +11,7 @@ use Data::Dumper;
 {
   my $nproc = `nproc`;
   app->config(hypnotoad => {
-    accepts => 0,
+    accepts => 100000,
     clients => int( 256 / $nproc ) + 1,
     graceful_timeout => 1,
     requests => 10000,

--- a/frameworks/Perl/mojolicious/cpanfile
+++ b/frameworks/Perl/mojolicious/cpanfile
@@ -1,7 +1,8 @@
 requires 'Mojolicious', '7.84';
 requires 'Mojo::Pg', '4.08';
-requires 'Cpanel::JSON::XS', '4.02';
+requires 'Cpanel::JSON::XS', '4.38';
 requires 'EV', '4.22';
 
 recommends 'IO::Socket::IP', '0.36';
 recommends 'IO::Socket::SSL';
+

--- a/frameworks/Perl/mojolicious/cpanfile.snapshot
+++ b/frameworks/Perl/mojolicious/cpanfile.snapshot
@@ -1,15 +1,15 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
-  Canary-Stability-2012
-    pathname: M/ML/MLEHMANN/Canary-Stability-2012.tar.gz
+  Canary-Stability-2013
+    pathname: M/ML/MLEHMANN/Canary-Stability-2013.tar.gz
     provides:
-      Canary::Stability 2012
+      Canary::Stability 2013
     requirements:
       ExtUtils::MakeMaker 0
-  Class-Method-Modifiers-2.12
-    pathname: E/ET/ETHER/Class-Method-Modifiers-2.12.tar.gz
+  Class-Method-Modifiers-2.15
+    pathname: E/ET/ETHER/Class-Method-Modifiers-2.15.tar.gz
     provides:
-      Class::Method::Modifiers 2.12
+      Class::Method::Modifiers 2.15
     requirements:
       B 0
       Carp 0
@@ -27,27 +27,36 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Storable 0
       perl 5.008001
-  Cpanel-JSON-XS-4.02
-    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.02.tar.gz
+  Cpanel-JSON-XS-4.38
+    pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.38.tar.gz
     provides:
-      Cpanel::JSON::XS 4.02
+      Cpanel::JSON::XS 4.38
       Cpanel::JSON::XS::Type undef
     requirements:
+      Carp 0
+      Config 0
+      Encode 1.9801
+      Exporter 0
       ExtUtils::MakeMaker 0
       Pod::Text 2.08
-  DBD-Pg-3.7.4
-    pathname: T/TU/TURNSTEP/DBD-Pg-3.7.4.tar.gz
+      XSLoader 0
+      overload 0
+      strict 0
+      warnings 0
+  DBD-Pg-3.18.0
+    pathname: T/TU/TURNSTEP/DBD-Pg-3.18.0.tar.gz
     provides:
-      Bundle::DBD::Pg v3.7.4
-      DBD::Pg v3.7.4
+      Bundle::DBD::Pg v3.18.0
+      DBD::Pg v3.18.0
     requirements:
       DBI 1.614
-      ExtUtils::MakeMaker 6.11
+      ExtUtils::MakeMaker 6.58
+      File::Temp 0
       Test::More 0.88
       Time::HiRes 0
       version 0
-  DBI-1.641
-    pathname: T/TI/TIMB/DBI-1.641.tar.gz
+  DBI-1.643
+    pathname: T/TI/TIMB/DBI-1.643.tar.gz
     provides:
       Bundle::DBI 12.008696
       DBD::DBM 0.08
@@ -103,7 +112,7 @@ DISTRIBUTIONS
       DBD::Sponge::dr 12.010003
       DBD::Sponge::st 12.010003
       DBDI 12.015129
-      DBI 1.641
+      DBI 1.643
       DBI::Const::GetInfo::ANSI 2.008697
       DBI::Const::GetInfo::ODBC 2.011374
       DBI::Const::GetInfoReturn 2.008697
@@ -143,128 +152,60 @@ DISTRIBUTIONS
       DBI::SQL::Nano::Table_ 1.015544
       DBI::Util::CacheMemory 0.010315
       DBI::Util::_accessor 0.009479
-      DBI::common 1.641
+      DBI::common 1.643
     requirements:
       ExtUtils::MakeMaker 6.48
       Test::Simple 0.90
-      perl 5.008
-  Devel-GlobalDestruction-0.14
-    pathname: H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz
+      perl 5.008001
+  EV-4.34
+    pathname: M/ML/MLEHMANN/EV-4.34.tar.gz
     provides:
-      Devel::GlobalDestruction 0.14
-    requirements:
-      ExtUtils::MakeMaker 0
-      Sub::Exporter::Progressive 0.001011
-      perl 5.006
-  EV-4.22
-    pathname: M/ML/MLEHMANN/EV-4.22.tar.gz
-    provides:
-      EV 4.22
+      EV 4.34
       EV::MakeMaker undef
     requirements:
       Canary::Stability 0
       ExtUtils::MakeMaker 6.52
       common::sense 0
-  Hash-Merge-0.300
-    pathname: R/RE/REHSACK/Hash-Merge-0.300.tar.gz
+  Hash-Merge-0.302
+    pathname: H/HE/HERMES/Hash-Merge-0.302.tar.gz
     provides:
-      Hash::Merge 0.300
+      Hash::Merge 0.302
     requirements:
       Clone::Choose 0.008
       ExtUtils::MakeMaker 6.64
       Scalar::Util 0
       perl 5.008001
-  MRO-Compat-0.13
-    pathname: H/HA/HAARG/MRO-Compat-0.13.tar.gz
+  MRO-Compat-0.15
+    pathname: H/HA/HAARG/MRO-Compat-0.15.tar.gz
     provides:
-      MRO::Compat 0.13
+      MRO::Compat 0.15
     requirements:
       ExtUtils::MakeMaker 0
       perl 5.006
-  Module-Build-0.4224
-    pathname: L/LE/LEONT/Module-Build-0.4224.tar.gz
+  Mojo-Pg-4.27
+    pathname: S/SR/SRI/Mojo-Pg-4.27.tar.gz
     provides:
-      Module::Build 0.4224
-      Module::Build::Base 0.4224
-      Module::Build::Compat 0.4224
-      Module::Build::Config 0.4224
-      Module::Build::Cookbook 0.4224
-      Module::Build::Dumper 0.4224
-      Module::Build::Notes 0.4224
-      Module::Build::PPMMaker 0.4224
-      Module::Build::Platform::Default 0.4224
-      Module::Build::Platform::MacOS 0.4224
-      Module::Build::Platform::Unix 0.4224
-      Module::Build::Platform::VMS 0.4224
-      Module::Build::Platform::VOS 0.4224
-      Module::Build::Platform::Windows 0.4224
-      Module::Build::Platform::aix 0.4224
-      Module::Build::Platform::cygwin 0.4224
-      Module::Build::Platform::darwin 0.4224
-      Module::Build::Platform::os2 0.4224
-      Module::Build::PodParser 0.4224
-    requirements:
-      CPAN::Meta 2.142060
-      CPAN::Meta::YAML 0.003
-      Cwd 0
-      Data::Dumper 0
-      ExtUtils::CBuilder 0.27
-      ExtUtils::Install 0
-      ExtUtils::Manifest 0
-      ExtUtils::Mkbootstrap 0
-      ExtUtils::ParseXS 2.21
-      File::Basename 0
-      File::Compare 0
-      File::Copy 0
-      File::Find 0
-      File::Path 0
-      File::Spec 0.82
-      File::Temp 0.15
-      Getopt::Long 0
-      Module::Metadata 1.000002
-      Parse::CPAN::Meta 1.4401
-      Perl::OSType 1
-      Pod::Man 2.17
-      TAP::Harness 3.29
-      Test::More 0.49
-      Text::Abbrev 0
-      Text::ParseWords 0
-      perl 5.006001
-      version 0.87
-  Module-Runtime-0.016
-    pathname: Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz
-    provides:
-      Module::Runtime 0.016
-    requirements:
-      Module::Build 0
-      Test::More 0.41
-      perl 5.006
-      strict 0
-      warnings 0
-  Mojo-Pg-4.08
-    pathname: S/SR/SRI/Mojo-Pg-4.08.tar.gz
-    provides:
-      Mojo::Pg 4.08
+      Mojo::Pg 4.27
       Mojo::Pg::Database undef
       Mojo::Pg::Migrations undef
       Mojo::Pg::PubSub undef
       Mojo::Pg::Results undef
       Mojo::Pg::Transaction undef
-      SQL::Abstract::Pg undef
     requirements:
-      DBD::Pg 3.005001
+      DBD::Pg 3.007004
       ExtUtils::MakeMaker 0
-      Mojolicious 7.53
-      SQL::Abstract 1.85
-      perl 5.010001
-  Mojolicious-7.84
-    pathname: S/SR/SRI/Mojolicious-7.84.tar.gz
+      Mojolicious 8.50
+      SQL::Abstract::Pg 1.0
+      perl 5.016
+  Mojolicious-9.37
+    pathname: S/SR/SRI/Mojolicious-9.37.tar.gz
     provides:
       Mojo undef
       Mojo::Asset undef
       Mojo::Asset::File undef
       Mojo::Asset::Memory undef
       Mojo::Base undef
+      Mojo::BaseUtil undef
       Mojo::ByteStream undef
       Mojo::Cache undef
       Mojo::Collection undef
@@ -278,6 +219,7 @@ DISTRIBUTIONS
       Mojo::DOM::CSS undef
       Mojo::DOM::HTML undef
       Mojo::Date undef
+      Mojo::DynamicMethods undef
       Mojo::EventEmitter undef
       Mojo::Exception undef
       Mojo::File undef
@@ -286,13 +228,8 @@ DISTRIBUTIONS
       Mojo::Home undef
       Mojo::IOLoop undef
       Mojo::IOLoop::Client undef
-      Mojo::IOLoop::Delay undef
       Mojo::IOLoop::Server undef
       Mojo::IOLoop::Stream undef
-      Mojo::IOLoop::Stream::HTTPClient undef
-      Mojo::IOLoop::Stream::HTTPServer undef
-      Mojo::IOLoop::Stream::WebSocketClient undef
-      Mojo::IOLoop::Stream::WebSocketServer undef
       Mojo::IOLoop::Subprocess undef
       Mojo::IOLoop::TLS undef
       Mojo::JSON undef
@@ -316,7 +253,6 @@ DISTRIBUTIONS
       Mojo::Server::Morbo::Backend undef
       Mojo::Server::Morbo::Backend::Poll undef
       Mojo::Server::PSGI undef
-      Mojo::Server::PSGI::_IO undef
       Mojo::Server::Prefork undef
       Mojo::Template undef
       Mojo::Transaction undef
@@ -331,37 +267,36 @@ DISTRIBUTIONS
       Mojo::UserAgent::Transactor undef
       Mojo::Util undef
       Mojo::WebSocket undef
-      Mojolicious 7.84
+      Mojolicious 9.37
       Mojolicious::Command undef
+      Mojolicious::Command::Author::cpanify undef
+      Mojolicious::Command::Author::generate undef
+      Mojolicious::Command::Author::generate::app undef
+      Mojolicious::Command::Author::generate::dockerfile undef
+      Mojolicious::Command::Author::generate::lite_app undef
+      Mojolicious::Command::Author::generate::makefile undef
+      Mojolicious::Command::Author::generate::plugin undef
+      Mojolicious::Command::Author::inflate undef
       Mojolicious::Command::cgi undef
-      Mojolicious::Command::cpanify undef
       Mojolicious::Command::daemon undef
       Mojolicious::Command::eval undef
-      Mojolicious::Command::generate undef
-      Mojolicious::Command::generate::app undef
-      Mojolicious::Command::generate::lite_app undef
-      Mojolicious::Command::generate::makefile undef
-      Mojolicious::Command::generate::plugin undef
       Mojolicious::Command::get undef
-      Mojolicious::Command::inflate undef
       Mojolicious::Command::prefork undef
       Mojolicious::Command::psgi undef
       Mojolicious::Command::routes undef
-      Mojolicious::Command::test undef
       Mojolicious::Command::version undef
       Mojolicious::Commands undef
       Mojolicious::Controller undef
       Mojolicious::Lite undef
       Mojolicious::Plugin undef
       Mojolicious::Plugin::Config undef
-      Mojolicious::Plugin::Config::Sandbox undef
       Mojolicious::Plugin::DefaultHelpers undef
       Mojolicious::Plugin::EPLRenderer undef
       Mojolicious::Plugin::EPRenderer undef
       Mojolicious::Plugin::HeaderCondition undef
       Mojolicious::Plugin::JSONConfig undef
       Mojolicious::Plugin::Mount undef
-      Mojolicious::Plugin::PODRenderer undef
+      Mojolicious::Plugin::NotYAMLConfig undef
       Mojolicious::Plugin::TagHelpers undef
       Mojolicious::Plugins undef
       Mojolicious::Renderer undef
@@ -379,52 +314,55 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       IO::Socket::IP 0.37
-      JSON::PP 2.27103
-      Pod::Simple 3.09
-      Time::Local 1.2
-      perl 5.010001
-  Moo-2.003004
-    pathname: H/HA/HAARG/Moo-2.003004.tar.gz
+      Sub::Util 1.41
+      perl 5.016
+  Moo-2.005005
+    pathname: H/HA/HAARG/Moo-2.005005.tar.gz
     provides:
       Method::Generate::Accessor undef
       Method::Generate::BuildAll undef
       Method::Generate::Constructor undef
       Method::Generate::DemolishAll undef
-      Moo 2.003004
+      Moo 2.005005
       Moo::HandleMoose undef
       Moo::HandleMoose::FakeConstructor undef
       Moo::HandleMoose::FakeMetaClass undef
       Moo::HandleMoose::_TypeMap undef
       Moo::Object undef
-      Moo::Role 2.003004
+      Moo::Role 2.005005
       Moo::_Utils undef
-      Moo::_mro undef
-      Moo::_strictures undef
       Moo::sification undef
       oo undef
     requirements:
-      Class::Method::Modifiers 1.1
-      Devel::GlobalDestruction 0.11
-      Exporter 5.57
+      Carp 0
+      Class::Method::Modifiers 1.10
+      Exporter 0
       ExtUtils::MakeMaker 0
-      Module::Runtime 0.014
-      Role::Tiny 2.000004
-      Scalar::Util 0
-      Sub::Defer 2.003001
-      Sub::Quote 2.003001
+      Role::Tiny 2.002003
+      Scalar::Util 1.00
+      Sub::Defer 2.006006
+      Sub::Quote 2.006006
       perl 5.006
-  Role-Tiny-2.000006
-    pathname: H/HA/HAARG/Role-Tiny-2.000006.tar.gz
+  Role-Tiny-2.002004
+    pathname: H/HA/HAARG/Role-Tiny-2.002004.tar.gz
     provides:
-      Role::Tiny 2.000006
-      Role::Tiny::With 2.000006
+      Role::Tiny 2.002004
+      Role::Tiny::With 2.002004
     requirements:
       Exporter 5.57
       perl 5.006
-  SQL-Abstract-1.85
-    pathname: I/IL/ILMARI/SQL-Abstract-1.85.tar.gz
+  SQL-Abstract-2.000001
+    pathname: M/MS/MSTROUT/SQL-Abstract-2.000001.tar.gz
     provides:
-      SQL::Abstract 1.85
+      Chunkstrumenter undef
+      DBIx::Class::SQLMaker::Role::SQLA2Passthrough undef
+      SQL::Abstract 2.000001
+      SQL::Abstract::Formatter undef
+      SQL::Abstract::Parts undef
+      SQL::Abstract::Plugin::BangOverrides undef
+      SQL::Abstract::Plugin::ExtraClauses undef
+      SQL::Abstract::Reference undef
+      SQL::Abstract::Role::Plugin undef
       SQL::Abstract::Test undef
       SQL::Abstract::Tree undef
     requirements:
@@ -436,26 +374,91 @@ DISTRIBUTIONS
       Moo 2.000001
       Scalar::Util 0
       Sub::Quote 2.000001
+      Test::Builder::Module 0.84
+      Test::Deep 0.101
       Text::Balanced 2.00
       perl 5.006
-  Sub-Exporter-Progressive-0.001013
-    pathname: F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz
+  SQL-Abstract-Pg-1.0
+    pathname: S/SR/SRI/SQL-Abstract-Pg-1.0.tar.gz
     provides:
-      Sub::Exporter::Progressive 0.001013
+      SQL::Abstract::Pg 1.0
     requirements:
       ExtUtils::MakeMaker 0
-  Sub-Quote-2.005001
-    pathname: H/HA/HAARG/Sub-Quote-2.005001.tar.gz
+      SQL::Abstract 2.0
+      perl 5.016
+  Sub-Quote-2.006008
+    pathname: H/HA/HAARG/Sub-Quote-2.006008.tar.gz
     provides:
-      Sub::Defer 2.005001
-      Sub::Quote 2.005001
+      Sub::Defer 2.006008
+      Sub::Quote 2.006008
     requirements:
       ExtUtils::MakeMaker 0
       Scalar::Util 0
       perl 5.006
-  common-sense-3.74
-    pathname: M/ML/MLEHMANN/common-sense-3.74.tar.gz
+  Test-Deep-1.204
+    pathname: R/RJ/RJBS/Test-Deep-1.204.tar.gz
     provides:
-      common::sense 3.74
+      Test::Deep 1.204
+      Test::Deep::All 1.204
+      Test::Deep::Any 1.204
+      Test::Deep::Array 1.204
+      Test::Deep::ArrayEach 1.204
+      Test::Deep::ArrayElementsOnly 1.204
+      Test::Deep::ArrayLength 1.204
+      Test::Deep::ArrayLengthOnly 1.204
+      Test::Deep::Blessed 1.204
+      Test::Deep::Boolean 1.204
+      Test::Deep::Cache 1.204
+      Test::Deep::Cache::Simple 1.204
+      Test::Deep::Class 1.204
+      Test::Deep::Cmp 1.204
+      Test::Deep::Code 1.204
+      Test::Deep::Hash 1.204
+      Test::Deep::HashEach 1.204
+      Test::Deep::HashElements 1.204
+      Test::Deep::HashKeys 1.204
+      Test::Deep::HashKeysOnly 1.204
+      Test::Deep::Ignore 1.204
+      Test::Deep::Isa 1.204
+      Test::Deep::ListMethods 1.204
+      Test::Deep::MM 1.204
+      Test::Deep::Methods 1.204
+      Test::Deep::NoTest 1.204
+      Test::Deep::None 1.204
+      Test::Deep::Number 1.204
+      Test::Deep::Obj 1.204
+      Test::Deep::Ref 1.204
+      Test::Deep::RefType 1.204
+      Test::Deep::Regexp 1.204
+      Test::Deep::RegexpMatches 1.204
+      Test::Deep::RegexpOnly 1.204
+      Test::Deep::RegexpRef 1.204
+      Test::Deep::RegexpRefOnly 1.204
+      Test::Deep::RegexpVersion 1.204
+      Test::Deep::ScalarRef 1.204
+      Test::Deep::ScalarRefOnly 1.204
+      Test::Deep::Set 1.204
+      Test::Deep::Shallow 1.204
+      Test::Deep::Stack 1.204
+      Test::Deep::String 1.204
+      Test::Deep::SubHash 1.204
+      Test::Deep::SubHashElements 1.204
+      Test::Deep::SubHashKeys 1.204
+      Test::Deep::SubHashKeysOnly 1.204
+      Test::Deep::SuperHash 1.204
+      Test::Deep::SuperHashElements 1.204
+      Test::Deep::SuperHashKeys 1.204
+      Test::Deep::SuperHashKeysOnly 1.204
+    requirements:
+      ExtUtils::MakeMaker 6.78
+      List::Util 1.09
+      Scalar::Util 1.09
+      Test::Builder 0
+      Test::More 0.96
+      perl 5.012
+  common-sense-3.75
+    pathname: M/ML/MLEHMANN/common-sense-3.75.tar.gz
+    provides:
+      common::sense 3.75
     requirements:
       ExtUtils::MakeMaker 0

--- a/frameworks/Perl/mojolicious/mojolicious.dockerfile
+++ b/frameworks/Perl/mojolicious/mojolicious.dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.26
+FROM perl:5.40
 
 WORKDIR /mojo
 
@@ -19,3 +19,4 @@ ADD ./app.pl ./
 EXPOSE 8080
 
 CMD hypnotoad -f /mojo/app.pl
+

--- a/frameworks/Perl/plack/README.md
+++ b/frameworks/Perl/plack/README.md
@@ -9,4 +9,5 @@ Plack
 * Twiggy::Prefork
 * JSON::XS
 * AnyEvent::DBI
-* DBD::mysql
+* DBD::MariaDB
+

--- a/frameworks/Perl/plack/app-async.psgi
+++ b/frameworks/Perl/plack/app-async.psgi
@@ -5,7 +5,7 @@ use AnyEvent::DBI;
 use Unix::Processors;
 use List::Util qw'min max';
 
-my @dsn = ('dbi:mysql:database=hello_world;host=tfb-database;port=3306', 'benchmarkdbuser', 'benchmarkdbpass');
+my @dsn = ('dbi:MariaDB:database=hello_world;host=tfb-database;port=3306', 'benchmarkdbuser', 'benchmarkdbpass');
 my $query = 'select randomNumber, id from World where id = ?';
 
 sub {
@@ -37,3 +37,4 @@ sub {
     }
     [404, [qw(Content-Type application/json)], ['not found']]
 }
+

--- a/frameworks/Perl/plack/app.pl
+++ b/frameworks/Perl/plack/app.pl
@@ -7,10 +7,10 @@ my $cpus = Unix::Processors->new->max_online;
 
 my @cmd = (
     ($opts->{a} # async server
-     ? [qw'plackup -s Twiggy::Prefork -E production --max-reqs-per-child=0 --backlog 16384
+     ? [qw'plackup -s Twiggy::Prefork -E production --max-reqs-per-child=100000 --backlog 16384
            --max-workers', $cpus, qw'-l /dev/shm/app.sock -a app-async.psgi']
      : [qw'start_server --backlog 16384 --path /dev/shm/app.sock --
-           plackup -s Gazelle -E production --max-reqs-per-child 10000000
+           plackup -s Gazelle -E production --max-reqs-per-child 100000
            --max-workers', $cpus, qw'-a app.psgi']),
     [qw'nginx -c nginx.conf -p', getcwd]
 );

--- a/frameworks/Perl/plack/app.psgi
+++ b/frameworks/Perl/plack/app.psgi
@@ -5,9 +5,9 @@ use List::Util qw'min max';
 
 sub {
     state $dbh = DBI->connect(
-	'dbi:mysql:database=hello_world;host=tfb-database;port=3306',
+	'dbi:MariaDB:database=hello_world;host=tfb-database;port=3306',
 	'benchmarkdbuser', 'benchmarkdbpass',
-	+{ qw'RaiseError 0 PrintError 0 mysql_enable_utf8 1' }
+	+{ qw'RaiseError 0 PrintError 0' }
     ) || die $!;
     state $sth = $dbh->prepare('select id,randomnumber from world where id = ?');
     my $env = shift;
@@ -25,3 +25,4 @@ sub {
     }
     [ 404, [], ['not found']];
 }
+

--- a/frameworks/Perl/plack/plack-async.dockerfile
+++ b/frameworks/Perl/plack/plack-async.dockerfile
@@ -1,7 +1,7 @@
 FROM perl:latest
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
-RUN cpanm --notest --no-man-page Plack JSON::XS Unix::Processors DBI DBD::mysql
+RUN cpanm --notest --no-man-page Plack JSON::XS Unix::Processors DBI DBD::MariaDB
 RUN cpanm --notest --no-man-page Cookie::Baker::XS Twiggy::Prefork HTTP::Parser::XS EV AnyEvent::DBI
 
 ADD nginx.conf ./
@@ -11,3 +11,4 @@ ADD app-async.psgi ./
 EXPOSE 8080
 
 CMD perl app.pl -a
+

--- a/frameworks/Perl/plack/plack.dockerfile
+++ b/frameworks/Perl/plack/plack.dockerfile
@@ -1,7 +1,7 @@
 FROM perl:latest
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
-RUN cpanm --notest --no-man-page Plack JSON::XS Unix::Processors DBI DBD::mysql
+RUN cpanm --notest --no-man-page Plack JSON::XS Unix::Processors DBI DBD::MariaDB
 RUN cpanm --notest --no-man-page Gazelle Cookie::Baker::XS
 
 ADD nginx.conf ./
@@ -11,3 +11,4 @@ ADD app.psgi ./
 EXPOSE 8080
 
 CMD perl app.pl
+

--- a/frameworks/Perl/web-simple/README.md
+++ b/frameworks/Perl/web-simple/README.md
@@ -7,7 +7,7 @@
 # Requirements
 
 * Web::Simple
-* DBD::mysql
+* DBD::MariaDB
 * Starman (if using Starman as web server)
 * Plack (for plackup)
 * nginx (if you want to front Dancer with nginx, nginx.conf provided)
@@ -21,3 +21,4 @@ Something along the lines of
 if you want to front it with nginx, otherwise
 
     plackup -E production -s Starman --port=8080 --workers=8 -a ./app.pl
+

--- a/frameworks/Perl/web-simple/app.pl
+++ b/frameworks/Perl/web-simple/app.pl
@@ -4,7 +4,7 @@ use JSON::XS;
 use DBI;
 
 sub get_database_handle {
-    DBI->connect_cached('dbi:mysql:database=hello_world;host=tfb-database', 'benchmarkdbuser', 'benchmarkdbpass', { RaiseError => 1 });
+    DBI->connect_cached('dbi:MariaDB:database=hello_world;host=tfb-database', 'benchmarkdbuser', 'benchmarkdbpass', { RaiseError => 1 });
 }
 
 sub dispatch_request {
@@ -54,3 +54,4 @@ sub dispatch_request {
 }
 
 __PACKAGE__->run_if_script;
+

--- a/frameworks/Perl/web-simple/benchmark_config.json
+++ b/frameworks/Perl/web-simple/benchmark_config.json
@@ -19,7 +19,8 @@
       "display_name": "web-simple",
       "notes": "",
       "versus": "",
-      "tags": ["broken"]
+      "tags": []
     }
   }]
 }
+

--- a/frameworks/Perl/web-simple/web-simple.dockerfile
+++ b/frameworks/Perl/web-simple/web-simple.dockerfile
@@ -21,4 +21,5 @@ EXPOSE 8080
 
 CMD nginx -c /simple/nginx.conf && \
     plackup -E production -s Starman --workers=$(nproc) \
+    --max-requests=100000 \
     -l /tmp/perl-simple.sock -a /simple/app.pl

--- a/frameworks/Perl/web-simple/web-simple.dockerfile
+++ b/frameworks/Perl/web-simple/web-simple.dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.26
+FROM perl:5.40
 
 RUN apt-get update -yqq && apt-get install -yqq nginx
 
@@ -8,7 +8,7 @@ RUN cpanm --notest --no-man-page  \
         JSON JSON::XS IO::Socket::IP IO::Socket::SSL \
         Web::Simple@0.033 \
         DBI@1.637 \
-        DBD::mysql@4.043 \
+        DBD::MariaDB@1.23 \
         Plack@1.0044 \
         Starman@0.4014 \
         JSON::XS@3.04
@@ -23,3 +23,4 @@ CMD nginx -c /simple/nginx.conf && \
     plackup -E production -s Starman --workers=$(nproc) \
     --max-requests=100000 \
     -l /tmp/perl-simple.sock -a /simple/app.pl
+


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
This PR attempts to unify the value of maximum requests per child to one hundred thousand across all Perl frameworks. This value can have drastic effects on performance and it was varying greatly across the frameworks. `100000` is not an unrealistic value and should allow the frameworks to still compete with other, faster languages. On the other hand, it will make comparisons between different Perl frameworks more accurate.

As a result of this PR, Mojolicious and Plack should become a bit slower, while Dancer and Web::Simple should become quite a lot faster. Kelp was already set to a proper value in recently merged PR.