### PR TITLE
[ruby] Copy Gemfile.lock in docker

### DIFF
--- a/frameworks/Ruby/agoo/agoo.dockerfile
+++ b/frameworks/Ruby/agoo/agoo.dockerfile
@@ -15,7 +15,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile app.rb ./
+COPY Gemfile* app.rb ./
 
 RUN bundle install --jobs=4
 

--- a/frameworks/Ruby/padrino/padrino-unicorn.dockerfile
+++ b/frameworks/Ruby/padrino/padrino-unicorn.dockerfile
@@ -7,6 +7,7 @@ COPY models models
 COPY .components .components
 COPY config.ru config.ru
 COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
 COPY Rakefile Rakefile
 
 RUN bundle config set with 'unicorn'

--- a/frameworks/Ruby/padrino/padrino.dockerfile
+++ b/frameworks/Ruby/padrino/padrino.dockerfile
@@ -7,6 +7,7 @@ COPY models models
 COPY .components .components
 COPY config.ru config.ru
 COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
 COPY Rakefile Rakefile
 
 RUN bundle config set with 'puma'

--- a/frameworks/Ruby/rack/rack-falcon.dockerfile
+++ b/frameworks/Ruby/rack/rack-falcon.dockerfile
@@ -9,7 +9,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'falcon'

--- a/frameworks/Ruby/rack/rack-iodine.dockerfile
+++ b/frameworks/Ruby/rack/rack-iodine.dockerfile
@@ -9,7 +9,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'iodine'

--- a/frameworks/Ruby/rack/rack-jruby.dockerfile
+++ b/frameworks/Ruby/rack/rack-jruby.dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && apt-get install netbase -y
 
 WORKDIR /rack
 
-COPY Gemfile  ./
+COPY Gemfile*  ./
 
 RUN bundle config set with 'puma'
 RUN bundle install --jobs=8

--- a/frameworks/Ruby/rack/rack-passenger.dockerfile
+++ b/frameworks/Ruby/rack/rack-passenger.dockerfile
@@ -9,7 +9,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'passenger'

--- a/frameworks/Ruby/rack/rack-pitchfork.dockerfile
+++ b/frameworks/Ruby/rack/rack-pitchfork.dockerfile
@@ -9,7 +9,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'pitchfork'

--- a/frameworks/Ruby/rack/rack-unicorn.dockerfile
+++ b/frameworks/Ruby/rack/rack-unicorn.dockerfile
@@ -9,7 +9,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'unicorn'

--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -10,7 +10,7 @@ ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /rack
 
-COPY Gemfile ./
+COPY Gemfile* ./
 
 ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'puma'


### PR DESCRIPTION
This makes sure the gem versions in the lock file are used, resulting in more predictable runs.