### PR TITLE
[php] Mark update to PHP 8.5

### DIFF
--- a/frameworks/PHP/mark/mark.dockerfile
+++ b/frameworks/PHP/mark/mark.dockerfile
@@ -5,20 +5,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php8.4-cli php8.4-pgsql php8.4-xml > /dev/null
+    apt-get install -yqq php8.5-cli php8.5-pgsql php8.5-xml > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev git > /dev/null
-RUN pecl install event-3.1.3 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev git > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/event.ini
  
-COPY php.ini /etc/php/8.4/cli/php.ini
+COPY php.ini /etc/php/8.5/cli/php.ini
 
 ADD ./ /mark
 WORKDIR /mark
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
-RUN sed -i "s|opcache.jit=off|opcache.jit=tracing|g" /etc/php/8.4/cli/conf.d/10-opcache.ini
+#RUN sed -i "s|opcache.jit=off|opcache.jit=tracing|g" /etc/php/8.5/cli/conf.d/10-opcache.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/mark/start.php
+++ b/frameworks/PHP/mark/start.php
@@ -27,12 +27,12 @@ $api->get('/json', function () {
     ], \json_encode(['message' => 'Hello, World!']));
 });
 
-$date = gmdate(DATE_RFC7231);
+$date = gmdate('D, d M Y H:i:s \G\M\T');
 
 $api->onWorkerStart = static function () {
     Timer::add(1, function () {
         global $date;
-        $date = gmdate(DATE_RFC7231);
+        $date = gmdate('D, d M Y H:i:s \G\M\T');
     });
 };
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Constant DATE_RFC7231 deprecated

#10303 