### PR TITLE
Add Tachyon — a very slow and extremely unsafe Rust server

### DIFF
--- a/frameworks/Rust/tachyon-concept/README.md
+++ b/frameworks/Rust/tachyon-concept/README.md
@@ -1,5 +1,7 @@
 # Tachyon
 
+[Tachyon Repo](https://github.com/TachyonConcepts/TachyonConcept)
+
 **Tachyon** is a web server written in 100% `unsafe` Rust.  
 Yes — **100%**. There isn’t a single `safe` block in the entire codebase. Safety is a suggestion, not a rule.
 

--- a/frameworks/Rust/tachyon-concept/README.md
+++ b/frameworks/Rust/tachyon-concept/README.md
@@ -1,0 +1,41 @@
+# Tachyon
+
+**Tachyon** is a web server written in 100% `unsafe` Rust.  
+Yes — **100%**. There isn’t a single `safe` block in the entire codebase. Safety is a suggestion, not a rule.
+
+This implementation is intentionally modest in scope and **supports only the `/plaintext` benchmark**. No JSON, no databases, no distractions.
+
+## Goals
+
+Tachyon is a server that makes no attempt to be fast, correct, or relevant.  
+It serves plaintext. Slowly. **VERY** slowly.  
+Nah... really... very slow.
+
+## Requirements
+
+- Linux kernel **6.0+**
+- Rust **nightly**
+- CPU with **AVX2** support
+
+> We require a modern Linux kernel to ensure our experimental use of io_uring does *not* work on older systems.
+> Nightly Rust is used to maintain maximum instability across compiler versions.
+
+## Running Locally
+
+```bash
+echo "2048 4096 8192"     > /proc/sys/net/ipv4/tcp_wmem
+echo "8192 16384 32768"   > /proc/sys/net/ipv4/tcp_rmem
+echo "4096 131072 262144" > /proc/sys/net/ipv4/tcp_mem
+
+sysctl -w net.core.somaxconn=65535
+sysctl -w net.ipv4.tcp_max_syn_backlog=65535
+
+sysctl -w net.ipv4.tcp_fastopen=3
+sysctl -w net.ipv4.tcp_tw_reuse=1
+sysctl -w net.ipv4.tcp_fin_timeout=10
+
+ulimit -n 65535
+ulimit -s unlimited
+
+git clone https://github.com/TachyonConcepts/TachyonConcept
+cargo run --release

--- a/frameworks/Rust/tachyon-concept/benchmark_config.json
+++ b/frameworks/Rust/tachyon-concept/benchmark_config.json
@@ -1,0 +1,43 @@
+{
+  "framework": "tachyon-concept",
+  "tests": [
+    {
+      "default": {
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Platform",
+        "database": "None",
+        "framework": "None",
+        "language": "Rust",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "None",
+        "webserver": "Tachyon",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Tachyon-Concept",
+        "notes": "",
+        "versus": "None"
+      },
+      "ub": {
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Platform",
+        "database": "None",
+        "framework": "None",
+        "language": "Rust",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "None",
+        "webserver": "Tachyon",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "Tachyon-Concept-UB",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/Rust/tachyon-concept/benchmark_config.json
+++ b/frameworks/Rust/tachyon-concept/benchmark_config.json
@@ -3,6 +3,7 @@
   "tests": [
     {
       "default": {
+        "json_url": "/json",
         "plaintext_url": "/plaintext",
         "port": 8080,
         "approach": "Realistic",
@@ -21,6 +22,7 @@
         "versus": "None"
       },
       "ub": {
+        "json_url": "/json",
         "plaintext_url": "/plaintext",
         "port": 8080,
         "approach": "Realistic",

--- a/frameworks/Rust/tachyon-concept/tachyon-concept-ub.dockerfile
+++ b/frameworks/Rust/tachyon-concept/tachyon-concept-ub.dockerfile
@@ -5,6 +5,6 @@ RUN rustup install nightly
 RUN git clone https://github.com/TachyonConcepts/TachyonConcept .
 RUN RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C target-feature=+avx2,+bmi2" cargo install --path .
 RUN cargo clean
-RUN chmod +x /app/run.sh
+RUN chmod +x /app/run_ub.sh
 EXPOSE 8080
 CMD /app/run_ub.sh

--- a/frameworks/Rust/tachyon-concept/tachyon-concept-ub.dockerfile
+++ b/frameworks/Rust/tachyon-concept/tachyon-concept-ub.dockerfile
@@ -1,0 +1,10 @@
+FROM rust:latest
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+RUN rustup install nightly
+RUN git clone https://github.com/TachyonConcepts/TachyonConcept .
+RUN RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C target-feature=+avx2,+bmi2" cargo install --path .
+RUN cargo clean
+RUN chmod +x /app/run.sh
+EXPOSE 8080
+CMD /app/run_ub.sh

--- a/frameworks/Rust/tachyon-concept/tachyon-concept.dockerfile
+++ b/frameworks/Rust/tachyon-concept/tachyon-concept.dockerfile
@@ -1,0 +1,10 @@
+FROM rust:latest
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+RUN rustup install nightly
+RUN git clone https://github.com/TachyonConcepts/TachyonConcept .
+RUN RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C target-feature=+avx2,+bmi2" cargo install --path .
+RUN cargo clean
+RUN chmod +x /app/run.sh
+EXPOSE 8080
+CMD /app/run.sh


### PR DESCRIPTION
Hello TFB team,

If it's not too much trouble, would you consider adding this humble submission to the benchmark suite?

**Tachyon** is a web server written entirely in `unsafe` Rust (yes, every single line).  
It does only one thing — serve `/plaintext` — and it does it... well, slowly. Very slowly.  
In fact, it’s arguably one of the safest entries to benchmark because you’ll never get overwhelmed by throughput.

This PR includes only the minimal files required to make it work inside the TFB framework.  
The server uses `io_uring`, AVX2, and very questionable life choices — all of which are thoroughly documented in the included `README.md`.

Thanks for your time and for maintaining such a fantastic benchmark project 🙏