### PR TITLE
[ruby/rack] Rescue Errno::ECONNRESET for Falcon

### DIFF
--- a/frameworks/Ruby/rack/Gemfile
+++ b/frameworks/Ruby/rack/Gemfile
@@ -16,6 +16,7 @@ gem 'tzinfo-data', '1.2023.3'
 
 group :falcon, optional: true do
   gem 'falcon', '~> 0.47', platforms: %i[ruby windows]
+  gem 'protocol-http1', git: 'https://github.com/socketry/protocol-http1', ref: 'read_line-error-handling'
 end
 
 group :iodine, optional: true do

--- a/frameworks/Ruby/rack/Gemfile.lock
+++ b/frameworks/Ruby/rack/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/socketry/protocol-http1
+  revision: 32717a99b5409aecb66e89d29389d9f215c7b7de
+  ref: read_line-error-handling
+  specs:
+    protocol-http1 (0.35.1)
+      protocol-http (~> 0.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,8 +94,6 @@ GEM
       rack (>= 2.0)
     protocol-hpack (1.5.1)
     protocol-http (0.49.0)
-    protocol-http1 (0.30.0)
-      protocol-http (~> 0.22)
     protocol-http2 (0.22.1)
       protocol-hpack (~> 1.4)
       protocol-http (~> 0.47)
@@ -156,6 +162,7 @@ DEPENDENCIES
   passenger (~> 6.0)
   pg (~> 1.5)
   pitchfork (~> 0.17)
+  protocol-http1!
   puma (~> 7.0)
   rack (~> 3.0)
   rack-test


### PR DESCRIPTION
Fixes the following errors:

    with unhandled exception.","event":{"type":"failure","root":"/rack","class":"Errno::ECONNRESET","message":"Connection reset by peer","backtrace":[
    /usr/local/lib/ruby/3.5.0+0/socket.rb:457:in 'BasicSocket#__read_nonblock'
    /usr/local/lib/ruby/3.5.0+0/socket.rb:457:in 'BasicSocket#read_nonblock'
    /usr/local/bundle/gems/io-stream-0.10.0/lib/io/stream/buffered.rb:138:in 'IO::Stream::Buffered#sysread'
    /usr/local/bundle/gems/io-stream-0.10.0/lib/io/stream/readable.rb:347:in 'IO::Stream::Readable#fill_read_buffer'
    /usr/local/bundle/gems/io-stream-0.10.0/lib/io/stream/readable.rb:268:in 'IO::Stream::Readable#gets'
    /usr/local/bundle/gems/protocol-http1-0.35.1/lib/protocol/http1/connection.rb:356:in 'Protocol::HTTP1::Connection#read_line?'
    /usr/local/bundle/gems/protocol-http1-0.35.1/lib/protocol/http1/connection.rb:378:in 'Protocol::HTTP1::Connection#read_request_line'
    /usr/local/bundle/gems/protocol-http1-0.35.1/lib/protocol/http1/connection.rb:399:in 'Protocol::HTTP1::Connection#read_request'
    /usr/local/bundle/gems/async-http-0.91.0/lib/async/http/protocol/http1/request.rb:26:in 'Async::HTTP::Protocol::HTTP1::Request.read'
    /usr/local/bundle/gems/async-http-0.91.0/lib/async/http/protocol/http1/server.rb:49:in 'Async::HTTP::Protocol::HTTP1::Server#next_request'
    /usr/local/bundle/gems/async-http-0.91.0/lib/async/http/protocol/http1/server.rb:66:in 'Async::HTTP::Protocol::HTTP1::Server#each'
    /usr/local/bundle/gems/async-http-0.91.0/lib/async/http/server.rb:49:in 'Async::HTTP::Server#accept'
    /usr/local/bundle/gems/falcon-0.52.3/lib/falcon/server.rb:57:in 'Falcon::Server#accept'
    /usr/local/bundle/gems/io-endpoint-0.15.2/lib/io/endpoint/wrapper.rb:216:in 'block (2 levels) in IO::Endpoint::Wrapper#accept'
    /usr/local/bundle/gems/async-2.32.0/lib/async/task.rb:207:in 'block in Async::Task#run'
    /usr/local/bundle/gems/async-2.32.0/lib/async/task.rb:452:in 'block in Async::Task#schedule'

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
