### PR TITLE
[F#/Oxpecker] Returned back command auto-prepare

### DIFF
--- a/frameworks/FSharp/oxpecker/src/App/Common.fs
+++ b/frameworks/FSharp/oxpecker/src/App/Common.fs
@@ -26,9 +26,9 @@ module Common =
     }
 
     [<Literal>]
-    let ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=1024;NoResetOnClose=true;Enlist=false"
+    let ConnectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=1024;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4"
     [<Literal>]
-    let MultiplexedConnectionString = ConnectionString + ";Max Auto Prepare=3;Multiplexing=true"
+    let MultiplexedConnectionString = ConnectionString + ";Multiplexing=true"
 
     let FortuneComparer = {
         new IComparer<Fortune> with

--- a/frameworks/FSharp/oxpecker/src/App/Db.fs
+++ b/frameworks/FSharp/oxpecker/src/App/Db.fs
@@ -14,7 +14,6 @@ module Db =
             use db = new NpgsqlConnection(ConnectionString)
             use cmd = db.CreateCommand(CommandText = "SELECT id, message FROM fortune")
             do! db.OpenAsync()
-            do! cmd.PrepareAsync()
             use! rdr = cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection)
             while! rdr.ReadAsync() do
                 result.Add { id = rdr.GetInt32(0); message = rdr.GetString(1) }
@@ -46,7 +45,6 @@ module Db =
             let struct(cmd', _) = createReadCommand db
             use cmd = cmd'
             do! db.OpenAsync()
-            do! cmd.PrepareAsync()
             return! readSingleRow cmd
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
