### PR TITLE
[spring-webflux] Leverage R2BDC recent optimizations

### DIFF
--- a/frameworks/Java/spring-webflux/pom.xml
+++ b/frameworks/Java/spring-webflux/pom.xml
@@ -19,6 +19,8 @@
     <properties>
         <java.version>21</java.version>
         <jstachio.version>1.3.6</jstachio.version>
+        <r2dbc-pool.version>1.0.2.RELEASE</r2dbc-pool.version>
+        <r2dbc-postgresql.version>1.0.7.RELEASE</r2dbc-postgresql.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Hey, I am Sébastien the Spring Framework committer. This simple PR that updates to the latest R2DBC version should improve some DB tests very significantly under high load thanks to some optimization found after profiling Techempower benchmark, kudos to @chemicL and @mp911de for crafting those optimizations and to @dsyer and @violetagg for providing inputs.

```
+-----------------------------------------------------------+
|                Type: db, Result: latencyAvg               |
+-------------------+----------------+----------------------+
| concurrencyLevels | spring-webflux | spring-webflux-batch |
+-------------------+----------------+----------------------+
|         16        |    328.16us    |       340.13us       |
|         32        |    428.06us    |       489.45us       |
|         64        |    810.57us    |       633.75us       |
|        128        |     1.68ms     |        1.15ms        |
|        256        |     5.31ms     |        2.38ms        |
|        512        |    66.29ms     |        4.90ms        |
+-------------------+----------------+----------------------+

+--------------------------------------------------------+
|            Type: query, Result: latencyAvg             |
+----------------+----------------+----------------------+
| queryIntervals | spring-webflux | spring-webflux-batch |
+----------------+----------------+----------------------+
|       1        |    25.23ms     |        4.89ms        |
|       5        |    24.33ms     |       14.88ms        |
|       10       |    139.04ms    |       27.31ms        |
|       15       |    104.10ms    |       38.82ms        |
|       20       |    135.86ms    |       51.44ms        |
+----------------+----------------+----------------------+

+-----------------------------------------------------------+
|              Type: db, Result: totalRequests              |
+-------------------+----------------+----------------------+
| concurrencyLevels | spring-webflux | spring-webflux-batch |
+-------------------+----------------+----------------------+
|         16        |     566361     |        541094        |
|         32        |     869461     |        763003        |
|         64        |    1166876     |       1485258        |
|        128        |    1199166     |       1632680        |
|        256        |    1170773     |       1647095        |
|        512        |    1175517     |       1596439        |
+-------------------+----------------+----------------------+

+-----------------------------------------------------------+
|            Type: update, Result: totalRequests            |
+-------------------+----------------+----------------------+
| concurrencyLevels | spring-webflux | spring-webflux-batch |
+-------------------+----------------+----------------------+
|         16        |     611458     |        747059        |
|         32        |     124010     |        185761        |
|         64        |     62833      |        96436         |
|        128        |     37867      |        65202         |
|        256        |     27630      |        49772         |
+-------------------+----------------+----------------------+

+--------------------------------------------------------+
|           Type: query, Result: totalRequests           |
+----------------+----------------+----------------------+
| queryIntervals | spring-webflux | spring-webflux-batch |
+----------------+----------------+----------------------+
|       1        |    1201011     |       1606122        |
|       5        |     291258     |        510179        |
|       10       |     136313     |        276967        |
|       15       |     89204      |        194901        |
|       20       |     66476      |        147094        |
+----------------+----------------+----------------------+

+-----------------------------------------------------------+
|                Type: db, Result: latencyMax               |
+-------------------+----------------+----------------------+
| concurrencyLevels | spring-webflux | spring-webflux-batch |
+-------------------+----------------+----------------------+
|         16        |    10.45ms     |        6.42ms        |
|         32        |     7.04ms     |        8.63ms        |
|         64        |    12.61ms     |       10.81ms        |
|        128        |    32.64ms     |       21.82ms        |
|        256        |    270.44ms    |       19.80ms        |
|        512        |     4.37s      |       36.42ms        |
+-------------------+----------------+----------------------+

+-----------------------------------------------------------+
|              Type: update, Result: latencyMax             |
+-------------------+----------------+----------------------+
| concurrencyLevels | spring-webflux | spring-webflux-batch |
+-------------------+----------------+----------------------+
|         16        |    699.14ms    |       108.82ms       |
|         32        |     3.88s      |       127.93ms       |
|         64        |    54.85ms     |       169.99ms       |
|        128        |     1.69s      |       235.00ms       |
|        256        |    323.66ms    |       247.90ms       |
+-------------------+----------------+----------------------+

+--------------------------------------------------------+
|            Type: query, Result: latencyMax             |
+----------------+----------------+----------------------+
| queryIntervals | spring-webflux | spring-webflux-batch |
+----------------+----------------+----------------------+
|       1        |     1.79s      |       52.74ms        |
|       5        |    465.37ms    |       87.00ms        |
|       10       |     5.20s      |       68.25ms        |
|       15       |     3.91s      |       87.12ms        |
|       20       |     3.39s      |       96.92ms        |
+----------------+----------------+----------------------+
```