### PR TITLE
feat: Add Relic framework.

### DIFF
--- a/frameworks/Dart/relic/.dockerignore
+++ b/frameworks/Dart/relic/.dockerignore
@@ -1,0 +1,9 @@
+# From https://hub.docker.com/_/dart
+.dockerignore
+Dockerfile
+build/
+.dart_tool/
+.git/
+.github/
+.gitignore
+.packages

--- a/frameworks/Dart/relic/.gitignore
+++ b/frameworks/Dart/relic/.gitignore
@@ -1,0 +1,5 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+*.lock
+!bin

--- a/frameworks/Dart/relic/README.md
+++ b/frameworks/Dart/relic/README.md
@@ -1,0 +1,23 @@
+# Relic Benchmarking Test
+
+### Test Type Implementation Source Code
+
+- [JSON](server.dart)
+- [PLAINTEXT](server.dart)
+
+## Important Libraries
+
+The tests were run with:
+
+- [pkg:relic](https://pub.dev/packages/relic)
+- [Dart](https://dart.dev/)
+
+## Test URLs
+
+### JSON
+
+http://localhost:8080/json
+
+### PLAINTEXT
+
+http://localhost:8080/plaintext

--- a/frameworks/Dart/relic/benchmark_config.json
+++ b/frameworks/Dart/relic/benchmark_config.json
@@ -1,0 +1,26 @@
+{
+  "framework": "relic",
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "None",
+        "framework": "relic",
+        "language": "Dart",
+        "flavor": "None",
+        "orm": "None",
+        "platform": "relic",
+        "webserver": "None",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "relic",
+        "notes": "",
+        "versus": "None"
+      }
+    }
+  ]
+}

--- a/frameworks/Dart/relic/bin/server.dart
+++ b/frameworks/Dart/relic/bin/server.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:relic/io_adapter.dart';
+import 'package:relic/relic.dart';
+
+void main() async {
+  /// Number of [Isolate]s to spawn
+  /// This is based on the number of available processors
+  /// minus one for the main isolate
+  final isolateCount = Platform.numberOfProcessors * 2 - 1;
+
+  /// Create an [Isolate] containing an [HttpServer]
+  await Future.wait(
+    List.generate(
+      isolateCount,
+      (final index) =>
+          Isolate.spawn((final _) => _serve(), null, debugName: '$index'),
+    ),
+  );
+
+  _serve();
+}
+
+/// [_serve] is called in each spawned isolate.
+Future<void> _serve() async {
+  final router = Router<Handler>()
+    ..get('/json', respondWith((req) => _responseJson()))
+    ..get('/plaintext', respondWith((req) => _responsePlainText()));
+
+  final handler = const Pipeline()
+      .addMiddleware(_requiredHeadersMiddleware())
+      .addMiddleware(routeWith(router))
+      .addHandler(respondWith((_) => Response.notFound()));
+
+  // start the server
+  await serve(handler, InternetAddress.anyIPv4, 8080, shared: true);
+}
+
+Middleware _requiredHeadersMiddleware() {
+  var addHeaders = createMiddleware(
+    onResponse: (response) => response.copyWith(
+      headers: response.headers.transform((headers) {
+        headers.server = 'relic';
+        // Date header is added by default, but we set it here for clarity.
+        headers.date = DateTime.now();
+      }),
+    ),
+  );
+  return addHeaders;
+}
+
+Response _responseJson() {
+  return Response.ok(
+    body: Body.fromData(
+      _jsonEncoder.convert(const {'message': 'Hello, World!'}) as Uint8List,
+      mimeType: MimeType.json,
+    ),
+  );
+}
+
+Response _responsePlainText() {
+  return Response.ok(
+    body: Body.fromString('Hello, World!', mimeType: MimeType.plainText),
+  );
+}
+
+final _jsonEncoder = JsonUtf8Encoder();

--- a/frameworks/Dart/relic/pubspec.yaml
+++ b/frameworks/Dart/relic/pubspec.yaml
@@ -1,0 +1,7 @@
+name: relicbenchmark
+description: A benchmark of pkg:relic
+environment:
+  sdk: ^3.8.0
+
+dependencies:
+  relic: ^0.7.0

--- a/frameworks/Dart/relic/relic.dockerfile
+++ b/frameworks/Dart/relic/relic.dockerfile
@@ -1,0 +1,14 @@
+
+FROM dart:3.9 AS builder
+
+COPY . /app
+WORKDIR /app
+RUN mkdir build
+RUN dart compile exe ./bin/server.dart -o build/server
+
+FROM scratch
+COPY --from=builder /runtime/ /
+COPY --from=builder /app/build /bin
+
+EXPOSE 8080
+CMD ["server"]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Closes: https://github.com/serverpod/relic/issues/199

Adds the Relic web server framework.