### PR TITLE
[ruby/rage] Use ERB::Escape for html escaping

### DIFF
--- a/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage-sequel/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record.id %></td><td><%= CGI.escape_html(record.message) %></td></tr>
+      <tr><td><%= record.id %></td><td><%= ERB::Escape.html_escape(record.message) %></td></tr>
     <% end %>
     </table>
   </body>

--- a/frameworks/Ruby/rage/app/views/fortunes.html.erb
+++ b/frameworks/Ruby/rage/app/views/fortunes.html.erb
@@ -5,7 +5,7 @@
     <table>
     <tr><th>id</th><th>message</th></tr>
     <% records.each do |record| %>
-      <tr><td><%= record[:id] %></td><td><%= CGI.escape_html(record[:message]) %></td></tr>
+      <tr><td><%= record[:id] %></td><td><%= ERB::Escape.html_escape(record[:message]) %></td></tr>
     <% end %>
     </table>
   </body>


### PR DESCRIPTION
It should be slight faster as it doesn't allocate a new string when nothing needs to be escaped.
https://github.com/ruby/erb/blob/6a5729b7e291e30432f3955e443cc3e6c9215b60/ext/erb/escape/escape.c