### PR TITLE
[F#/Oxpecker] Improvements for json and fortunes benchmarks

### DIFF
--- a/frameworks/FSharp/oxpecker/README.md
+++ b/frameworks/FSharp/oxpecker/README.md
@@ -19,5 +19,5 @@ This includes tests for plaintext, json, fortunes, single query, mutliple querie
 
 * [Oxpecker](https://github.com/Lanayx/Oxpecker)
 * [Npgsql](https://github.com/npgsql/npgsql)
-* [System.Text.Json](https://github.com/dotnet/runtime/tree/main/src/libraries/System.Text.Json)
+* [SpanJson](https://github.com/Tornhoof/SpanJson)
 * ASP.NET Core

--- a/frameworks/FSharp/oxpecker/src/App/App.fsproj
+++ b/frameworks/FSharp/oxpecker/src/App/App.fsproj
@@ -17,5 +17,6 @@
     <PackageReference Include="Oxpecker" Version="0.14.1" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="0.14.0" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="SpanJson" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/frameworks/FSharp/oxpecker/src/App/App.fsproj
+++ b/frameworks/FSharp/oxpecker/src/App/App.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="8.0.400" />
     <PackageReference Include="Oxpecker" Version="0.14.1" />
+    <PackageReference Include="Oxpecker.ViewEngine" Version="0.14.0" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/frameworks/FSharp/oxpecker/src/App/Program.fs
+++ b/frameworks/FSharp/oxpecker/src/App/Program.fs
@@ -40,7 +40,7 @@ module HtmlViews =
 module HttpHandlers =
     open System.Text
     open Microsoft.AspNetCore.Http
-    open System.Text.Json
+    open SpanJson
 
     let private extra =
         {
@@ -98,9 +98,9 @@ module HttpHandlers =
             ctx.WriteBytes(result)
 
     let jsonSimple value : EndpointHandler =
-        let options = JsonSerializerOptions(JsonSerializerDefaults.Web)
         fun ctx ->
-            ctx.Response.WriteAsJsonAsync(value, options)
+            ctx.SetContentType("application/json")
+            JsonSerializer.Generic.Utf8.SerializeAsync<_>(value, stream = ctx.Response.Body).AsTask()
 
     let endpoints =
         [|

--- a/frameworks/FSharp/oxpecker/src/App/Program.fs
+++ b/frameworks/FSharp/oxpecker/src/App/Program.fs
@@ -2,6 +2,7 @@ namespace App
 
 open System
 open Oxpecker
+open System.Runtime.InteropServices
 
 [<RequireQualifiedAccess>]
 module HtmlViews =
@@ -26,15 +27,14 @@ module HtmlViews =
         ) |> RenderHelpers.prerender
 
     let fortunes (fortunesData: ResizeArray<Fortune>) =
-        RenderHelpers.combine head tail (
-            __() {
-                for fortune in fortunesData do
-                    tr() {
-                        td() { raw <| string fortune.id }
-                        td() { fortune.message }
-                    }
+        let fragment = __()
+        for fortune in CollectionsMarshal.AsSpan fortunesData do
+            tr() {
+                td() { raw <| string fortune.id }
+                td() { fortune.message }
             }
-        )
+            |> fragment.AddChild
+        RenderHelpers.combine head tail fragment
 
 [<RequireQualifiedAccess>]
 module HttpHandlers =


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
