### PR TITLE
Add extensions used in Laravel, Symfony.

### DIFF
--- a/frameworks/PHP/laravel/deploy/conf/php.ini
+++ b/frameworks/PHP/laravel/deploy/conf/php.ini
@@ -1770,14 +1770,14 @@ opcache.enable=1
 opcache.enable_cli=1
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=128
+opcache.memory_consumption=256
 
 ; The amount of memory for interned strings in Mbytes.
 ;opcache.interned_strings_buffer=8
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 1000000 are allowed.
-;opcache.max_accelerated_files=10000
+opcache.max_accelerated_files=20000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5

--- a/frameworks/PHP/laravel/laravel.dockerfile
+++ b/frameworks/PHP/laravel/laravel.dockerfile
@@ -7,7 +7,7 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.4-cli php8.4-fpm php8.4-mysql  php8.4-mbstring php8.4-xml  php8.4-curl > /dev/null
+    php8.4-bcmath php8.4-cli php8.4-fpm php8.4-mysql php8.4-mbstring php8.4-xml php8.4-curl php8.4-intl > /dev/null
 
 COPY --from=composer --link /usr/bin/composer /usr/local/bin/composer
 

--- a/frameworks/PHP/symfony/symfony.dockerfile
+++ b/frameworks/PHP/symfony/symfony.dockerfile
@@ -7,8 +7,8 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
 RUN apt-get install -yqq nginx git unzip curl \
-    php8.4-cli php8.4-fpm php8.4-pgsql  \
-    php8.4-mbstring php8.4-xml php8.4-curl php8.4-dev > /dev/null
+    php8.4-bcmath php8.4-cli php8.4-fpm php8.4-pgsql  \
+    php8.4-mbstring php8.4-xml php8.4-curl php8.4-dev php8.4-intl > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 


### PR DESCRIPTION
1. Added PHP extension (Intl ,bcmath) to Docker setup.

Symfony and Laravel use bcmath and intl, The current setup is using polyfills.
These extensions (bcmath, intl) are commonly used in PHP projects and are recommended to be enabled in default setups.


2. Changed the Laravel opcache configuration to match Symfony.

Laravel makes heavy use of Symphony components, and the recommended settings for these full-stack PHP frameworks are similar.