### PR TITLE
[php] Fix the issue of the extension loading repeatedly

### DIFF
--- a/frameworks/PHP/swoole/10-opcache.ini
+++ b/frameworks/PHP/swoole/10-opcache.ini
@@ -2,9 +2,8 @@ zend_extension=opcache.so
 opcache.enable=1
 opcache.enable_cli=1
 opcache.validate_timestamps=0
+opcache.save_comments=0
 opcache.enable_file_override=1
 opcache.huge_code_pages=1
-memory_limit=1024M
-
 opcache.jit_buffer_size=128M
 opcache.jit=1225

--- a/frameworks/PHP/swoole/swoole-async-mysql.dockerfile
+++ b/frameworks/PHP/swoole/swoole-async-mysql.dockerfile
@@ -18,15 +18,17 @@ RUN apt update -yqq > /dev/null \
     && ./configure > /dev/null \
     && make -j8 > /dev/null \
     && make install > /dev/null \
-    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini
+    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini \
+    && echo "memory_limit=1024M" >> /etc/php/8.3/cli/php.ini \
+    && php -m
 
 WORKDIR /swoole
 
 ADD ./swoole-server.php /swoole
-ADD ./php.ini /swoole
+ADD 10-opcache.ini /swoole
 ADD ./database.php /swoole
 
-RUN cat /swoole/php.ini >> /etc/php/8.3/cli/php.ini
+COPY 10-opcache.ini /etc/php/8.3/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 CMD php /swoole/swoole-server.php

--- a/frameworks/PHP/swoole/swoole-async-postgres.dockerfile
+++ b/frameworks/PHP/swoole/swoole-async-postgres.dockerfile
@@ -18,15 +18,17 @@ RUN apt update -yqq > /dev/null \
     && ./configure --enable-swoole-pgsql > /dev/null \
     && make -j8 > /dev/null \
     && make install > /dev/null \
-    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini
+    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini \
+    && echo "memory_limit=1024M" >> /etc/php/8.3/cli/php.ini \
+    && php -m
 
 WORKDIR /swoole
 
 ADD ./swoole-server.php /swoole
-ADD ./php.ini /swoole
+ADD 10-opcache.ini /swoole
 ADD ./database.php /swoole
 
-RUN cat /swoole/php.ini >> /etc/php/8.3/cli/php.ini
+COPY 10-opcache.ini /etc/php/8.3/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 CMD php /swoole/swoole-server.php

--- a/frameworks/PHP/swoole/swoole-sync-mysql.dockerfile
+++ b/frameworks/PHP/swoole/swoole-sync-mysql.dockerfile
@@ -18,15 +18,17 @@ RUN apt update -yqq > /dev/null \
     && ./configure > /dev/null \
     && make -j8 > /dev/null \
     && make install > /dev/null \
-    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini
+    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini \
+    && echo "memory_limit=1024M" >> /etc/php/8.3/cli/php.ini \
+    && php -m
 
 WORKDIR /swoole
 
 ADD ./swoole-server.php /swoole
-ADD ./php.ini /swoole
+ADD 10-opcache.ini /swoole
 ADD ./database.php /swoole
 
-RUN cat /swoole/php.ini >> /etc/php/8.3/cli/php.ini
+COPY 10-opcache.ini /etc/php/8.3/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 CMD php /swoole/swoole-server.php

--- a/frameworks/PHP/swoole/swoole-sync-postgres.dockerfile
+++ b/frameworks/PHP/swoole/swoole-sync-postgres.dockerfile
@@ -18,15 +18,17 @@ RUN apt update -yqq > /dev/null \
     && ./configure > /dev/null \
     && make -j8 > /dev/null \
     && make install > /dev/null \
-    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini
+    && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/50-swoole.ini \
+    && echo "memory_limit=1024M" >> /etc/php/8.3/cli/php.ini \
+    && php -m
 
 WORKDIR /swoole
 
 ADD ./swoole-server.php /swoole
-ADD ./php.ini /swoole
+ADD 10-opcache.ini /swoole
 ADD ./database.php /swoole
 
-RUN cat /swoole/php.ini >> /etc/php/8.3/cli/php.ini
+COPY 10-opcache.ini /etc/php/8.3/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 CMD php /swoole/swoole-server.php


### PR DESCRIPTION
I'm very sorry, I forgot that the PHP installed via apt actually comes with opcache by default. The last PR would cause the opcache extension to be loaded repeatedly.