### PR TITLE
[ruby/rack] Don't use async_thread_pool

### DIFF
--- a/frameworks/Ruby/rack/pg_db.rb
+++ b/frameworks/Ruby/rack/pg_db.rb
@@ -19,11 +19,7 @@ class PgDb
 
   def initialize(connection_string = nil, max_connections = 512)
     @connection = Sequel.connect(connection_string, max_connections: max_connections, sql_log_level: :warning)
-    if defined?(Falcon)
-      Sequel.extension :fiber_concurrency if defined?(Falcon)
-    else
-      @connection.extension :async_thread_pool
-    end
+    Sequel.extension :fiber_concurrency if defined?(Falcon)
 
     prepare_statements
   end


### PR DESCRIPTION
Not using async_thread_pool seems faster:

|              branch_name|plaintext|update|  json|   db|query|fortune|weighted_score|
|-------------------------|---------|------|------|-----|-----|-------|--------------|
|                   master|   101265| 13921|113730|33371|24701|  28719|          1794|
|disable-async-thread-pool|   102381| 13441|126911|40248|28379|  43834|          1928|