### PR TITLE
[php] Fix Swoole and faster docker builds

### DIFF
--- a/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
+++ b/frameworks/PHP/laravel/laravel-laravel-s.dockerfile
@@ -1,25 +1,17 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-RUN docker-php-ext-install pdo_mysql pcntl opcache > /dev/null
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-ADD ./ /laravel
 WORKDIR /laravel
+COPY --link . .
 
 RUN mkdir -p /laravel/bootstrap/cache /laravel/storage/logs /laravel/storage/framework/sessions /laravel/storage/framework/views /laravel/storage/framework/cache
-RUN chmod -R 777 /laravel
 
-RUN apt-get update > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php && php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
-
-COPY deploy/laravel-s/composer.json ./
+COPY --link deploy/laravel-s/composer.json .
 
 RUN echo "LARAVELS_LISTEN_IP=0.0.0.0" >> .env
 RUN echo "LARAVELS_LISTEN_PORT=8080" >> .env
@@ -30,4 +22,4 @@ RUN php artisan laravels publish
 
 EXPOSE 8080
 
-CMD php bin/laravels start
+ENTRYPOINT [ "php", "bin/laravels", "start" ]

--- a/frameworks/PHP/laravel/laravel-swoole.dockerfile
+++ b/frameworks/PHP/laravel/laravel-swoole.dockerfile
@@ -1,33 +1,23 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-RUN docker-php-ext-install pdo_mysql pcntl opcache > /dev/null
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-ADD ./ /laravel
 WORKDIR /laravel
+COPY --link . .
 
 RUN mkdir -p /laravel/bootstrap/cache  /laravel/storage/framework/sessions /laravel/storage/framework/views /laravel/storage/framework/cache
-RUN chmod -R 777 /laravel
 
-RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
-
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php && php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
-
-COPY deploy/swoole/composer.json ./
+COPY --link deploy/swoole/composer.json .
 
 RUN echo "APP_SWOOLE=true" >> .env
 
 RUN composer install -a --no-dev --quiet
 RUN php artisan optimize
 
-
 EXPOSE 8080
 
-CMD php artisan swoole:http start
+ENTRYPOINT [ "php", "artisan", "swoole:http", "start" ]

--- a/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
+++ b/frameworks/PHP/lumen/lumen-laravel-s.dockerfile
@@ -1,23 +1,16 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-RUN docker-php-ext-install pdo_mysql pcntl opcache > /dev/null
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 #RUN echo "opcache.jit=1205" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 #RUN echo "opcache.jit_buffer_size=128M" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-ADD ./ /lumen
 WORKDIR /lumen
+ADD --link . .
 
 RUN mkdir -p /lumen/bootstrap/cache /lumen/storage/logs /lumen/storage/framework/sessions /lumen/storage/framework/views /lumen/storage/framework/cache
 RUN chmod -R 777 /lumen
-
-RUN apt-get update > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
-RUN php -r "copy('https://install.phpcomposer.com/installer', 'composer-setup.php');" && php composer-setup.php && php -r "unlink('composer-setup.php');"
-RUN mv composer.phar /usr/local/bin/composer
 
 COPY deploy/laravel-s/composer.json ./
 
@@ -29,4 +22,4 @@ RUN php artisan laravels publish
 
 EXPOSE 8080
 
-CMD php bin/laravels start
+ENTRYPOINT [ "php", "bin/laravels", "start" ]

--- a/frameworks/PHP/lumen/lumen-swoole.dockerfile
+++ b/frameworks/PHP/lumen/lumen-swoole.dockerfile
@@ -1,31 +1,16 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
-RUN docker-php-ext-install pdo_mysql > /dev/null
-
-ADD ./ /lumen
 WORKDIR /lumen
-COPY deploy/swoole/php.ini /usr/local/etc/php/
+ADD --link . .
 
-RUN mkdir -p /lumen/storage/framework/sessions
-RUN mkdir -p /lumen/storage/framework/views
-RUN mkdir -p /lumen/storage/framework/cache
+COPY --link deploy/swoole/php.ini /usr/local/etc/php/
 
-RUN chmod -R 777 /lumen
-
-# Install composer using the installation method documented at https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
-# This method was chosen because composer is not part of the apt repositories that are in the default PHP 7.2 docker image
-# Adding alternate apt php repos can potentially cause problems with extension compatibility between the php build from the docker image and the alternate php build
-# An additional benefit of this method is that the correct version of composer will be used for the environment and version of the php system in the docker image
-RUN deploy/swoole/install-composer.sh
-
-RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
+RUN mkdir -p /lumen/storage/framework/sessions /lumen/storage/framework/views /lumen/storage/framework/cache
 
 COPY deploy/swoole/composer* ./
-RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN echo "APP_SWOOLE=true" >> .env
 
@@ -33,4 +18,4 @@ RUN chmod -R 777 /lumen
 
 EXPOSE 8080
 
-CMD php artisan swoole:http start
+ENTRYPOINT [ "php", "artisan", "swoole:http", "start" ]

--- a/frameworks/PHP/mixphp/mixphp-swoole-mysql.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp-swoole-mysql.dockerfile
@@ -1,13 +1,10 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && docker-php-ext-enable swoole
+RUN docker-php-ext-install pcntl opcache bcmath > /dev/null
 
-RUN docker-php-ext-install opcache pdo_mysql bcmath > /dev/null
-
-RUN apt -yqq update && apt -yqq install git unzip > /dev/null
-
-COPY . /mixphp
-COPY php.ini /usr/local/etc/php/
+WORKDIR /mixphp
+COPY --link . .
+COPY --link php.ini /usr/local/etc/php/
 RUN echo "opcache.enable=1" >> /usr/local/etc/php/php.ini
 RUN echo "opcache.enable_cli=1" >> /usr/local/etc/php/php.ini
 RUN echo "pcre.jit=1" >> /usr/local/etc/php/php.ini
@@ -16,9 +13,6 @@ RUN echo "opcache.jit_buffer_size=256M" >> /usr/local/etc/php/php.ini
 
 RUN php -v && php -i | grep opcache
 
-WORKDIR /mixphp
-
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 RUN composer install --no-dev --classmap-authoritative --quiet > /dev/null
 RUN composer dumpautoload -o
 
@@ -27,4 +21,4 @@ RUN chmod -R 777 /mixphp/runtime/logs
 
 EXPOSE 9501
 
-CMD php /mixphp/bin/swoole.php start
+ENTRYPOINT [ "php", "/mixphp/bin/swoole.php", "start" ]

--- a/frameworks/PHP/simps/simps-micro.dockerfile
+++ b/frameworks/PHP/simps/simps-micro.dockerfile
@@ -1,22 +1,15 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-
-RUN docker-php-ext-install opcache pdo_mysql > /dev/null
-
-RUN apt -yqq update > /dev/null && \
-    apt -yqq install git unzip > /dev/null
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
 WORKDIR /simps
 
-COPY . /simps
-COPY php.ini /usr/local/etc/php/
+COPY --link . .
+COPY --link php.ini /usr/local/etc/php/
 
-RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN composer install --no-dev --classmap-authoritative --quiet > /dev/null
 RUN composer dumpautoload -o
 
 EXPOSE 8080
 
-CMD php sbin/simps.php http:start
+ENTRYPOINT [ "php", "sbin/simps.php", "http:start" ]

--- a/frameworks/PHP/simps/simps.dockerfile
+++ b/frameworks/PHP/simps/simps.dockerfile
@@ -1,22 +1,15 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-
-RUN docker-php-ext-install opcache pdo_mysql > /dev/null
-
-RUN apt -yqq update > /dev/null && \
-    apt -yqq install git unzip > /dev/null
+RUN docker-php-ext-install pcntl opcache curl > /dev/null
 
 WORKDIR /simps
 
-COPY . /simps
-COPY php.ini /usr/local/etc/php/
+COPY --link . .
+COPY --link php.ini /usr/local/etc/php/
 
-RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN composer install --no-dev --classmap-authoritative --quiet > /dev/null
 RUN composer dumpautoload -o
 
 EXPOSE 8080
 
-CMD php sbin/simps.php http:start
+ENTRYPOINT [ "php", "sbin/simps.php", "http:start" ]

