### PR TITLE
Switch JSON library for photon-http

### DIFF
--- a/frameworks/D/photon-http/dub.json
+++ b/frameworks/D/photon-http/dub.json
@@ -7,7 +7,7 @@
 		"mir-ion": "~>2.3.4",
 		"xbuf" : "~>0.2.1",
 		"photon": "~>0.18.5",
-		"photon-http": "~>0.6.7"
+		"photon-http": "~>0.6.8"
 	},
 	"description": "Benchmark of photon-http",
 	"license": "BSL-1.0",

--- a/frameworks/D/photon-http/source/app.d
+++ b/frameworks/D/photon-http/source/app.d
@@ -27,13 +27,13 @@ class BenchmarkProcessor : HttpProcessor {
 
     override void handle(HttpRequest req) {
 		if (req.uri == "/plaintext") {
-			respondWith("Hello, world!", 200, plainText);
+			respondWith("Hello, world!", HttpStatus.OK, plainText);
 		} else if(req.uri == "/json") {
 			jsonBuf.clear();
 			serializeJsonPretty!""(jsonBuf, Message("Hello, World!"));
-			respondWith(jsonBuf.data, 200, json);
+			respondWith(jsonBuf.data, HttpStatus.OK, json);
 		} else {
-			respondWith("Not found", 404, plainText);
+			respondWith("Not found", HttpStatus.NotFound, plainText);
 		}
     }
 }


### PR DESCRIPTION
ASDF library would create a closure for writing out a JSON, which botlenecks the performance on high concurrency. Mir Ion is more recent and avoids closure allocation. I expect this to greatly improve JSON perf.
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
