### PR TITLE
Bump ubuntu from 18.04 to 22.04

### DIFF
--- a/frameworks/Nim/httpbeast/httpbeast.dockerfile
+++ b/frameworks/Nim/httpbeast/httpbeast.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt update && apt install -y libgc-dev gcc build-essential curl git
 

--- a/frameworks/Nim/jester/jester.dockerfile
+++ b/frameworks/Nim/jester/jester.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt update && apt install -y libgc-dev gcc build-essential curl git
 


### PR DESCRIPTION
* reduce image fragmentation and thus reduce testing time.
* ubuntu 18.04 is EOL
