### PR TITLE
[nextjs] Use config to set HTTP `Server` header

### DIFF
--- a/frameworks/TypeScript/nextjs/middleware.ts
+++ b/frameworks/TypeScript/nextjs/middleware.ts
@@ -1,7 +1,0 @@
-import { NextRequest, NextResponse } from "next/server"
-
-export function middleware(request: NextRequest) {
-  const response = NextResponse.next()
-  response.headers.set("Server", "Next.js")
-  return response
-}

--- a/frameworks/TypeScript/nextjs/next.config.ts
+++ b/frameworks/TypeScript/nextjs/next.config.ts
@@ -2,6 +2,17 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+
+  async headers() {
+    return [
+      {
+        source: "/(.*?)",
+        headers: [
+          { key: "Server", value: "Next.js" },
+        ],
+      },
+    ]
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
[According to Next.js maintainers][suggestion], this can improve performance:

> If you only need custom headers, you might see better performance by using the `headers` option in `next.config.js` instead of middleware.

[suggestion]: https://github.com/vercel/next.js/discussions/75930#discussioncomment-12187436
