### PR TITLE
[rails] Enable config.api_only

### DIFF
--- a/frameworks/Ruby/rails/config/application.rb
+++ b/frameworks/Ruby/rails/config/application.rb
@@ -30,26 +30,19 @@ module Hello
 
     config.action_dispatch.default_headers.merge!('Server' => 'WebServer')
 
+    config.api_only = true
+
     config.middleware.delete ActionDispatch::Callbacks
-    config.middleware.delete ActionDispatch::ContentSecurityPolicy::Middleware
-    config.middleware.delete ActionDispatch::Cookies
     config.middleware.delete ActionDispatch::DebugExceptions
     config.middleware.delete ActionDispatch::Executor
-    config.middleware.delete ActionDispatch::Flash
-    config.middleware.delete ActionDispatch::PermissionsPolicy::Middleware
-    config.middleware.delete ActionDispatch::Reloader
     config.middleware.delete ActionDispatch::RemoteIp
     config.middleware.delete ActionDispatch::RequestId
-    config.middleware.delete ActionDispatch::Session::CookieStore
     config.middleware.delete ActionDispatch::ShowExceptions
-    config.middleware.delete ActiveRecord::Migration::CheckPending
     config.middleware.delete Rack::ConditionalGet
     config.middleware.delete Rack::ETag
     config.middleware.delete Rack::Head
-    config.middleware.delete Rack::MethodOverride
     config.middleware.delete Rack::Runtime
     config.middleware.delete Rack::Sendfile
-    config.middleware.delete Rack::TempfileReaper
     config.middleware.delete Rails::Rack::Logger
 
     config.active_support.isolation_level = :fiber if defined?(Falcon)


### PR DESCRIPTION
`config.api_only` disables a lot of middleware like Cookies and Session so we no longer have to delete them specifically.