### PR TITLE
Fix bad `benchmark_config.json` in frameworks

### DIFF
--- a/frameworks/Clojure/ring-http-exchange/benchmark_config.json
+++ b/frameworks/Clojure/ring-http-exchange/benchmark_config.json
@@ -20,9 +20,7 @@
         "display_name": "ring-http-exchange",
         "notes": "",
         "versus": "httpserver"
-      }
-    },
-    {
+      },
       "robaho": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",
@@ -41,9 +39,7 @@
         "display_name": "ring-http-exchange-robaho",
         "notes": "",
         "versus": "httpserver-robaho"
-      }
-    },
-    {
+      },
       "graalvm": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",
@@ -62,9 +58,7 @@
         "display_name": "ring-http-exchange-graalvm",
         "notes": "",
         "versus": "ring-http-exchange"
-      }
-    },
-    {
+      },
       "robaho-graalvm": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",

--- a/frameworks/Java/httpserver/benchmark_config.json
+++ b/frameworks/Java/httpserver/benchmark_config.json
@@ -57,9 +57,7 @@
         "display_name": "httpserver-graalvm",
         "notes": "",
         "versus": "httpserver"
-      }
-    },
-    {
+      },
       "robaho": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",

--- a/frameworks/Kotlin/http4k/benchmark_config.json
+++ b/frameworks/Kotlin/http4k/benchmark_config.json
@@ -2,7 +2,7 @@
   "framework": "http4k",
   "tests": [
     {
-      "apache": {
+      "default": {
         "orm": "Raw",
         "database_os": "Linux",
         "cached_query_url": "/cached?queries=",

--- a/frameworks/TypeScript/oak/benchmark_config.json
+++ b/frameworks/TypeScript/oak/benchmark_config.json
@@ -20,9 +20,7 @@
         "display_name": "oak",
         "notes": "",
         "versus": "nodejs"
-      }
-    },
-    {
+      },
       "postgresjs": {
         "json_url": "/json",
         "plaintext_url": "/plaintext",


### PR DESCRIPTION
Problem when run `./tfb`:

```
 => => naming to docker.io/techempower/tfb                                                                                                                0.0s
Framework oak does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework http4k does not define a default test in benchmark_config.json
Framework hyperlane does not define a default test in benchmark_config.json
Framework httpserver does not define a default test in benchmark_config.json
Framework oak does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework ring-http-exchange does not define a default test in benchmark_config.json
Framework http4k does not define a default test in benchmark_config.json
Framework hyperlane does not define a default test in benchmark_config.json
Framework httpserver does not define a default test in benchmark_config.json
================================================================================
Running Tests...

```

They have bad json or not default.
And create noisy lines when running any test locally.
Perhaps we need to add a test for this file.

PD: as this PR don't touch the code, any fail was there before.


### Worst and need to fix

Hyperlane need to be redone.

Actually each test alone have a dockerfile and is compiling the rust, very bad for the running time and not realistic.
https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/Rust/hyperlane/benchmark_config.json

@尤雨东  @尤雨东

I can't contact the authors by mention, and the last PRs for this problem don't exist (#9987, #9976, #9959, ...)
https://github.com/TechEmpower/FrameworkBenchmarks/commits/master/frameworks/Rust/hyperlane

This change in Hyperlane can't pass a review.


@msmith-techempower @NateBrady23  What we do with this situation ?

Mark as bad, revert PR, ...   ?
