### PR TITLE
Update armeria to 1.33.4, etc

### DIFF
--- a/frameworks/Java/armeria/README.md
+++ b/frameworks/Java/armeria/README.md
@@ -4,10 +4,10 @@ This is the armeria portion of a [benchmarking test suite](../) comparing a vari
 
 ## Infrastructure Software Versions
 
-* [Armeria 0.71.1](https://line.github.io/armeria/)
-* [HikariCP 2.7.8](https://github.com/brettwooldridge/HikariCP)
-* [Postgresql 42.1.4](https://jdbc.postgresql.org/)
-* [Mustache 0.9.5](https://mustache.github.io/)
+* [Armeria 1.33.4](https://armeria.dev/)
+* [HikariCP 7.0.2](https://github.com/brettwooldridge/HikariCP)
+* [Postgresql 42.7.8](https://jdbc.postgresql.org/)
+* [Mustache 0.9.14](https://mustache.github.io/)
 
 ## Source for Tests
 

--- a/frameworks/Java/armeria/armeria.dockerfile
+++ b/frameworks/Java/armeria/armeria.dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.6.1-jdk-11-slim as maven
+FROM maven:3.9.11-eclipse-temurin-25-alpine as maven
 WORKDIR /armeria
 COPY src src
 COPY pom.xml pom.xml
 RUN mvn package -q
 
-FROM openjdk:11.0.3-jdk-slim
+FROM eclipse-temurin:25-jre-alpine
 WORKDIR /armeria
 COPY --from=maven /armeria/target/hello-1.0-SNAPSHOT.jar app.jar
 

--- a/frameworks/Java/armeria/pom.xml
+++ b/frameworks/Java/armeria/pom.xml
@@ -12,11 +12,11 @@
 
   <properties>
     <!-- Compiler options -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
 
     <!-- Dependency versions -->
-    <armeria.version>1.24.3</armeria.version>
+    <armeria.version>1.33.4</armeria.version>
   </properties>
 
   <dependencies>
@@ -28,22 +28,22 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.12.1</version>
+      <version>2.25.2</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.2</version>
+      <version>42.7.8</version>
     </dependency>
     <dependency>
       <groupId>com.github.spullara.mustache.java</groupId>
       <artifactId>compiler</artifactId>
-      <version>0.9.6</version>
+      <version>0.9.14</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>3.3.1</version>
+      <version>7.0.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>
@@ -53,7 +53,7 @@
       <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-compiler-plugin</artifactId>
-         <version>3.8.0</version>
+         <version>3.14.1</version>
          <configuration>
            <debug>false</debug>
          </configuration>
@@ -62,7 +62,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.1.8.RELEASE</version>
+        <version>3.5.6</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Update armeria, etc

- armeria: 1.24.3 -> 1.33.4
- jdk: 11 -> 25
- hikaricp: 3.3.1 -> 7.0.2
- ...