### PR TITLE
[php] Frankenphp marked as broken [ci skip]

### DIFF
--- a/frameworks/PHP/php/benchmark_config.json
+++ b/frameworks/PHP/php/benchmark_config.json
@@ -182,7 +182,8 @@
       "database_os": "Linux",
       "display_name": "PHP-frankenphp",
       "notes": "",
-      "versus": "php"
+      "versus": "php",
+      "tags": ["broken"]
     },
     "workerman": {
       "json_url": "/json.php",

--- a/frameworks/PHP/symfony/benchmark_config.json
+++ b/frameworks/PHP/symfony/benchmark_config.json
@@ -162,7 +162,7 @@
       "display_name": "symfony-frankenphp",
       "notes": "Use php 8.2",
       "versus": "php",
-      "tags": []
+      "tags": ["broken"]
     }
   }]
 }


### PR DESCRIPTION
As it's failing in the last runs, without any change in the code, is marked as broken till fixed.
I can't find the problem.

And it don't show any error, even with debug true:
https://tfb-status.techempower.com/unzip/results.2025-07-25-13-52-41-279.zip/symfony-franken
https://tfb-status.techempower.com/unzip/results.2025-07-25-13-52-41-279.zip/php-franken

The last run that worked is from May 15, 2025, ~ when was released Caddy 2.10.

`Laravel-franken` with `Octane` is working OK.

@dunglas could you help to fix it ?
