### PR TITLE
[CSharp] Match AOT settings with JIT settings

### DIFF
--- a/frameworks/CSharp/aspnetcore/src/Platform/Platform.csproj
+++ b/frameworks/CSharp/aspnetcore/src/Platform/Platform.csproj
@@ -27,6 +27,7 @@
 
   <PropertyGroup Condition="$(PublishAot) == 'true'">
     <DefaultItemExcludes>$(MSBuildThisFileDirectory)Templates/**;$(DefaultItemExcludes)</DefaultItemExcludes>
+    <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.HillClimbing.Disable" Value="true" />
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
JIT disables threadpool hillclimbing here: https://github.com/TechEmpower/FrameworkBenchmarks/blob/c0164be4be7c5ffca6b799b81e03eff6559bbb7a/frameworks/CSharp/aspnetcore/aspnetcore.dockerfile#L10C12-L10C32. AOT uses a different mechanism.
