### PR TITLE
Add Clace framework

### DIFF
--- a/frameworks/Python/clace/.dockerignore
+++ b/frameworks/Python/clace/.dockerignore
@@ -1,0 +1,2 @@
+.venv
+README.md

--- a/frameworks/Python/clace/README.md
+++ b/frameworks/Python/clace/README.md
@@ -1,0 +1,11 @@
+# Introduction
+
+[Clace](https://github.com/claceio/clace) is a platform for developing and deploying internal tools.
+
+Clace is implemented in Go. Clace apps are written in [Starlark](https://starlark-lang.org/). Starlark is a thread-safe language with Python syntax, designed for embedding. Clace uses the [Starlark Go](https://github.com/google/starlark-go) implementation. Since apps are developed using a python like syntax, the benchmark is added under the Python category.
+
+# Benchmarking
+
+The JSON and plaintext tests are implemented. Clace supports SQLite database only currently, so the database tests are not implemented.
+
+The Dockerfile starts the Clace server and creates a single app which implements the benchmark apis (app.star).

--- a/frameworks/Python/clace/app.star
+++ b/frameworks/Python/clace/app.star
@@ -1,0 +1,6 @@
+app = ace.app("testapp",
+    routes = [
+        ace.api("/json", lambda req: {'message': 'Hello, world!'}, type=ace.JSON),
+        ace.api("/plaintext", lambda req: 'Hello, world!', type=ace.TEXT)
+    ]
+)

--- a/frameworks/Python/clace/benchmark_config.json
+++ b/frameworks/Python/clace/benchmark_config.json
@@ -1,0 +1,23 @@
+{
+  "framework": "clace",
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "framework": "Clace",
+        "language": "python",
+        "flavor": "Starlark",
+        "platform": "None",
+        "webserver": "Clace",
+        "os": "Linux",
+        "display_name": "Clace",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/Python/clace/clace.dockerfile
+++ b/frameworks/Python/clace/clace.dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11
+WORKDIR /clace/
+
+RUN curl -L https://clace.io/install.sh | bash
+ENV CL_HOME="/root/clhome"
+ENV PATH="/root/clhome/bin:$PATH"
+
+COPY . .
+
+EXPOSE 8080
+CMD /clace/run.sh

--- a/frameworks/Python/clace/run.sh
+++ b/frameworks/Python/clace/run.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+cd /root
+
+cat <<EOF > /root/clhome/clace.toml
+[logging]
+console = false
+file = false
+access_logging = false
+
+[http]
+host = "0.0.0.0"
+port = 8080
+EOF
+
+
+clace server start &
+sleep 2
+clace app create --auth=none --approve /clace tfb-server:/
+tail -f /dev/null


### PR DESCRIPTION
[Clace](https://github.com/claceio/clace) is a platform for developing and deploying internal tools.

Clace is implemented in Go. Clace apps are written in [Starlark](https://starlark-lang.org/). Starlark is a thread-safe language with Python syntax, designed for embedding. Clace uses the [Starlark Go](https://github.com/google/starlark-go) implementation. Since apps are developed using a python like syntax, the benchmark is added under the Python category.

The JSON and plaintext tests are implemented. Clace supports SQLite database only currently, so the database tests are not implemented.

The Dockerfile starts the Clace server and creates a single app which implements the benchmark apis (app.star).