--- a/frameworks/PHP/symfony/public/swoole.php
+++ b/frameworks/PHP/symfony/public/swoole.php
@@ -15,6 +15,6 @@ $_SERVER['APP_RUNTIME_OPTIONS'] = [
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-return function (array $context) {
+return function (array $context): Kernel {
     return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
 };

--- a/frameworks/PHP/symfony/symfony-swoole.dockerfile
+++ b/frameworks/PHP/symfony/symfony-swoole.dockerfile
@@ -1,16 +1,11 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
+RUN apt-get update -yqq && \
+    apt-get install -yqq libpq-dev libicu-dev > /dev/null && \
+    docker-php-ext-install pdo_pgsql opcache intl > /dev/null
 
 RUN pecl install apcu > /dev/null && \
     docker-php-ext-enable apcu
-
-RUN apt-get update -yqq && \
-    apt-get install -yqq libpq-dev libicu-dev git unzip > /dev/null && \ 
-    docker-php-ext-install pdo_pgsql opcache intl > /dev/null
-
-COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
 COPY --link deploy/swoole/php.ini /usr/local/etc/php/
 WORKDIR /symfony

--- a/frameworks/PHP/ubiquity/ubiquity-swoole-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-swoole-mysql.dockerfile
@@ -1,29 +1,17 @@
-FROM php:8.3-cli
+FROM phpswoole/swoole:5.1.3-php8.3
 
-RUN apt-get update > /dev/null
-
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
-
-RUN docker-php-ext-install pdo_mysql opcache pcntl > /dev/null
+RUN docker-php-ext-install pcntl opcache > /dev/null
 
 COPY deploy/conf/php-async.ini /usr/local/etc/php/php.ini
 
-ADD ./ /ubiquity
 WORKDIR /ubiquity
+ADD --link . .
 
 RUN chmod -R 777 /ubiquity
 
-RUN ["chmod", "+x", "deploy/run/install-composer.sh"]
+RUN composer require phpmv/ubiquity-devtools:dev-master phpmv/ubiquity-swoole:dev-master --quiet
 
-RUN deploy/run/install-composer.sh
-
-RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
-
-RUN php composer.phar require phpmv/ubiquity-devtools:dev-master phpmv/ubiquity-swoole:dev-master --quiet
-
-RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN chmod 777 -R /ubiquity/.ubiquity/*
 
@@ -36,4 +24,4 @@ COPY deploy/conf/swoole/mysql/swooleServices.php app/config/swooleServices.php
 
 EXPOSE 8080
 
-CMD /ubiquity/vendor/bin/Ubiquity serve -t=swoole -p=8080 -h=0.0.0.0
+ENTRYPOINT [ "/ubiquity/vendor/bin/Ubiquity", "serve", "-t=swoole", "-p=8080", "-h=0.0.0.0" ]

--- a/frameworks/PHP/ubiquity/ubiquity-swoole.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-swoole.dockerfile
@@ -1,9 +1,4 @@
-FROM php:8.3-cli
-
-RUN apt-get update > /dev/null
-
-RUN pecl install swoole > /dev/null && \
-    docker-php-ext-enable swoole
+FROM phpswoole/swoole:5.1.3-php8.3
 
 RUN apt-get install -y libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
@@ -11,21 +6,14 @@ RUN apt-get install -y libpq-dev \
 
 COPY deploy/conf/php-async.ini /usr/local/etc/php/php.ini
 
-ADD ./ /ubiquity
 WORKDIR /ubiquity
+ADD --link . .
 
 RUN chmod -R 777 /ubiquity
 
-RUN ["chmod", "+x", "deploy/run/install-composer.sh"]
+RUN composer require phpmv/ubiquity-devtools:dev-master phpmv/ubiquity-swoole:dev-master --quiet
 
-RUN deploy/run/install-composer.sh
-
-RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git unzip > /dev/null
-
-RUN php composer.phar require phpmv/ubiquity-devtools:dev-master phpmv/ubiquity-swoole:dev-master --quiet
-
-RUN php composer.phar install --optimize-autoloader --classmap-authoritative --no-dev --quiet
+RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
 RUN chmod 777 -R /ubiquity/.ubiquity/*
 
@@ -38,4 +26,4 @@ COPY deploy/conf/swoole/pgsql/swooleServices.php app/config/swooleServices.php
 
 EXPOSE 8080
 
-CMD /ubiquity/vendor/bin/Ubiquity serve -t=swoole -p=8080 -h=0.0.0.0
+ENTRYPOINT [ "/ubiquity/vendor/bin/Ubiquity", "serve", "-t=swoole", "-p=8080", "-h=0.0.0.0" ]


### PR DESCRIPTION
The last version require `libbrotlienc` and break the build in last runs. Also break the semantic versioning.
We can add `libbrotli-dev `before install Swoole, but this will break the docker cache from our last PR. And Swoole need some time to compile.

Now we use `phpswoole/swoole:5.1.3-php8.3` docker image, to have faster docker builds and fix this and future problems.

