### PR TITLE
chore: set `keepAliveTimeout = 0` and upgrade docker image for list of JavaScript frameworks

### DIFF
--- a/frameworks/JavaScript/express/app.js
+++ b/frameworks/JavaScript/express/app.js
@@ -41,5 +41,6 @@ if (cluster.isPrimary) {
   app.get('/plaintext', (req, res) =>
     res.header('Content-Type', 'text/plain').send('Hello, World!'));
 
-  app.listen(8080);
+  const server = app.listen(8080);
+  server.keepAliveTimeout = 0;
 }

--- a/frameworks/JavaScript/express/express-chakra.dockerfile
+++ b/frameworks/JavaScript/express/express-chakra.dockerfile
@@ -1,4 +1,4 @@
-FROM node:chakracore
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-mongodb.dockerfile
+++ b/frameworks/JavaScript/express/express-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-mysql.dockerfile
+++ b/frameworks/JavaScript/express/express-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-postgres.dockerfile
+++ b/frameworks/JavaScript/express/express-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express-postgresjs.dockerfile
+++ b/frameworks/JavaScript/express/express-postgresjs.dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.1.0-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/express/express.dockerfile
+++ b/frameworks/JavaScript/express/express.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/fastify/create-server.js
+++ b/frameworks/JavaScript/fastify/create-server.js
@@ -1,4 +1,4 @@
-const fastify = require("fastify")();
+const fastify = require("fastify")({ logger: false, keepAliveTimeout: 0 });
 const handlers = require("./handlers");
 
 fastify.setErrorHandler((error, request, reply) => {

--- a/frameworks/JavaScript/hapi/create-server.js
+++ b/frameworks/JavaScript/hapi/create-server.js
@@ -13,6 +13,7 @@ const options = {
 };
 
 const server = new Hapi.server(options);
+server.listener.keepAliveTimeout = 0;
 
 const provision = async () => {
 

--- a/frameworks/JavaScript/hapi/hapi-mysql.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/hapi/hapi-postgres.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/JavaScript/hapi/hapi.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-fastify-mongo.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify-mongo.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-fastify-mysql.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-fastify.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-fastify.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-mongo.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-mongo.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs-mysql.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/nestjs.dockerfile
+++ b/frameworks/TypeScript/nest/nestjs.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-slim
+FROM node:20.16-slim
 
 COPY ./ ./
 

--- a/frameworks/TypeScript/nest/src/main.ts
+++ b/frameworks/TypeScript/nest/src/main.ts
@@ -23,6 +23,7 @@ async function bootstrapExpress() {
     app = await NestFactory.create<NestExpressApplication>(SqlModule, {
       logger: false,
     });
+    app.getHttpServer().keepAliveTimeout = 0;
   }
 
   app.setBaseViewsDir(join(__dirname, '..', 'views'));
@@ -40,12 +41,14 @@ async function bootstrapFastify() {
       new FastifyAdapter(),
       { logger: false },
     );
+    app.getHttpServer().keepAliveTimeout = 0;
   } else {
     app = await NestFactory.create<NestFastifyApplication>(
       SqlModule,
       new FastifyAdapter(),
       { logger: false },
     );
+    app.getHttpServer().keepAliveTimeout = 0;
   }
 
   app.setViewEngine({


### PR DESCRIPTION
Set `keepAliveTimeout = 0` and upgrade docker image to `node:20.16-slim` for:
- `express`
- `fastify`
- `hapi`
- `nest`
