### PR TITLE
[ruby/rack] Require ERB explicitly

### DIFF
--- a/frameworks/Ruby/rack/hello_world.rb
+++ b/frameworks/Ruby/rack/hello_world.rb
@@ -6,6 +6,7 @@ require_relative 'pg_db'
 require_relative 'config/auto_tune'
 require 'rack'
 require 'json'
+require 'erb'
 
 if RUBY_PLATFORM == 'java'
   DEFAULT_DATABASE_URL = 'jdbc:postgresql://tfb-database/hello_world?user=benchmarkdbuser&password=benchmarkdbpass'


### PR DESCRIPTION
Avoids the following warning when running just the fortune tests:

    #<NameError: uninitialized constant HelloWorld::ERB