### PR TITLE
[php] OpenSwoole update to PHP/8.4

### DIFF
--- a/frameworks/PHP/openswoole/openswoole-no-async.dockerfile
+++ b/frameworks/PHP/openswoole/openswoole-no-async.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 RUN apt-get update && apt-get install -y git > /dev/null
 

--- a/frameworks/PHP/openswoole/openswoole.dockerfile
+++ b/frameworks/PHP/openswoole/openswoole.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 RUN apt-get update && apt-get install -y git > /dev/null
 


### PR DESCRIPTION
Using openswoole/25.2.0 released Feb 2, 2025, that support PHP/8.4.

Still the openswoole with postgresql variant fail, for now still with PHP/8.3.


#9408
