### PR TITLE
Update the set of broken implementations part 2

### DIFF
--- a/frameworks/C++/ffead-cpp/benchmark_config.json
+++ b/frameworks/C++/ffead-cpp/benchmark_config.json
@@ -198,7 +198,7 @@
 			"display_name": "ffead-cpp [pg-raw-async-prof-pool-m]",
 			"notes": "async memory profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		},
 		"postgresql-raw-async-clibpqb-profiled": {
 			"db_url": "/t4/d",
@@ -301,7 +301,7 @@
 			"display_name": "ffead-cpp [pg-raw-async-qw-prof-pool-m]",
 			"notes": "async memory profiled",
 			"versus": "",
-			"tags": []
+			"tags": ["broken"]
 		}
 	}]
 }

--- a/frameworks/CSharp/aspnetcore-mono/benchmark_config.json
+++ b/frameworks/CSharp/aspnetcore-mono/benchmark_config.json
@@ -40,6 +40,7 @@
 			"database_os": "Linux",
 			"display_name": "ASP.NET Core [Platform, Mono, Pg]",
 			"notes": "",
+			"tags": ["broken"],
 			"versus": "aspcore-ado-pg"
 		},
 		"mw": {

--- a/frameworks/CSharp/revenj/benchmark_config.json
+++ b/frameworks/CSharp/revenj/benchmark_config.json
@@ -22,6 +22,7 @@
       "os": "Linux",
       "display_name": "Revenj",
       "notes": "",
+      "tags": ["broken"],
       "versus": "Revenj"
     }
  }]

--- a/frameworks/Crystal/grip/benchmark_config.json
+++ b/frameworks/Crystal/grip/benchmark_config.json
@@ -23,6 +23,7 @@
         "database_os": "Linux",
         "display_name": "Grip",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Erlang/cowboy/benchmark_config.json
+++ b/frameworks/Erlang/cowboy/benchmark_config.json
@@ -20,6 +20,7 @@
       "database_os": "Linux",
       "display_name": "Cowboy",
       "notes": "",
+      "tags": ["broken"],
       "versus": ""
   }}]
 }

--- a/frameworks/Erlang/elli/benchmark_config.json
+++ b/frameworks/Erlang/elli/benchmark_config.json
@@ -19,6 +19,7 @@
       "database_os": "Linux",
       "display_name": "elli",
       "notes": "",
+      "tags": ["broken"],
       "versus": ""
   }}]
 }

--- a/frameworks/Erlang/mochiweb/benchmark_config.json
+++ b/frameworks/Erlang/mochiweb/benchmark_config.json
@@ -21,6 +21,7 @@
       "database_os": "Linux",
       "display_name": "mochiweb",
       "notes": "",
+      "tags": ["broken"],
       "versus": ""
   }}]
 }

--- a/frameworks/Go/goravel/benchmark_config.json
+++ b/frameworks/Go/goravel/benchmark_config.json
@@ -48,6 +48,7 @@
         "database_os": "Linux",
         "display_name": "Goravel Fiber",
         "notes": "",
+        "tags": ["broken"],
         "versus": "go"
       }
     }

--- a/frameworks/Go/ronykit/benchmark_config.json
+++ b/frameworks/Go/ronykit/benchmark_config.json
@@ -18,6 +18,7 @@
         "os": "Linux",
         "display_name": "RonyKIT",
         "notes": "",
+        "tags": ["broken"],
         "versus": "go"
       },
       "prefork": {
@@ -36,6 +37,7 @@
         "os": "Linux",
         "display_name": "RonyKIT",
         "notes": "",
+        "tags": ["broken"],
         "versus": "go"
       }
     }

--- a/frameworks/Go/sprapp/benchmark_config.json
+++ b/frameworks/Go/sprapp/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "SPRAPP",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Java/gemini/benchmark_config.json
+++ b/frameworks/Java/gemini/benchmark_config.json
@@ -20,6 +20,7 @@
         "database_os": "Linux",
         "display_name": "Gemini",
         "notes": "",
