### PR TITLE
feat: begone 60s "Clean up" time ^_^

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -yqq update && \
       gcc \
       git-core \
       gosu \
+      iproute2 \
       # Needed for mysqlclient
       libmysqlclient-dev \
       libpq-dev \


### PR DESCRIPTION
Removes the 60-second cleanup time introduced in #5602. If the assumption that the issue is due to hitting the limit of TCP sockets is correct, this change should solve the problem. The proposed script counts all TCP connections, including those currently in the closing process.

However, I am not entirely sure how to reproduce #5602.