### PR TITLE
[ruby/sinatra] Use trilogy for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/sinatra/Gemfile
+++ b/frameworks/Ruby/sinatra/Gemfile
@@ -5,7 +5,7 @@ gem 'json', '~> 2.8'
 gem 'sinatra', '~> 4.0', require: 'sinatra/base'
 
 group :mysql, optional: true do
-  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :windows]
+  gem 'trilogy', '~> 2.9.0', platforms: [:ruby, :windows]
 end
 
 group :postgresql, optional: true do

--- a/frameworks/Ruby/sinatra/Gemfile.lock
+++ b/frameworks/Ruby/sinatra/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
     minitest (5.25.5)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.6)
     nio4r (2.7.4)
     pg (1.5.9)
     puma (6.6.0)
@@ -58,6 +57,7 @@ GEM
       tilt (~> 2.0)
     tilt (2.6.0)
     timeout (0.4.3)
+    trilogy (2.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.3)
@@ -71,10 +71,10 @@ DEPENDENCIES
   activerecord (~> 8.0)
   iodine (~> 0.7)
   json (~> 2.8)
-  mysql2 (~> 0.5)
   pg (~> 1.5)
   puma (~> 6.4)
   sinatra (~> 4.0)
+  trilogy (~> 2.9.0)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/sinatra/boot.rb
+++ b/frameworks/Ruby/sinatra/boot.rb
@@ -15,12 +15,21 @@ def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
 
   opts = {
-    adapter: (dbtype == :mysql ? 'mysql2' : 'postgresql'),
     username: 'benchmarkdbuser',
     password: 'benchmarkdbpass',
     host: 'tfb-database',
     database: 'hello_world'
   }
+
+  if dbtype == :mysql
+    opts[:adapter] = 'trilogy'
+    opts[:ssl] = true
+    opts[:ssl_mode] = 4 # Trilogy::SSL_PREFERRED_NOVERIFY
+    opts[:tls_min_version] = 3 # Trilogy::TLS_VERSION_12
+  else
+    opts[:adapter] = 'postgresql'
+  end
+
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
@@ -44,7 +53,7 @@ class World < ActiveRecord::Base
   alias_attribute(:randomNumber, :randomnumber) \
     if connection.adapter_name.downcase.start_with?('postgres')
 
-  if connection.adapter_name.downcase.start_with?('mysql')
+  if connection.adapter_name.downcase.start_with?('trilogy')
     def self.upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
       # On MySQL Batch updates verification isn't supported yet by TechEmpower.
       # https://github.com/TechEmpower/FrameworkBenchmarks/issues/5983


### PR DESCRIPTION
Trilogy is a new client library for MySQL-compatible database servers, designed for performance, flexibility, and ease of embedding. It is used by Github and Shopify in production and will probably replace the `mysql2` library.
https://github.com/trilogy-libraries/trilogy