### PR TITLE
hyper: simplify handlers

### DIFF
--- a/frameworks/Rust/hyper/hyper.dockerfile
+++ b/frameworks/Rust/hyper/hyper.dockerfile
@@ -1,8 +1,17 @@
 FROM rust:1.85 AS hyper
 
 WORKDIR /src
-COPY . .
-RUN RUSTFLAGS="-C target-cpu=native" cargo install --path . --locked
+ENV RUSTFLAGS="-C target-cpu=native"
+
+# Cache dependency builds (requires passing --force-rm False to tfb command)
+COPY Cargo.toml Cargo.lock /src/
+RUN mkdir src \
+    && echo "fn main() {println!(\"if you see this, the build broke\")}" > src/main.rs \
+    && cargo build --release \
+    && rm -rfv src/ target/release/hyper-techempower* target/release/deps/hyper_techempower*
+
+COPY . /src/
+RUN cargo install --path . --locked
 EXPOSE 8080
 CMD ["hyper-techempower"]
 HEALTHCHECK CMD curl --fail http://localhost:8080/ping || exit 1

--- a/frameworks/Rust/hyper/src/json.rs
+++ b/frameworks/Rust/hyper/src/json.rs
@@ -1,13 +1,10 @@
-use std::convert::Infallible;
-
-use http::header::{CONTENT_LENGTH, CONTENT_TYPE, SERVER};
+use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use http::Response;
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::body::Bytes;
 use serde::Serialize;
 
-use crate::{Error, Result, APPLICATION_JSON, SERVER_HEADER};
+use crate::{Error, Result, APPLICATION_JSON};
 
 #[derive(Serialize)]
 struct JsonResponse<'a> {
@@ -18,12 +15,12 @@ static CONTENT: JsonResponse = JsonResponse {
     message: "Hello, world!",
 };
 
-pub fn get() -> Result<Response<BoxBody<Bytes, Infallible>>> {
+pub fn get() -> Result<Response<Full<Bytes>>> {
     let content = serde_json::to_vec(&CONTENT)?;
+
     Response::builder()
-        .header(SERVER, SERVER_HEADER.clone())
         .header(CONTENT_TYPE, APPLICATION_JSON.clone())
         .header(CONTENT_LENGTH, content.len())
-        .body(Full::from(content).boxed())
+        .body(content.into())
         .map_err(Error::from)
 }

--- a/frameworks/Rust/hyper/src/plaintext.rs
+++ b/frameworks/Rust/hyper/src/plaintext.rs
@@ -1,20 +1,16 @@
-use std::convert::Infallible;
-
-use http::header::{CONTENT_LENGTH, CONTENT_TYPE, SERVER};
+use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use http::Response;
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::body::Bytes;
 
-use crate::{Error, Result, SERVER_HEADER, TEXT_PLAIN};
+use crate::{Error, Result, TEXT_PLAIN};
 
 static CONTENT: &[u8] = b"Hello, world!";
 
-pub fn get() -> Result<Response<BoxBody<Bytes, Infallible>>> {
+pub fn get() -> Result<Response<Full<Bytes>>> {
     Response::builder()
-        .header(SERVER, SERVER_HEADER.clone())
         .header(CONTENT_TYPE, TEXT_PLAIN.clone())
         .header(CONTENT_LENGTH, CONTENT.len())
-        .body(Full::from(CONTENT).boxed())
+        .body(CONTENT.into())
         .map_err(Error::from)
 }

--- a/toolset/run-tests.py
+++ b/toolset/run-tests.py
@@ -208,6 +208,10 @@ def main(argv=None):
         nargs='*',
         default=None,
         help='Extra docker arguments to be passed to the test container')
+    parser.add_argument(
+        '--force-rm',
+        default=True,
+        help='Remove intermediate docker containers after running.')
 
     # Network options
     parser.add_argument(

--- a/toolset/utils/benchmark_config.py
+++ b/toolset/utils/benchmark_config.py
@@ -55,6 +55,7 @@ class BenchmarkConfig:
         self.cpuset_cpus = args.cpuset_cpus
         self.test_container_memory = args.test_container_memory
         self.extra_docker_runtime_args = args.extra_docker_runtime_args
+        self.force_rm_intermediate_docker_layers = args.force_rm
 
         if self.network_mode is None:
             self.network = 'tfb'

--- a/toolset/utils/docker_helper.py
+++ b/toolset/utils/docker_helper.py
@@ -39,7 +39,7 @@ class DockerHelper:
                     path=path,
                     dockerfile=dockerfile,
                     tag=tag,
-                    forcerm=True,
+                    forcerm=self.benchmarker.config.force_rm_intermediate_docker_layers,
                     timeout=3600,
                     pull=True,
                     buildargs=buildargs,


### PR DESCRIPTION
- move the server header to the router and add it to all responses.
- move the response boxing to the router simplifying the return types of
  each handler.

https://github.com/hyperium/http-body/pull/150 will simplify the router
code even futher to the following:

```rust
let mut response = match request.uri().path() {
     "/ping" => ping()?.box_body(),
     "/json" => json::get()?.box_body(),
     "/db" => single_query::get().await?.box_body(),
     "/queries" => multiple_queries::get(request.uri().query()).await?.box_body(),
     "/fortunes" => fortunes::get().await?.box_body(),
     "/plaintext" => plaintext::get()?.box_body(),
     _ => not_found_error()?.box_body(),
};
```

Note: includes commits from #9727 