### PR TITLE
[C++/poco] Upgrade to Latest Version and Increase Max Connections

### DIFF
--- a/frameworks/C++/poco/README.md
+++ b/frameworks/C++/poco/README.md
@@ -1,0 +1,15 @@
+# POCO C++ Libraries Benchmarking Test
+
+- [POCO Github Repository](https://github.com/pocoproject/poco)
+- [POCO Website](https://pocoproject.org/)
+
+## Software Versions
+
+- [buildpack-deps noble](https://hub.docker.com/_/buildpack-deps)
+- [g++ 14](https://gcc.gnu.org/gcc-14/)
+- [c++17](https://en.cppreference.com/w/cpp/17)
+- [POCO 1.13.1](https://pocoproject.org/releases/poco-1.13.1/poco-1.13.1-all.zip)
+ 
+## Test URLs
+
+- `PLAINTEXT` - [http://127.0.0.1:8080/plaintext](http://127.0.0.1:8080/plaintext) 

--- a/frameworks/C++/poco/poco.dockerfile
+++ b/frameworks/C++/poco/poco.dockerfile
@@ -1,11 +1,11 @@
-FROM buildpack-deps:xenial
+FROM buildpack-deps:noble
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common unzip cmake
 
-RUN apt-get install -yqq g++-4.8 libjson0-dev
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+RUN apt-get install -yqq g++-14
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 50
 
-ENV POCO_VERSION 1.6.1
+ENV POCO_VERSION 1.13.3
 ENV POCO_HOME /poco
 
 WORKDIR ${POCO_HOME}
@@ -20,10 +20,10 @@ ENV LD_LIBRARY_PATH ${POCO_HOME}/lib/Linux/x86_64
 
 COPY benchmark.cpp benchmark.cpp
 
-RUN g++-4.8 \
+RUN g++-14 \
     -O3 \
     -DNDEBUG \
-    -std=c++0x \
+    -std=c++17 \
     -o \
     poco \
     benchmark.cpp \


### PR DESCRIPTION
POCO C++ needs some love <3

I've upgrade POCO to the latest version which also required upgrading dependencies such as the docker image, compiler, and C++ standard.

Since POCO's connection queue is really quite small by default, I've increased it to handle the high level of traffic demanded by the benchmarks. In my testing, this reduced the number of read errors from 100k+ to 0 and significantly increased requests/sec in the upper ranges.

The project was also missing a `README.md`, so I've included one here.