### PR TITLE
Correction of appmpower-odbc-pg.dockerfile build and version upgrades

### DIFF
--- a/frameworks/CSharp/appmpower/appmpower-odbc-my.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower-odbc-my.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 RUN apt-get update
 RUN apt-get -yqq install clang zlib1g-dev
 RUN apt-get update
@@ -8,7 +8,7 @@ COPY src .
 RUN dotnet publish -c Release -o out /p:Database=mysql
 
 # Construct the actual image that will run
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 
 RUN apt-get update
 # The following installs standard versions unixodbc and pgsqlodbc
@@ -18,6 +18,7 @@ RUN apt-get update
 
 WORKDIR /odbc
 
+#TODOGITHUB
 RUN curl -L -o mariadb-connector-odbc-3.1.20-debian-bookworm-amd64.tar.gz https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.20/mariadb-connector-odbc-3.1.20-debian-bookworm-amd64.tar.gz
 RUN tar -xvzf mariadb-connector-odbc-3.1.20-debian-bookworm-amd64.tar.gz
 RUN cp mariadb-connector-odbc-3.1.20-debian-bookworm-amd64/lib/mariadb/libm* /usr/lib/
@@ -45,8 +46,10 @@ WORKDIR /app
 COPY --from=build /app/out ./
 
 RUN cp /usr/lib/libm* /app
-#RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
+#TODOGITHUB
 RUN cp /usr/lib/x86_64-linux-gnu/libodbc* /app
+#TODOLOCAL
+#RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
 
 EXPOSE 8080
 

--- a/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 RUN apt-get update
-RUN apt-get -yqq install clang zlib1g-dev libkrb5-dev libtinfo5
+RUN apt-get -yqq install clang zlib1g-dev
 
 WORKDIR /app
 COPY src .
 RUN dotnet publish -c Release -o out /p:Database=postgresql
 
 # Construct the actual image that will run
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 
 RUN apt-get update
 RUN apt-get install -y unixodbc-dev unixodbc odbc-postgresql
@@ -27,9 +27,10 @@ ENV ASPNETCORE_URLS http://+:8080
 WORKDIR /app
 COPY --from=build /app/out ./
 
-#RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
+#TODOGITHUB
 RUN cp /usr/lib/x86_64-linux-gnu/libodbc* /app
-
+#TODOLOCAL
+RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
 
 EXPOSE 8080
 

--- a/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower-odbc-pg.dockerfile
@@ -30,7 +30,7 @@ COPY --from=build /app/out ./
 #TODOGITHUB
 RUN cp /usr/lib/x86_64-linux-gnu/libodbc* /app
 #TODOLOCAL
-RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
+#RUN cp /usr/lib/aarch64-linux-gnu/libodbc* /app
 
 EXPOSE 8080
 

--- a/frameworks/CSharp/appmpower/appmpower.dockerfile
+++ b/frameworks/CSharp/appmpower/appmpower.dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 RUN apt-get update
-RUN apt-get -yqq install clang zlib1g-dev libkrb5-dev libtinfo5
+RUN apt-get -yqq install clang zlib1g-dev
 
 WORKDIR /app
 COPY src .
@@ -8,7 +8,7 @@ COPY src .
 RUN dotnet publish -c Release -o out
 
 # Construct the actual image that will run
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 # Full PGO
 ENV DOTNET_TieredPGO 1 
 ENV DOTNET_TC_QuickJitForLoops 1 

--- a/frameworks/CSharp/appmpower/src/appMpower.Orm/appMpower.Orm.csproj
+++ b/frameworks/CSharp/appmpower/src/appMpower.Orm/appMpower.Orm.csproj
@@ -8,6 +8,7 @@
     <SelfContained>true</SelfContained>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     
+    <!--TODOGITHUB-->
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier> <!-- docker server -->
     <!--TODOLOCAL-->
     <!--<RuntimeIdentifier>linux-arm64</RuntimeIdentifier>--> <!-- docker local -->
@@ -36,7 +37,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.Odbc" Version="9.0.0" />
+    <RuntimeHostConfigurationOption Include="System.Threading.ThreadPool.HillClimbing.Disable" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Data.Odbc" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/frameworks/CSharp/appmpower/src/appMpower/appMpower.csproj
+++ b/frameworks/CSharp/appmpower/src/appMpower/appMpower.csproj
@@ -9,14 +9,15 @@
   <ItemGroup>
     <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
 
+    <!--TODOLOCAL-->
     <!--
-    <Content Include="../appMpower.Orm/bin/Release/net8.0/appMpower.Orm.dll">
+    <Content Include="../appMpower.Orm/bin/Release/net9.0/appMpower.Orm.dll">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content> 
     -->
-    <!--TODOLOCAL-->
+    <!--TODOLOCAL AOT-->
     <!--
-    <Content Include="../appMpower.Orm/bin/Release/net8.0/osx-arm64/native/appMpower.Orm.dylib">
+    <Content Include="../appMpower.Orm/bin/Release/net9.0/osx-arm64/native/appMpower.Orm.dylib">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content> 
     -->


### PR DESCRIPTION
The appmpower-odbc-pg.dockerfile failed because of an issue with a linux package that at the end was not needed anymore. This pull request will correct this. Also some upgrades and extra comments have been included. 