### PR TITLE
Aiohttp switch to orjson

### DIFF
--- a/frameworks/Python/aiohttp/app/views.py
+++ b/frameworks/Python/aiohttp/app/views.py
@@ -1,11 +1,10 @@
-from functools import partial
 from operator import attrgetter, itemgetter
 from pathlib import Path
 from random import randint
 
 import jinja2
-import ujson
-from aiohttp.web import Response, json_response
+import orjson
+from aiohttp.web import Response
 from sqlalchemy import select
 
 from .models import sa_fortunes, sa_worlds, Fortune, World
@@ -16,7 +15,6 @@ READ_ROW_SQL = 'SELECT "randomnumber", "id" FROM "world" WHERE id = $1'
 READ_SELECT_ORM = select(World.randomnumber)
 WRITE_ROW_SQL = 'UPDATE "world" SET "randomnumber"=$2 WHERE id=$1'
 
-json_response = partial(json_response, dumps=ujson.dumps)
 template_path = Path(__file__).parent / 'templates' / 'fortune.jinja'
 template = jinja2.Template(template_path.read_text())
 sort_fortunes_orm = attrgetter('message')
@@ -34,6 +32,11 @@ def get_num_queries(request):
         return 500
     return num_queries
 
+def json_response(payload):
+    return Response(
+        body=orjson.dumps(payload),
+        content_type="application/json",
+    )
 
 async def json(request):
     """

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -1,8 +1,8 @@
-aiohttp==3.11.14
+aiohttp==3.11.16
 asyncpg==0.30.0
 gunicorn==23.0.0
-jinja2==3.1.5
+jinja2==3.1.6
 psycopg2==2.9.10
 SQLAlchemy==2.0.39
-ujson==5.10.0
+orjson==3.10.16
 uvloop==0.21.0

--- a/frameworks/Python/aiohttp/requirements.txt
+++ b/frameworks/Python/aiohttp/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.11.16
 asyncpg==0.30.0
 gunicorn==23.0.0
 jinja2==3.1.6
-psycopg2==2.9.10
 SQLAlchemy==2.0.39
 orjson==3.10.16
 uvloop==0.21.0


### PR DESCRIPTION
Switch to `orjson` since it outperforms `ujson` https://dev.to/dollardhingra/benchmarking-python-json-serializers-json-vs-ujson-vs-orjson-1o16

```python
pip install aiohttp orjson ujson

from aiohttp.web import Response
from aiohttp import web
import orjson
import ujson

def json_response(payload):
    return Response(
        body=orjson.dumps(payload),
        content_type="application/json",
    )


async def orjson_handler(request):
    return json_response(
        {'message': 'Hello, World!'},
    )

async def ujson_handler(request):
    return web.json_response(
        text=ujson.dumps({'message': 'Hello, World!'}),
        content_type="application/json",
    )

app = web.Application()
app.router.add_get('/orjson', orjson_handler)
app.router.add_get('/ujson', ujson_handler)

if __name__ == '__main__':
    web.run_app(app, port=8080)
```

### Local benchmark
```
 wrk -t8 -c20 -d20s http://localhost:8080/orjson 
Running 20s test @ http://localhost:8080/orjson
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   622.93us    1.14ms  38.03ms   99.60%
    Req/Sec     3.56k   165.63     3.94k    82.90%
  569116 requests in 20.10s, 93.35MB read
Requests/sec:  28310.04
Transfer/sec:      4.64MB
```


```
 wrk -t8 -c20 -d20s http://localhost:8080/ujson
Running 20s test @ http://localhost:8080/ujson
  8 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   805.26us    3.19ms  77.12ms   99.31%
    Req/Sec     3.48k   218.00     3.76k    96.52%
  556324 requests in 20.10s, 99.21MB read
Requests/sec:  27675.67
Transfer/sec:      4.94MB
```