### PR TITLE
[ruby/roda-sequel] Detect workers for Iodine

### DIFF
--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-iodine-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-iodine-mri.dockerfile
@@ -18,4 +18,4 @@ ENV DBTYPE=postgresql
 
 EXPOSE 8080
 
-CMD bundle exec iodine -p 8080
+CMD bundle exec iodine -p 8080 -w $(ruby config/auto_tune.rb | grep -Eo '[0-9]+' | head -n 1)


### PR DESCRIPTION
|                   branch_name|plaintext|update|  json|   db|query|fortune|weighted_score|
|------------------------------|---------|------|------|-----|-----|-------|--------------|
|                        master|   227545| 22971|213942|52774|37141|  49660|          2923|
|roda-sequel/iodine-set-workers|   327473| 25126|276279|89255|81149|  63912|          4227|