### PR TITLE
[ruby/sinatra-sequel] Use trilogy for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/roda-sequel/Gemfile
+++ b/frameworks/Ruby/roda-sequel/Gemfile
@@ -7,7 +7,7 @@ gem "roda", "~> 3.66"
 gem "tilt", "~> 2.1", require: "tilt/erb"
 
 group :mysql, optional: true do
-  gem 'trilogy', '~> 2.9.0', platforms: [:ruby, :windows]
+  gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
 end
 
 group :postgresql, optional: true do

--- a/frameworks/Ruby/roda-sequel/Gemfile.lock
+++ b/frameworks/Ruby/roda-sequel/Gemfile.lock
@@ -35,7 +35,7 @@ DEPENDENCIES
   sequel (~> 5.67)
   sequel_pg (~> 1.17)
   tilt (~> 2.1)
-  trilogy (~> 2.9.0)
+  trilogy (~> 2.9)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/sinatra-sequel/Gemfile
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile
@@ -5,7 +5,7 @@ gem 'sequel', '~> 5.0'
 gem 'sinatra', '~> 4.0', :require=>'sinatra/base'
 
 group :mysql, optional: true do
-  gem 'mysql2', '~> 0.5', :platforms=>[:ruby, :windows]
+  gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
 end
 
 group :postgresql, optional: true do

--- a/frameworks/Ruby/sinatra-sequel/Gemfile.lock
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
     logger (1.6.6)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.6)
     nio4r (2.7.4)
     pg (1.5.9)
     puma (6.6.0)
@@ -35,6 +34,7 @@ GEM
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     tilt (2.6.0)
+    trilogy (2.9.0)
 
 PLATFORMS
   ruby
@@ -44,12 +44,12 @@ PLATFORMS
 DEPENDENCIES
   iodine (~> 0.7)
   json (~> 2.8)
-  mysql2 (~> 0.5)
   pg (~> 1.5)
   puma (~> 6.4)
   sequel (~> 5.0)
   sequel_pg (~> 1.6)
   sinatra (~> 4.0)
+  trilogy (~> 2.9)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/sinatra-sequel/boot.rb
+++ b/frameworks/Ruby/sinatra-sequel/boot.rb
@@ -15,12 +15,16 @@ Bundler.require(:default) # Load core modules
 def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
 
-  adapters = {
-    mysql: 'mysql2',
-    postgresql: 'postgres'
-  }
-
   opts = {}
+
+  if dbtype == :mysql
+    adapter = 'trilogy'
+    opts[:ssl] = true
+    opts[:ssl_mode] = 4 # Trilogy::SSL_PREFERRED_NOVERIFY
+    opts[:tls_min_version] = 3 # Trilogy::TLS_VERSION_12
+  else
+    adapter = 'postgresql'
+  end
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
@@ -30,7 +34,7 @@ def connect(dbtype)
 
   Sequel.connect \
     '%{adapter}://%{host}/%{database}?user=%{user}&password=%{password}' % {
-      adapter: (dbtype == :mysql ? 'mysql2' : 'postgresql'),
+      adapter: adapter,
       host: 'tfb-database',
       database: 'hello_world',
       user: 'benchmarkdbuser',


### PR DESCRIPTION
Trilogy is a new client library for MySQL-compatible database servers, designed for performance, flexibility, and ease of embedding. It is used by Github and Shopify in production and will probably replace the mysql2 library.
https://github.com/trilogy-libraries/trilogy
