### PR TITLE
Revert "[ruby] Use Rack::Utils.escape_html for escaping (#10032)"

### DIFF
--- a/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record.id %></td><td><%= Rack::Utils.escape_html(record.message) %></td></tr>
+      <tr><td><%= record.id %></td><td><%= CGI.escape_html(record.message) %></td></tr>
     <% end %>
     </table>
   </body>

--- a/frameworks/Ruby/rage/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record[:id] %></td><td><%= Rack::Utils.escape_html(record[:message]) %></td></tr>
+      <tr><td><%= record[:id] %></td><td><%= CGI.escape_html(record[:message]) %></td></tr>
     <% end %>
     </table>
   </body>


### PR DESCRIPTION
This reverts commit 6c26a89dd7f9bf03fa5b6211d5462f030c7dc6bb.

Changing CGI.escape_html to Rack::Utils.escape_html made things slower instead of faster for fortunes.

Before commit 6c26a89dd7f9

|       name|fortunes|query|
|-----------|--------|-----|
|rage-sequel|  171239|28494|
|rage       |  105726|18625|

After commit 6c26a89dd7f9

|       name|fortunes|query|
|-----------|--------|-----|
|rage-sequel|  153681|28319|
|rage       |   99163|19365|