### PR TITLE
[Elysia] Use Bun's SQL API

### DIFF
--- a/frameworks/TypeScript/elysia/elysia-compiled.dockerfile
+++ b/frameworks/TypeScript/elysia/elysia-compiled.dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.1
+FROM oven/bun:1.2
 
 EXPOSE 8080
 

--- a/frameworks/TypeScript/elysia/elysia-postgres.dockerfile
+++ b/frameworks/TypeScript/elysia/elysia-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.1
+FROM oven/bun:1.2
 
 EXPOSE 8080
 

--- a/frameworks/TypeScript/elysia/elysia-smol-postgres.dockerfile
+++ b/frameworks/TypeScript/elysia/elysia-smol-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.1
+FROM oven/bun:1.2
 
 EXPOSE 8080
 

--- a/frameworks/TypeScript/elysia/elysia.dockerfile
+++ b/frameworks/TypeScript/elysia/elysia.dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.1
+FROM oven/bun:1.2
 
 EXPOSE 8080
 

--- a/frameworks/TypeScript/elysia/src/postgres.ts
+++ b/frameworks/TypeScript/elysia/src/postgres.ts
@@ -1,12 +1,9 @@
-import postgres from "postgres";
+import { SQL } from "bun";
 import { rand } from "./db-handlers";
 import type { Fortune, World } from "./types";
 
-const sql = postgres({
-	host: "tfb-database",
-	user: "benchmarkdbuser",
-	password: "benchmarkdbpass",
-	database: "hello_world",
+const sql = new SQL({
+	url: "postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world",
 	max: 1,
 });
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Bun released a new [SQL](https://bun.sh/docs/api/sql) API that works with Postgres and claims nearly 2x faster performance compared to `postgres.js`. Elysia can use it as a drop-in replacement for `postgres.js`.