### PR TITLE
[php] CakePHP remove xdebug (#9675)

### DIFF
--- a/frameworks/PHP/cakephp/cakephp-workerman.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp-workerman.dockerfile
@@ -24,8 +24,6 @@ RUN composer install --optimize-autoloader --classmap-authoritative --no-dev  --
 
 RUN chmod -R 777 /cakephp
 
-#ENV XDEBUG_CONFIG="remote_host=$(ipconfig getifaddr en0)"
-ENV XDEBUG_SESSION=xdebug_is_great
 #COPY deploy/conf/cli-php.ini /etc/php/8.3/cli/php.ini
 
 CMD php -c deploy/conf/cli-php.ini \

--- a/frameworks/PHP/cakephp/cakephp.dockerfile
+++ b/frameworks/PHP/cakephp/cakephp.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.4-fpm php8.4-mysql php8.4-xml php8.4-mbstring php8.4-intl php8.4-dev php8.4-curl php-xdebug > /dev/null
+    php8.4-fpm php8.4-mysql php8.4-xml php8.4-mbstring php8.4-intl php8.4-dev php8.4-curl > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 


### PR DESCRIPTION
CakePHP Benchmark performance degreed because Xdebug is installed.

* remove xdebug
