### PR TITLE
[FrankenPHP] Remove unnecessary file-exists checks.

### DIFF
--- a/frameworks/PHP/laravel/deploy/franken/Caddyfile
+++ b/frameworks/PHP/laravel/deploy/franken/Caddyfile
@@ -1,0 +1,24 @@
+{
+	{$CADDY_GLOBAL_OPTIONS}
+
+	admin {$CADDY_SERVER_ADMIN_HOST}:{$CADDY_SERVER_ADMIN_PORT}
+
+	frankenphp {
+		worker "{$APP_PUBLIC_PATH}/frankenphp-worker.php" {$CADDY_SERVER_WORKER_COUNT}
+	}
+}
+
+{$CADDY_SERVER_SERVER_NAME} {
+	route {
+		# Mercure configuration is injected here...
+		{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+		# FrankenPHP!
+		# disable static files for this benchmark
+		# by using php instead of php_server
+		rewrite frankenphp-worker.php
+		php {
+			root "{$APP_PUBLIC_PATH}"
+		}
+	}
+}

--- a/frameworks/PHP/laravel/laravel-octane-frankenphp.dockerfile
+++ b/frameworks/PHP/laravel/laravel-octane-frankenphp.dockerfile
@@ -1,7 +1,6 @@
 FROM dunglas/frankenphp
  
 RUN install-php-extensions \
-    intl \
 	opcache \
 	pcntl \
     pdo_mysql \
@@ -26,4 +25,4 @@ RUN frankenphp -v
 
 EXPOSE 8080
 
-ENTRYPOINT ["php", "artisan", "octane:frankenphp", "--port=8080"]
+ENTRYPOINT ["php", "artisan", "octane:frankenphp", "--port=8080", "--caddyfile=/app/deploy/franken/Caddyfile"]

--- a/frameworks/PHP/php/deploy/franken/Caddyfile
+++ b/frameworks/PHP/php/deploy/franken/Caddyfile
@@ -11,11 +11,14 @@
 :8080
 
 route {
-    root * /php
 
     # FrankenPHP!
+    # disable static files for this benchmark
+    # by using php instead of php_server
     @phpFiles path *.php
-    php @phpFiles
+    php @phpFiles {
+        root /php
+    }
 
     respond 404
 }

--- a/frameworks/PHP/symfony/deploy/Caddyfile
+++ b/frameworks/PHP/symfony/deploy/Caddyfile
@@ -11,18 +11,13 @@
 :8080
 
 route {
-    root * /symfony/public
 
-    # If the requested file does not exist, try index files
-    @indexFiles file {
-        try_files {path} {path}/runtime.php runtime.php
-        split_path .php
+	# FrankenPHP!
+	# disable static files for this benchmark
+	# by using php instead of php_server
+    rewrite runtime.php
+    php {
+        root /symfony/public
     }
-    rewrite @indexFiles {http.matchers.file.relative}
-    
-    # FrankenPHP!
-    @phpFiles path *.php
-    php @phpFiles
 
-    respond 404
 }

--- a/frameworks/PHP/symfony/symfony-franken.dockerfile
+++ b/frameworks/PHP/symfony/symfony-franken.dockerfile
@@ -2,7 +2,6 @@ FROM dunglas/frankenphp
 
 # add additional extensions here:
 RUN install-php-extensions \
-    intl \
     opcache \
     pdo_pgsql \
     zip > /dev/null


### PR DESCRIPTION
Optimizes FrankenPHP/Symfony/Laravel by deactivating the `file server`/`try files` checks and forwarding directly to the PHP runtime (which is all we need in this case). 