### PR TITLE
[ruby/roda-sequel] Use an instance variable for Fortunes

### DIFF
--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -3,7 +3,7 @@
 # Our Rack application to be executed by rackup
 class HelloWorld < Roda
   plugin :hooks
-  plugin :render, escape: true, assume_fixed_locals: true, template_opts: { extract_fixed_locals: true}, layout_opts: { cache_key: "default_layout" }
+  plugin :render, escape: true, layout_opts: { cache_key: "default_layout" }
 
   def bounded_queries
     queries = request.params["queries"].to_i
@@ -57,13 +57,13 @@ class HelloWorld < Roda
     # Test type 4: Fortunes
     r.is "fortunes" do
       response[CONTENT_TYPE] = HTML_TYPE
-      fortunes = Fortune.all
-      fortunes << Fortune.new(
+      @fortunes = Fortune.all
+      @fortunes << Fortune.new(
         id: 0,
         message: "Additional fortune added at request time."
       )
-      fortunes.sort_by!(&:message)
-      view :fortunes, locals: { fortunes: fortunes }
+      @fortunes.sort_by!(&:message)
+      view :fortunes
     end
 
     # Test type 5: Database updates

--- a/frameworks/Ruby/roda-sequel/views/fortunes.erb
+++ b/frameworks/Ruby/roda-sequel/views/fortunes.erb
@@ -3,7 +3,7 @@
   <th>id</th>
   <th>message</th>
 </tr>
-<% fortunes.each do |fortune| %>
+<% @fortunes.each do |fortune| %>
 <tr>
   <td><%= fortune.id %></td>
   <td><%= fortune.message %></td>


### PR DESCRIPTION
It seems 00416748fb572cfc20acba63d762d5565b315bae slowed things down instead. This reverts those template changes.