### PR TITLE
Add CodeBehind Framework

### DIFF
--- a/frameworks/CSharp/codebehind/Benchmarks.csproj
+++ b/frameworks/CSharp/codebehind/Benchmarks.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="CodeBehind" Version="3.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/frameworks/CSharp/codebehind/Benchmarks.csproj.user
+++ b/frameworks/CSharp/codebehind/Benchmarks.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ActiveDebugProfile>https</ActiveDebugProfile>
+  </PropertyGroup>
+</Project>

--- a/frameworks/CSharp/codebehind/Program.cs
+++ b/frameworks/CSharp/codebehind/Program.cs
@@ -1,0 +1,13 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddMemoryCache();
+
+ConnectionString.Set(builder.Configuration.GetConnectionString("BenchmarkConnection"));
+
+var app = builder.Build();
+
+SetCodeBehind.CodeBehindCompiler.Initialization();
+
+app.UseCodeBehind();
+
+app.Run();

--- a/frameworks/CSharp/codebehind/appsettings.Development.json
+++ b/frameworks/CSharp/codebehind/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/frameworks/CSharp/codebehind/appsettings.json
+++ b/frameworks/CSharp/codebehind/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "BenchmarkConnection": "Server=localhost;Database=YourDatabaseName;User ID=YourUsername;Password=YourPassword;"
+  }
+}

--- a/frameworks/CSharp/codebehind/code_behind/dll_import_list.ini
+++ b/frameworks/CSharp/codebehind/code_behind/dll_import_list.ini
@@ -1,0 +1,6 @@
+[CodeBehind dll import list]
+dll_path={run_time_path}/System.IO.dll
+dll_path={run_time_path}/System.Collections.dll
+dll_path={run_time_path}/System.Linq.dll
+dll_path={run_time_path}/System.Threading.dll
+dll_path={run_time_path}/System.Web.HttpUtility.dll

--- a/frameworks/CSharp/codebehind/controller/CachedQueriesController.cs
+++ b/frameworks/CSharp/codebehind/controller/CachedQueriesController.cs
@@ -1,0 +1,46 @@
+using CodeBehind;
+using System.Text.Json;
+
+public partial class CachedQueriesController : CodeBehindController
+{
+    public async void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "application/json";
+
+        Write(await GetCachedResult(context));
+    }
+
+    private async Task<string> GetCachedResult(HttpContext context)
+    {
+        string Count = context.Request.Query["count"];
+
+        ViewCache cache = new ViewCache(context);
+        string CacheResult = cache.GetViewCache("cached_query_" + Count);
+        if (cache.ViewHasCache)
+            return CacheResult;
+
+        CacheResult = LoadMultipleCachedQueryRow(Count.ToNumber());
+        cache.SetViewCache("cached_query_" + Count, CacheResult, 3600);
+        return CacheResult;
+    }
+
+    private string LoadMultipleCachedQueryRow(int Count)
+    {
+        Count = Count < 1 ? 1 : Count > 500 ? 500 : Count;
+
+        var wr = new CachedWorldRow[Count];
+        var dbc = new DatabaseContext();
+        var random = new Random();
+
+        for (int i = 0; i < Count; i++)
+        {
+            int RandomId = random.Next(1, 10001);
+            var row = dbc.CachedWorld.Find(RandomId);
+            wr[i] = row;
+        }
+
+        string json = JsonSerializer.Serialize(wr);
+
+        return json;
+    }
+}

--- a/frameworks/CSharp/codebehind/controller/DBController.cs
+++ b/frameworks/CSharp/codebehind/controller/DBController.cs
@@ -1,0 +1,26 @@
+using CodeBehind;
+using System.Text.Json;
+
+public partial class DBController : CodeBehindController
+{
+    public async void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "application/json";
+
+        Write(await LoadSingleQueryRow());
+    }
+
+    private async Task<string> LoadSingleQueryRow()
+    {
+        var dbc = new DatabaseContext();
+        //var row = new WorldRow { randomNumber = new Random().Next(1, 10001)};
+        //dbc.World.Add(row);
+        //dbc.SaveChanges();
+
+        int RandomId = Random.Shared.Next(1, 10001);
+        var world = dbc.World.Find(RandomId);
+        string json = JsonSerializer.Serialize(world);
+
+        return json;
+    }
+}

