### PR TITLE
[php] Mixphp update to PHP/8.4

### DIFF
--- a/frameworks/PHP/mixphp/mixphp-swoole-mysql.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp-swoole-mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM phpswoole/swoole:5.1.3-php8.3
+FROM phpswoole/swoole:6.0.2-php8.4
 
 RUN docker-php-ext-install pcntl opcache bcmath > /dev/null
 

--- a/frameworks/PHP/mixphp/mixphp-workerman-mysql.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp-workerman-mysql.dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.3-cli php8.3-mbstring php8.3-curl php8.3-xml php8.3-mysql > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.4-cli php8.4-mbstring php8.4-curl php8.4-xml php8.4-mysql > /dev/null
 
-RUN apt-get install -y php8.3-dev libevent-dev > /dev/null
+RUN apt-get install -y php8.4-dev libevent-dev > /dev/null
 RUN wget http://pear.php.net/go-pear.phar --quiet && php go-pear.phar
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-COPY php-jit.ini /etc/php/8.3/cli/php.ini
+COPY php-jit.ini /etc/php/8.4/cli/php.ini
 
 ADD ./ /mixphp
 WORKDIR /mixphp

--- a/frameworks/PHP/mixphp/mixphp-workerman-pgsql.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp-workerman-pgsql.dockerfile
@@ -1,16 +1,16 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.3-cli php8.3-mbstring php8.3-curl php8.3-xml php8.3-pgsql > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential php8.4-cli php8.4-mbstring php8.4-curl php8.4-xml php8.4-pgsql > /dev/null
 
-RUN apt-get install -y php8.3-dev libevent-dev > /dev/null
+RUN apt-get install -y php8.4-dev libevent-dev > /dev/null
 RUN wget http://pear.php.net/go-pear.phar --quiet && php go-pear.phar
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.3/cli/conf.d/event.ini
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
 
-COPY php-jit.ini /etc/php/8.3/cli/php.ini
+COPY php-jit.ini /etc/php/8.4/cli/php.ini
 
 ADD ./ /mixphp
 WORKDIR /mixphp

--- a/frameworks/PHP/mixphp/mixphp.dockerfile
+++ b/frameworks/PHP/mixphp/mixphp.dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
-RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential nginx php8.3-fpm php8.3-mysql php8.3-dev > /dev/null
+RUN apt-get update -yqq && apt-get install -yqq git unzip wget curl build-essential nginx php8.4-fpm php8.4-mysql php8.4-dev > /dev/null
 
-COPY deploy/conf/* /etc/php/8.3/fpm/
+COPY deploy/conf/* /etc/php/8.4/fpm/
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.3/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
 
 ADD ./ /mixphp
 WORKDIR /mixphp
@@ -22,5 +22,5 @@ RUN chmod -R 777 /mixphp/runtime/logs
 
 EXPOSE 8080
 
-CMD service php8.3-fpm start && \
+CMD service php8.4-fpm start && \
     nginx -c /mixphp/deploy/nginx.conf


### PR DESCRIPTION
Also update:
* Event 3.1.14
* Swoole 6.0.2
* Ubuntu 24.04

With Swoole show warnings:
```
mixphp-swoole-mysql: 2025-07-25 08:34:07.868601  INFO  Start swoole server
mixphp-swoole-mysql: Deprecated: Mix\Database\Connection::queryOne(): Implicitly marking parameter $fetchStyle as nullable is deprecated, the explicit nullable type must be used instead in /mixphp/vendor/mix/database/src/Connection.php on line 14
mixphp-swoole-mysql: Deprecated: Mix\Database\Connection::queryAll(): Implicitly marking parameter $fetchStyle as nullable is deprecated, the explicit nullable type must be used instead in /mixphp/vendor/mix/database/src/Connection.php on line 19
mixphp-swoole-mysql: Deprecated: Mix\Database\AbstractConnection::queryOne(): Implicitly marking parameter $fetchStyle as nullable is deprecated, the explicit nullable type must be used instead in /mixphp/vendor/mix/database/src/AbstractConnection.php on line 456
mixphp-swoole-mysql: Deprecated: Mix\Database\AbstractConnection::queryAll(): Implicitly marking parameter $fetchStyle as nullable is deprecated, the explicit nullable type must be used instead in /mixphp/vendor/mix/database/src/AbstractConnection.php on line 467
```

Created issue 

#9408
