### PR TITLE
[python/flask] Fix some failing tests

### DIFF
--- a/frameworks/Python/flask/requirements.txt
+++ b/frameworks/Python/flask/requirements.txt
@@ -10,3 +10,4 @@ Jinja2==3.1.4
 MarkupSafe==2.1.2
 ujson==5.4.0
 orjson==3.8.7; implementation_name=='cpython' 
+Werkzeug==2.3.8


### PR DESCRIPTION
This fixes the failing flask test because Werkzeug version 3 removed `url_quote` raising:

    ImportError: cannot import name 'url_quote' from 'werkzeug.urls'

The `flask-socketify-wsgi-pypy` errors are another issue I couldn't fix.
