### PR TITLE
[rails] Don't use a logger

### DIFF
--- a/frameworks/Ruby/rails/config/environments/production.rb
+++ b/frameworks/Ruby/rails/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   # config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  config.logger = nil
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = :fatal


### PR DESCRIPTION
Not using a logger is faster than setting the log level to fatal.

|     branch_name|  json|   db|query|update|fortune|plaintext|weighted_score|
|----------------|------|-----|-----|------|-------|---------|--------------|
|          master|152537|33415|28714| 13947|  20249|   186596|          1901|
|rails/nil-logger|157689|34283|30021| 15317|  21485|   184987|          2034|