### PR TITLE
[ruby/rack-sequel] Use `with_pk` instead of contants for queries

### DIFF
--- a/frameworks/Ruby/rack-sequel/boot.rb
+++ b/frameworks/Ruby/rack-sequel/boot.rb
@@ -41,16 +41,11 @@ DB = connect ENV.fetch('DBTYPE').to_sym
 
 # Define ORM models
 class World < Sequel::Model(:World)
-  BY_ID = naked.where(id: :$id).prepare(:first, :world_by_id)
-  UPDATE = where(id: :$id).prepare(:update, :world_update, randomnumber: :$randomnumber)
-
   def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
 
   def self.batch_update(worlds)
     if DB.database_type == :mysql
-      worlds.each do |world|
-        UPDATE.(id: world[:id], randomnumber: world[:randomnumber])
-      end
+      worlds.map(&:save_changes)
     else
       ids = []
       sql = String.new("UPDATE world SET randomnumber = CASE id ")

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -30,14 +30,14 @@ class HelloWorld
   end
 
   def db
-    World::BY_ID.(id: rand1)
+    World.with_pk(rand1).values
   end
 
   def queries(env)
     ids = ALL_IDS.sample(bounded_queries(env))
     DB.synchronize do
       ids.map do |id|
-        World::BY_ID.(id: id)
+        World.with_pk(id).values
       end
     end
   end
@@ -84,17 +84,20 @@ class HelloWorld
   end
 
   def updates(env)
+    worlds = []
     ids = ALL_IDS.sample(bounded_queries(env))
     DB.synchronize do
       worlds =
         ids.map do |id|
-          world = World::BY_ID.(id: id)
-          world[:randomnumber] = rand1
+          world = World.with_pk(id)
+          new_value = rand1
+          new_value = rand1 while new_value == world.randomnumber
+          world.randomnumber = new_value
           world
         end
       World.batch_update(worlds)
-      worlds
     end
+    worlds.map!(&:values)
   end
 
   def call(env)


### PR DESCRIPTION
rack-sequel has connection pools timeouts, unlike roda-sequel and sinatra-sequel:

      rack-sequel: 2025-09-13 11:30:07 +0000 Rack app ("GET /queries?queries=10" - (10.0.1.3)): #<Sequel::PoolTimeout: timeout: 10.0>

https://tfb-status.techempower.com/unzip/results.2025-09-18-05-29-59-113.zip/results/20250910230442/rack-sequel/run/rack-sequel.log

The only difference appears to be the prepared statements. Let's see if this fixes things.