### PR TITLE
Disable bulk update

### DIFF
--- a/frameworks/PHP/imi/ApiServer/Controller/PgController.php
+++ b/frameworks/PHP/imi/ApiServer/Controller/PgController.php
@@ -179,22 +179,18 @@ class PgController extends HttpController
         }
         $db = Db::getInstance(self::POOL_NAME);
         $stmtSelect = $db->prepare('SELECT id, randomnumber FROM World WHERE id = ? LIMIT 1');
-        $stmtUpdate = $db->prepare('UPDATE World SET randomNumber = CASE id' . \str_repeat(' WHEN ?::INTEGER THEN ?::INTEGER ', $queryCount) . 'END WHERE id IN (' . \str_repeat('?::INTEGER,', $queryCount - 1) . '?::INTEGER)');
+        $stmtUpdate = $db->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         $list = [];
-        $keys = $values = [];
         while ($queryCount--)
         {
-            $values[] = $keys[] = $id = \mt_rand(1, 10000);
+            $id = \mt_rand(1, 10000);
             $stmtSelect->execute([$id]);
             $row = $stmtSelect->fetch();
 
-            $values[] = $row['randomNumber'] = \mt_rand(1, 10000);
+            $row['randomNumber'] = \mt_rand(1, 10000);
+            $stmtUpdate->execute([$row['randomNumber'], $row['id']]);
             $list[] = $row;
         }
-        $stmtUpdate->execute([
-            ...$values,
-            ...$keys
-        ]);
 
         return $list;
     }

--- a/frameworks/PHP/kumbiaphp/bench/app/controllers/ku_controller.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/controllers/ku_controller.php
@@ -31,17 +31,15 @@ class KuController extends AppController
     {
         $count = min(max((int) $count, 1), 500);
         $random = KuRaw::$random;
+        $update = KuRaw::$update;
 
         while ($count--) {
-
             $random->execute([mt_rand(1, 10000)]);
             $row = $random->fetch();
             $row['randomNumber'] = mt_rand(1, 10000);
-
+            $update->execute([$row['randomNumber'], $row['id']]);
             $worlds[] = $row;
         }
-        
-        KuRaw::update($worlds);
 
         echo json_encode($worlds);
     }

--- a/frameworks/PHP/kumbiaphp/bench/app/libs/ku_raw.php
+++ b/frameworks/PHP/kumbiaphp/bench/app/libs/ku_raw.php
@@ -6,10 +6,7 @@ class KuRaw
     public static PDOStatement $db;
     public static PDOStatement $fortune;
     public static PDOStatement $random;
