### PR TITLE
[ruby/padrino] Don't hardcode number of workers to 8 for Puma

### DIFF
--- a/frameworks/Ruby/padrino/config/auto_tune.rb
+++ b/frameworks/Ruby/padrino/config/auto_tune.rb
@@ -9,7 +9,7 @@ KB_PER_WORKER = 128 * 1_024 # average of peak PSS of single-threaded processes (
 MIN_WORKERS = 2
 MAX_WORKERS_PER_VCPU = 1.25 # virtual/logical
 MIN_THREADS_PER_WORKER = 1
-MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 8)
+MAX_THREADS = Integer(ENV['MAX_CONCURRENCY'] || 256)
 
 def meminfo(arg)
   File.open('/proc/meminfo') do |f|

--- a/frameworks/Ruby/padrino/padrino.dockerfile
+++ b/frameworks/Ruby/padrino/padrino.dockerfile
@@ -16,4 +16,4 @@ EXPOSE 8080
 
 ENV RUBY_YJIT_ENABLE=1
 
-CMD bundle exec puma -C config/puma.rb -w 8 --preload
+CMD bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Use autotune instead as the server can handle a lot more than 8 threads.