### PR TITLE
[rails] Use higher log level

### DIFF
--- a/frameworks/Ruby/rails/config/environments/production.rb
+++ b/frameworks/Ruby/rails/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = :fatal
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, {


### PR DESCRIPTION
Using a higher log level bypasses a lot of unused instrumentation code.

| branch |plaintext|update|  json|   db|query|fortune|cached-query|weighted_score|
|-------------------------|---------|------|------|-----|-----|-------|------------|--------------|
|              master|    22816|  8249| 82981|21715|12531|  11234|       13259|          1006|
| increase-log-level|    24719| 11040| 90706|25126|16022|  16666|       14304|          1309|