### PR TITLE
[php] Fix Phalcon and update with PHP/8.4

### DIFF
--- a/frameworks/PHP/phalcon/phalcon-micro.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-micro.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,21 +6,21 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -y php-pear php8.3-dev > /dev/null
-RUN mkdir -p /etc/php/8.3/fpm/conf.d
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.3/fpm/conf.d/phalcon.ini
+RUN apt-get install -y php-pear php8.4-dev > /dev/null
+RUN mkdir -p /etc/php/8.4/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.4/fpm/conf.d/phalcon.ini
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.3-cli php8.3-fpm php8.3-mysql php8.3-mbstring php8.3-xml > /dev/null
+    php8.4-cli php8.4-fpm php8.4-mysql php8.4-mbstring php8.4-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.3/fpm/
+COPY deploy/conf/* /etc/php/8.4/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --ignore-platform-reqs
 
@@ -30,5 +30,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php8.3-fpm start && \
+CMD service php8.4-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon-mongodb.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,21 +6,21 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -y php-pear php8.3-dev > /dev/null
-RUN mkdir -p /etc/php/8.3/fpm/conf.d
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.3/fpm/conf.d/phalcon.ini
+RUN apt-get install -y php-pear php8.4-dev > /dev/null
+RUN mkdir -p /etc/php/8.4/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.4/fpm/conf.d/phalcon.ini
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.3-cli php8.3-fpm php8.3-mbstring php8.3-xml php8.3-mongodb > /dev/null
+    php8.4-cli php8.4-fpm php8.4-mbstring php8.4-xml php8.4-mongodb > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.3/fpm/
+COPY deploy/conf/* /etc/php/8.4/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet --ignore-platform-reqs
 
@@ -30,5 +30,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php8.3-fpm start && \
+CMD service php8.4-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf

--- a/frameworks/PHP/phalcon/phalcon.dockerfile
+++ b/frameworks/PHP/phalcon/phalcon.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,21 +6,21 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -y php-pear php8.3-dev > /dev/null
-RUN mkdir -p /etc/php/8.3/fpm/conf.d
-RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.3/fpm/conf.d/phalcon.ini
+RUN apt-get install -y php-pear php8.4-dev > /dev/null
+RUN mkdir -p /etc/php/8.4/fpm/conf.d
+RUN pecl install phalcon > /dev/null && echo "extension=phalcon.so" > /etc/php/8.4/fpm/conf.d/phalcon.ini
 
 RUN apt-get install -yqq nginx git unzip \
-    php8.3-cli php8.3-fpm php8.3-mysql php8.3-mbstring php8.3-xml > /dev/null
+    php8.4-cli php8.4-fpm php8.4-mysql php8.4-mbstring php8.4-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.3/fpm/
+COPY deploy/conf/* /etc/php/8.4/fpm/
 
 ADD ./ /phalcon
 WORKDIR /phalcon
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --ignore-platform-reqs
 
@@ -28,5 +28,5 @@ RUN chmod -R 777 app
 
 EXPOSE 8080
 
-CMD service php8.3-fpm start && \
+CMD service php8.4-fpm start && \
     nginx -c /phalcon/deploy/nginx.conf


### PR DESCRIPTION
Fix as fail in the last runs.

Now uses Ubuntu/24.04 and PHP/8.4.

Phalcon support PHP/8.4 from Phalcon/5.9.0 released March 10, 2025.

#9408
