### PR TITLE
[ruby] Update Bundler to 2.7.0 and fix deprecation warnings

### DIFF
--- a/frameworks/Ruby/agoo/Gemfile.lock
+++ b/frameworks/Ruby/agoo/Gemfile.lock
@@ -23,4 +23,4 @@ DEPENDENCIES
   rack
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/grape/Gemfile.lock
+++ b/frameworks/Ruby/grape/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   unicorn (= 6.1.0)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/hanami/Gemfile.lock
+++ b/frameworks/Ruby/hanami/Gemfile.lock
@@ -178,4 +178,4 @@ DEPENDENCIES
   rom-sql (~> 3.6)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/padrino/Gemfile
+++ b/frameworks/Ruby/padrino/Gemfile
@@ -13,5 +13,5 @@ group :puma, optional: true do
 end
 
 group :unicorn, optional: true do
-  gem 'unicorn', '~> 6.1', platforms: [:ruby, :mswin], require: false
+  gem 'unicorn', '~> 6.1', platforms: [:ruby, :windows], require: false
 end

--- a/frameworks/Ruby/padrino/Gemfile.lock
+++ b/frameworks/Ruby/padrino/Gemfile.lock
@@ -146,4 +146,4 @@ DEPENDENCIES
   unicorn (~> 6.1)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/rack-sequel/Gemfile
+++ b/frameworks/Ruby/rack-sequel/Gemfile
@@ -5,11 +5,11 @@ gem 'sequel', '~> 5.0'
 gem 'rack', '~> 3.1'
 
 group :mysql, optional: true do
-  gem 'mysql2', '~> 0.4', platforms: [:ruby, :mswin]
+  gem 'mysql2', '~> 0.4', platforms: [:ruby, :windows]
 end
 
 group :postgresql, optional: true do
-  gem 'pg', '~> 1.5', platforms: [:ruby, :mswin]
+  gem 'pg', '~> 1.5', platforms: [:ruby, :windows]
   gem 'sequel_pg', '~> 1.6', platforms: :ruby, require: false
 end
 

--- a/frameworks/Ruby/rack-sequel/Gemfile.lock
+++ b/frameworks/Ruby/rack-sequel/Gemfile.lock
@@ -30,4 +30,4 @@ DEPENDENCIES
   sequel_pg (~> 1.6)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/rack/Gemfile
+++ b/frameworks/Ruby/rack/Gemfile
@@ -9,23 +9,23 @@ gem 'rack', '~> 3.0'
 gem 'connection_pool', '~> 2.4'
 gem 'jdbc-postgres', '~> 42.2', platforms: :jruby, require: 'jdbc/postgres'
 gem 'json', '~> 2.10'
-gem 'pg', '~> 1.5', platforms: %i[ruby mswin]
+gem 'pg', '~> 1.5', platforms: %i[ruby windows]
 gem 'sequel'
-gem 'sequel_pg', platforms: %i[ruby mswin]
+gem 'sequel_pg', platforms: %i[ruby windows]
 gem 'tzinfo-data', '1.2023.3'
 
 group :falcon, optional: true do
-  gem 'falcon', '~> 0.47', platforms: %i[ruby mswin]
+  gem 'falcon', '~> 0.47', platforms: %i[ruby windows]
 end
 
 group :iodine, optional: true do
-  gem 'iodine', '~> 0.7', platforms: %i[ruby mswin]
+  gem 'iodine', '~> 0.7', platforms: %i[ruby windows]
 end
 
 group :passenger, optional: true do
   gem 'base64' # required by passenger on Ruby 3.4
   gem 'logger' # required by passenger on Ruby 3.5
-  gem 'passenger', '~> 6.0', platforms: [:ruby, :mswin], require: false
+  gem 'passenger', '~> 6.0', platforms: [:ruby, :windows], require: false
 end
 
 group :pitchfork, optional: true do
@@ -38,10 +38,10 @@ end
 
 group :unicorn, optional: true do
   gem 'logger' # required by unicorn on Ruby 3.5
-  gem 'unicorn', '~> 6.1', platforms: %i[ruby mswin]
+  gem 'unicorn', '~> 6.1', platforms: %i[ruby windows]
 end
 
 group :development, optional: true do
   gem 'rack-test'
-  gem 'rubocop', platforms: %i[ruby mswin]
+  gem 'rubocop', platforms: %i[ruby windows]
 end

--- a/frameworks/Ruby/rack/Gemfile.lock
+++ b/frameworks/Ruby/rack/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
       raindrops (~> 0.7)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-23
   x86_64-linux
 
