### PR TITLE
[ruby/roda-sequel] Pass environment as RACK_ENV

### DIFF
--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres-iodine-mri.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres-iodine-mri.dockerfile
@@ -14,6 +14,7 @@ ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'postgresql iodine'
 RUN bundle install --jobs=8
 
+ENV RACK_ENV=production
 ENV DBTYPE=postgresql
 
 EXPOSE 8080

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
@@ -14,9 +14,10 @@ ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'postgresql puma'
 RUN bundle install --jobs=8
 
+ENV RACK_ENV=production
 ENV DBTYPE=postgresql
 
 ENV WEB_CONCURRENCY=auto
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -15,9 +15,10 @@ ENV BUNDLE_FORCE_RUBY_PLATFORM=true
 RUN bundle config set with 'mysql puma'
 RUN bundle install --jobs=8
 
+ENV RACK_ENV=production
 ENV DBTYPE=mysql
 
 ENV WEB_CONCURRENCY=auto
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080


### PR DESCRIPTION
Instead of passing it as an option to the server.