### PR TITLE
Upgrade to microdot 2.3 and add orjson

### DIFF
--- a/frameworks/Python/microdot/requirements.txt
+++ b/frameworks/Python/microdot/requirements.txt
@@ -5,8 +5,9 @@ asyncpg
 jinja2
 cachetools
 asyncache
+orjson
 
 alchemical
-microdot>=2.0.1
+microdot>=2.3.1
 gunicorn
 uvicorn[standard]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Upgrade to the latest version of Microdot, which can take advantage of orjson when installed.