### PR TITLE
Updates to Vert.x

### DIFF
--- a/frameworks/Java/vertx/pom.xml
+++ b/frameworks/Java/vertx/pom.xml
@@ -42,18 +42,6 @@
 			<version>0.0.5</version>
 		</dependency>
 		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport-native-kqueue</artifactId>
-			<version>${netty.version}</version>
-			<classifier>osx-x86_64</classifier>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-transport-native-epoll</artifactId>
-			<version>${netty.version}</version>
-			<classifier>linux-x86_64</classifier>
-		</dependency>
-		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
 			<version>3.1.3</version>
@@ -149,9 +137,12 @@
 
 	<profiles>
 		<profile>
-			<id>Linux</id>
+			<id>linux-x86_64</id>
 			<activation>
-				<activeByDefault>false</activeByDefault>
+				<os>
+					<family>linux</family>
+					<arch>x86_64</arch>
+				</os>
 			</activation>
 			<dependencies>
 				<dependency>
@@ -162,6 +153,91 @@
 				</dependency>
 			</dependencies>
 		</profile>
+
+		<profile>
+			<id>linux-amd64</id>
+			<activation>
+				<os>
+					<family>linux</family>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-io_uring</artifactId>
+					<version>${netty.version}</version>
+					<classifier>linux-x86_64</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>linux-aarch64</id>
+			<activation>
+				<os>
+					<family>linux</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-io_uring</artifactId>
+					<version>${netty.version}</version>
+					<classifier>linux-aarch_64</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>osx-x86_64</id>
+			<activation>
+				<os>
+					<family>mac</family>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-resolver-dns-native-macos</artifactId>
+					<version>${netty.version}</version>
+					<classifier>osx-x86_64</classifier>
+				</dependency>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-kqueue</artifactId>
+					<version>${netty.version}</version>
+					<classifier>osx-x86_64</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>osx-aarch64</id>
+			<activation>
+				<os>
+					<family>mac</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-resolver-dns-native-macos</artifactId>
+					<version>${netty.version}</version>
+					<classifier>osx-aarch_64</classifier>
+				</dependency>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-kqueue</artifactId>
+					<version>${netty.version}</version>
+					<classifier>osx-aarch_64</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+
 	</profiles>
 
 </project>

--- a/frameworks/Java/vertx/src/main/java/vertx/App.java
+++ b/frameworks/Java/vertx/src/main/java/vertx/App.java
@@ -171,7 +171,7 @@ public class App extends AbstractVerticle implements Handler<HttpServerRequest> 
     options.setPassword(config.getString("password", "benchmarkdbpass"));
     options.setCachePreparedStatements(true);
     options.setPreparedStatementCacheMaxSize(1024);
-    options.setPipeliningLimit(100_000); // Large pipelining means less flushing and we use a single connection anyway
+    options.setPipeliningLimit(256); // Large pipelining means less flushing and we use a single connection anyway
     Future<?> clientsInit = initClients(options);
     clientsInit
             .transform(ar -> {

--- a/frameworks/Java/vertx/vertx-postgres.dockerfile
+++ b/frameworks/Java/vertx/vertx-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.0-eclipse-temurin-17 as maven
+FROM maven:3.9.9-eclipse-temurin-24-noble as maven
 WORKDIR /vertx
 COPY src src
 COPY pom.xml pom.xml
@@ -9,6 +9,9 @@ EXPOSE 8080
 CMD export DBIP=`getent hosts tfb-database | awk '{ print $1 }'` && \
     sed -i "s|tfb-database|$DBIP|g" /vertx/src/main/conf/config.json && \
     java \
+      --enable-native-access=ALL-UNNAMED \
+      --sun-misc-unsafe-memory-access=allow \
+      --add-opens=java.base/java.lang=ALL-UNNAMED \
       -Xms2G \
       -Xmx2G \
       -server \
@@ -22,7 +25,8 @@ CMD export DBIP=`getent hosts tfb-database | awk '{ print $1 }'` && \
       -Dvertx.cacheImmutableHttpResponseHeaders=true \
       -Dvertx.internCommonHttpRequestHeadersToLowerCase=true \
       -Dvertx.eventLoopPoolSize=$((`grep --count ^processor /proc/cpuinfo`)) \
-      -Dio.netty.buffer.checkBounds=false  \
+      -Dio.netty.noUnsafe=false \
+      -Dio.netty.buffer.checkBounds=false \
       -Dio.netty.buffer.checkAccessible=false \
       -jar \
       target/vertx.benchmark-0.0.1-SNAPSHOT-fat.jar \

--- a/frameworks/Java/vertx/vertx.dockerfile
+++ b/frameworks/Java/vertx/vertx.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.0-eclipse-temurin-17 as maven
+FROM maven:3.9.9-eclipse-temurin-24-noble as maven
 WORKDIR /vertx
 COPY src src
 COPY pom.xml pom.xml
@@ -6,4 +6,4 @@ RUN mvn package -q
 
 EXPOSE 8080
 
-CMD ["java", "-Xms2G", "-Xmx2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Djava.lang.Integer.IntegerCache.high=10000", "-Dvertx.disableMetrics=true", "-Dvertx.disableWebsockets=true", "-Dvertx.disableContextTimings=true", "-Dvertx.disableHttpHeadersValidation=true", "-Dvertx.cacheImmutableHttpResponseHeaders=true", "-Dvertx.internCommonHttpRequestHeadersToLowerCase=true", "-Dio.netty.buffer.checkBounds=false", "-Dio.netty.buffer.checkAccessible=false", "-jar", "target/vertx.benchmark-0.0.1-SNAPSHOT-fat.jar", "src/main/conf/config.json"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow", "--add-opens=java.base/java.lang=ALL-UNNAMED", "-Xms2G", "-Xmx2G", "-server", "-XX:+UseNUMA", "-XX:+UseParallelGC", "-Djava.lang.Integer.IntegerCache.high=10000", "-Dvertx.disableMetrics=true", "-Dvertx.disableWebsockets=true", "-Dvertx.disableContextTimings=true", "-Dvertx.disableHttpHeadersValidation=true", "-Dvertx.cacheImmutableHttpResponseHeaders=true", "-Dvertx.internCommonHttpRequestHeadersToLowerCase=true", "-Dio.netty.noUnsafe=false", "-Dio.netty.buffer.checkBounds=false", "-Dio.netty.buffer.checkAccessible=false", "-jar", "target/vertx.benchmark-0.0.1-SNAPSHOT-fat.jar", "src/main/conf/config.json"]


### PR DESCRIPTION
- use OpenJDK 24
- fix large pipelining limit that cause failures in benchmark due to default allocator change
- enable io_uring again on Linux
