### PR TITLE
[rails] Delete remaining unused middleware

### DIFF
--- a/frameworks/Ruby/rails/config/application.rb
+++ b/frameworks/Ruby/rails/config/application.rb
@@ -30,27 +30,26 @@ module Hello
 
     config.action_dispatch.default_headers.merge!('Server' => 'WebServer')
 
-    config.middleware.delete ActionDispatch::HostAuthorization
-    config.middleware.delete Rack::Sendfile
-    config.middleware.delete ActionDispatch::Static
-    config.middleware.delete ActionDispatch::Executor
-    config.middleware.delete Rack::Runtime
-    config.middleware.delete Rack::MethodOverride
-    config.middleware.delete ActionDispatch::RequestId
-    config.middleware.delete ActionDispatch::RemoteIp
-    config.middleware.delete Rails::Rack::Logger
-    config.middleware.delete ActionDispatch::ShowExceptions
-    config.middleware.delete ActionDispatch::DebugExceptions
-    config.middleware.delete ActionDispatch::ActionableExceptions
-    config.middleware.delete ActionDispatch::Reloader
-    config.middleware.delete ActiveRecord::Migration::CheckPending
-    config.middleware.delete ActionDispatch::Cookies
-    config.middleware.delete ActionDispatch::Session::CookieStore
-    config.middleware.delete ActionDispatch::Flash
+    config.middleware.delete ActionDispatch::Callbacks
     config.middleware.delete ActionDispatch::ContentSecurityPolicy::Middleware
+    config.middleware.delete ActionDispatch::Cookies
+    config.middleware.delete ActionDispatch::DebugExceptions
+    config.middleware.delete ActionDispatch::Executor
+    config.middleware.delete ActionDispatch::Flash
     config.middleware.delete ActionDispatch::PermissionsPolicy::Middleware
-    config.middleware.delete Rack::Head
+    config.middleware.delete ActionDispatch::Reloader
+    config.middleware.delete ActionDispatch::RemoteIp
+    config.middleware.delete ActionDispatch::RequestId
+    config.middleware.delete ActionDispatch::Session::CookieStore
+    config.middleware.delete ActionDispatch::ShowExceptions
+    config.middleware.delete ActiveRecord::Migration::CheckPending
     config.middleware.delete Rack::ConditionalGet
     config.middleware.delete Rack::ETag
+    config.middleware.delete Rack::Head
+    config.middleware.delete Rack::MethodOverride
+    config.middleware.delete Rack::Runtime
+    config.middleware.delete Rack::Sendfile
+    config.middleware.delete Rack::TempfileReaper
+    config.middleware.delete Rails::Rack::Logger
   end
 end

--- a/frameworks/Ruby/rails/config/environments/production.rb
+++ b/frameworks/Ruby/rails/config/environments/production.rb
@@ -21,7 +21,8 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
+  # This disables the ActionDispatch::Static middleware.
+  config.public_file_server.enabled = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
The following middleware is unused for the benchmark:
- Callbacks
- Rack::TempfileReaper

The following middleware is already disabled in production by default,
so they don't need to be deleted:
- ActionDispatch::HostAuthorization
- ActionDispatch::Static

The remaining middleware are:
- ActiveSupport::Cache::Strategy::LocalCache::Middleware
- Hello::Application.routes

Also sort the middleware.

The middleware can be checked using the following command:

     SECRET_KEY_BASE_DUMMY=1  RAILS_ENV=production_mysql bin/rails middleware
