### PR TITLE
[rails] Replace Agoo server with Pitchfork

### DIFF
--- a/frameworks/Ruby/rails/Gemfile
+++ b/frameworks/Ruby/rails/Gemfile
@@ -12,11 +12,6 @@ group :postgresql, optional: true do
   gem 'pg', '~> 1.5'
 end
 
-group :agoo, optional: true do
-  gem 'agoo', require: false
-  gem 'rackup'
-end
-
 group :iodine, optional: true do
   gem 'iodine', '~> 0.7', require: false
 end
@@ -27,4 +22,8 @@ end
 
 group :puma, optional: true do
   gem 'puma', '~> 6.5', require: false
+end
+
+group :pitchfork, optional: true do
+  gem 'pitchfork', '~> 0.17'
 end

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -72,7 +72,6 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    agoo (2.15.13)
     async (2.23.0)
       console (~> 1.29)
       fiber-annotation
@@ -184,6 +183,9 @@ GEM
       racc (~> 1.4)
     openssl (3.3.0)
     pg (1.5.9)
+    pitchfork (0.17.0)
+      logger
+      rack (>= 2.0)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -276,12 +278,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  agoo
   falcon (~> 0.47)
   iodine (~> 0.7)
   pg (~> 1.5)
+  pitchfork (~> 0.17)
   puma (~> 6.5)
-  rackup
   rails (~> 8.0.0)
   redis (~> 5.0)
   trilogy (~> 2.8.1)

--- a/frameworks/Ruby/rails/README.md
+++ b/frameworks/Ruby/rails/README.md
@@ -17,6 +17,7 @@ The tests were run with:
 - [Puma 6.4](http://puma.io/)
 - [Iodine](https://github.com/boazsegev/iodine)
 - [Falcon](https://github.com/socketry/falcon)
+- [Pitchfork](https://github.com/Shopify/pitchfork)
 - [MySQL](https://dev.mysql.com/)
 - [PostgreSQL](https://www.postgresql.org/)
 - [Redis 6](https://redis.io)

--- a/frameworks/Ruby/rails/benchmark_config.json
+++ b/frameworks/Ruby/rails/benchmark_config.json
@@ -91,7 +91,7 @@
       "notes": "",
       "versus": "rack-iodine-mri-sequel-raw"
     },
-    "agoo": {
+    "pitchfork": {
       "db_url": "/db",
       "json_url": "/json",
       "query_url": "/queries?queries=",
@@ -107,12 +107,12 @@
       "language": "Ruby",
       "orm": "Full",
       "platform": "Rack",
-      "webserver": "Agoo",
+      "webserver": "Pitchfork",
       "os": "Linux",
       "database_os": "Linux",
-      "display_name": "rails-agoo",
+      "display_name": "rails-pitchfork",
       "notes": "",
-      "versus": ""
+      "versus": "rack-pitchfork-mri-sequel-raw"
     }
   }]
 }

--- a/frameworks/Ruby/rails/config/pitchfork.rb
+++ b/frameworks/Ruby/rails/config/pitchfork.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require_relative 'auto_tune'
+
+num_workers, = auto_tune
+
+worker_processes num_workers

--- a/frameworks/Ruby/rails/rails-pitchfork.dockerfile
+++ b/frameworks/Ruby/rails/rails-pitchfork.dockerfile
@@ -15,7 +15,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 COPY ./Gemfile* /rails/
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
-ENV BUNDLE_WITH=postgresql:agoo
+ENV BUNDLE_WITH=postgresql:pitchfork
 RUN bundle install --jobs=8
 
 COPY . /rails/
@@ -24,4 +24,4 @@ ENV RAILS_ENV=production_postgresql
 ENV PORT=8080
 ENV REDIS_URL=redis://localhost:6379/0
 CMD service redis-server start && \
-    RACK_ENV=production bundle exec rackup -r agoo -s agoo -p 8080 -q -O workers=$(ruby config/auto_tune.rb | grep -Eo '[0-9]+' | head -n 1)
+    RACK_ENV=production bundle exec pitchfork -c config/pitchfork.rb


### PR DESCRIPTION
Agoo is a less commonly used server and can be somewhat unstable. Pitchfork is a maintained alternative for Unicorn (which hasn't seen updates since 2021).