### PR TITLE
Racket: bump Racket to 8.18

### DIFF
--- a/frameworks/Racket/racket/racket.dockerfile
+++ b/frameworks/Racket/racket/racket.dockerfile
@@ -11,7 +11,7 @@ RUN echo 'APT::Get::Install-Recommends "false";' > /etc/apt/apt.conf.d/00-genera
 
 FROM debian AS racket
 
-ARG RACKET_VERSION=8.9
+ARG RACKET_VERSION=8.18
 
 RUN apt-get update -q \
     && apt-get install --no-install-recommends -q -y \


### PR DESCRIPTION
What it says on the tin. Just updating Racket to the latest released version.