### PR TITLE
Make logger less spammy

### DIFF
--- a/frameworks/Kotlin/ktor/ktor-asyncdb/src/main/resources/logback.xml
+++ b/frameworks/Kotlin/ktor/ktor-asyncdb/src/main/resources/logback.xml
@@ -11,11 +11,11 @@
      </appender>
 
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="ASYNC"/>
     </root>
 
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
 
 </configuration>

--- a/frameworks/Kotlin/ktor/ktor-pgclient/src/main/resources/logback.xml
+++ b/frameworks/Kotlin/ktor/ktor-pgclient/src/main/resources/logback.xml
@@ -11,11 +11,11 @@
      </appender>
 
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="ASYNC"/>
     </root>
 
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
 
 </configuration>

--- a/frameworks/Kotlin/ktor/ktor-r2dbc/src/main/resources/logback.xml
+++ b/frameworks/Kotlin/ktor/ktor-r2dbc/src/main/resources/logback.xml
@@ -10,12 +10,12 @@
         <appender-ref ref="STDOUT" />
     </appender>
 
-    <root level="WARN">
+    <root level="ERROR">
         <appender-ref ref="ASYNC"/>
     </root>
 
-    <logger name="org.eclipse.jetty" level="WARN"/>
-    <logger name="io.netty" level="WARN"/>
-    <logger name="io.r2dbc" level="WARN"/>
-    <logger name="reactor" level="WARN"/>
+    <logger name="org.eclipse.jetty" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
+    <logger name="io.r2dbc" level="ERROR"/>
+    <logger name="reactor" level="ERROR"/>
 </configuration>

--- a/frameworks/Kotlin/ktor/ktor/src/main/resources/logback.xml
+++ b/frameworks/Kotlin/ktor/ktor/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
         <appender-ref ref="ASYNC"/>
     </root>
 
-    <logger name="org.eclipse.jetty" level="INFO"/>
-    <logger name="io.netty" level="INFO"/>
+    <logger name="org.eclipse.jetty" level="ERROR"/>
+    <logger name="io.netty" level="ERROR"/>
 
 </configuration>

--- a/frameworks/Kotlin/ktor/ktor/src/main/resources/logback.xml
+++ b/frameworks/Kotlin/ktor/ktor/src/main/resources/logback.xml
@@ -11,7 +11,7 @@
      </appender>
 
 
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="ASYNC"/>
     </root>
 


### PR DESCRIPTION
- Logger less spammy
- Some tests didn't even use loggers, this will make things more consistent and probably improve performance