+        "tags": ["broken"],
         "versus": "servlet"
       },
       "mysql": {
@@ -42,6 +43,7 @@
         "database_os": "Linux",
         "display_name": "Gemini",
         "notes": "",
+        "tags": ["broken"],
         "versus": "servlet"
       },
       "postgres": {
@@ -64,6 +66,7 @@
         "database_os": "Linux",
         "display_name": "Gemini",
         "notes": "",
+        "tags": ["broken"],
         "versus": "servlet"
       }
     }

--- a/frameworks/Java/officefloor/benchmark_config.json
+++ b/frameworks/Java/officefloor/benchmark_config.json
@@ -47,6 +47,7 @@
 				"os": "Linux",
 				"database_os": "Linux",
 				"display_name": "OfficeFloor-r2dbc",
+				"tags": ["broken"],
 				"notes": ""
 			},
 			"sqlclient": {
@@ -69,6 +70,7 @@
 				"os": "Linux",
 				"database_os": "Linux",
 				"display_name": "OfficeFloor-sqlclient",
+				"tags": ["broken"],
 				"notes": ""
 			},
 			"rawsqlclient": {
@@ -91,6 +93,7 @@
 				"os": "Linux",
 				"database_os": "Linux",
 				"display_name": "OfficeFloor-rawsqlclient",
+				"tags": ["broken"],
 				"notes": ""
 			},
 			"async": {
@@ -162,6 +165,7 @@
 				"database_os": "Linux",
 				"display_name": "OfficeFloor-thread_affinity",
 				"notes": "",
+				"tags": ["broken"],
 				"versus": "OfficeFloor-r2dbc"
 			},
 			"netty": {

--- a/frameworks/Java/ratpack/benchmark_config.json
+++ b/frameworks/Java/ratpack/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "Ratpack",
         "notes": "",
+        "tags": ["broken"],
         "versus": "Netty"
       },
       "jdbc": {
@@ -40,6 +41,7 @@
         "database_os": "Linux",
         "display_name": "Ratpack-jdbc",
         "notes": "",
+        "tags": ["broken"],
         "versus": "Netty"
       },
       "pgclient": {
@@ -61,6 +63,7 @@
         "database_os": "Linux",
         "display_name": "Ratpack-pgclient",
         "notes": "",
+        "tags": ["broken"],
         "versus": "Netty"
       }
     }

--- a/frameworks/Java/revenj-jvm/benchmark_config.json
+++ b/frameworks/Java/revenj-jvm/benchmark_config.json
@@ -22,6 +22,7 @@
       "database_os": "Linux",
       "display_name": "Revenj.JVM",
       "notes": "",
+      "tags": ["broken"],
       "versus": "servlet"
     }
   }]

--- a/frameworks/Java/servlet3/benchmark_config.json
+++ b/frameworks/Java/servlet3/benchmark_config.json
@@ -17,6 +17,7 @@
       "database_os": "Linux",
       "display_name": "servlet3",
       "notes": "Servlet 3.1 Async I/O",
+      "tags": ["broken"],
       "versus": "servlet"
     },
     "sync": {
@@ -35,6 +36,7 @@
       "database_os": "Linux",
       "display_name": "servlet3",
       "notes": "",
+      "tags": ["broken"],
       "versus": "servlet"
     }
   }]

--- a/frameworks/Java/wildfly-ee/benchmark_config.json
+++ b/frameworks/Java/wildfly-ee/benchmark_config.json
@@ -22,7 +22,8 @@
       "database_os": "Linux",
       "display_name": "wildfly-ee",
       "notes": "",
+      "tags": ["broken"],
       "versus": ""
-    }   
+    }
   }]
 }

--- a/frameworks/JavaScript/elide/benchmark_config.json
+++ b/frameworks/JavaScript/elide/benchmark_config.json
@@ -14,6 +14,7 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "elide",
+      "tags": ["broken"],
       "versus": "nodejs"
     }
   }]

--- a/frameworks/JavaScript/spliffy/benchmark_config.json
+++ b/frameworks/JavaScript/spliffy/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "spliffy",
         "notes": "directory based routing for node",
