### PR TITLE
[ruby] Use Rack::Utils.escape_html for escaping

### DIFF
--- a/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record.id %></td><td><%= CGI.escape_html(record.message) %></td></tr>
+      <tr><td><%= record.id %></td><td><%= Rack::Utils.escape_html(record.message) %></td></tr>
     <% end %>
     </table>
   </body>

--- a/frameworks/Ruby/rage/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record[:id] %></td><td><%= CGI.escape_html(record[:message]) %></td></tr>
+      <tr><td><%= record[:id] %></td><td><%= Rack::Utils.escape_html(record[:message]) %></td></tr>
     <% end %>
     </table>
   </body>


### PR DESCRIPTION
Rack::Utils.escape_html is faster than CGI.escape_html:

```ruby
require 'benchmark/ips'
require 'cgi'
require 'rack'

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)

  message = 'Additional fortune added at request time.'
  x.report("CGI") do
    CGI.escape_html(message)
  end

  x.report("Rack") do
    Rack::Utils.escape_html(message)
  end

  x.compare!
end
```

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                 CGI     1.016M i/100ms
                Rack     1.586M i/100ms
Calculating -------------------------------------
                 CGI     10.821M (± 0.3%) i/s   (92.42 ns/i) -     54.837M in   5.067830s
                Rack     15.861M (± 0.3%) i/s   (63.05 ns/i) -     80.886M in   5.099606s

Comparison:
                Rack: 15861352.0 i/s
                 CGI: 10820753.9 i/s - 1.47x  slower
```

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
