### PR TITLE
[php] Workerman update to PHP 8.5

### DIFF
--- a/frameworks/PHP/workerman/workerman-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-jit.dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-mysql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-mysql php8.5-xml > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null && \
-    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /workerman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php-jit.ini /etc/php/8.4/cli/conf.d/10-opcache.ini
+COPY php-jit.ini /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/workerman/workerman-mysql-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-mysql-jit.dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-mysql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-mysql php8.5-xml > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null && \
-    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /workerman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php-jit.ini /etc/php/8.4/cli/conf.d/10-opcache.ini
+COPY php-jit.ini /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/workerman/workerman-pgsql-jit.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql-jit.dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-pgsql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-pgsql php8.5-xml > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null && \
-    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /workerman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php-jit.ini /etc/php/8.4/cli/conf.d/10-opcache.ini
+COPY php-jit.ini /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/workerman/workerman-pgsql.dockerfile
+++ b/frameworks/PHP/workerman/workerman-pgsql.dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-pgsql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-pgsql php8.5-xml > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null && \
-    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /workerman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php.ini /etc/php/8.4/cli/php.ini
+COPY php.ini /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/workerman/workerman.dockerfile
+++ b/frameworks/PHP/workerman/workerman.dockerfile
@@ -10,18 +10,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-mysql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-mysql php8.5-xml > /dev/null
 
 COPY --from=composer/composer:latest-bin --link /composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null && \
-    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null && \
+    pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /workerman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php.ini /etc/php/8.4/cli/php.ini
+COPY php.ini /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Still need to update swow and swoole when ready for PHP 8.5.

@walkor :+1: 

#10303