--- a/frameworks/CSharp/codebehind/controller/FortunesController.cs
+++ b/frameworks/CSharp/codebehind/controller/FortunesController.cs
@@ -1,0 +1,30 @@
+using CodeBehind;
+using Microsoft.EntityFrameworkCore;
+
+public partial class FortunesController : CodeBehindController
+{
+    public async void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "text/html; charset=UTF-8";
+
+        await LoadFortunesRows();
+    }
+
+    private readonly Func<DatabaseContext, IEnumerable<FortuneRow>> _FortunesQuery
+    = EF.CompileQuery((DatabaseContext context) => context.Fortune);
+
+    private async Task<string> LoadFortunesRows()
+    {
+        FortunesModel model = new FortunesModel();
+        var dbc = new DatabaseContext();
+
+        foreach (var fortune in _FortunesQuery(dbc))
+            model.Fortune.Add(fortune);
+
+        model.Fortune.Add(new FortuneRow { message = "Additional fortune added at request time." });
+
+        model.Fortune.Sort();
+        View(model);
+        return "";
+    }
+}

--- a/frameworks/CSharp/codebehind/controller/JsonController.cs
+++ b/frameworks/CSharp/codebehind/controller/JsonController.cs
@@ -1,0 +1,20 @@
+using CodeBehind;
+using System.Text.Json;
+
+public partial class JsonController : CodeBehindController
+{
+    public void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "application/json";
+
+        MyJsonObject MyObject = new MyJsonObject { message = "Hello, World!" };
+        string json = JsonSerializer.Serialize(MyObject);
+
+        Write(json);
+    }
+}
+
+public class MyJsonObject
+{
+    public string message { get; set; }
+}

--- a/frameworks/CSharp/codebehind/controller/PlainTextController.cs
+++ b/frameworks/CSharp/codebehind/controller/PlainTextController.cs
@@ -1,0 +1,11 @@
+using CodeBehind;
+
+public partial class PlainTextController : CodeBehindController
+{
+    public void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "text/plain";
+
+        Write("Hello, World!");
+    }
+}

--- a/frameworks/CSharp/codebehind/controller/QueriesController.cs
+++ b/frameworks/CSharp/codebehind/controller/QueriesController.cs
@@ -1,0 +1,32 @@
+using CodeBehind;
+using System.Text.Json;
+
+public partial class QueriesController : CodeBehindController
+{
+    public async void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "application/json";
+        int Count = context.Request.Query["queries"].ToNumber();
+
+        Write(await LoadMultipleQueryRow(Count));
+    }
+
+    private async Task<string> LoadMultipleQueryRow(int Count)
+    {
+        Count = Count < 1 ? 1 : Count > 500 ? 500 : Count;
+
+        var wr = new WorldRow[Count];
+        var dbc = new DatabaseContext();
+
+        for (int i = 0; i < Count; i++)
+        {
+            int RandomId = Random.Shared.Next(1, 10001);
+            var row = dbc.World.Find(RandomId);
+            wr[i] = row;
+        }
+
+        string json = JsonSerializer.Serialize(wr);
+
+        return json;
+    }
+}

--- a/frameworks/CSharp/codebehind/controller/UpdateController.cs
+++ b/frameworks/CSharp/codebehind/controller/UpdateController.cs
@@ -1,0 +1,35 @@
+using CodeBehind;
+using System.Text.Json;
+
+public partial class UpdateController : CodeBehindController
+{
+    public async void PageLoad(HttpContext context)
+    {
+        context.Response.ContentType = "application/json";
+        int Count = context.Request.Query["queries"].ToNumber();
+
+        Write(await LoadUpdatesQueryRow(Count));
+    }
+
+    private async Task<string> LoadUpdatesQueryRow(int Count)
+    {
+        Count = Count < 1 ? 1 : Count > 500 ? 500 : Count;
+
+        var wr = new WorldRow[Count];
+        var dbc = new DatabaseContext();
+
+        for (int i = 0; i < Count; i++)
+        {
+            int RandomId = Random.Shared.Next(1, 10001);
+            var row = dbc.World.Find(RandomId);
+            row.randomNumber = Random.Shared.Next(1, 10001);
+            wr[i] = row;
+        }
+
+        dbc.SaveChangesAsync();
+
+        string json = JsonSerializer.Serialize(wr);
+
+        return json;
+    }
+}

