### PR TITLE
Replace openjdk:25-jdk-slim with amazoncorretto:25

### DIFF
--- a/frameworks/Clojure/aleph/aleph.dockerfile
+++ b/frameworks/Clojure/aleph/aleph.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY project.clj project.clj
 RUN lein uberjar
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 
 WORKDIR /aleph
 COPY --from=lein /aleph/target/hello-aleph-standalone.jar app.jar

--- a/frameworks/Clojure/donkey/donkey.dockerfile
+++ b/frameworks/Clojure/donkey/donkey.dockerfile
@@ -4,7 +4,7 @@ COPY src src
 COPY project.clj project.clj
 RUN lein uberjar
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 COPY --from=lein /donkey/target/hello-donkey-standalone.jar  app.jar
 
 EXPOSE 8080

--- a/frameworks/Clojure/kit/kit-majavat.dockerfile
+++ b/frameworks/Clojure/kit/kit-majavat.dockerfile
@@ -6,7 +6,7 @@ COPY . /
 
 RUN clj -Sforce -T:build all
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 
 COPY --from=build /target/te-bench-standalone.jar /te-bench/te-bench-standalone.jar
 

--- a/frameworks/Clojure/kit/kit.dockerfile
+++ b/frameworks/Clojure/kit/kit.dockerfile
@@ -6,7 +6,7 @@ COPY . /
 
 RUN clj -Sforce -T:build all
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 
 COPY --from=build /target/te-bench-standalone.jar /te-bench/te-bench-standalone.jar
 

--- a/frameworks/Clojure/luminus/luminus.dockerfile
+++ b/frameworks/Clojure/luminus/luminus.dockerfile
@@ -6,7 +6,7 @@ COPY resources resources
 COPY src src
 RUN lein uberjar
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /luminus
 COPY --from=lein /luminus/target/hello.jar app.jar
 

--- a/frameworks/Clojure/ring-http-exchange/ring-http-exchange-robaho.dockerfile
+++ b/frameworks/Clojure/ring-http-exchange/ring-http-exchange-robaho.dockerfile
@@ -5,7 +5,7 @@ COPY resources resources
 COPY src src
 RUN lein with-profile robaho uberjar
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /ring-http-exchange
 COPY --from=lein /ring-http-exchange/target/ring-http-server-1.0.0-standalone.jar app.jar
 

--- a/frameworks/Clojure/ring-http-exchange/ring-http-exchange.dockerfile
+++ b/frameworks/Clojure/ring-http-exchange/ring-http-exchange.dockerfile
@@ -5,7 +5,7 @@ COPY resources resources
 COPY src src
 RUN lein uberjar
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /ring-http-exchange
 COPY --from=lein /ring-http-exchange/target/ring-http-server-1.0.0-standalone.jar app.jar
 

--- a/frameworks/Java/httpserver/httpserver-postgres.dockerfile
+++ b/frameworks/Java/httpserver/httpserver-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 

--- a/frameworks/Java/httpserver/httpserver-robaho-postgres.dockerfile
+++ b/frameworks/Java/httpserver/httpserver-robaho-postgres.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile -P robaho assembly:single -q
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /httpserver-robaho
 COPY --from=maven /httpserver-robaho/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 

--- a/frameworks/Java/httpserver/httpserver-robaho.dockerfile
+++ b/frameworks/Java/httpserver/httpserver-robaho.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile -P robaho assembly:single -q
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /httpserver-robaho
 COPY --from=maven /httpserver-robaho/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 

--- a/frameworks/Java/httpserver/httpserver.dockerfile
+++ b/frameworks/Java/httpserver/httpserver.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /httpserver
 COPY --from=maven /httpserver/target/httpserver-1.0-jar-with-dependencies.jar app.jar
 

--- a/frameworks/Java/jetty/jetty-servlet.dockerfile
+++ b/frameworks/Java/jetty/jetty-servlet.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q -P servlet
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /jetty
 COPY --from=maven /jetty/target/jetty-example-0.1-jar-with-dependencies.jar app.jar
 

--- a/frameworks/Java/jetty/jetty.dockerfile
+++ b/frameworks/Java/jetty/jetty.dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml pom.xml
 COPY src src
 RUN mvn compile assembly:single -q
 
-FROM openjdk:25-jdk-slim
+FROM amazoncorretto:25
 WORKDIR /jetty
 COPY --from=maven /jetty/target/jetty-example-0.1-jar-with-dependencies.jar app.jar
 


### PR DESCRIPTION
openjdk/25-jdk-slim image has been removed, therefore swapped out most  usages to amazoncorretto:25.

Helidon and reitit were left out due to failing tests.