### PR TITLE
[spring] Bring back the connection pool size to 256

### DIFF
--- a/frameworks/Java/spring-webflux/src/main/resources/application.yml
+++ b/frameworks/Java/spring-webflux/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     password: ${database.password}
     url: r2dbc:postgresql://${database.host}:${database.port}/${database.name}?loggerLevel=OFF&disableColumnSanitiser=true&assumeMinServerVersion=16&sslmode=disable
     pool:
-      max-size: 512
+      max-size: 256
 
 ---
 spring:

--- a/frameworks/Java/spring/src/main/resources/application.yml
+++ b/frameworks/Java/spring/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
     username: ${database.username}
     password: ${database.password}
     hikari:
-      maximum-pool-size: 512
+      maximum-pool-size: 256
 database:
   name: hello_world
   host: tfb-database


### PR DESCRIPTION
Hey, I am Sébastien, the Spring Framework code committer. I am bring back the connection pool size to 256 due to some performance regressions detected on the continuous benchmarking results.