### PR TITLE
[python/quart] Fix some failing tests

### DIFF
--- a/frameworks/Python/quart/requirements.txt
+++ b/frameworks/Python/quart/requirements.txt
@@ -14,5 +14,5 @@ priority==2.0.0
 quart==0.18.0
 toml==0.10.2
 uvloop==0.16.0
-Werkzeug==3.0.3
+Werkzeug==2.3.8
 wsproto==1.2.0


### PR DESCRIPTION
This fixes the failing quart test because Werkzeug version 3 removed `url_quote` raising:

    ImportError: cannot import name 'url_quote' from 'werkzeug.urls'

The update is still failing for the uvicorn version, but that is another problem.