### PR TITLE
[ruby/rack] Set timeslice to 10ms

### DIFF
--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -2,6 +2,7 @@ FROM ruby:3.5-rc
 
 ENV RUBY_YJIT_ENABLE=1
 ENV RUBY_MN_THREADS=1
+ENV RUBY_THREAD_TIMESLICE=10
 
 # Use Jemalloc
 RUN apt-get update && \


### PR DESCRIPTION
By default this is set to 100ms.
https://github.com/ruby/ruby/pull/11981