### PR TITLE
[ruby/roda-sequel] Use trilogy for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/roda-sequel/Gemfile
+++ b/frameworks/Ruby/roda-sequel/Gemfile
@@ -7,7 +7,7 @@ gem "roda", "~> 3.66"
 gem "tilt", "~> 2.1", require: "tilt/erb"
 
 group :mysql, optional: true do
-  gem "mysql2", "~> 0.5", platforms: %i[ruby windows]
+  gem 'trilogy', '~> 2.9.0', platforms: [:ruby, :windows]
 end
 
 group :postgresql, optional: true do

--- a/frameworks/Ruby/roda-sequel/Gemfile.lock
+++ b/frameworks/Ruby/roda-sequel/Gemfile.lock
@@ -5,7 +5,6 @@ GEM
     erubi (1.13.1)
     iodine (0.7.58)
     json (2.13.2)
-    mysql2 (0.5.6)
     nio4r (2.7.4)
     pg (1.5.9)
     puma (6.6.0)
@@ -19,6 +18,7 @@ GEM
       pg (>= 0.18.0, != 1.2.0)
       sequel (>= 4.38.0)
     tilt (2.6.0)
+    trilogy (2.9.0)
 
 PLATFORMS
   ruby
@@ -29,13 +29,13 @@ DEPENDENCIES
   erubi (~> 1.12)
   iodine (~> 0.7)
   json (~> 2.8)
-  mysql2 (~> 0.5)
   pg (~> 1.4)
   puma (~> 6.2)
   roda (~> 3.66)
   sequel (~> 5.67)
   sequel_pg (~> 1.17)
   tilt (~> 2.1)
+  trilogy (~> 2.9.0)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/roda-sequel/boot.rb
+++ b/frameworks/Ruby/roda-sequel/boot.rb
@@ -22,16 +22,16 @@ SERVER_HEADER = 'Server'
 def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
 
-  adapters = {
-    mysql: {
-      mri: "mysql2"
-    },
-    postgresql: {
-      mri: "postgres"
-    }
-  }
-
   opts = {}
+
+  if dbtype == :mysql
+    adapter = 'trilogy'
+    opts[:ssl] = true
+    opts[:ssl_mode] = 4 # Trilogy::SSL_PREFERRED_NOVERIFY
+    opts[:tls_min_version] = 3 # Trilogy::TLS_VERSION_12
+  else
+    adapter = 'postgresql'
+  end
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) &&
@@ -42,8 +42,7 @@ def connect(dbtype)
 
   Sequel.connect "%{adapter}://%{host}/%{database}?user=%{user}&password=%{password}" %
                    {
-                     adapter:
-                       adapters.fetch(dbtype).fetch(:mri),
+                     adapter: adapter,
                      host: "tfb-database",
                      database: "hello_world",
                      user: "benchmarkdbuser",


### PR DESCRIPTION
Trilogy is a new client library for MySQL-compatible database servers, designed for performance, flexibility, and ease of embedding. It is used by Github and Shopify in production and will probably replace the mysql2 library.
https://github.com/trilogy-libraries/trilogy