### PR TITLE
Add 3 new routes for photon-http + postgres

### DIFF
--- a/frameworks/D/photon-http/README.md
+++ b/frameworks/D/photon-http/README.md
@@ -8,11 +8,16 @@ A benchmark for photon fiber scheduler for D running with minimalistic http serv
 
 * [JSON](./source/app.d)
 * [PLAINTEXT](./source/app.d)
+* [DB](./source/app.d)
+* [QUERIES](./source/app.d)
+* [UPDATES](./source/app.d)
 
 ## Important Libraries
+
 The tests were run with:
 * [photon](https://github.com/DmitryOlshansky/photon)
 * [photon-http][https://github.com/DmitryOlshansky/photon-http]
+* [dpq2](https://github.com/denizzzka/dpq2)
 
 ## Test URLs
 
@@ -23,3 +28,16 @@ http://localhost:8080/json
 ### PLAINTEXT
 
 http://localhost:8080/plaintext
+
+### Data-Store/Database Mapping Test
+
+http://localhost:8080/db
+
+### Multiple queries
+
+http://localhost:8080/queries?queries=...
+
+### Multiple queries with updates
+
+http://localhost:8080/updates?queries=...
+

--- a/frameworks/D/photon-http/benchmark_config.json
+++ b/frameworks/D/photon-http/benchmark_config.json
@@ -3,16 +3,19 @@
   "tests": [
     {
       "default": {
+        "update_url": "/updates?queries=",
+        "query_url": "/queries?queries=",
+        "db_url": "/db",
         "json_url": "/json",
         "plaintext_url": "/plaintext",
         "port": 8080,
         "approach": "Realistic",
         "classification": "Platform",
-        "database": "None",
+        "database": "Postgres",
         "framework": "None",
         "language": "D",
         "flavor": "None",
-        "orm": "None",
+        "orm": "raw",
         "platform": "None",
         "webserver": "None",
         "os": "Linux",

--- a/frameworks/D/photon-http/dub.json
+++ b/frameworks/D/photon-http/dub.json
@@ -4,9 +4,11 @@
 	],
 	"copyright": "Copyright © 2025, Dmitry Olshansky",
 	"dependencies": {
+		"dpq2": "~>1.2.4",
+		"mir-random": "~>2.2.20",
 		"mir-ion": "~>2.3.4",
 		"xbuf" : "~>0.2.1",
-		"photon": "~>0.18.5",
+		"photon": "~>0.18.10",
 		"photon-http": "~>0.6.8"
 	},
 	"description": "Benchmark of photon-http",

--- a/frameworks/D/photon-http/photon-http.dockerfile
+++ b/frameworks/D/photon-http/photon-http.dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 
 COPY . .
 
+RUN apt-get update -yqq && apt-get install -yqq libpq-dev zlib1g-dev
+
 RUN dub build -b release --compiler=ldc2
 
 EXPOSE 8080

--- a/frameworks/D/photon-http/source/app.d
+++ b/frameworks/D/photon-http/source/app.d
@@ -1,9 +1,14 @@
 import std.stdio;
 import std.socket;
 import std.array;
+import std.algorithm;
+import std.conv;
+import std.ascii;
 
 import mir.ser;
 import mir.ser.json;
+
+import core.time;
 
 import std.range.primitives;
 
@@ -11,30 +16,149 @@ import glow.xbuf;
 
 import photon, photon.http;
 
-struct Message
-{
+import mir.random : unpredictableSeedOf;
+import mir.random.variable : UniformVariable;
+import mir.random.engine.xorshift : Xorshift;
+
+import dpq2;
+
+struct Message {
     string message;
 }
 
+struct WorldResponse {
+	int id;
+	int randomNumber;
+}
+
+enum connectionInfo = "host=tfb-database port=5432 "
+						~ "dbname=hello_world  user=benchmarkdbuser password=benchmarkdbpass";
+enum worldSize = 10000;
+enum poolSize = 64;
+
+shared Pool!Connection connectionPool;
+
 class BenchmarkProcessor : HttpProcessor {
-    HttpHeader[] plainText = [HttpHeader("Content-Type", "text/plain; charset=utf-8")];
-    HttpHeader[] json = [HttpHeader("Content-Type", "application/json")];
+    HttpHeader[] plainTextHeaders = [HttpHeader("Content-Type", "text/plain; charset=utf-8")];
+    HttpHeader[] jsonHeaders = [HttpHeader("Content-Type", "application/json")];
     Buffer!char jsonBuf;
+    Buffer!WorldResponse worlds;
+    UniformVariable!uint uniformVariable;
+    Xorshift gen;
+
     this(Socket sock) {
 		super(sock);
+        gen = Xorshift(unpredictableSeed!uint);
+		uniformVariable = UniformVariable!uint(1, worldSize);
 		jsonBuf = Buffer!char(256);
+        worlds = Buffer!WorldResponse(500);
 	}
 
     override void handle(HttpRequest req) {
 		if (req.uri == "/plaintext") {
-			respondWith("Hello, world!", HttpStatus.OK, plainText);
+			plaintext();
 		} else if(req.uri == "/json") {
-			jsonBuf.clear();
-			serializeJsonPretty!""(jsonBuf, Message("Hello, World!"));
-			respondWith(jsonBuf.data, HttpStatus.OK, json);
-		} else {
-			respondWith("Not found", HttpStatus.NotFound, plainText);
+			json();
+		} else if(req.uri == "/db") {
+            db();
+        } else if(req.uri.startsWith("/queries")) {
+            queries(req.uri);
+        } else if(req.uri.startsWith("/updates")) {
+            updates(req.uri);
+        }
+        else {
+			respondWith("Not found", HttpStatus.NotFound, plainTextHeaders);
 		}
+    }
+
+    final void plaintext() {
+        respondWith("Hello, world!", HttpStatus.OK, plainTextHeaders);
+    }
+
+    final void json() {
+        jsonBuf.clear();
+        serializeJsonPretty!""(jsonBuf, Message("Hello, World!"));
+        respondWith(jsonBuf.data, HttpStatus.OK, jsonHeaders);
+    }
+
+    final void db() {
+        jsonBuf.clear();
+        int id = uniformVariable(gen);
+        auto c = connectionPool.acquire();
+        scope(exit) connectionPool.release(c);
+        QueryParams qp;
+		qp.preparedStatementName("db_prpq");
+		qp.argsVariadic(id);
+		immutable result = c.execPrepared(qp).rangify.front;
+		auto w = WorldResponse(id, result[0].as!PGinteger);
+        serializeJsonPretty!""(jsonBuf, w);
+        respondWith(jsonBuf.data, HttpStatus.OK, jsonHeaders);
+    }
+
+    // GET /queries?queries=...
+    final void queries(const(char)[] uri) {
+        jsonBuf.clear();
+        worlds.clear();
+        auto c = connectionPool.acquire();
+        scope(exit) connectionPool.release(c);
+
+		int count = 1;
+        auto i = uri.indexOf("?queries=");
+        if (i > 0 && i + 9 <= uri.length && isDigit(uri[i+9]))
+		{
+			try count = min(max(uri[i+9..$].to!int, 1), 500);
+			catch (ConvException) {}
+		}
+
+		QueryParams qp;
+		qp.preparedStatementName("db_prpq");
+		foreach (_; 0..count) {
+			int id = uniformVariable(gen);
+			qp.argsVariadic(id);
+			immutable result = c.execPrepared(qp).rangify.front;
+			worlds.put(WorldResponse(id, result[0].as!PGinteger));
+		}
+        serializeJsonPretty!""(jsonBuf, worlds.data);
+        respondWith(jsonBuf.data, HttpStatus.OK, jsonHeaders);
+    }
+    
+    // GET /updates?queries=...
+    final void updates(const(char)[] uri) {
+        jsonBuf.clear();
+        worlds.clear();
+        auto c = connectionPool.acquire();
+        scope(exit) connectionPool.release(c);
+
+		int count = 1;
+        auto i = uri.indexOf("?queries=");
+        if (i > 0 && i + 9 <= uri.length && isDigit(uri[i+9]))
+		{
+			try count = min(max(uri[i+9..$].to!int, 1), 500);
+			catch (ConvException) {}
+		}
+
+		QueryParams qp;
+		qp.preparedStatementName("db_prpq");
+
+		QueryParams qp_update;
+		qp_update.preparedStatementName("db_update_prpq");
+
+		foreach (_; 0..count) {
+			int id = uniformVariable(gen);
+			qp.argsVariadic(id);
+			immutable result = c.execPrepared(qp).rangify.front;
+			auto w = WorldResponse(id, result[0].as!PGinteger);
+            
+            // update random number
+			w.randomNumber = uniformVariable(gen);
+			qp_update.argsVariadic(w.randomNumber, id);
+
+			// persist to DB
+			c.execPrepared(qp_update);
+            worlds.put(w);
+		}
+        serializeJsonPretty!""(jsonBuf, worlds.data);
+        respondWith(jsonBuf.data, HttpStatus.OK, jsonHeaders);
     }
 }
 
@@ -75,6 +199,14 @@ void server() {
 
 void main() {
     initPhoton();
+    connectionPool = pool(poolSize, 15.seconds, () {
+        auto c = new Connection(connectionInfo);
+        c.prepareEx("db_prpq", "SELECT randomNumber, id FROM world WHERE id = $1");
+        c.prepareEx("db_update_prpq", "UPDATE world SET randomNumber = $1  WHERE id = $2");
+        return c;
+    }, (ref Connection c) {
+        destroy(c);
+    });
     go(() => server());
     runScheduler();
 }


### PR DESCRIPTION
This patch adds 3 database-related routes to photon-http framework.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
