### PR TITLE
[ruby/sinatra] Pass environment as APP_ENV

### DIFF
--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-iodine-mri.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres-iodine-mri.dockerfile
@@ -13,6 +13,7 @@ WORKDIR /sinatra-sequel
 ENV BUNDLE_WITH=postgresql:iodine
 RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
+ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
@@ -14,8 +14,9 @@ ENV BUNDLE_WITH=postgresql:puma
 RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV WEB_CONCURRENCY=auto
+ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
@@ -14,8 +14,9 @@ ENV BUNDLE_WITH=mysql:puma
 RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 
 ENV WEB_CONCURRENCY=auto
+ENV APP_ENV=production
 ENV DBTYPE=mysql
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra/sinatra-postgres-iodine-mri.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres-iodine-mri.dockerfile
@@ -13,6 +13,7 @@ WORKDIR /sinatra
 ENV BUNDLE_WITH=postgresql:iodine
 RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
+ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -14,8 +14,9 @@ ENV BUNDLE_WITH=postgresql:puma
 RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
 ENV WEB_CONCURRENCY=auto
+ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -13,9 +13,10 @@ WORKDIR /sinatra
 ENV BUNDLE_WITH=mysql:puma
 RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 
+ENV APP_ENV=production
 ENV DBTYPE=mysql
 
 ENV WEB_CONCURRENCY=auto
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080


### PR DESCRIPTION
Instead of passing it as an option to the server.
This also fixes the iodine versions, as these were using development instead of production.