--- a/frameworks/CSharp/codebehind/database/DatabaseContext.cs
+++ b/frameworks/CSharp/codebehind/database/DatabaseContext.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+public static class ConnectionString
+{
+    public static string? Value { get; set; }
+    public static string Set(string ConnectionString) => Value = ConnectionString;
+}
+
+public class DatabaseContext : DbContext
+{
+    public DatabaseContext() : base()
+    {
+        // Create Database And Tables If Database Not Exist; If Exist Database, If Never Exist Any Tables, Create Tables In Database
+        Database.EnsureCreated();
+    }
+
+    // Define Tables
+    public DbSet<WorldRow> World { get; set; }
+    public DbSet<CachedWorldRow> CachedWorld { get; set; }
+    public DbSet<FortuneRow> Fortune { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.UseSqlServer(ConnectionString.Value);
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+
+    }
+}
+
+/* Start Table Rows */
+
+public class WorldRow : object
+{
+    [Key]
+    public int id { get; set; }
+    public int randomNumber { get; set; }
+}
+
+public class CachedWorldRow : object
+{
+    [Key]
+    public int id { get; set; }
+    public int randomNumber { get; set; }
+}
+
+public class FortuneRow : IComparable<FortuneRow>, IComparable
+{
+    [Key]
+    public int id { get; set; }
+
+    [StringLength(2048)]
+    [IgnoreDataMember]
+    [Required]
+    public string? message { get; set; }
+
+    public int CompareTo(object? obj)
+    {
+        return CompareTo((FortuneRow?)obj);
+    }
+
+    public int CompareTo(FortuneRow? other)
+    {
+        return string.CompareOrdinal(message, other?.message);
+    }
+}
+
+/* End Table Rows */

--- a/frameworks/CSharp/codebehind/model/FortunesModel.cs
+++ b/frameworks/CSharp/codebehind/model/FortunesModel.cs
@@ -1,0 +1,4 @@
+public partial class FortunesModel
+{
+    public List<FortuneRow> Fortune = new List<FortuneRow>();
+}

--- a/frameworks/CSharp/codebehind/wwwroot/cached-queries/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/cached-queries/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller CachedQueriesController

--- a/frameworks/CSharp/codebehind/wwwroot/db/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/db/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller DBController

--- a/frameworks/CSharp/codebehind/wwwroot/fortunes/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/fortunes/Default.aspx
@@ -1,0 +1,11 @@
+﻿@page
+@controller FortunesController
+@model {FortunesModel}
+<!DOCTYPE html>
+<html>
+<head><title>Fortunes</title></head>
+<body><table><tr><th>id</th><th>message</th></tr>
+@foreach (var item in @model.Fortune)
+{<tr><td>@item.id</td><td>@(System.Web.HttpUtility.HtmlEncode(item.message))</td></tr>}
+</table></body>
+</html>

--- a/frameworks/CSharp/codebehind/wwwroot/json/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/json/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller JsonController

--- a/frameworks/CSharp/codebehind/wwwroot/plaintext/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/plaintext/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller PlainTextController

--- a/frameworks/CSharp/codebehind/wwwroot/queries/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/queries/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller QueriesController

--- a/frameworks/CSharp/codebehind/wwwroot/updates/Default.aspx
+++ b/frameworks/CSharp/codebehind/wwwroot/updates/Default.aspx
@@ -1,0 +1,2 @@
+﻿@page
+@controller UpdateController


### PR DESCRIPTION
**CodeBehind** is a modern back-end framework under ASP.NET Core. CodeBehind was developed by [Elanat](https://elanat.net) in 2023 and competes with Microsoft's default web frameworks (**ASP.NET Core MVC** and **Razor Pages** and **Blazor**). CodeBehind is an engineering masterpiece that simultaneously provides the possibility of development based on MVC, Model-View, Controller-View, only View and Web-Forms. The type of structure and naming in CodeBehind is a nostalgia that reminds of former Microsoft Web-Forms.

![ASP.NET Core web frameworks list](https://github.com/the-benchmarker/web-frameworks/assets/111444759/4a6de8a8-41fb-4784-abb2-7de82da16648)

This pull request is the source code of the FrameworkBenchmarks test, which is made with the CodeBehind framework and is ready to be compiled in .NET Core version 8.
It is necessary to explain that the CodeBehind framework creates the final View class on the first request and then compiles it. Before starting test, you need to make a request to the server once.
More information:
[How is the list of views finally made?](https://github.com/elanatframework/Code_behind/blob/elanat_framework/doc/how_is_the_list_of_views_finally_made.md)

Also, after completing the project and before performing the test, it is necessary to call the `Initialization` method in the `program.cs` class with the value true as shown below.
`SetCodeBehind.CodeBehindCompiler.Initialization(true);`

By setting the above code, the final View class is created and compiled only once, then the compiled assembly is also stored in the drive.; A new request after the application sleeps on the web server causes the assembly to be placed in memory from the drive.

> Note: If you make a request to the server once before testing and the test is done before the application goes to sleep on the web server, there is no need to change the Initialization method.

GitHub link:
https://github.com/elanatframework/Code_behind