### PR TITLE
jooby: 4.0.11

### DIFF
--- a/frameworks/Java/jooby/jooby-jetty.dockerfile
+++ b/frameworks/Java/jooby/jooby-jetty.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Java/jooby/jooby-mvc.dockerfile
+++ b/frameworks/Java/jooby/jooby-mvc.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Java/jooby/jooby-netty.dockerfile
+++ b/frameworks/Java/jooby/jooby-netty.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Java/jooby/jooby-pgclient.dockerfile
+++ b/frameworks/Java/jooby/jooby-pgclient.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Java/jooby/jooby.dockerfile
+++ b/frameworks/Java/jooby/jooby.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /jooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Java/jooby/pom.xml
+++ b/frameworks/Java/jooby/pom.xml
@@ -11,12 +11,12 @@
   <name>jooby</name>
 
   <properties>
-    <jooby.version>4.0.9</jooby.version>
+    <jooby.version>4.0.11</jooby.version>
     <dsl-json.version>2.0.2</dsl-json.version>
     <postgresql.version>42.7.7</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>24</maven.compiler.source>
-    <maven.compiler.target>24</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
 
     <!-- Startup class -->
     <application.class>com.techempower.App</application.class>

--- a/frameworks/Java/jooby/src/main/java/com/techempower/App.java
+++ b/frameworks/Java/jooby/src/main/java/com/techempower/App.java
@@ -5,7 +5,6 @@ import static com.techempower.Util.randomWorld;
 import static io.jooby.ExecutionMode.EVENT_LOOP;
 import static io.jooby.MediaType.JSON;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/frameworks/Java/jooby/src/main/java/com/techempower/ReactivePg.java
+++ b/frameworks/Java/jooby/src/main/java/com/techempower/ReactivePg.java
@@ -110,10 +110,9 @@ public class ReactivePg extends Jooby {
     private void selectWorlds(Context ctx, int queries, Consumer<List<World>> consumer) {
         sqlClient.group(
                 client -> {
-                    var statement = client.preparedQuery(SELECT_WORLD);
                     List<World> worlds = new ArrayList<>(queries);
                     for (int i = 0; i < queries; i++) {
-                        statement
+                        client.preparedQuery(SELECT_WORLD)
                                 .execute(Tuple.of(Util.boxedRandomWorld()))
                                 .map(rs -> new World(rs.iterator().next().getInteger(0), Util.boxedRandomWorld()))
                                 .onComplete(

--- a/frameworks/Java/jooby/src/main/java/com/techempower/Util.java
+++ b/frameworks/Java/jooby/src/main/java/com/techempower/Util.java
@@ -24,7 +24,7 @@ public class Util {
     return 1 + ThreadLocalRandom.current().nextInt(10000);
   }
 
-  public static int boxedRandomWorld() {
+  public static Integer boxedRandomWorld() {
     final int rndValue = ThreadLocalRandom.current().nextInt(1, 10001);
     return BOXED_RND[rndValue - 1];
   }

--- a/frameworks/Kotlin/kooby/kooby.dockerfile
+++ b/frameworks/Kotlin/kooby/kooby.dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-24-noble as maven
+FROM maven:3.9.11-eclipse-temurin-25-noble as maven
 WORKDIR /kooby
 COPY pom.xml pom.xml
 COPY src src

--- a/frameworks/Kotlin/kooby/pom.xml
+++ b/frameworks/Kotlin/kooby/pom.xml
@@ -12,11 +12,11 @@
   <name>kooby: jooby+kotlin</name>
 
   <properties>
-    <jooby.version>4.0.9</jooby.version>
+    <jooby.version>4.0.11</jooby.version>
     <postgresql.version>42.7.7</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>24</maven.compiler.source>
-    <maven.compiler.target>24</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
     <kotlin.version>2.2.0</kotlin.version>
 
     <!-- Startup class -->


### PR DESCRIPTION
- fix classpath issue on jetty/undertow tests

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
