### PR TITLE
Update to MySQL 9.0

### DIFF
--- a/toolset/databases/mysql/create.sql
+++ b/toolset/databases/mysql/create.sql
@@ -2,14 +2,14 @@
 # http://stackoverflow.com/questions/37719818/the-server-time-zone-value-aest-is-unrecognized-or-represents-more-than-one-ti
 SET GLOBAL time_zone = '+00:00';
 
-CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'%' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
-CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'localhost' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
+CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'%' IDENTIFIED WITH caching_sha2_password BY 'benchmarkdbpass';
+CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'benchmarkdbpass';
 
 -- GitHub Actions/CI run the database server on the same system as the benchmarks.
 -- Because we setup MySQL with the skip-name-resolve option, the IP address 127.0.0.1 might not be resolved to localhost
 -- anymore. This does not seem to matter, as long as Unix sockets are being used (e.g. when setting up the docker image),
 -- because the host is set to be localhost implicitly, but it matters for local TCP connections.
-CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'benchmarkdbpass';
+CREATE USER IF NOT EXISTS 'benchmarkdbuser'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY 'benchmarkdbpass';
 
 # modified from SO answer http://stackoverflow.com/questions/5125096/for-loop-in-mysql
 CREATE DATABASE IF NOT EXISTS hello_world;

--- a/toolset/databases/mysql/my.cnf
+++ b/toolset/databases/mysql/my.cnf
@@ -16,7 +16,7 @@ default-character-set=utf8
 # * Basic Settings
 #
 default-storage-engine = innodb
-mysql_native_password = ON
+#mysql_native_password = ON  # disabled in v9
 #default_authentication_plugin = mysql_native_password
 
 user            = mysql

--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.4
+FROM mysql:9.0
 
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=benchmarkdbuser


### PR DESCRIPTION
See #9175
Using the new auth default `caching_sha2_password`.

Checking the frameworks that fail.

~Work in progress.~
EDIT: I didn't see any framework that fail with the new auth.
Some fail, but also fail in the last runs.