### PR TITLE
Gnet is unrealistic

### DIFF
--- a/frameworks/Go/gnet/benchmark_config.json
+++ b/frameworks/Go/gnet/benchmark_config.json
@@ -4,7 +4,7 @@
     "default": {
       "plaintext_url": "/plaintext",
       "port": 8080,
-      "approach": "Realistic",
+      "approach": "Unrealistic",
       "classification": "Platform",
       "database": "None",
       "framework": "gnet",


### PR DESCRIPTION
gnet is definitely not realistic.

* Its entire "HTTP parser" is a 1-line seek for "\r\n\r\n" and doesn't even handle a TCP segment being... segmented. It does no header parsing whatsoever.
* Its response is fully pre-formatted except for the Date.

gnet is baically a TCP benchmark, not an HTTP benchmark. Any TCP server could be made as complex as gnet with less than 5 lines of code added.

Therefore, it definitely is not "realistic". Especially not since it literally placed 1st in Round 22. How this slipped past quality control is beyond me, but also doesn't shock me.