### PR TITLE
[rails] Update stringio to 3.1.7

### DIFF
--- a/frameworks/Ruby/rails/Gemfile.lock
+++ b/frameworks/Ruby/rails/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       console (~> 1.0)
       mapping (~> 1.0)
     securerandom (0.4.1)
-    stringio (3.1.5)
+    stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
     traces (0.15.2)


### PR DESCRIPTION
This fixes the following error:

    rails: Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
    rails:     current directory: /usr/local/bundle/gems/stringio-3.1.5/ext/stringio
    rails: /usr/local/bin/ruby extconf.rb
    rails: creating Makefile
    rails: current directory: /usr/local/bundle/gems/stringio-3.1.5/ext/stringio
    rails: make DESTDIR\= sitearchdir\=./.gem.20250821-7-vydpnd
    rails: sitelibdir\=./.gem.20250821-7-vydpnd clean
    rails: current directory: /usr/local/bundle/gems/stringio-3.1.5/ext/stringio
    rails: make DESTDIR\= sitearchdir\=./.gem.20250821-7-vydpnd
    rails: sitelibdir\=./.gem.20250821-7-vydpnd
    rails: compiling stringio.c
    rails: stringio.c: In function ‘strio_init’:
    rails: stringio.c:295:52: error: passing argument 5 of ‘rb_io_extract_modeenc’ from
    rails: incompatible pointer type [-Wincompatible-pointer-types]
    rails: 295 |     rb_io_extract_modeenc(&vmode, 0, opt, &oflags, &ptr->flags,
    rails: &convconfig);
    rails:       |                                                    ^~~~~~~~~~~
    rails:       |                                                    |
    rails:       |                                                    int *
    rails: In file included from stringio.c:21:
    rails: /usr/local/include/ruby-3.5.0+0/ruby/io.h:877:107: note: expected ‘enum
    rails: rb_io_mode *’ but argument is of type ‘int *’
    rails: 877 | void rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE
    rails: opthash, int *oflags_p, enum rb_io_mode *fmode_p, rb_io_enc_t *convconfig_p);

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
