### PR TITLE
chore: improve uvicorn settings

### DIFF
--- a/frameworks/Python/fastapi/fastapi-uvicorn-orjson.dockerfile
+++ b/frameworks/Python/fastapi/fastapi-uvicorn-orjson.dockerfile
@@ -15,4 +15,4 @@ COPY . ./
 
 EXPOSE 8080
 
-CMD uvicorn app:app --host 0.0.0.0 --port 8080 --workers $(nproc) --log-level error
+CMD uvicorn app:app --host 0.0.0.0 --port 8080 --workers $(nproc) --log-level error --no-access-log --no-proxy-headers

--- a/frameworks/Python/fastapi/fastapi-uvicorn.dockerfile
+++ b/frameworks/Python/fastapi/fastapi-uvicorn.dockerfile
@@ -15,4 +15,4 @@ COPY . ./
 
 EXPOSE 8080
 
-CMD uvicorn app:app --host 0.0.0.0 --port 8080 --workers $(nproc) --log-level error
+CMD uvicorn app:app --host 0.0.0.0 --port 8080 --workers $(nproc) --log-level error --no-access-log --no-proxy-headers


### PR DESCRIPTION
In this PR we disable the access log and the `ProxyHeaderMiddleware` (https://www.uvicorn.org/deployment/?h=proxyheaders#proxies-and-forwarded-headers).

Disable logging is recommended in point 3 of the General Test Requirements (https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview#general-test-requirements) and has been done for other python tests like in https://github.com/TechEmpower/FrameworkBenchmarks/pull/9844/files.

The `ProxyHeadersMiddleware` is enabled by default (trusting localhost) and adds considerable latency. As such it should be disabled if not required by test requirements.

Enabling these flags increases performance (req/s) by 85% as seen in the numbers below

```
-- Before
wrk http://localhost:8000/async
Running 10s test @ http://localhost:8000/async
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   268.56us   36.54us   3.49ms   96.57%
    Req/Sec    18.34k   408.35    18.84k    91.58%
  368739 requests in 10.10s, 49.23MB read
Requests/sec:  36508.05
Transfer/sec:      4.87MB

-- After
wrk http://localhost:8000/async
Running 10s test @ http://localhost:8000/async
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   143.21us   46.20us   2.00ms   98.02%
    Req/Sec    33.97k     1.16k   36.29k    82.67%
  682461 requests in 10.10s, 91.12MB read
Requests/sec:  67570.84
Transfer/sec:      9.02MB
```
