### PR TITLE
[ruby/roda-sequel] Only set headers not created by servers

### DIFF
--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -15,9 +15,19 @@ class HelloWorld < Roda
     rand(MAX_PK) + 1
   end
 
+  if defined?(Puma)
+    def set_default_headers(response)
+      response[DATE_HEADER] = Time.now.httpdate
+      response[SERVER_HEADER] = SERVER_STRING
+    end
+  else
+    def set_default_headers(response)
+      response[SERVER_HEADER] = SERVER_STRING
+    end
+  end
+
   route do |r|
-    response[DATE_HEADER] = Time.now.httpdate
-    response[SERVER_HEADER] = SERVER_STRING if SERVER_STRING
+    set_default_headers(response)
 
     # Test type 1: JSON serialization
     r.is "json" do


### PR DESCRIPTION
Servers like Iodine set the `Date` header itself, so no need to duplicate that effort.

|                         branch_name|  json|   db|query|update|fortune|plaintext|weighted_score|
|------------------------------------|------|-----|-----|------|-------|---------|--------------|
|                              master|213942|52774|37141| 22971|  49660|   227545|          2923|
|remove-redundant-headers|280527|89348|61538| 24688|  57966|   335448|          3752|