### PR TITLE
[xitca-web] add bench for async orm

### DIFF
--- a/frameworks/Rust/xitca-web/Cargo.lock
+++ b/frameworks/Rust/xitca-web/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "8f43644eed690f5374f1af436ecd6aea01cd201f6fbdf0178adaf6907afb2cec"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -68,16 +68,16 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "tower",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
 dependencies = [
  "async-trait",
  "bytes",
@@ -88,7 +88,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -115,6 +115,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bb8"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,15 +161,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -228,6 +246,20 @@ dependencies = [
  "itoa",
  "pq-sys",
  "r2d2",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.5.0"
+source = "git+https://github.com/weiznich/diesel_async#5b8262b86d8ed0e13adbbc4aee39500b9931ef8d"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -317,10 +349,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
@@ -335,6 +394,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -471,6 +532,15 @@ name = "itoap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -644,26 +714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -715,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "pq-sys"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92c30dd81695321846d4dfe348da67b1752ebb61cd1549d203a7b57e323c435"
+checksum = "f6cc05d7ea95200187117196eee9edd0644424911821aeb28a18ce60ea0b8793"
 dependencies = [
  "vcpkg",
 ]
@@ -851,6 +901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1048,6 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
+ "bytes",
  "libc",
  "mio",
  "parking_lot",
@@ -1055,6 +1116,32 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.7",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1073,18 +1160,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1155,9 +1265,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -1185,6 +1295,88 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"
@@ -1337,9 +1529,10 @@ dependencies = [
 [[package]]
 name = "xitca-postgres"
 version = "0.1.0"
-source = "git+https://github.com/HFQR/xitca-web.git?rev=0cda225#0cda2254f98b40f21bc3170dd8983f16444f0bd0"
+source = "git+https://github.com/HFQR/xitca-web.git?rev=55afa4a#55afa4a0ef421019ad3fa7e2e56c526ef53df89d"
 dependencies = [
  "fallible-iterator",
+ "futures-core",
  "percent-encoding",
  "phf",
  "postgres-protocol",
@@ -1348,6 +1541,19 @@ dependencies = [
  "tracing",
  "xitca-io",
  "xitca-unsafe-collection",
+]
+
+[[package]]
+name = "xitca-postgres-diesel"
+version = "0.1.0"
+source = "git+https://github.com/fakeshadow/xitca-postgres-diesel#7d004873ada7e76cd34eda2d2f07454ef4bd32c4"
+dependencies = [
+ "diesel",
+ "diesel-async",
+ "futures-core",
+ "scoped-futures",
+ "tokio",
+ "xitca-postgres",
 ]
 
 [[package]]
@@ -1396,7 +1602,9 @@ dependencies = [
  "atoi",
  "axum",
  "diesel",
+ "diesel-async",
  "futures-core",
+ "futures-util",
  "http-body",
  "mimalloc",
  "rand",
@@ -1404,11 +1612,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower",
+ "tokio-uring",
+ "tower 0.4.13",
  "tower-http",
  "xitca-http",
  "xitca-io",
  "xitca-postgres",
+ "xitca-postgres-diesel",
  "xitca-server",
  "xitca-service",
  "xitca-unsafe-collection",

--- a/frameworks/Rust/xitca-web/Cargo.toml
+++ b/frameworks/Rust/xitca-web/Cargo.toml
@@ -24,27 +24,34 @@ path = "./src/main_axum.rs"
 required-features = ["axum", "io-uring", "perf", "pg-sync", "template"]
 
 [[bin]]
+name = "xitca-web-orm"
+path = "./src/main_orm.rs"
+required-features = ["pg-orm-async", "template", "web-codegen"]
+
+[[bin]]
 name = "xitca-web-sync"
 path = "./src/main_sync.rs"
 required-features = ["pg-orm", "template", "web-codegen"]
 
 [features]
-# pg optional
+# pg client optional
 pg = ["dep:xitca-postgres"]
-# pg send/sync optional
+# pg client send/sync optional
 pg-sync = ["dep:xitca-postgres"]
-# pg orm optional
-pg-orm = ["dep:diesel"]
+# diesel orm optional
+pg-orm = ["diesel/r2d2"]
+# diesel async orm optional
+pg-orm-async = ["dep:diesel", "dep:diesel-async", "dep:xitca-postgres-diesel", "futures-util"]
 # http router optional
 router = ["xitca-http/router"]
 # web optional
 web = ["dep:xitca-web"]
-# web codegen optional
+# web with macros optional
 web-codegen = ["xitca-web/codegen", "xitca-web/urlencoded"]
 # template optional
 template = ["dep:sailfish"]
 # io-uring optional
-io-uring = ["xitca-http/io-uring", "xitca-server/io-uring"]
+io-uring = ["dep:tokio-uring", "xitca-http/io-uring", "xitca-server/io-uring"]
 # axum optional
 axum = ["dep:axum", "dep:http-body", "dep:tower", "dep:tower-http", "xitca-web/tower-http-compat" ]
 # unrealistic performance optimization
@@ -68,7 +75,12 @@ xitca-web = { version = "0.6", features = ["json"], optional = true }
 xitca-postgres = { version = "0.1", optional = true }
 
 # orm optional
-diesel = { version = "2", features = ["postgres", "r2d2"], optional = true }
+diesel = { version = "2", features = ["postgres"], optional = true }
+
+# orm async optional
+diesel-async = { version = "0.5", features = ["bb8", "postgres"], optional = true }
+xitca-postgres-diesel = { version = "0.1", optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 
 # template optional
 sailfish = { version = "0.9", default-features = false, features = ["derive", "perf-inline"], optional = true }
@@ -78,6 +90,9 @@ axum = { version = "0.7", optional = true, default-features = false, features = 
 http-body = { version = "1", optional = true }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["set-header"], optional = true }
+
+# io-uring optional
+tokio-uring = { version = "0.5", optional = true }
 
 # perf optional
 mimalloc = { version = "0.1", default-features = false, optional = true }
@@ -95,5 +110,8 @@ codegen-units = 1
 panic = "abort"
 
 [patch.crates-io]
-xitca-postgres = { git = "https://github.com/HFQR/xitca-web.git", rev = "0cda225" }
+xitca-postgres = { git = "https://github.com/HFQR/xitca-web.git", rev = "55afa4a" }
 mio = { git = "https://github.com/fakeshadow/mio", rev = "9bae6012b7ecfc6083350785f71a5e8265358178" }
+
+xitca-postgres-diesel = { git = "https://github.com/fakeshadow/xitca-postgres-diesel" }
+diesel-async = { git = "https://github.com/weiznich/diesel_async" }

--- a/frameworks/Rust/xitca-web/benchmark_config.json
+++ b/frameworks/Rust/xitca-web/benchmark_config.json
@@ -86,6 +86,28 @@
         "notes": "",
         "versus": ""
       },
+      "orm": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "db_url": "/db",
+        "fortune_url": "/fortunes",
+        "query_url": "/queries?q=",
+        "update_url": "/updates?q=",
+        "port": 8080,
+        "approach": "realistic",
+        "classification": "fullstack",
+        "database": "postgres",
+        "framework": "xitca-web [orm]",
+        "language": "rust",
+        "orm": "full",
+        "platform": "none",
+        "webserver": "xitca-server",
+        "os": "linux",
+        "database_os": "linux",
+        "display_name": "xitca-web [orm]",
+        "notes": "",
+        "versus": ""
+      },
       "sync": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",

--- a/frameworks/Rust/xitca-web/src/db_diesel_async.rs
+++ b/frameworks/Rust/xitca-web/src/db_diesel_async.rs
@@ -1,0 +1,153 @@
+use std::{
+    io,
+    sync::{Arc, Mutex},
+};
+
+use diesel::prelude::*;
+use diesel_async::{
+    pooled_connection::{bb8, AsyncDieselConnectionManager},
+    RunQueryDsl,
+};
+use futures_util::{
+    future::join,
+    stream::{FuturesUnordered, TryStreamExt},
+};
+use xitca_postgres_diesel::AsyncPgConnection;
+
+use crate::{
+    ser::{Fortune, Fortunes, World},
+    util::{bulk_update_gen, Error, HandleResult, Rand, DB_URL},
+};
+
+pub type Pool = Arc<_Pool>;
+
+pub struct _Pool {
+    pool: bb8::Pool<AsyncPgConnection>,
+    rng: Mutex<Rand>,
+}
+
+pub async fn create() -> io::Result<Arc<_Pool>> {
+    bb8::Pool::builder()
+        .max_size(1)
+        .min_idle(Some(1))
+        .test_on_check_out(false)
+        .build(AsyncDieselConnectionManager::new(DB_URL))
+        .await
+        .map_err(io::Error::other)
+        .map(|pool| {
+            Arc::new(_Pool {
+                pool,
+                rng: Mutex::new(Rand::default()),
+            })
+        })
+}
+
+#[cold]
+#[inline(never)]
+fn not_found() -> Error {
+    "world not found".into()
+}
+
+impl _Pool {
+    pub async fn get_world(&self) -> HandleResult<World> {
+        use crate::schema::world::dsl::*;
+        {
+            let w_id = self.rng.lock().unwrap().gen_id();
+            let mut conn = self.pool.get().await?;
+            world.filter(id.eq(w_id)).load(&mut conn)
+        }
+        .await?
+        .pop()
+        .ok_or_else(not_found)
+    }
+
+    pub async fn get_worlds(&self, num: u16) -> HandleResult<Vec<World>> {
+        use crate::schema::world::dsl::*;
+        {
+            let mut conn = self.pool.get().await?;
+            let mut rng = self.rng.lock().unwrap();
+            (0..num)
+                .map(|_| {
+                    let w_id = rng.gen_id();
+                    let fut = world.filter(id.eq(w_id)).load::<World>(&mut conn);
+                    async { fut.await?.pop().ok_or_else(not_found) }
+                })
+                .collect::<FuturesUnordered<_>>()
+        }
+        .try_collect()
+        .await
+    }
+
+    pub async fn update(&self, num: u16) -> HandleResult<Vec<World>> {
+        use crate::schema::world::dsl::*;
+
+        let mut rngs = Vec::with_capacity(num as _);
+
+        let (select_res, update_res) = {
+            let mut conn = self.pool.get().await?;
+
+            let mut rng = self.rng.lock().unwrap();
+
+            let select = (0..num)
+                .map(|_| {
+                    let w_id = rng.gen_id();
+                    let num = rng.gen_id();
+
+                    rngs.push((w_id, num));
+
+                    let fut = world.filter(id.eq(w_id)).load::<World>(&mut conn);
+
+                    async move {
+                        fut.await?
+                            .pop()
+                            .map(|mut w| {
+                                w.randomnumber = num;
+                                w
+                            })
+                            .ok_or_else(not_found)
+                    }
+                })
+                .collect::<FuturesUnordered<_>>();
+
+            rngs.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+            let update = diesel::sql_query(update_query(&rngs)).execute(&mut conn);
+
+            join(select.try_collect::<Vec<_>>(), update)
+        }
+        .await;
+
+        update_res?;
+        let mut worlds = select_res?;
+
+        worlds.sort_by_key(|w| w.id);
+
+        Ok(worlds)
+    }
+
+    pub async fn tell_fortune(&self) -> HandleResult<Fortunes> {
+        use crate::schema::fortune::dsl::*;
+
+        let mut items = {
+            let mut conn = self.pool.get().await?;
+            fortune.load::<Fortune>(&mut conn)
+        }
+        .await?;
+
+        items.push(Fortune::new(0, "Additional fortune added at request time."));
+        items.sort_by(|it, next| it.message.cmp(&next.message));
+
+        Ok(Fortunes::new(items))
+    }
+}
+
+// diesel does not support high level bulk update api. use raw sql to bypass the limitation.
+// relate discussion: https://github.com/diesel-rs/diesel/discussions/2879
+fn update_query(ids: &[(i32, i32)]) -> String {
+    bulk_update_gen(|query| {
+        use std::fmt::Write;
+        ids.iter().for_each(|(w_id, num)| {
+            write!(query, "({}::int,{}::int),", w_id, num).unwrap();
+        });
+    })
+}

--- a/frameworks/Rust/xitca-web/src/main_iou.rs
+++ b/frameworks/Rust/xitca-web/src/main_iou.rs
@@ -1,6 +1,8 @@
-// used as reference of if/how moving from epoll to io-uring(or mixture of the two) make sense for
-// network io.
+// reference of if/how moving from epoll to io-uring(or mixture of the two) make sense for network io.
+// with comment on explaining why some practice are unrealistic
 
+// custom global memory allocation don't affect real world performance in noticeable amount.
+// in real world they should be used for reason like security, debug/profiling capability etc. 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
@@ -15,7 +17,7 @@ use xitca_http::{
     http::{self, header::SERVER, StatusCode},
     HttpServiceBuilder,
 };
-use xitca_service::{fn_service, ServiceExt};
+use xitca_service::{fn_service, Service, ServiceExt};
 
 use self::{
     ser::{error_response, IntoResponse, Message, Request},
@@ -23,21 +25,78 @@ use self::{
 };
 
 fn main() -> io::Result<()> {
-    let service = fn_service(handler)
-        .enclosed(context_mw())
-        .enclosed(HttpServiceBuilder::h1().io_uring());
-    xitca_server::Builder::new()
-        .bind("xitca-iou", "0.0.0.0:8080", service)?
-        .build()
-        .wait()
+    let addr = "0.0.0.0:8080".parse().unwrap();
+
+    let cores = std::thread::available_parallelism().map(|num| num.get()).unwrap_or(56);
+
+    let handle = core::iter::repeat_with(|| {
+        std::thread::spawn(move || {
+            tokio_uring::start(async {
+                let service = std::rc::Rc::new(
+                    fn_service(handler)
+                        .enclosed(context_mw())
+                        .enclosed(HttpServiceBuilder::h1().io_uring())
+                        .call(())
+                        .await
+                        .unwrap(),
+                );
+
+                let socket = tokio::net::TcpSocket::new_v4()?;
+                socket.set_reuseaddr(true)?;
+                // unrealistic due to following reason:
+                // 1. this only works good on unix system.
+                // 2. no resource distribution adjustment between sockets on different threads. causing uneven workload
+                // where some threads are idle while others busy. resulting in overall increased latency
+                socket.set_reuseport(true)?;
+                socket.bind(addr)?;
+                let listener = socket.listen(1024)?;
+
+                let service = fn_service(handler)
+                    .enclosed(context_mw())
+                    .enclosed(HttpServiceBuilder::h1().io_uring())
+                    .call(())
+                    .await
+                    .unwrap();
+
+                let service = std::rc::Rc::new(service);
+
+                loop {
+                    match listener.accept().await {
+                        Ok((stream, addr)) => {
+                            let stream = stream.into_std()?;
+                            let stream = xitca_io::net::io_uring::TcpStream::from_std(stream);
+                            let service = service.clone();
+                            tokio::task::spawn_local(async move {
+                                let _ = service.call((stream, addr)).await;
+                            });
+                        }
+                        Err(e) => return Err(e),
+                    };
+                }
+            })
+        })
+    })
+    .take(cores)
+    .collect::<Vec<_>>();
+
+    // unrealistic due to no signal handling, not shutdown handling. when killing this process all resources that
+    // need clean async shutdown will be leaked.
+    for handle in handle {
+        handle.join().unwrap()?;
+    }
+
+    Ok(())
 }
 
 async fn handler<B>(ctx: Ctx<'_, Request<B>>) -> Result<http::Response<ResponseBody>, Infallible> {
     let (req, state) = ctx.into_parts();
+    // unrealistic due to lack of http method check
     let mut res = match req.uri().path() {
+        // unrealistic due to lack of dynamic route matching.
         "/plaintext" => req.text_response().unwrap(),
         "/json" => req.json_response(state, &Message::new()).unwrap(),
         "/db" => {
+            // unrealistic due to no error handling. any db/serialization error will cause process crash
             let world = state.client.get_world().await.unwrap();
             req.json_response(state, &world).unwrap()
         }

--- a/frameworks/Rust/xitca-web/src/main_orm.rs
+++ b/frameworks/Rust/xitca-web/src/main_orm.rs
@@ -1,0 +1,67 @@
+mod db_diesel_async;
+mod schema;
+mod ser;
+mod util;
+
+use serde::Serialize;
+use xitca_web::{
+    codegen::route,
+    handler::{html::Html, json::Json, query::Query, state::StateRef, text::Text},
+    http::{header::SERVER, WebResponse},
+    route::get,
+    App,
+};
+
+use db_diesel_async::Pool;
+use ser::Num;
+use util::{HandleResult, SERVER_HEADER_VALUE};
+
+fn main() -> std::io::Result<()> {
+    App::new()
+        .with_async_state(db_diesel_async::create)
+        .at("/plaintext", get(Text("Hello, World!")))
+        .at("/json", get(Json(ser::Message::new())))
+        .at_typed(db)
+        .at_typed(fortunes)
+        .at_typed(queries)
+        .at_typed(updates)
+        .map(header)
+        .serve()
+        .disable_vectored_write()
+        .bind("0.0.0.0:8080")?
+        .run()
+        .wait()
+}
+
+fn header(mut res: WebResponse) -> WebResponse {
+    res.headers_mut().insert(SERVER, SERVER_HEADER_VALUE);
+    res
+}
+
+#[route("/db", method = get)]
+async fn db(StateRef(pool): StateRef<'_, Pool>) -> HandleResult<Json<impl Serialize>> {
+    pool.get_world().await.map(Json)
+}
+
+#[route("/fortunes", method = get)]
+async fn fortunes(StateRef(pool): StateRef<'_, Pool>) -> HandleResult<Html<String>> {
+    use sailfish::TemplateOnce;
+    let html = pool.tell_fortune().await?.render_once()?;
+    Ok(Html(html))
+}
+
+#[route("/queries", method = get)]
+async fn queries(
+    Query(Num(num)): Query<Num>,
+    StateRef(pool): StateRef<'_, Pool>,
+) -> HandleResult<Json<impl Serialize>> {
+    pool.get_worlds(num).await.map(Json)
+}
+
+#[route("/updates", method = get)]
+async fn updates(
+    Query(Num(num)): Query<Num>,
+    StateRef(pool): StateRef<'_, Pool>,
+) -> HandleResult<Json<impl Serialize>> {
+    pool.update(num).await.map(Json)
+}

--- a/frameworks/Rust/xitca-web/src/ser.rs
+++ b/frameworks/Rust/xitca-web/src/ser.rs
@@ -33,7 +33,7 @@ impl Message {
 
 pub struct Num(pub u16);
 
-#[cfg_attr(feature = "pg-orm", derive(diesel::Queryable))]
+#[cfg_attr(any(feature = "pg-orm", feature = "pg-orm-async"), derive(diesel::Queryable))]
 pub struct World {
     pub id: i32,
     pub randomnumber: i32,
@@ -46,7 +46,7 @@ impl World {
     }
 }
 
-#[cfg_attr(feature = "pg-orm", derive(diesel::Queryable))]
+#[cfg_attr(any(feature = "pg-orm", feature = "pg-orm-async"), derive(diesel::Queryable))]
 pub struct Fortune {
     pub id: i32,
     pub message: Cow<'static, str>,

--- a/frameworks/Rust/xitca-web/xitca-web-orm.dockerfile
+++ b/frameworks/Rust/xitca-web/xitca-web-orm.dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.81
+
+ADD ./ /xitca-web
+WORKDIR /xitca-web
+
+RUN cargo build --release --bin xitca-web-orm --features pg-orm-async,template,web-codegen
+
+EXPOSE 8080
+
+CMD ./target/release/xitca-web-orm


### PR DESCRIPTION
add `xitca-postgres-diesel` as async ORM where it integrates into `diesel` and `diesel-async` ecosystem.