### PR TITLE
[scala/zio-http] updated to the latest RC version

### DIFF
--- a/frameworks/Scala/zio-http/build.sbt
+++ b/frameworks/Scala/zio-http/build.sbt
@@ -3,11 +3,12 @@ version := "1.0.0"
 scalaVersion := "2.13.6"
 lazy val root = (project in file("."))
   .settings(
-    libraryDependencies ++=
-      Seq(
-        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % "2.9.1",
-        "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.9.1" % "compile-internal",
-        "io.d11"                                 % "zhttp"                 % "1.0.0-RC5",
-      ),
+    libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC10",
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    assembly / assemblyMergeStrategy  := {
+      case x if x.contains("io.netty.versions.properties") => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    }
   )

--- a/frameworks/Scala/zio-http/build.sbt
+++ b/frameworks/Scala/zio-http/build.sbt
@@ -1,6 +1,6 @@
 name := "zio-http"
 version := "1.0.0"
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.14"
 lazy val root = (project in file("."))
   .settings(
     libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC10",

--- a/frameworks/Scala/zio-http/project/build.properties
+++ b/frameworks/Scala/zio-http/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.10.0

--- a/frameworks/Scala/zio-http/project/plugins.sbt
+++ b/frameworks/Scala/zio-http/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")

--- a/frameworks/Scala/zio-http/src/main/scala/Main.scala
+++ b/frameworks/Scala/zio-http/src/main/scala/Main.scala
@@ -2,6 +2,7 @@ import zio._
 import zio.http._
 import zio.http.netty.NettyConfig
 import zio.http.netty.NettyConfig.LeakDetectionLevel
+import java.lang.{Runtime => JRuntime}
 
 object Main extends ZIOAppDefault {
 
@@ -9,7 +10,7 @@ object Main extends ZIOAppDefault {
   private val jsonMessage: String      = """{"message": "hello, world!"}"""
 
   private val STATIC_SERVER_NAME = "zio-http"
-  private val NUM_PROCESSORS     = Runtime.getRuntime.availableProcessors()
+  private val NUM_PROCESSORS     = JRuntime.getRuntime.availableProcessors()
 
   val app: Routes[Any, Response] = Routes(
     Method.GET / "/plaintext" ->
@@ -38,5 +39,5 @@ object Main extends ZIOAppDefault {
   private val nettyConfigLayer = ZLayer.succeed(nettyConfig)
 
   val run: UIO[ExitCode] =
-    Server.serve(app.toHttpApp).provide(configLayer, nettyConfigLayer, Server.customized).exitCode
+    Server.serve(app).provide(configLayer, nettyConfigLayer, Server.customized).exitCode
 }

--- a/frameworks/Scala/zio-http/src/main/scala/Main.scala
+++ b/frameworks/Scala/zio-http/src/main/scala/Main.scala
@@ -1,42 +1,42 @@
-import zhttp.http._
-import zhttp.service.Server
-import zio.{App, ExitCode, URIO}
-import com.github.plokhotnyuk.jsoniter_scala.macros._
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import zhttp.http.Response
+import zio._
+import zio.http._
+import zio.http.netty.NettyConfig
+import zio.http.netty.NettyConfig.LeakDetectionLevel
 
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, ZoneOffset}
+object Main extends ZIOAppDefault {
 
-case class Message(message: String)
+  private val plainTextMessage: String = "hello, world!"
+  private val jsonMessage: String      = """{"message": "hello, world!"}"""
 
-object Main extends App {
-  val message: String                         = "Hello, World!"
-  implicit val codec: JsonValueCodec[Message] = JsonCodecMaker.make
+  private val STATIC_SERVER_NAME = "zio-http"
+  private val NUM_PROCESSORS     = Runtime.getRuntime.availableProcessors()
 
-  val app: Http[Any, HttpError, Request, Response] = Http.collect[Request] {
-    case Method.GET -> Root / "plaintext" =>
-      Response.http(
-        content = HttpContent.Complete(message),
-        headers = Header.contentTypeTextPlain :: headers(),
-      )
-    case Method.GET -> Root / "json"      =>
-      Response.http(
-        content = HttpContent.Complete(writeToString(Message(message))),
-        headers = Header.contentTypeJson :: headers(),
-      )
-  }
+  val app: Routes[Any, Response] = Routes(
+    Method.GET / "/plaintext" ->
+      Handler.fromResponse(
+        Response
+          .text(plainTextMessage)
+          .addHeader(Header.Server(STATIC_SERVER_NAME)),
+      ),
+    Method.GET / "/json"      ->
+      Handler.fromResponse(
+        Response
+          .json(jsonMessage)
+          .addHeader(Header.Server(STATIC_SERVER_NAME)),
+      ),
+  )
 
-  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = Server.start(8080, app).exitCode
+  private val config = Server.Config.default
+    .port(8080)
+    .enableRequestStreaming
 
-  val formatter: DateTimeFormatter                = DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
-  val constantHeaders: List[Header]               = Header("server", "zio-http") :: Nil
-  @volatile var lastHeaders: (Long, List[Header]) = (0, Nil)
+  private val nettyConfig = NettyConfig.default
+    .leakDetection(LeakDetectionLevel.DISABLED)
+    .maxThreads(NUM_PROCESSORS)
 
-  def headers(): List[Header] = {
-    val t = System.currentTimeMillis()
-    if (t - lastHeaders._1 >= 1000)
-      lastHeaders = (t, Header("date", formatter.format(Instant.ofEpochMilli(t))) :: constantHeaders)
-    lastHeaders._2
-  }
+  private val configLayer      = ZLayer.succeed(config)
+  private val nettyConfigLayer = ZLayer.succeed(nettyConfig)
+
+  val run: UIO[ExitCode] =
+    Server.serve(app.toHttpApp).provide(configLayer, nettyConfigLayer, Server.customized).exitCode
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
- Updated `zio-http` to version `3.0.0-RC10`