### PR TITLE
[php] Nette update to PHP 8.5

### DIFF
--- a/frameworks/PHP/nette/nette.dockerfile
+++ b/frameworks/PHP/nette/nette.dockerfile
@@ -5,9 +5,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get install -yqq nginx git unzip \
-    php8.4-fpm php8.4-mysql php8.4-xml php8.4-mbstring php8.4-intl php8.4-dev  php8.4-curl > /dev/null
+    php8.5-fpm php8.5-mysql php8.5-xml php8.5-mbstring php8.5-intl php8.5-dev  php8.5-curl > /dev/null
 
-COPY deploy/conf/* /etc/php/8.4/fpm/
+COPY deploy/conf/* /etc/php/8.5/fpm/
 
 WORKDIR /nette
 COPY --link . .
@@ -17,11 +17,11 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.5/fpm/php-fpm.conf ; fi;
 
 RUN chmod -R 777 /nette
 
 EXPOSE 8080
 
-CMD service php8.4-fpm start && \
+CMD service php8.5-fpm start && \
     nginx -c /nette/deploy/nginx.conf 2>&1 > /dev/stderr


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
#10303 