### PR TITLE
[rust/viz]: use multiple current thread runtimes in json

### DIFF
--- a/frameworks/Rust/viz/Cargo.toml
+++ b/frameworks/Rust/viz/Cargo.toml
@@ -35,6 +35,8 @@ mime = "0.3"
 rand = { version = "0.9", features = ["small_rng"] }
 thiserror = "2.0"
 futures-util = "0.3"
+socket2 = "0.5.8"
+num_cpus = "1.16.0"
 
 [target.'cfg(not(unix))'.dependencies]
 nanorand = { version = "0.7" }

--- a/frameworks/Rust/viz/src/main_diesel.rs
+++ b/frameworks/Rust/viz/src/main_diesel.rs
@@ -77,8 +77,7 @@ async fn updates(req: Request) -> Result<Response> {
     Ok(res)
 }
 
-#[tokio::main]
-async fn main() {
+async fn app() {
     let max = available_parallelism().map(|n| n.get()).unwrap_or(16) as u32;
 
     let pool = Pool::<AsyncPgConnection>::builder()
@@ -98,4 +97,8 @@ async fn main() {
         .with(State::new(rng));
 
     server::serve(app).await.unwrap()
+}
+
+fn main() {
+    server::run(app)
 }

--- a/frameworks/Rust/viz/src/main_pg.rs
+++ b/frameworks/Rust/viz/src/main_pg.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    thread::{available_parallelism, spawn},
-};
+use std::sync::Arc;
 
 use viz::{
     header::{HeaderValue, SERVER},
@@ -76,26 +73,7 @@ async fn updates(req: Request) -> Result<Response> {
     Ok(res)
 }
 
-fn main() {
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-
-    for _ in 1..available_parallelism().map(|n| n.get()).unwrap_or(16) {
-        spawn(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
-            rt.block_on(serve());
-        });
-    }
-
-    rt.block_on(serve());
-}
-
-async fn serve() {
+async fn app() {
     let conn = PgConnection::connect(DB_URL).await;
 
     let app = Router::new()
@@ -106,4 +84,8 @@ async fn serve() {
         .with(State::new(conn));
 
     server::serve(app).await.unwrap()
+}
+
+fn main() {
+    server::run(app)
 }

--- a/frameworks/Rust/viz/src/main_sqlx.rs
+++ b/frameworks/Rust/viz/src/main_sqlx.rs
@@ -79,8 +79,7 @@ async fn updates(mut req: Request) -> Result<Response> {
     Ok(res)
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+async fn app() -> Result<()> {
     let max = available_parallelism().map(|n| n.get()).unwrap_or(16) as u32;
 
     let pool = PgPoolOptions::new()
@@ -101,6 +100,10 @@ async fn main() -> Result<()> {
         .with(State::new(rng));
 
     server::serve(app).await.map_err(Error::Boxed)
+}
+
+fn main() {
+    server::run(app)
 }
 
 markup::define! {


### PR DESCRIPTION
Previously PR #9721  did not work, and found no use multiple current thread runtimes.