### PR TITLE
[ruby/sinatra] Only set headers not created by servers

### DIFF
--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -33,7 +33,7 @@ class HelloWorld < Sinatra::Base
 
   after do
     response['Date'] = Time.now.httpdate
-  end
+  end if defined?(Falcon) || defined?(Puma)
 
   after do
     response['Server'] = SERVER_STRING

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -33,7 +33,7 @@ class HelloWorld < Sinatra::Base
 
   after do
     response['Date'] = Time.now.httpdate
-  end
+  end if defined?(Falcon) || defined?(Puma) || defined?(Agoo)
 
   after do
     response['Server'] = SERVER_STRING


### PR DESCRIPTION
|                     branch_name| json|   db|query|update|fortune|plaintext|weighted_score|
|--------------------------------|-----|-----|-----|------|-------|---------|--------------|
|                          master|62219|24663| 8786|  6706|  20755|    62218|           849|
|remove-redundant-headers|76413|31652|13103|  6976|  19379|    60110|           982|