### PR TITLE
[rails] Enable YJIT after boot

### DIFF
--- a/frameworks/Ruby/rails/config/initializers/enable_yjit.rb
+++ b/frameworks/Ruby/rails/config/initializers/enable_yjit.rb
@@ -1,0 +1,11 @@
+# Automatically enable YJIT as of Ruby 3.3, as it bring very
+# sizeable performance improvements.
+
+# If you are deploying to a memory constrained environment
+# you may want to delete this file, but otherwise it's free
+# performance.
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end

--- a/frameworks/Ruby/rails/rails-mysql.dockerfile
+++ b/frameworks/Ruby/rails/rails-mysql.dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends redis-se
 EXPOSE 8080
 WORKDIR /rails
 
-ENV RUBY_YJIT_ENABLE=1
+# ENV RUBY_YJIT_ENABLE=1 YJIT is enabled in config/initializers/enable_yjit.rb
 
 # Use Jemalloc
 RUN apt-get update && \

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends redis-se
 EXPOSE 8080
 WORKDIR /rails
 
-ENV RUBY_YJIT_ENABLE=1
+# ENV RUBY_YJIT_ENABLE=1 YJIT is enabled in config/initializers/enable_yjit.rb
+
 # Use Jemalloc
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2


### PR DESCRIPTION
There is no need to run the JIT on code that is only used during boot. This is also the new default in newer Rails applications.