### PR TITLE
[ruby/puma] Use same number of connections as threads

### DIFF
--- a/frameworks/Ruby/padrino/config/database.rb
+++ b/frameworks/Ruby/padrino/config/database.rb
@@ -9,7 +9,7 @@ opts = {
 
 # Determine threading/thread pool size and timeout
 if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-  opts[:pool] = (2 * Math.log(threads)).floor
+  opts[:pool] = threads
   opts[:checkout_timeout] = 10
 else
   # TODO: ActiveRecord doesn't have a single-threaded mode?

--- a/frameworks/Ruby/rack-sequel/boot.rb
+++ b/frameworks/Ruby/rack-sequel/boot.rb
@@ -21,8 +21,10 @@ def connect(dbtype)
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-    opts[:max_connections] = (2 * Math.log(threads)).floor
+    opts[:max_connections] = threads
     opts[:pool_timeout] = 10
+  else
+    opts[:max_connections] = 512
   end
 
   Sequel.connect \

--- a/frameworks/Ruby/roda-sequel/boot.rb
+++ b/frameworks/Ruby/roda-sequel/boot.rb
@@ -36,8 +36,10 @@ def connect(dbtype)
   # Determine threading/thread pool size and timeout
   if defined?(Puma) &&
         (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-    opts[:max_connections] = (2 * Math.log(threads)).floor
+    opts[:max_connections] = threads
     opts[:pool_timeout] = 10
+  else
+    opts[:max_connections] = 512
   end
 
   Sequel.connect "%{adapter}://%{host}/%{database}?user=%{user}&password=%{password}" %

--- a/frameworks/Ruby/sinatra-sequel/boot.rb
+++ b/frameworks/Ruby/sinatra-sequel/boot.rb
@@ -28,8 +28,10 @@ def connect(dbtype)
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-    opts[:max_connections] = (2 * Math.log(threads)).floor
+    opts[:max_connections] = threads
     opts[:pool_timeout] = 10
+  else
+    opts[:max_connections] = 512
   end
 
   Sequel.connect \

--- a/frameworks/Ruby/sinatra/boot.rb
+++ b/frameworks/Ruby/sinatra/boot.rb
@@ -33,12 +33,10 @@ def connect(dbtype)
 
   # Determine threading/thread pool size and timeout
   if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-    opts[:pool] = (2 * Math.log(threads)).floor
+    opts[:pool] = threads
     opts[:checkout_timeout] = 10
   else
-    # TODO: ActiveRecord doesn't have a single-threaded mode?
-    opts[:pool] = 1
-    opts[:checkout_timeout] = 0
+    opts[:pool] = 512
   end
 
   ActiveRecord::Base.establish_connection(opts)


### PR DESCRIPTION
When using puma use the same amount of connections as threads. For other servers default to 512.