### PR TITLE
[php] Ubiquity update to PHP/8.4

### DIFF
--- a/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 
+FROM ubuntu:24.04 
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -8,14 +8,14 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev \
                     php8.3-cli php8.3-dev php8.3-mbstring libphp8.3-embed nginx > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-ADD ./ ./
+COPY ./ ./
 
-ENV NGINX_VERSION=1.25.3
+ENV NGINX_VERSION=1.27.3
 
 RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx-raw.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -8,14 +8,14 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-pgsql nginx > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-ADD ./ ./
+COPY ./ ./
 
-ENV NGINX_VERSION=1.25.3
+ENV NGINX_VERSION=1.27.3
 
 RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-ngx.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -8,14 +8,14 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq wget git unzip libxml2-dev cmake make systemtap-sdt-dev \
-                    zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev \
+                    zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev \
                     php8.3-cli php8.3-dev libphp8.3-embed php8.3-pgsql nginx > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-ADD ./ ./
+COPY ./ ./
 
-ENV NGINX_VERSION=1.25.3
+ENV NGINX_VERSION=1.27.3
 
 RUN git clone -b v0.0.28 --single-branch --depth 1 https://github.com/rryqszq4/ngx_php7.git > /dev/null
 

--- a/frameworks/PHP/ubiquity/ubiquity-swoole-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-swoole-mysql.dockerfile
@@ -1,11 +1,11 @@
-FROM phpswoole/swoole:5.1.3-php8.3
+FROM phpswoole/swoole:php8.4
 
 RUN docker-php-ext-install pcntl opcache > /dev/null
 
 COPY deploy/conf/php-async.ini /usr/local/etc/php/php.ini
 
 WORKDIR /ubiquity
-ADD --link . .
+COPY --link . .
 
 RUN chmod -R 777 /ubiquity
 

--- a/frameworks/PHP/ubiquity/ubiquity-swoole.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-swoole.dockerfile
@@ -1,4 +1,4 @@
-FROM phpswoole/swoole:5.1.3-php8.3
+FROM phpswoole/swoole:php8.4
 
 RUN apt-get install -y libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
@@ -7,7 +7,7 @@ RUN apt-get install -y libpq-dev \
 COPY deploy/conf/php-async.ini /usr/local/etc/php/php.ini
 
 WORKDIR /ubiquity
-ADD --link . .
+COPY --link . .
 
 RUN chmod -R 777 /ubiquity
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.3-cli php8.3-mysql php8.3-xml php8.3-mbstring > /dev/null
+    apt-get install -yqq git php8.4-cli php8.4-mysql php8.4-xml php8.4-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.3-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.3/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/mysql/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.3/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.3/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.3-cli php8.3-pgsql php8.3-xml php8.3-mbstring > /dev/null
+    apt-get install -yqq git php8.4-cli php8.4-pgsql php8.4-xml php8.4-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.3-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.3/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/pgsql/raw/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.3/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.3/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.3-cli php8.3-pgsql php8.3-xml php8.3-mbstring > /dev/null
+    apt-get install -yqq git php8.4-cli php8.4-pgsql php8.4-xml php8.4-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.3-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.3/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/pgsql/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.3/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.3/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.4/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity.dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php8.3 php8.3-common php8.3-cli php8.3-fpm php8.3-mysql php8.3-dev > /dev/null
+    apt-get install -yqq nginx git unzip php8.4 php8.4-common php8.4-cli php8.4-fpm php8.4-mysql php8.4-dev > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.3/fpm/
+COPY deploy/conf/* /etc/php/8.4/fpm/
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
@@ -22,9 +22,9 @@ RUN chmod 777 -R /ubiquity/app/cache/*
 
 COPY deploy/conf/ubiquity-config.php app/config/config.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.3/fpm/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/fpm/php.ini
 
 EXPOSE 8080
 
-CMD service php8.3-fpm start && \
+CMD service php8.4-fpm start && \
     nginx -c /ubiquity/deploy/nginx.conf -g "daemon off;"


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Except RoadRunner variant and ngx-php

Swoole and Workerman (and mongodb) variants have deprecation warnings !!
@jcheron 

#9408