### PR TITLE
jooby: upgrade 3.2.4

### DIFF
--- a/frameworks/Java/jooby/pom.xml
+++ b/frameworks/Java/jooby/pom.xml
@@ -11,8 +11,8 @@
   <name>jooby</name>
 
   <properties>
-    <jooby.version>3.1.2</jooby.version>
-    <netty.version>4.1.110.Final</netty.version>
+    <jooby.version>3.2.4</jooby.version>
+    <netty.version>4.1.111.Final</netty.version>
     <dsl-json.version>2.0.2</dsl-json.version>
     <postgresql.version>42.7.3</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/frameworks/Java/jooby/src/main/java/com/techempower/App.java
+++ b/frameworks/Java/jooby/src/main/java/com/techempower/App.java
@@ -28,13 +28,8 @@ public class App extends Jooby {
 
   private static final byte[] MESSAGE_BYTES = MESSAGE.getBytes(StandardCharsets.US_ASCII);
 
-  private static final ByteBuffer MESSAGE_BUFFER = (ByteBuffer) ByteBuffer
-      .allocateDirect(MESSAGE_BYTES.length)
-      .put(MESSAGE_BYTES)
-      .flip();
-
   {
-
+    var bufferFactory = getBufferFactory();
     /** Database: */
     install(new HikariModule());
     DataSource ds = require(DataSource.class);
@@ -43,7 +38,7 @@ public class App extends Jooby {
     install(new RockerModule());
 
     get("/plaintext", ctx ->
-        ctx.send(MESSAGE_BUFFER.duplicate())
+        ctx.send(bufferFactory.wrap(MESSAGE_BYTES))
     );
 
     get("/json", ctx -> ctx

--- a/frameworks/Java/jooby/src/main/java/com/techempower/rocker/BufferRockerOutput.java
+++ b/frameworks/Java/jooby/src/main/java/com/techempower/rocker/BufferRockerOutput.java
@@ -1,0 +1,65 @@
+package com.techempower.rocker;
+
+import com.fizzed.rocker.ContentType;
+import com.fizzed.rocker.RockerOutput;
+import com.fizzed.rocker.RockerOutputFactory;
+
+import java.io.IOException;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class BufferRockerOutput implements RockerOutput<BufferRockerOutput> {
+    private final ByteBuffer buffer;
+
+    public BufferRockerOutput(ByteBuffer buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public ContentType getContentType() {
+        return ContentType.RAW;
+    }
+
+    @Override
+    public Charset getCharset() {
+        return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public BufferRockerOutput w(String string) throws IOException {
+        buffer.put(string.getBytes(getCharset()));
+        return this;
+    }
+
+    @Override
+    public BufferRockerOutput w(byte[] bytes) throws IOException {
+        buffer.put(bytes);
+        return this;
+    }
+
+    @Override
+    public int getByteLength() {
+        return buffer.remaining();
+    }
+
+    public ByteBuffer toBuffer() {
+        return buffer.flip();
+    }
+
+    public static RockerOutputFactory<BufferRockerOutput> factory() {
+        var cache = new ThreadLocal<BufferRockerOutput>() {
+            @Override
+            protected BufferRockerOutput initialValue() {
+                return new BufferRockerOutput(ByteBuffer.allocateDirect(2048));
+            }
+        };
+        return (contentType, charsetName) -> cache.get().reset();
+    }
+
+    private BufferRockerOutput reset() {
+        buffer.clear();
+        return this;
+    }
+}


### PR DESCRIPTION
- get back threadlocal buffer for fortunes
- implements vertx like sql updates

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
