### PR TITLE
[ruby/sinatra] Don't use `JSON.fast_generate`

### DIFF
--- a/frameworks/Ruby/sinatra-sequel/Gemfile.lock
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.8)
     iodine (0.7.58)
-    json (2.8.2)
+    json (2.9.1)
     kgio (2.11.4)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -22,7 +22,7 @@ class HelloWorld < Sinatra::Base
 
     def json(data)
       content_type :json
-      JSON.fast_generate(data)
+      data.to_json
     end
 
     # Return a random number between 1 and MAX_PK

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -22,7 +22,7 @@ class HelloWorld < Sinatra::Base
 
     def json(data)
       content_type :json
-      JSON.fast_generate(data)
+      data.to_json
     end
 
     # Return a random number between 1 and MAX_PK


### PR DESCRIPTION
`fast_generate` is not faster for small payloads.

|         branch_name|update|   db|query|fortune|weighted_score|
|--------------------|------|-----|-----|-------|--------------|
|              master|  8301|36433|15826|  28025|          1089|
|remove-fast-generate|  8897|38895|16317|  27660|          1143|

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
