### PR TITLE
Update aspnetcore Platform to use latest Razor Slices

### DIFF
--- a/frameworks/CSharp/aspnetcore/README.md
+++ b/frameworks/CSharp/aspnetcore/README.md
@@ -6,5 +6,5 @@ See [.NET Core](http://dot.net) and [ASP.NET Core](https://github.com/dotnet/asp
 
 **Language**
 
-* C# 8.0
+* C# 13.0
 

--- a/frameworks/CSharp/aspnetcore/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore/benchmark_config.json
@@ -30,6 +30,7 @@
         "json_url": "/json",
         "db_url": "/db",
         "query_url": "/queries/",
+        "fortune_url": "/fortunes",
         "update_url": "/updates/",
         "cached_query_url": "/cached-worlds/",
         "port": 8080,

--- a/frameworks/CSharp/aspnetcore/src/Platform/BenchmarkApplication.Fortunes.cs
+++ b/frameworks/CSharp/aspnetcore/src/Platform/BenchmarkApplication.Fortunes.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if !AOT
+using System;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -19,7 +19,7 @@ public partial class BenchmarkApplication
             FortunesTemplateFactory);
     }
 
-    private ValueTask OutputFortunes<TModel>(PipeWriter pipeWriter, TModel model, SliceFactory<TModel> templateFactory)
+    private ValueTask OutputFortunes<TModel>(PipeWriter pipeWriter, TModel model, Func<TModel, RazorSlice<TModel>> templateFactory)
     {
         // Render headers
         var preamble = """
@@ -39,7 +39,7 @@ public partial class BenchmarkApplication
         // Kestrel PipeWriter span size is 4K, headers above already written to first span & template output is ~1350 bytes,
         // so 2K chunk size should result in only a single span and chunk being used.
         var chunkedWriter = GetChunkedWriter(pipeWriter, chunkSizeHint: 2048);
-        var renderTask = template.RenderAsync(chunkedWriter, null, HtmlEncoder);
+        var renderTask = template.RenderAsync(chunkedWriter, HtmlEncoder);
 
         if (renderTask.IsCompletedSuccessfully)
         {
@@ -51,18 +51,17 @@ public partial class BenchmarkApplication
         return AwaitTemplateRenderTask(renderTask, chunkedWriter, template);
     }
 
-    private static async ValueTask AwaitTemplateRenderTask(ValueTask renderTask, ChunkedBufferWriter<WriterAdapter> chunkedWriter, RazorSlice template)
+    private static async ValueTask AwaitTemplateRenderTask(ValueTask renderTask, ChunkedPipeWriter chunkedWriter, RazorSlice template)
     {
         await renderTask;
         EndTemplateRendering(chunkedWriter, template);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void EndTemplateRendering(ChunkedBufferWriter<WriterAdapter> chunkedWriter, RazorSlice template)
+    private static void EndTemplateRendering(ChunkedPipeWriter chunkedWriter, RazorSlice template)
     {
-        chunkedWriter.End();
+        chunkedWriter.Complete();
         ReturnChunkedWriter(chunkedWriter);
         template.Dispose();
     }
 }
-#endif

--- a/frameworks/CSharp/aspnetcore/src/Platform/BenchmarkApplication.HttpConnection.cs
+++ b/frameworks/CSharp/aspnetcore/src/Platform/BenchmarkApplication.HttpConnection.cs
@@ -193,15 +193,15 @@ public partial class BenchmarkApplication : IHttpConnection
         => new(new(pipeWriter), sizeHint);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ChunkedBufferWriter<WriterAdapter> GetChunkedWriter(PipeWriter pipeWriter, int chunkSizeHint)
+    private static ChunkedPipeWriter GetChunkedWriter(PipeWriter pipeWriter, int chunkSizeHint)
     {
         var writer = ChunkedWriterPool.Get();
-        writer.SetOutput(new WriterAdapter(pipeWriter), chunkSizeHint);
+        writer.SetOutput(pipeWriter, chunkSizeHint);
         return writer;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ReturnChunkedWriter(ChunkedBufferWriter<WriterAdapter> writer) => ChunkedWriterPool.Return(writer);
+    private static void ReturnChunkedWriter(ChunkedPipeWriter writer) => ChunkedWriterPool.Return(writer);
 
     private struct WriterAdapter : IBufferWriter<byte>
     {

--- a/frameworks/CSharp/aspnetcore/src/Platform/ChunkedPipeWriter.cs
+++ b/frameworks/CSharp/aspnetcore/src/Platform/ChunkedPipeWriter.cs
@@ -5,18 +5,21 @@ using System;
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace PlatformBenchmarks;
 
-internal sealed class ChunkedBufferWriter<TWriter> : IBufferWriter<byte> where TWriter : IBufferWriter<byte>
+internal sealed class ChunkedPipeWriter : PipeWriter
 {
     private const int DefaultChunkSizeHint = 2048;
     private static readonly StandardFormat DefaultHexFormat = GetHexFormat(DefaultChunkSizeHint);
     private static ReadOnlySpan<byte> ChunkTerminator => "\r\n"u8;
 
-    private TWriter _output;
+    private PipeWriter _output;
     private int _chunkSizeHint;
     private StandardFormat _hexFormat = DefaultHexFormat;
     private Memory<byte> _currentFullChunk;
@@ -26,12 +29,12 @@ internal sealed class ChunkedBufferWriter<TWriter> : IBufferWriter<byte> where T
 
     public Memory<byte> Memory => _currentChunk;
 
-    public TWriter Output => _output;
+    public PipeWriter Output => _output;
 
     public int Buffered => _buffered;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SetOutput(TWriter output, int chunkSizeHint = DefaultChunkSizeHint)
+    public void SetOutput(PipeWriter output, int chunkSizeHint = DefaultChunkSizeHint)
     {
         _buffered = 0;
         _chunkSizeHint = chunkSizeHint;
@@ -52,7 +55,7 @@ internal sealed class ChunkedBufferWriter<TWriter> : IBufferWriter<byte> where T
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Advance(int count)
+    public override void Advance(int count)
     {
         ThrowIfEnded();
 
@@ -60,7 +63,7 @@ internal sealed class ChunkedBufferWriter<TWriter> : IBufferWriter<byte> where T
         _currentChunk = _currentChunk[count..];
     }
 
-    public Memory<byte> GetMemory(int sizeHint = 0)
+    public override Memory<byte> GetMemory(int sizeHint = 0)
     {
         ThrowIfEnded();
 
@@ -71,15 +74,25 @@ internal sealed class ChunkedBufferWriter<TWriter> : IBufferWriter<byte> where T
         return _currentChunk;
     }
 
-    public Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
+    public override Span<byte> GetSpan(int sizeHint = 0) => GetMemory(sizeHint).Span;
 
-    public void End()
+    public override void CancelPendingFlush()
+    {
+        _output.CancelPendingFlush();
+    }
+
+    public override void Complete(Exception exception = null)
     {
         ThrowIfEnded();
 
         CommitCurrentChunk(isFinal: true);
 
         _ended = true;
+    }
+
+    public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+    {
+        return _output.FlushAsync(cancellationToken);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/frameworks/CSharp/aspnetcore/src/Platform/Platform.csproj
+++ b/frameworks/CSharp/aspnetcore/src/Platform/Platform.csproj
@@ -6,7 +6,6 @@
     <IsTestAssetProject>true</IsTestAssetProject>
     <LangVersion>preview</LangVersion>
     <UserSecretsId>38063504-d08c-495a-89c9-daaad2f60f31</UserSecretsId>
-    <DefineConstants Condition="'$(PublishAot)' == 'true'">AOT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,12 +21,9 @@
     <PackageReference Include="Npgsql" Version="8.0.5" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="RazorSlices" Version="0.7.0" Condition="$(PublishAot) != 'true'" />
+    <PackageReference Include="RazorSlices" Version="0.8.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition="$(PublishAot) == 'true'">
-    <DefaultItemExcludes>$(MSBuildThisFileDirectory)Templates/**;$(DefaultItemExcludes)</DefaultItemExcludes>
-  </PropertyGroup>
   <ItemGroup Condition="$(PublishAot) == 'true'">
     <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.HillClimbing.Disable" Value="true" />
   </ItemGroup>


### PR DESCRIPTION
This enables the Platform Fortunes benchmark in native AOT too as the updated Razor Slices supports this.

/Cc @sebastienros 