### PR TITLE
Update PostgreSQL to version 18

### DIFF
--- a/toolset/databases/postgres/postgres.dockerfile
+++ b/toolset/databases/postgres/postgres.dockerfile
@@ -1,9 +1,7 @@
-FROM postgres:17-bookworm
+FROM postgres:18-trixie
 
 ENV PGDATA=/ssd/postgresql \
     POSTGRES_DB=hello_world \
-    POSTGRES_HOST_AUTH_METHOD=md5 \
-    POSTGRES_INITDB_ARGS=--auth-host=md5 \
     POSTGRES_PASSWORD=benchmarkdbpass \
     POSTGRES_USER=benchmarkdbuser
 


### PR DESCRIPTION
Also, disable password-based authentication using the MD5 hash algorithm, since that functionality has been [officially deprecated](https://www.postgresql.org/docs/18/auth-password.html).

Fix: #8061