### PR TITLE
[php] Webman update to PHP 8.5

### DIFF
--- a/frameworks/PHP/webman/support/bootstrap/Date.php
+++ b/frameworks/PHP/webman/support/bootstrap/Date.php
@@ -30,9 +30,9 @@ class Date implements Bootstrap {
      */
     public static function start($worker)
     {
-        self::$date = gmdate(DATE_RFC7231);
+        self::$date = gmdate('D, d M Y H:i:s \G\M\T');
         Timer::add(1, function() {
-            self::$date = gmdate(DATE_RFC7231);
+            self::$date = gmdate('D, d M Y H:i:s \G\M\T');
         });
     }
 

--- a/frameworks/PHP/webman/webman-pgsql.dockerfile
+++ b/frameworks/PHP/webman/webman-pgsql.dockerfile
@@ -8,18 +8,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-pgsql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-pgsql php8.5-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update -yqq && apt-get install -y php-pear php8.4-dev libevent-dev git  > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get update -yqq && apt-get install -y php-pear php8.5-dev libevent-dev git  > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /webman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php.ini /etc/php/8.4/cli/conf.d/10-opcache.ini
+COPY php.ini /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/webman/webman.dockerfile
+++ b/frameworks/PHP/webman/webman.dockerfile
@@ -8,18 +8,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null && \
     apt-get update -yqq > /dev/null && apt-get upgrade -yqq > /dev/null
 
-RUN apt-get install -yqq php8.4-cli php8.4-pgsql php8.4-xml > /dev/null
+RUN apt-get install -yqq php8.5-cli php8.5-pgsql php8.5-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update -yqq && apt-get install -y php-pear php8.4-dev libevent-dev git  > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/30-event.ini
+RUN apt-get update -yqq && apt-get install -y php-pear php8.5-dev libevent-dev git  > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/30-event.ini
 
 WORKDIR /webman
 COPY --link . .
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-COPY php.ini /etc/php/8.4/cli/conf.d/10-opcache.ini
+COPY php.ini /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

Constant DATE_RFC7231 deprecated

@walkor :+1: 

#10303
