### PR TITLE
Bump Unhinged to 9.0.2, attempt to fix pipelined h1

### DIFF
--- a/frameworks/CSharp/wiredio/src/Platform/Platform.csproj
+++ b/frameworks/CSharp/wiredio/src/Platform/Platform.csproj
@@ -20,6 +20,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Unhinged" Version="9.0.1" />
+      <PackageReference Include="Unhinged" Version="9.0.2" />
     </ItemGroup>
 </Project>

--- a/frameworks/CSharp/wiredio/src/Platform/Program.cs
+++ b/frameworks/CSharp/wiredio/src/Platform/Program.cs
@@ -39,7 +39,7 @@ internal static class Program
             // It's the number of real cpu cores not cpu threads
             // This can improve the cache hits on L1/L2 since only one thread
             // is running per cpu core.
-            .SetNWorkersSolver(() => Environment.ProcessorCount/2)  
+            .SetNWorkersSolver(() => Environment.ProcessorCount / 2)  
             
             // Accept up to 16384 connections
             .SetBacklog(16384) 


### PR DESCRIPTION
Bump Unhinged engine to 9.0.2, attempt to fix plaintext test with pipelined h1