### PR TITLE
[ruby/roda-sequel] Use CGI.escape_html

### DIFF
--- a/frameworks/Ruby/roda-sequel/Gemfile
+++ b/frameworks/Ruby/roda-sequel/Gemfile
@@ -5,6 +5,7 @@ gem "json", "~> 2.8"
 gem "sequel", "~> 5.67"
 gem "roda", "~> 3.66"
 gem "tilt", "~> 2.1", require: "tilt/erb"
+gem "cgi" # Make sure the h plugin uses the faster CGI.escape_html
 
 group :mysql, optional: true do
   gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]

--- a/frameworks/Ruby/roda-sequel/Gemfile.lock
+++ b/frameworks/Ruby/roda-sequel/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     bigdecimal (3.1.9)
+    cgi (0.5.0)
     erubi (1.13.1)
     iodine (0.7.58)
     json (2.13.2)
@@ -26,6 +27,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  cgi
   erubi (~> 1.12)
   iodine (~> 0.7)
   json (~> 2.8)


### PR DESCRIPTION
Roda will use the faster `CGI.escape_html` if the "cgi" gem is installed:
https://github.com/jeremyevans/roda/blob/d89cd5d7310dad20eb706eb392ebbce49f815e67/lib/roda/plugins/h.rb

```ruby
require 'benchmark/ips'
require 'erb'

Benchmark.ips do |x|
  x.config(time: 5)

  messages = []
  messages <<  'Additional fortune added at request time.'
  messages << 'フレームワークのベンチマーク'
  messages << '<script>alert("This should not be displayed in a browser alert box.");</script>'

  require 'cgi'
  x.report("CGI") do
    messages.each do |m|
      CGI.escape_html(m)
    end
  end

  ESCAPE_HTML = {
    "&" => "&amp;".freeze,
    "<" => "&lt;".freeze,
    ">" => "&gt;".freeze,
    "'" => "&#39;".freeze,
    '"' => "&quot;".freeze,
  }.freeze

  # A Regexp of HTML entities to match for escaping.
  ESCAPE_HTML_PATTERN = Regexp.union(*ESCAPE_HTML.keys)

  x.report("ESCAPE_HTML") do
    messages.each do |m|
      m.to_s.gsub(ESCAPE_HTML_PATTERN){|c| ESCAPE_HTML[c] }
    end
  end

  x.compare!
end
```

```
ruby 3.4.5 (2025-07-16 revision 20cda200d3) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                 CGI    39.444k i/100ms
         ESCAPE_HTML    33.482k i/100ms
Calculating -------------------------------------
                 CGI    394.120k (± 1.0%) i/s    (2.54 μs/i) -      1.972M in   5.004594s
         ESCAPE_HTML    333.558k (± 1.6%) i/s    (3.00 μs/i) -      1.674M in   5.020278s

Comparison:
                 CGI:   394120.5 i/s
         ESCAPE_HTML:   333557.6 i/s - 1.18x  slower
```

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