+        "tags": ["broken"],
         "versus": "nodejs"
       },
       "mongodb": {
@@ -41,6 +42,7 @@
         "database_os": "Linux",
         "display_name": "spliffy",
         "notes": "directory based routing for node",
+        "tags": ["broken"],
         "versus": "nodejs"
       },
       "mysql": {
@@ -63,6 +65,7 @@
         "database_os": "Linux",
         "display_name": "spliffy",
         "notes": "directory based routing for node",
+        "tags": ["broken"],
         "versus": "nodejs"
       },
       "postgres": {
@@ -85,6 +88,7 @@
         "database_os": "Linux",
         "display_name": "spliffy",
         "notes": "directory based routing for node",
+        "tags": ["broken"],
         "versus": "nodejs"
       }
     }

--- a/frameworks/Kotlin/vertx-web-kotlin-coroutines/benchmark_config.json
+++ b/frameworks/Kotlin/vertx-web-kotlin-coroutines/benchmark_config.json
@@ -18,6 +18,7 @@
       "database_os": "Linux",
       "display_name": "vertx-web-kotlin-coroutines",
       "notes": "",
+      "tags": ["broken"],
       "versus": "vertx-web"
     },
     "postgres": {

--- a/frameworks/Lua/openresty/benchmark_config.json
+++ b/frameworks/Lua/openresty/benchmark_config.json
@@ -20,6 +20,7 @@
       "database_os": "Linux",
       "display_name": "openresty",
       "notes": "",
+      "tags": ["broken"],
       "versus": "openresty"
     }
   }]

--- a/frameworks/Nim/basolato/benchmark_config.json
+++ b/frameworks/Nim/basolato/benchmark_config.json
@@ -23,6 +23,7 @@
         "database_os": "Linux",
         "display_name": "Basolato",
         "notes": "",
+        "tags": ["broken"],
         "versus": "httpbeast, prologue"
       }
     }

--- a/frameworks/Nim/httpbeast/benchmark_config.json
+++ b/frameworks/Nim/httpbeast/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "HttpBeast",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Nim/jester/benchmark_config.json
+++ b/frameworks/Nim/jester/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "Jester",
         "notes": "",
+        "tags": ["broken"],
         "versus": "httpbeast"
       }
     }

--- a/frameworks/Nim/nim-stdlib/benchmark_config.json
+++ b/frameworks/Nim/nim-stdlib/benchmark_config.json
@@ -23,6 +23,7 @@
           "database_os": "Linux",
           "display_name": "nim-stdlib",
           "notes": "",
+          "tags": ["broken"],
           "versus": "httpbeast"
         }
       }

--- a/frameworks/Nim/scorper/benchmark_config.json
+++ b/frameworks/Nim/scorper/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "scorper",
         "notes": "",
+        "tags": ["broken"],
         "versus": "httpbeast"
       }
     }

--- a/frameworks/PHP/fomo/benchmark_config.json
+++ b/frameworks/PHP/fomo/benchmark_config.json
@@ -23,9 +23,9 @@
 		  "database_os": "Linux",
 		  "display_name": "Fomo",
 		  "notes": "",
+		  "tags": ["broken"],
 		  "versus": "swoole"
 		}
 	  }
 	]
   }
-  

--- a/frameworks/PHP/fuel/benchmark_config.json
+++ b/frameworks/PHP/fuel/benchmark_config.json
@@ -20,6 +20,7 @@
       "database_os": "Linux",
       "display_name": "fuel",
       "notes": "",
+      "tags": ["broken"],
       "versus": "php"
     }
   }]

--- a/frameworks/Perl/plack/benchmark_config.json
+++ b/frameworks/Perl/plack/benchmark_config.json
@@ -39,6 +39,7 @@
       "database_os": "Linux",
       "display_name": "plack-async",
       "notes": "",
+      "tags": ["broken"],
       "versus": "plack"
     }
   }]

--- a/frameworks/Python/eve/benchmark_config.json
+++ b/frameworks/Python/eve/benchmark_config.json
@@ -18,6 +18,7 @@
       "database_os": "Linux",
       "display_name": "Eve",
       "notes": "",
+      "tags": ["broken"],
       "versus": ""
     }
   }]