-    /**
-     * @var []PDOStatement
-     */
-    private static $update;
+    public static PDOStatement $update;
 
     public static function init()
     {
@@ -26,63 +23,7 @@ class KuRaw
 
         self::$fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
         self::$random    = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+        self::$update    = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         self::$instance  = $pdo;
-    }
-
-    /**
-     * Postgres bulk update
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = CASE id'
-                . str_repeat(' WHEN ?::INTEGER THEN ?::INTEGER ', $rows)
-                . 'END WHERE id IN ('
-                . str_repeat('?::INTEGER,', $rows - 1) . '?::INTEGER)';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        $keys = [];
-        foreach ($worlds as $world) {
-            $val[] = $keys[] = $world['id'];
-            $val[] = $world['randomNumber'];
-        }
-
-        self::$update[$rows]->execute([...$val, ...$keys]);
-    }
-
-    /**
-     * Alternative bulk update in Postgres
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update2(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = temp.randomNumber FROM (VALUES '
-                . implode(', ', array_fill(0, $rows, '(?::INTEGER, ?::INTEGER)')) .
-                ' ORDER BY 1) AS temp(id, randomNumber) WHERE temp.id = world.id';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        foreach ($worlds as $world) {
-            $val[] = $world['id'];
-            $val[] = $world['randomNumber'];
-            //$update->bindParam(++$i, $world['id'], PDO::PARAM_INT);
-        }
-
-        self::$update[$rows]->execute($val);
     }
 }

--- a/frameworks/PHP/php-ngx/app-pg.php
+++ b/frameworks/PHP/php-ngx/app-pg.php
@@ -36,16 +36,14 @@ function update()
     if ($params > 1) {
         $query_count = min($params, 500);
     }
-    while ($query_count--) {
 
+    while ($query_count--) {
         DbRaw::$random->execute([mt_rand(1, 10000)]);
         $row = DbRaw::$random->fetch();
         $row['randomNumber'] = mt_rand(1, 10000);
-
+        DbRaw::$update->execute([$row['randomNumber'], $row['id']]);
         $worlds[] = $row;
     }
-
-    DbRaw::update($worlds);
 
     echo json_encode($worlds, JSON_NUMERIC_CHECK);
 }

--- a/frameworks/PHP/php-ngx/dbraw.php
+++ b/frameworks/PHP/php-ngx/dbraw.php
@@ -6,10 +6,7 @@ class DbRaw
     public static PDOStatement $db;
     public static PDOStatement $fortune;
     public static PDOStatement $random;
-    /**
-     * @var []PDOStatement
-     */
-    private static $update;
+    public static PDOStatement $update;
 
     public static function init()
     {
@@ -26,63 +23,7 @@ class DbRaw
 
         self::$fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
         self::$random    = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+        self::$update    = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         self::$instance  = $pdo;
-    }
-
-    /**
-     * Postgres bulk update
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = CASE id'
-                . str_repeat(' WHEN ?::INTEGER THEN ?::INTEGER ', $rows)
-                . 'END WHERE id IN ('
-                . str_repeat('?::INTEGER,', $rows - 1) . '?::INTEGER)';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        $keys = [];
-        foreach ($worlds as $world) {
-            $val[] = $keys[] = $world['id'];
-            $val[] = $world['randomNumber'];
-        }
-
-        self::$update[$rows]->execute([...$val, ...$keys]);
-    }
-
-    /**
-     * Alternative bulk update in Postgres
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update2(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = temp.randomNumber FROM (VALUES '
-                . implode(', ', array_fill(0, $rows, '(?::INTEGER, ?::INTEGER)')) .
-                ' ORDER BY 1) AS temp(id, randomNumber) WHERE temp.id = world.id';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        foreach ($worlds as $world) {
-            $val[] = $world['id'];
-            $val[] = $world['randomNumber'];
-            //$update->bindParam(++$i, $world['id'], PDO::PARAM_INT);
-        }
-
-        self::$update[$rows]->execute($val);
     }
 }

--- a/frameworks/PHP/slim/db/Raw.php
+++ b/frameworks/PHP/slim/db/Raw.php
@@ -10,10 +10,7 @@ class Raw
     public static PDOStatement $db;
     public static PDOStatement $fortune;
     public static PDOStatement $random;
-    /**
-     * @var []PDOStatement
-     */
-    private static $update;
+    public static PDOStatement $update;
 
     public static function init()
     {
@@ -30,63 +27,7 @@ class Raw
 
         self::$fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
         self::$random    = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+        self::$update    = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         self::$instance  = $pdo;
-    }
-
-    /**
-     * Postgres bulk update
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = CASE id'
-                . str_repeat(' WHEN ?::INTEGER THEN ?::INTEGER ', $rows)
-                . 'END WHERE id IN ('
-                . str_repeat('?::INTEGER,', $rows - 1) . '?::INTEGER)';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        $keys = [];
-        foreach ($worlds as $world) {
-            $val[] = $keys[] = $world['id'];
-            $val[] = $world['randomNumber'];
-        }
-
-        self::$update[$rows]->execute([...$val, ...$keys]);
-    }
-
-    /**
-     * Alternative bulk update in Postgres
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update2(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = temp.randomNumber FROM (VALUES '
-                . implode(', ', array_fill(0, $rows, '(?::INTEGER, ?::INTEGER)')) .
-                ' ORDER BY 1) AS temp(id, randomNumber) WHERE temp.id = world.id';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        foreach ($worlds as $world) {
-            $val[] = $world['id'];
-            $val[] = $world['randomNumber'];
-            //$update->bindParam(++$i, $world['id'], PDO::PARAM_INT);
-        }
-
-        self::$update[$rows]->execute($val);
     }
 }

--- a/frameworks/PHP/slim/start.php
+++ b/frameworks/PHP/slim/start.php
@@ -74,6 +74,7 @@ $app->get('/updates', function (Request $request, Response $response) {
     }
 
     $sth = Raw::$random;
+    $update = Raw::$update;
     //$updateSth = Raw::update();
 
     $worlds = [];
@@ -81,11 +82,9 @@ $app->get('/updates', function (Request $request, Response $response) {
         $sth->execute([mt_rand(1, 10000)]);
         $world = $sth->fetch();
         $world['randomNumber'] = mt_rand(1, 10000);
-
+        $update->execute([$world['randomNumber'], $world['id']]);
         $worlds[] = $world;
     }
-
-    Raw::update($worlds);
 
     return $response
         ->withJson($worlds);

--- a/frameworks/PHP/webman/app/controller/Index.php
+++ b/frameworks/PHP/webman/app/controller/Index.php
@@ -83,6 +83,7 @@ class Index
     public function updates($request, $q = 1)
     {
         $random = Db::$random;
+        $update = Db::$update;
 
         $query_count = 1;
         if ((int) $q > 1) {
@@ -95,17 +96,13 @@ class Index
             $random->execute([\mt_rand(1, 10000)]);
             $world = $random->fetch();
             $world['randomNumber'] = \mt_rand(1, 10000);
-
+            $update->execute([$world['randomNumber'], $world['id']]);
             $worlds[] = $world;
         }
-
-        Db::update($worlds);
 
         return new Response(200, [
             'Content-Type' => 'application/json',
             'Date'         => Date::$date
         ], \json_encode($worlds));
     }
-
-
 }

--- a/frameworks/PHP/webman/app/controller/Index.php
+++ b/frameworks/PHP/webman/app/controller/Index.php
@@ -1,11 +1,9 @@
 <?php
 namespace app\controller;
 
-use support\Request;
 use support\bootstrap\Date;
 use support\bootstrap\db\Raw as Db;
 use support\Response;
-use PDO;
 
 class Index
 {

--- a/frameworks/PHP/workerman/app-pg.php
+++ b/frameworks/PHP/workerman/app-pg.php
@@ -69,6 +69,7 @@ function query($request)
 function updateraw($request)
 {
     $random = DbRaw::$random;
+    $update = DbRaw::$update;
 
     $query_count = 1;
     $q = (int) $request->get('q');
@@ -77,15 +78,12 @@ function updateraw($request)
     }
 
     while ($query_count--) {
-
         $random->execute([mt_rand(1, 10000)]);
         $row = $random->fetch();
         $row['randomNumber'] = mt_rand(1, 10000);
-
+        $update->execute([$row['randomNumber'], $row['id']]);
         $worlds[] = $row;
     }
-
-    DbRaw::update($worlds);
 
     return new Response(200, [
         'Content-Type' => 'application/json',

--- a/frameworks/PHP/workerman/dbraw.php
+++ b/frameworks/PHP/workerman/dbraw.php
@@ -6,10 +6,7 @@ class DbRaw
     public static PDOStatement $db;
     public static PDOStatement $fortune;
     public static PDOStatement $random;
-    /**
-     * @var []PDOStatement
-     */
-    private static $update;
+    public static PDOStatement $update;
 
     public static function init()
     {
@@ -26,63 +23,7 @@ class DbRaw
 
         self::$fortune   = $pdo->prepare('SELECT id,message FROM Fortune');
         self::$random    = $pdo->prepare('SELECT id,randomNumber FROM World WHERE id = ?');
+        self::$update    = $pdo->prepare('UPDATE World SET randomNumber=? WHERE id=?');
         self::$instance  = $pdo;
-    }
-
-    /**
-     * Postgres bulk update
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = CASE id'
-                . str_repeat(' WHEN ?::INTEGER THEN ?::INTEGER ', $rows)
-                . 'END WHERE id IN ('
-                . str_repeat('?::INTEGER,', $rows - 1) . '?::INTEGER)';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        $keys = [];
-        foreach ($worlds as $world) {
-            $val[] = $keys[] = $world['id'];
-            $val[] = $world['randomNumber'];
-        }
-
-        self::$update[$rows]->execute([...$val, ...$keys]);
-    }
-
-    /**
-     * Alternative bulk update in Postgres
-     *
-     * @param array $worlds
-     * @return void
-     */
-    public static function update2(array $worlds)
-    {
-        $rows = count($worlds);
-
-        if (!isset(self::$update[$rows])) {
-            $sql = 'UPDATE world SET randomNumber = temp.randomNumber FROM (VALUES '
-                . implode(', ', array_fill(0, $rows, '(?::INTEGER, ?::INTEGER)')) .
-                ' ORDER BY 1) AS temp(id, randomNumber) WHERE temp.id = world.id';
-
-            self::$update[$rows] = self::$instance->prepare($sql);
-        }
-
-        $val = [];
-        foreach ($worlds as $world) {
-            $val[] = $world['id'];
-            $val[] = $world['randomNumber'];
-            //$update->bindParam(++$i, $world['id'], PDO::PARAM_INT);
-        }
-
-        self::$update[$rows]->execute($val);
     }
 }


### PR DESCRIPTION
This PR is to address the issue that some frameworks do not modify database records one by one according to the Data Update requirements, but instead combine these modified records into a single SQL to achieve batch updates, which does not meet the requirements of the Data Update stress test.

Below are the requirements for Data Update:

```shell
Requirements summary

This test exercises database writes. Each request is processed by fetching multiple rows from a simple database table, converting 
the rows to in-memory objects, modifying one attribute of each object in memory, updating each associated row in the database 
individually, and then serializing the list of objects as a JSON response. The test is run multiple times: testing 1, 5, 10, 15, and 20 
updates per request. Note that the number of statements per request is twice the number of updates since each update is paired 
with one query to fetch the object. All tests are run at 512 concurrency.
```

see https://github.com/TechEmpower/FrameworkBenchmarks/issues/2204