### PR TITLE
[php] Fix Caddy server

### DIFF
--- a/frameworks/PHP/php/php-caddy.dockerfile
+++ b/frameworks/PHP/php/php-caddy.dockerfile
@@ -15,7 +15,7 @@ COPY deploy/conf/* /etc/php/8.4/fpm/
 RUN apt-get install -y debian-keyring debian-archive-keyring apt-transport-https > /dev/null \
     && curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg \
     && curl -sf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list \
-    && apt-get update > /dev/null && apt-get install caddy > /dev/null
+    && apt-get update > /dev/null && apt-get install caddy=2.9.1 > /dev/null
 
 ADD ./ /php
 WORKDIR /php


### PR DESCRIPTION
Fix Caddy server to v 2.9.1

Why:
for the Via header in v2.10.0 https://github.com/caddyserver/caddy/releases/tag/v2.10.0
Check https://github.com/caddyserver/caddy/issues/6275

As the issue conversation has been locked and limited to collaborators, they never will see this PR as message in the issue !!

PD: created a issue for that https://github.com/caddyserver/caddy/issues/7003