### PR TITLE
Use plaintext for connectivity test

### DIFF
--- a/toolset/benchmark/framework_test.py
+++ b/toolset/benchmark/framework_test.py
@@ -74,7 +74,7 @@ class FrameworkTest:
 
         url = "http://%s:%s%s" % (self.benchmarker.config.server_host,
                                   self.port,
-                                  self.runTests[test_type].get_url())
+                                  self.runTests["plaintext"].get_url())
 
         return self.benchmarker.docker_helper.test_client_connection(url)
 


### PR DESCRIPTION
By using plaintext for connectivity testing instead of a DB related one we rule out any issues related to the database while checking if the server is up

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
