### PR TITLE
[php] Update for Workerman/5

### DIFF
--- a/frameworks/PHP/cakephp/server.php
+++ b/frameworks/PHP/cakephp/server.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/vendor/autoload.php';
 
 use Adapterman\Adapterman;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 use Workerman\Worker;
 
 Adapterman::init();

--- a/frameworks/PHP/cakephp/server.php
+++ b/frameworks/PHP/cakephp/server.php
@@ -9,6 +9,7 @@ Adapterman::init();
 
 $http_worker        = new Worker('http://0.0.0.0:8080');
 $http_worker->count = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort = true;
 $http_worker->name  = 'AdapterMan-CakePHP';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/flight/server.php
+++ b/frameworks/PHP/flight/server.php
@@ -2,7 +2,7 @@
 require_once __DIR__.'/vendor/autoload.php';
 
 use Adapterman\Adapterman;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 use Workerman\Worker;
 
 Adapterman::init();

--- a/frameworks/PHP/flight/server.php
+++ b/frameworks/PHP/flight/server.php
@@ -9,6 +9,7 @@ Adapterman::init();
 
 $http_worker        = new Worker('http://0.0.0.0:8080');
 $http_worker->count = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort = true;
 $http_worker->name  = 'AdapterMan-Flight';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/kumbiaphp/server.php
+++ b/frameworks/PHP/kumbiaphp/server.php
@@ -9,6 +9,7 @@ Adapterman::init();
 
 $http_worker            = new Worker('http://0.0.0.0:8080');
 $http_worker->count     = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort = true;
 $http_worker->name      = 'KumbiaPHP';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/laravel/server-man.php
+++ b/frameworks/PHP/laravel/server-man.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 Adapterman::init();
 

--- a/frameworks/PHP/laravel/server-man.php
+++ b/frameworks/PHP/laravel/server-man.php
@@ -10,6 +10,7 @@ Adapterman::init();
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort     = true;
 $http_worker->name          = 'AdapterMan-Laravel';
 $http_worker->onWorkerStart = static function () {
     Header::$date = gmdate(DATE_RFC7231);

--- a/frameworks/PHP/leaf/server.php
+++ b/frameworks/PHP/leaf/server.php
@@ -10,6 +10,7 @@ Adapterman::init();
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort     = true;
 $http_worker->name          = 'AdapterMan-Leaf';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/leaf/server.php
+++ b/frameworks/PHP/leaf/server.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 Adapterman::init();
 

--- a/frameworks/PHP/php/deploy/workerman/start.php
+++ b/frameworks/PHP/php/deploy/workerman/start.php
@@ -2,7 +2,7 @@
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/frameworks/PHP/php/deploy/workerman/start.php
+++ b/frameworks/PHP/php/deploy/workerman/start.php
@@ -10,6 +10,7 @@ Adapterman::init();
 // WebServer
 $web = new Worker("http://0.0.0.0:8080");
 $web->count = (int) shell_exec('nproc') * 4;
+$web->reusePort = true;
 $web->name = 'workerman';
 
 define('WEBROOT', '/php/');

--- a/frameworks/PHP/slim/server.php
+++ b/frameworks/PHP/slim/server.php
@@ -10,6 +10,7 @@ Adapterman::init();
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort     = true;
 $http_worker->name          = 'AdapterMan-Slim';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/slim/server.php
+++ b/frameworks/PHP/slim/server.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 Adapterman::init();
 

--- a/frameworks/PHP/symfony/server.php
+++ b/frameworks/PHP/symfony/server.php
@@ -10,6 +10,7 @@ Adapterman::init();
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort     = true;
 $http_worker->name          = 'AdapterMan-Symfony';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/symfony/server.php
+++ b/frameworks/PHP/symfony/server.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 Adapterman::init();
 

--- a/frameworks/PHP/yii2/server.php
+++ b/frameworks/PHP/yii2/server.php
@@ -11,6 +11,7 @@ require __DIR__.'/app/index.php';
 
 $http_worker                = new Worker('http://0.0.0.0:8080');
 $http_worker->count         = (int) shell_exec('nproc') * 4;
+$http_worker->reusePort     = true;
 $http_worker->name          = 'AdapterMan-Yii2';
 
 $http_worker->onWorkerStart = static function () {

--- a/frameworks/PHP/yii2/server.php
+++ b/frameworks/PHP/yii2/server.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Adapterman\Adapterman;
 use Workerman\Worker;
-use Workerman\Lib\Timer;
+use Workerman\Timer;
 
 Adapterman::init();
 


### PR DESCRIPTION
The namespace for the Timer change in Workerman/5.
We fix it with this PR, or the next run will fail almost all.

We add also reuseport.
Actually all AdapterMan implementations are not using JIT.