### PR TITLE
[ruby/sinatra] Release connection to pool outside block

### DIFF
--- a/frameworks/Ruby/sinatra/Gemfile
+++ b/frameworks/Ruby/sinatra/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 7.1', require: 'active_record'
+gem 'activerecord', '~> 7.2', require: 'active_record'
 gem 'oj'
 gem 'passenger', '~> 6.0', platforms: [:ruby, :mswin], require: false
 gem 'puma', '~> 6.4', require: false


### PR DESCRIPTION
ActiveRecord 7.2 introduced ActiveRecord::Base.with_connection which releases the connection after the block has run. This allows us to remove clearing active connections after the request has finished.

|                |plaintext|update| json|   db|query|fortune|weighted_score|
|----------|---------|------|-----|-----|-----|-------|--------------|
|master     |    73851|  7851|84330|37661|15144|  19934|          1109|
|branch     |    83429|  8401|91051|41432|14251|  21369|          1147|