### PR TITLE
[clace] Added localhost path

### DIFF
--- a/frameworks/Python/clace/run.sh
+++ b/frameworks/Python/clace/run.sh
@@ -15,5 +15,6 @@ EOF
 
 clace server start &
 sleep 2
+clace app create --auth=none --approve /clace /
 clace app create --auth=none --approve /clace tfb-server:/
 tail -f /dev/null


### PR DESCRIPTION
Added app at localhost path also. The previous test run for Clace failed https://tfb-status.techempower.com/unzip/results.2025-01-23-22-49-18-014.zip/results/20250117182557/clace possibly because the app was at tfb-server path only.