### PR TITLE
[aiohttp] - disable reset query and remove explicit call prepare

### DIFF
--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -1,7 +1,7 @@
 import os
 import multiprocessing
 
-import asyncpg.connection
+import asyncpg
 from aiohttp import web
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine

--- a/frameworks/Python/aiohttp/app/main.py
+++ b/frameworks/Python/aiohttp/app/main.py
@@ -1,7 +1,7 @@
 import os
 import multiprocessing
 
-import asyncpg
+import asyncpg.connection
 from aiohttp import web
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -37,6 +37,11 @@ def pg_dsn(dialect=None) -> str:
     )
     return url.render_as_string(hide_password=False)
 
+class NoResetConnection(asyncpg.Connection):
+    __slots__ = ()
+
+    def get_reset_query(self):
+        return ''
 
 async def db_ctx(app: web.Application):
     # number of gunicorn workers = multiprocessing.cpu_count() as per gunicorn_conf.py
@@ -52,7 +57,7 @@ async def db_ctx(app: web.Application):
         app['db_session'] = async_sessionmaker(engine)
     else:
         dsn = pg_dsn()
-        app['pg'] = await asyncpg.create_pool(dsn=dsn, min_size=min_size, max_size=max_size, loop=app.loop)
+        app['pg'] = await asyncpg.create_pool(dsn=dsn, min_size=min_size, max_size=max_size, loop=app.loop, connection_class=NoResetConnection)
 
     yield
 


### PR DESCRIPTION
- `asyncpg` reset query called each time the connection is released from pool. This do a lot of stuff like close active listeners, release advisory locks, etc. not used in our benchmark so we can omit it.
- `asyncpg` call prepare statement internally, and cache the result inside connection cache => no need to call it explicitly.

### Before 
```
---------------------------------------------------------
 Queries: 1 for query
 wrk -H 'Host: tfb-server' -H 'Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7' -H 'Connection: keep-alive' --latency -d 30 -c 32 --timeout 8 -t 6 "http://tfb-server:8080/queries/1"
---------------------------------------------------------
Running 30s test @ http://tfb-server:8080/queries/1
  6 threads and 32 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.39ms    1.08ms  48.55ms   91.12%
    Req/Sec     3.87k     0.93k    5.33k    75.06%
  Latency Distribution
     50%    1.13ms
     75%    1.68ms
     90%    2.36ms
     99%    5.08ms
  693193 requests in 30.01s, 123.47MB read
Requests/sec:  23100.21
Transfer/sec:      4.11MB
STARTTIME 1744784708
ENDTIME 1744784738
```

```
---------------------------------------------------------
 Queries: 20 for query
 wrk -H 'Host: tfb-server' -H 'Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7' -H 'Connection: keep-alive' --latency -d 30 -c 32 --timeout 8 -t 6 "http://tfb-server:8080/queries/20"
---------------------------------------------------------
Running 30s test @ http://tfb-server:8080/queries/20
  6 threads and 32 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.83ms    5.36ms  92.00ms   84.83%
    Req/Sec   688.64    268.40     1.25k    59.11%
  Latency Distribution
     50%    6.34ms
     75%    9.36ms
     90%   13.78ms
     99%   29.06ms
  123464 requests in 30.03s, 93.19MB read
Requests/sec:   4111.13
Transfer/sec:      3.10MB
STARTTIME 1744784836
ENDTIME 1744784866
```

### After


```
 Queries: 1 for query
 wrk -H 'Host: tfb-server' -H 'Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7' -H 'Connection: keep-alive' --latency -d 30 -c 32 --timeout 8 -t 6 "http://tfb-server:8080/queries/1"
---------------------------------------------------------
Running 30s test @ http://tfb-server:8080/queries/1
  6 threads and 32 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   786.25us  642.33us  24.76ms   92.01%
    Req/Sec     6.82k   782.73    16.25k    84.51%
  Latency Distribution
     50%  651.00us
     75%    0.95ms
     90%    1.33ms
     99%    2.79ms
  1222301 requests in 30.10s, 217.72MB read
Requests/sec:  40608.53
Transfer/sec:      7.23MB
STARTTIME 1744785790
ENDTIME 1744785820
---------------------------------------------------------
...

```

```
 Queries: 20 for query
 wrk -H 'Host: tfb-server' -H 'Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7' -H 'Connection: keep-alive' --latency -d 30 -c 32 --timeout 8 -t 6 "http://tfb-server:8080/queries/20"
---------------------------------------------------------
Running 30s test @ http://tfb-server:8080/queries/20
  6 threads and 32 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.68ms    1.43ms  36.10ms   77.92%
    Req/Sec     1.38k   131.73     1.81k    71.94%
  Latency Distribution
     50%    3.47ms
     75%    4.32ms
     90%    5.27ms
     99%    7.91ms
  247057 requests in 30.01s, 186.49MB read
Requests/sec:   8232.68
Transfer/sec:      6.21MB
STARTTIME 1744785918
ENDTIME 1744785949
```
