### PR TITLE
Fix the framework order for each continuous benchmarking run

### DIFF
--- a/toolset/continuous/tfb-startup.sh
+++ b/toolset/continuous/tfb-startup.sh
@@ -20,10 +20,12 @@ git clone \
 echo "moving to tfb directory"
 cd $TFB_REPOPARENT/$TFB_REPONAME
 
-if [ -z "$TFB_RUN_ORDER" ]; then
+if [ -e "${TFB_REPOPARENT}/tfb-reverse-order" ]; then
   export TFB_RUN_ORDER="reverse"
+  sudo rm -rf "${TFB_REPOPARENT}/tfb-reverse-order"
 else
   unset TFB_RUN_ORDER
+  touch "${TFB_REPOPARENT}/tfb-reverse-order"
 fi
 
 echo "building tfb docker image"


### PR DESCRIPTION
The environment variable values used by system services are not persistent, so any changes to them are lost after services finish execution. As a result, the framework order was not toggled properly after each continuous benchmarking run completed. Instead, use a regular file to keep track of the order.

This is another attempt to fix the framework order after pull request #9103. Of course, the copy of the respective script in the Citrine environment would have to be updated if my changes are acceptable; fortunately, there shouldn't be any need to interrupt a run to this  end.