### PR TITLE
[FSharp] Fix: Improve FSharp Falco benchmarks by moving to Dapper

### DIFF
--- a/frameworks/FSharp/falco/src/App/App.fsproj
+++ b/frameworks/FSharp/falco/src/App/App.fsproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="dapper" Version="2.1.66" />
     <PackageReference Include="Falco" Version="5.*" />
     <PackageReference Include="Npgsql" Version="9.*" />
   </ItemGroup>


### PR DESCRIPTION
Updating FSharp Falco benchmark to improve its performance.

## Context 

* Falco has been trailing Giraffe even though they are both similar under the hood.
* Giraffe uses Dapper instead of a raw Npgsql connection / command for data reads ([github](https://github.com/TechEmpower/FrameworkBenchmarks/blob/a0ebdee082564967b5d929096aac195acc9c06c9/frameworks/FSharp/giraffe/src/App/Program.fs#L79C17-L80C88))
* So here we move to Dapper to make the benchmark more similar to Giraffe's

## Results

Running this locally: `./tfb --test falco`

* Original fortunes - 512 connections @ 109k requests / second
* New with Dapper - 512 connections @ 160k requests / second (46% increase)

All verifications pass: 

![image](https://github.com/user-attachments/assets/7ddb6bfc-fc7f-4920-a866-a9337af065a8)


