### PR TITLE
(Laravel) - force updating to a new number

### DIFF
--- a/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
+++ b/frameworks/PHP/laravel/app/Http/Controllers/Controller.php
@@ -52,7 +52,7 @@ class Controller extends BaseController
 
         while ($queries--) {
             $row = World::query()->find(self::randomInt());
-            $row->randomNumber = self::randomInt();
+            $row->randomNumber = ($randomInt = self::randomInt()) !== $row->randomNumber ? $randomInt : $randomInt + 1;
             $row->save();
 
             $rows[] = $row;


### PR DESCRIPTION
In Laravel, if you attempt to update a Model but have made no changes to its data, it will not write to the database. See [Eloquent@save()](https://github.com/laravel/framework/blob/f880ec20247a962fd8b553f5049afe4125e9dac4/src/Illuminate/Database/Eloquent/Model.php#L1203-L1206).

While the chances are vanishingly small that this would happen enough times to significantly affect benchmarks, I wanted to remove noise from the benchmarks.