### PR TITLE
[go] Silverlining change display name in prefork

### DIFF
--- a/frameworks/Go/silverlining/benchmark_config.json
+++ b/frameworks/Go/silverlining/benchmark_config.json
@@ -35,7 +35,7 @@
         "webserver": "None",
         "os": "Linux",
         "database_os": "Linux",
-        "display_name": "silverlining",
+        "display_name": "silverlining [prefork]",
         "notes": "",
         "versus": "go"
       }


### PR DESCRIPTION
As it have the same `display_name` don't exist distinction with the prefork variant.