@@ -165,4 +166,4 @@ DEPENDENCIES
   unicorn (~> 6.1)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/rage-sequel/Gemfile.lock
+++ b/frameworks/Ruby/rage-sequel/Gemfile.lock
@@ -36,4 +36,4 @@ DEPENDENCIES
   sequel_pg (~> 1.6)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/rage/Gemfile.lock
+++ b/frameworks/Ruby/rage/Gemfile.lock
@@ -61,4 +61,4 @@ DEPENDENCIES
   rage-rb (~> 1.10)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -289,4 +289,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/roda-sequel/Gemfile
+++ b/frameworks/Ruby/roda-sequel/Gemfile
@@ -8,11 +8,11 @@ gem "roda", "~> 3.66"
 gem "tilt", "~> 2.1", require: "tilt/erb"
 
 group :mysql, optional: true do
-  gem "mysql2", "~> 0.5", platforms: %i[ruby mswin]
+  gem "mysql2", "~> 0.5", platforms: %i[ruby windows]
 end
 
 group :postgresql, optional: true do
-  gem "pg", "~> 1.4", platforms: %i[ruby mswin]
+  gem "pg", "~> 1.4", platforms: %i[ruby windows]
   gem "sequel_pg", "~> 1.17", platforms: :ruby, require: false
 end
 

--- a/frameworks/Ruby/roda-sequel/Gemfile.lock
+++ b/frameworks/Ruby/roda-sequel/Gemfile.lock
@@ -40,4 +40,4 @@ DEPENDENCIES
   tilt (~> 2.1)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/sinatra-sequel/Gemfile
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile
@@ -5,16 +5,16 @@ gem 'sequel', '~> 5.0'
 gem 'sinatra', '~> 4.0', :require=>'sinatra/base'
 
 group :mysql, optional: true do
-  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :mswin]
+  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :windows]
 end
 
 group :postgresql, optional: true do
-  gem 'pg', '~> 1.5', :platforms=>[:ruby, :mswin]
+  gem 'pg', '~> 1.5', :platforms=>[:ruby, :windows]
   gem 'sequel_pg', '~> 1.6', :platforms=>:ruby, :require=>false
 end
 
 group :iodine, optional: true do
-  gem 'iodine', '~> 0.7', platforms: [:ruby, :mswin], require: false
+  gem 'iodine', '~> 0.7', platforms: [:ruby, :windows], require: false
 end
 
 group :puma, optional: true do

--- a/frameworks/Ruby/sinatra-sequel/Gemfile.lock
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile.lock
@@ -52,4 +52,4 @@ DEPENDENCIES
   sinatra (~> 4.0)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0

--- a/frameworks/Ruby/sinatra/Gemfile
+++ b/frameworks/Ruby/sinatra/Gemfile
@@ -5,15 +5,15 @@ gem 'json', '~> 2.8'
 gem 'sinatra', '~> 4.0', require: 'sinatra/base'
 
 group :mysql, optional: true do
-  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :mswin]
+  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :windows]
 end
 
 group :postgresql, optional: true do
-  gem 'pg', '~> 1.5', platforms: [:ruby, :mswin]
+  gem 'pg', '~> 1.5', platforms: [:ruby, :windows]
 end
 
 group :iodine, optional: true do
-  gem 'iodine', '~> 0.7', platforms: [:ruby, :mswin], require: false
+  gem 'iodine', '~> 0.7', platforms: [:ruby, :windows], require: false
 end
 
 group :puma, optional: true do

--- a/frameworks/Ruby/sinatra/Gemfile.lock
+++ b/frameworks/Ruby/sinatra/Gemfile.lock
@@ -30,7 +30,6 @@ GEM
       concurrent-ruby (~> 1.0)
     iodine (0.7.58)
     json (2.11.3)
-    kgio (2.11.4)
     logger (1.6.6)
     minitest (5.25.4)
     mustermann (3.0.3)
@@ -48,7 +47,6 @@ GEM
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
-    raindrops (0.20.1)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     sinatra (4.1.1)
@@ -62,9 +60,6 @@ GEM
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicorn (6.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     uri (1.0.3)
 
 PLATFORMS
@@ -80,7 +75,6 @@ DEPENDENCIES
   pg (~> 1.5)
   puma (~> 6.4)
   sinatra (~> 4.0)
-  unicorn (~> 6.1)
 
 BUNDLED WITH
-   2.6.2
+   2.7.0


### PR DESCRIPTION
This fixes the following warning:

    [DEPRECATED] Platform :mswin is deprecated. Please use platform :windows instead.