### PR TITLE
[sisk] Fix warning

### DIFF
--- a/frameworks/CSharp/sisk/benchmark_config.json
+++ b/frameworks/CSharp/sisk/benchmark_config.json
@@ -17,9 +17,7 @@
                 "os": "Linux",
                 "database_os": "Linux",
                 "display_name": "Sisk Framework"
-            }
-        },
-        {
+            },
             "cadente": {
                 "plaintext_url": "/plaintext",
                 "json_url": "/json",


### PR DESCRIPTION
`benchmark_config.json` wasn't correct resulting in the following warning:

    Framework sisk does not define a default test in benchmark_config.json