--- a/frameworks/Python/flask/benchmark_config.json
+++ b/frameworks/Python/flask/benchmark_config.json
@@ -45,7 +45,7 @@
       "display_name": "Flask [Meinheld] [Raw]",
       "notes": "",
       "versus": "wsgi",
-      "tags": [ ]
+      "tags": [ "broken" ]
     },
     "socketify-wsgi": {
       "json_url": "/json-raw",
@@ -83,6 +83,7 @@
       "database_os": "Linux",
       "display_name": "Flask [socketify.py] [PyPy3]",
       "notes": "PyPy",
+      "tags": ["broken"],
       "versus": "wsgi"
     },
     "pypy": {

--- a/frameworks/Python/klein/benchmark_config.json
+++ b/frameworks/Python/klein/benchmark_config.json
@@ -21,6 +21,7 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "Klein",
+      "tags": ["broken"],
       "notes": "CPython 2.7"
     }
   }]

--- a/frameworks/Python/turbogears/benchmark_config.json
+++ b/frameworks/Python/turbogears/benchmark_config.json
@@ -21,6 +21,7 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "TurboGears",
+      "tags": ["broken"],
       "notes": "CPython 2.7"
     }
   }]

--- a/frameworks/Python/web2py/benchmark_config.json
+++ b/frameworks/Python/web2py/benchmark_config.json
@@ -22,6 +22,7 @@
       "database_os": "Linux",
       "display_name": "web2py-standard",
       "notes": "CPython 2.7",
+      "tags": ["broken"],
       "versus": "wsgi"
     },
     "optimized": {
@@ -44,6 +45,7 @@
       "database_os": "Linux",
       "display_name": "web2py-optimized",
       "notes": "CPython 2.7",
+      "tags": ["broken"],
       "versus": "wsgi"
     }
   }]

--- a/frameworks/Rust/gotham/benchmark_config.json
+++ b/frameworks/Rust/gotham/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "Gotham",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Rust/pavex/benchmark_config.json
+++ b/frameworks/Rust/pavex/benchmark_config.json
@@ -18,6 +18,7 @@
         "database_os": "Linux",
         "display_name": "pavex",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Rust/rocket/benchmark_config.json
+++ b/frameworks/Rust/rocket/benchmark_config.json
@@ -22,6 +22,7 @@
       "database_os": "Linux",
       "display_name": "Rocket",
       "notes": "",
+      "tags": ["broken"],
       "versus": "None"
     },
     "diesel": {

--- a/frameworks/Rust/salvo/benchmark_config.json
+++ b/frameworks/Rust/salvo/benchmark_config.json
@@ -19,6 +19,7 @@
         "database_os": "Linux",
         "display_name": "Salvo",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "diesel": {
@@ -39,6 +40,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [postgres-diesel]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "pg": {
@@ -59,6 +61,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [postgres]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "pg-pool": {
@@ -79,6 +82,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [postgres-deadpool]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "mongo": {
@@ -99,6 +103,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [mongodb]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "mongo-raw": {
@@ -118,6 +123,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [mongodb-raw]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "sqlx": {
@@ -136,6 +142,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [postgres-sqlx]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       },
       "lru": {
@@ -153,6 +160,7 @@
         "database_os": "Linux",
         "display_name": "Salvo [lru]",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }

--- a/frameworks/Rust/warp-rust/benchmark_config.json
+++ b/frameworks/Rust/warp-rust/benchmark_config.json
@@ -22,6 +22,7 @@
         "database_os": "Linux",
         "display_name": "warp-rust",
         "notes": "",
+        "tags": ["broken"],
         "versus": "None"
       }
     }


### PR DESCRIPTION
The list is based on the output of the [tfb-fail-detector.py](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/scripts/tfb-fail-detector.py) script, however I [modified](https://github.com/TechEmpower/FrameworkBenchmarks/blob/65fc874dad60351b8634bba3d8442da12b0522db/scripts/tfb-fail-detector.py#L17) it to consider 11 continuous benchmarking runs (roughly 3 months back) instead of the default 3. Also, I excluded implementations that had been affected by recent commit activity - many haven't seen any changes in years.