### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.16.0

### DIFF
--- a/frameworks/Java/activeweb/pom.xml
+++ b/frameworks/Java/activeweb/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 

--- a/frameworks/Java/bayou/pom.xml
+++ b/frameworks/Java/bayou/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
 
     </dependencies>

--- a/frameworks/Java/grizzly/pom.xml
+++ b/frameworks/Java/grizzly/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/frameworks/Java/httpserver/pom.xml
+++ b/frameworks/Java/httpserver/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/frameworks/Java/jlhttp/pom.xml
+++ b/frameworks/Java/jlhttp/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/frameworks/Java/microhttp/pom.xml
+++ b/frameworks/Java/microhttp/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/frameworks/Java/nanohttpd/pom.xml
+++ b/frameworks/Java/nanohttpd/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.4.2</version>
+        <version>2.16.0</version>
     </dependency>
     <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>

--- a/frameworks/Java/servlet/pom.xml
+++ b/frameworks/Java/servlet/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<cache2k-version>1.2.3.Final</cache2k-version>
-		<jackson-version>2.13.4.2</jackson-version>
+		<jackson-version>2.16.0</jackson-version>
 		<!-- This is the default web.xml for plaintext and json only -->
 		<maven.war.xml>src/main/webapp/WEB-INF/web.xml</maven.war.xml>
 	</properties>

--- a/frameworks/Java/servlet3/pom.xml
+++ b/frameworks/Java/servlet3/pom.xml
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.4.2</version>
+			<version>2.16.0</version>
 		</dependency>
 
 		<dependency>

--- a/frameworks/Java/tapestry/pom.xml
+++ b/frameworks/Java/tapestry/pom.xml
@@ -95,7 +95,7 @@ of testing facilities designed for use with TestNG (http://testng.org/), so it's
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>

--- a/frameworks/Java/undertow-jersey/pom.xml
+++ b/frameworks/Java/undertow-jersey/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/frameworks/Java/undertow/pom.xml
+++ b/frameworks/Java/undertow/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.release>18</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <hikaricp.version>5.0.1</hikaricp.version>
-    <jackson.version>2.13.4.2</jackson.version>
+    <jackson.version>2.16.0</jackson.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>

--- a/frameworks/Prolog/tuProlog/pom.xml
+++ b/frameworks/Prolog/tuProlog/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>16</maven.compiler.target>
         <tuprolog.version>0.18.2</tuprolog.version>
         <vertx.version>4.3.8</vertx.version>
-        <jackson.version>2.13.4.2</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.13.4.2
- [CVE-2022-42003](https://www.oscs1024.com/hd/CVE-2022-42003)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.4.2 to 2.16.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS