### PR TITLE
[php] Update date for headers

### DIFF
--- a/frameworks/PHP/cakephp/server.php
+++ b/frameworks/PHP/cakephp/server.php
@@ -36,9 +36,9 @@ class HeaderDate
 
     public static function init(): void
     {
-        self::$date = self::NAME.gmdate('D, d M Y H:i:s').' GMT';
+        self::$date = self::NAME.gmdate(DATE_RFC7231);
         Timer::add(1, static function () {
-            self::$date = self::NAME.gmdate('D, d M Y H:i:s').' GMT';
+            self::$date = self::NAME.gmdate(DATE_RFC7231);
         });
     }
 }

--- a/frameworks/PHP/comet/app.php
+++ b/frameworks/PHP/comet/app.php
@@ -24,9 +24,9 @@ $app = new Comet([
 $app->init(
     function() {
         ORM::init();	
-	    Storage::$date = gmdate('D, d M Y H:i:s').' GMT';
+	    Storage::$date = gmdate(DATE_RFC7231);
     	Timer::add(1, function() {
-        	Storage::$date = gmdate('D, d M Y H:i:s').' GMT';
+        	Storage::$date = gmdate(DATE_RFC7231);
 	    });
 });
 

--- a/frameworks/PHP/cyberphp/src/Response.php
+++ b/frameworks/PHP/cyberphp/src/Response.php
@@ -127,7 +127,7 @@ class Response
         }
 
         $headers['Content-Type'] = 'application/json; charset=utf-8';
-        $headers['Date'] = gmdate('D, d M Y H:i:s').' GMT';
+        $headers['Date'] = gmdate(DATE_RFC7231);
         return new static($json, $status, $headers);
     }
 
@@ -137,7 +137,7 @@ class Response
     public static function html(string $html, int $status = 200, array $headers = []): static
     {
         $headers['Content-Type'] = 'text/html; charset=utf-8';
-        $headers['Date'] = gmdate('D, d M Y H:i:s').' GMT';
+        $headers['Date'] = gmdate(DATE_RFC7231);
         return new static($html, $status, $headers);
     }
 
@@ -147,7 +147,7 @@ class Response
     public static function text(string $text, int $status = 200, array $headers = []): static
     {
         $headers['Content-Type'] = 'text/plain; charset=utf-8';
-        $headers['Date'] = gmdate('D, d M Y H:i:s').' GMT';
+        $headers['Date'] = gmdate(DATE_RFC7231);
         return new static($text, $status, $headers);
     }
     /**
@@ -156,7 +156,7 @@ class Response
     public static function file(string $file, string $filename, int $status = 200, array $headers = []): static
     {
         $headers['Content-Type'] = 'application/octet-stream';
-        $headers['Date'] = gmdate('D, d M Y H:i:s').' GMT';
+        $headers['Date'] = gmdate(DATE_RFC7231);
         $headers['Content-Disposition'] = 'attachment; filename="' . $filename . '"';
         return new static(file_get_contents($file), $status, $headers);
     }

--- a/frameworks/PHP/imi/Listener/WorkermanWorkerStart.php
+++ b/frameworks/PHP/imi/Listener/WorkermanWorkerStart.php
@@ -19,9 +19,9 @@ class WorkermanWorkerStart implements IEventListener
      */
     public function handle(EventParam $e): void
     {
-        App::set('test_date', gmdate('D, d M Y H:i:s').' GMT');
+        App::set('test_date', gmdate(DATE_RFC7231));
         Timer::tick(1000, function() {
-            App::set('test_date', gmdate('D, d M Y H:i:s').' GMT');
+            App::set('test_date', gmdate(DATE_RFC7231));
         });
     }
 

--- a/frameworks/PHP/laravel/server-man.php
+++ b/frameworks/PHP/laravel/server-man.php
@@ -12,9 +12,9 @@ $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->name          = 'AdapterMan-Laravel';
 $http_worker->onWorkerStart = static function () {
-    Header::$date = gmdate('D, d M Y H:i:s').' GMT';
+    Header::$date = gmdate(DATE_RFC7231);
     Timer::add(1, function() {
-         Header::$date = gmdate('D, d M Y H:i:s').' GMT';
+         Header::$date = gmdate(DATE_RFC7231);
     });
     //init();
     require __DIR__.'/start.php';

--- a/frameworks/PHP/leaf/server.php
+++ b/frameworks/PHP/leaf/server.php
@@ -38,9 +38,9 @@ class HeaderDate
 
     public static function init(): void
     {
-        self::$date = self::NAME . gmdate('D, d M Y H:i:s').' GMT';
+        self::$date = self::NAME . gmdate(DATE_RFC7231);
         Timer::add(1, static function() {
-            self::$date = self::NAME . gmdate('D, d M Y H:i:s').' GMT';
+            self::$date = self::NAME . gmdate(DATE_RFC7231);
         });
     }
 }

--- a/frameworks/PHP/mark/start.php
+++ b/frameworks/PHP/mark/start.php
@@ -27,12 +27,12 @@ $api->get('/json', function () {
     ], \json_encode(['message' => 'Hello, World!']));
 });
 
-$date = gmdate('D, d M Y H:i:s').' GMT';
+$date = gmdate(DATE_RFC7231);
 
 $api->onWorkerStart = static function () {
     Timer::add(1, function () {
         global $date;
-        $date = gmdate('D, d M Y H:i:s').' GMT';
+        $date = gmdate(DATE_RFC7231);
     });
 };
 

--- a/frameworks/PHP/slim/server.php
+++ b/frameworks/PHP/slim/server.php
@@ -38,9 +38,9 @@ class HeaderDate
 
     public static function init(): void
     {
-        self::$date = self::NAME . gmdate('D, d M Y H:i:s').' GMT';
+        self::$date = self::NAME . gmdate(DATE_RFC7231);
         Timer::add(1, static function() {
-            self::$date = self::NAME . gmdate('D, d M Y H:i:s').' GMT';
+            self::$date = self::NAME . gmdate(DATE_RFC7231);
         });
     }
 }

--- a/frameworks/PHP/symfony/server.php
+++ b/frameworks/PHP/symfony/server.php
@@ -13,9 +13,9 @@ $http_worker->count         = (int) shell_exec('nproc') * 4;
 $http_worker->name          = 'AdapterMan-Symfony';
 
 $http_worker->onWorkerStart = static function () {
-    Header::$date = gmdate('D, d M Y H:i:s').' GMT';
+    Header::$date = gmdate(DATE_RFC7231);
     Timer::add(1, function() {
-         Header::$date = gmdate('D, d M Y H:i:s').' GMT';
+         Header::$date = gmdate(DATE_RFC7231);
     });
     //init();
     require __DIR__.'/start.php';

--- a/frameworks/PHP/webman/support/bootstrap/Date.php
+++ b/frameworks/PHP/webman/support/bootstrap/Date.php
@@ -30,9 +30,9 @@ class Date implements Bootstrap {
      */
     public static function start($worker)
     {
-        self::$date = gmdate('D, d M Y H:i:s').' GMT';
+        self::$date = gmdate(DATE_RFC7231);
         Timer::add(1, function() {
-            self::$date = gmdate('D, d M Y H:i:s').' GMT';
+            self::$date = gmdate(DATE_RFC7231);
         });
     }
 

--- a/frameworks/PHP/workerman/Date.php
+++ b/frameworks/PHP/workerman/Date.php
@@ -4,12 +4,12 @@ use Workerman\Timer;
 
 class Date
 {
-    public $date = null;
+    public $date;
     public function __construct()
     {
-        $this->date = gmdate('D, d M Y H:i:s').' GMT';
+        $this->date = gmdate(DATE_RFC7231);
         Timer::add(1, function() {
-            $this->date = gmdate('D, d M Y H:i:s').' GMT';
+            $this->date = gmdate(DATE_RFC7231);
         });
     }
 }

--- a/frameworks/PHP/yii2/server.php
+++ b/frameworks/PHP/yii2/server.php
@@ -33,9 +33,9 @@ class WorkerTimer
 
     public static function init()
     {
-        self::$date = 'Date: '.gmdate('D, d M Y H:i:s').' GMT';
+        self::$date = 'Date: ' . gmdate(DATE_RFC7231);
         Timer::add(1, function() {
-            WorkerTimer::$date = 'Date: '.gmdate('D, d M Y H:i:s').' GMT';
+            WorkerTimer::$date = 'Date: ' . gmdate(DATE_RFC7231);
         });
     }
 }


### PR DESCRIPTION
For historical reasons, as this benchmark started with PHP/5, we didn't use the constants to familiar date formats that come in PHP/7.
