### PR TITLE
[F#/Oxpecker] Improved fortunes rendering

### DIFF
--- a/frameworks/FSharp/oxpecker/src/App/App.fsproj
+++ b/frameworks/FSharp/oxpecker/src/App/App.fsproj
@@ -8,12 +8,13 @@
   <ItemGroup>
     <Compile Include="Common.fs" />
     <Compile Include="Db.fs" />
+    <Compile Include="RenderHelpers.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.300" />
-    <PackageReference Include="Oxpecker" Version="0.13.0" />
+    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+    <PackageReference Include="Oxpecker" Version="0.14.1" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/frameworks/FSharp/oxpecker/src/App/Program.fs
+++ b/frameworks/FSharp/oxpecker/src/App/Program.fs
@@ -7,32 +7,34 @@ open Oxpecker
 module HtmlViews =
     open Oxpecker.ViewEngine
 
-    let private fortunesHead =
-        head() {
-            title() { raw "Fortunes" }
-        }
-
-    let private layout (content: HtmlElement) =
-        html() {
-            fortunesHead
-            body() { content }
-        }
-
-    let private fortunesTableHeader =
-        tr() {
-            th() { raw "id" }
-            th() { raw "message" }
-        }
+    let private head, tail =
+        (fun (content: HtmlElement) ->
+            html() {
+                head() {
+                    title() { "Fortunes" }
+                }
+                body() {
+                    table() {
+                        tr() {
+                            th() { "id" }
+                            th() { "message" }
+                        }
+                        content
+                    }
+                }
+            } :> HtmlElement
+        ) |> RenderHelpers.prerender
 
     let fortunes (fortunesData: ResizeArray<Fortune>) =
-        table() {
-            fortunesTableHeader
-            for fortune in fortunesData do
-                tr() {
-                    td() { raw <| string fortune.id }
-                    td() { fortune.message }
-                }
-        } |> layout
+        RenderHelpers.combine head tail (
+            __() {
+                for fortune in fortunesData do
+                    tr() {
+                        td() { raw <| string fortune.id }
+                        td() { fortune.message }
+                    }
+            }
+        )
 
 [<RequireQualifiedAccess>]
 module HttpHandlers =

--- a/frameworks/FSharp/oxpecker/src/App/RenderHelpers.fs
+++ b/frameworks/FSharp/oxpecker/src/App/RenderHelpers.fs
@@ -1,0 +1,24 @@
+﻿module RenderHelpers
+
+    open System.Text
+    open Oxpecker.ViewEngine
+
+    let prerender (view: HtmlElement -> HtmlElement) =
+        let sb = StringBuilder()
+        let mutable head = ""
+        let fakeHole =
+           { new HtmlElement with
+                member this.Render(sb) =
+                 head <- sb.ToString()
+                 sb.Clear() |> ignore }
+        let readyView = view fakeHole
+        readyView.Render(sb)
+        (head, sb.ToString())
+
+    let inline combine (head: string) (tail: string) (hole: HtmlElement) =
+        { new HtmlElement with
+            member this.Render(sb) =
+                sb.Append(head) |> ignore
+                hole.Render(sb)
+                sb.Append(tail) |> ignore
+        }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
