### PR TITLE
upgrade mORMot to 2.3.10796 - fixed memory corruption

### DIFF
--- a/frameworks/Pascal/mormot/setup_and_build.sh
+++ b/frameworks/Pascal/mormot/setup_and_build.sh
@@ -35,7 +35,7 @@ echo "Download statics from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot/static
 
 # uncomment for fixed commit URL
-URL=https://github.com/synopse/mORMot2/tarball/e5ece53ec4ac4788d356f17d2d32ea16379a65a9
+URL=https://github.com/synopse/mORMot2/tarball/bfe812b82a35361274324afb203bd6a5b213444a
 #URL="https://api.github.com/repos/synopse/mORMot2/tarball/$USED_TAG"
 echo "Download and unpacking mORMot sources from $URL ..."
 wget -qO- "$URL" | tar -xz -C ./libs/mORMot  --strip-components=1


### PR DESCRIPTION
upgrade mORMot to 2.3.10796 - fixed memory corruption