### PR TITLE
[php] Amp update to PHP/8.4

### DIFF
--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,20 +6,19 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq git unzip wget curl build-essential \
-    php8.3-cli php8.3-mbstring php8.3-dev php8.3-xml php8.3-curl > /dev/null
+    php8.4-cli php8.4-mbstring php8.4-dev php8.4-xml php8.4-curl > /dev/null
 
 # An extension is required!
 # We deal with concurrencies over 1k, which stream_select doesn't support.
 RUN wget http://pear.php.net/go-pear.phar --quiet && php go-pear.phar
 #RUN apt-get install -y libuv1-dev > /dev/null
 RUN apt-get install -y libevent-dev > /dev/null
-#RUN pecl install uv-0.2.4 > /dev/null && echo "extension=uv.so" > /etc/php/8.3/cli/conf.d/uv.ini
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+#RUN pecl install uv-0.2.4 > /dev/null && echo "extension=uv.so" > /etc/php/8.4/cli/conf.d/uv.ini
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-ADD ./ /amp
 WORKDIR /amp
-
-COPY deploy/conf/* /etc/php/8.3/cli/conf.d/
+COPY --link . .
+COPY deploy/conf/* /etc/php/8.4/cli/conf.d/
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/amp/amp.dockerfile
+++ b/frameworks/PHP/amp/amp.dockerfile
@@ -22,7 +22,7 @@ COPY deploy/conf/* /etc/php/8.4/cli/conf.d/
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN composer install --prefer-dist --optimize-autoloader --no-dev 
+RUN composer install --prefer-dist --optimize-autoloader --no-dev --quiet
 
 EXPOSE 8080
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
#9408

Show deprecation warnings, but work OK.
We need to update it to v3 in another PR.