### PR TITLE
[php] Ubiquity update to PHP 8.5

### DIFF
--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner-mysql.dockerfile
@@ -1,17 +1,17 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php8.3 php8.3-common php8.3-cgi php-curl php8.3-mysql > /dev/null
+    apt-get install -yqq php8.4 php8.4-common php8.4-cgi php-curl php8.4-mysql > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev > /dev/null
 
-COPY deploy/conf/php-async.ini /etc/php/8.3/cgi/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.4/cgi/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -33,8 +33,8 @@ RUN chmod 755 /bin/envwrapper.sh
 
 RUN chmod 777 -R /ubiquity/.ubiquity/*
 
-#RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.3/cgi/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.3/cgi/php.ini
+#RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/cgi/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cgi/php.ini
 
 COPY deploy/conf/roadrunner/mysql/rrServices.php app/config/rrServices.php
 

--- a/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-roadrunner.dockerfile
@@ -1,18 +1,17 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq php8.3 php8.3-common php8.3-cgi php8.3-pgsql php-curl > /dev/null
+    apt-get install -yqq php8.4 php8.4-common php8.4-cgi php8.4-pgsql php-curl > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get install -y php-pear php-dev > /dev/null
 
-
-COPY deploy/conf/php-async.ini /etc/php/8.3/cgi/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.4/cgi/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -34,8 +33,8 @@ RUN chmod 755 /bin/envwrapper.sh
 
 RUN chmod 777 -R /ubiquity/.ubiquity/*
 
-#RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.3/cgi/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.3/cgi/php.ini
+#RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/cgi/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.4/cgi/php.ini
 
 COPY deploy/conf/roadrunner/pgsql/rrServices.php app/config/rrServices.php
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mongo.dockerfile
@@ -5,14 +5,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php > /dev/null
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.4-cli php8.4-mongodb php8.4-xml php8.4-mbstring > /dev/null
+    apt-get install -yqq git php8.5-cli php8.5-mongodb php8.5-xml php8.5-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.5/cli/php.ini
 
 ADD ./ /ubiquity
 
@@ -31,8 +31,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/mongo/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.5/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-mysql.dockerfile
@@ -5,14 +5,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.4-cli php8.4-mysql php8.4-xml php8.4-mbstring > /dev/null
+    apt-get install -yqq git php8.5-cli php8.5-mysql php8.5-xml php8.5-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.5/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/mysql/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.5/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman-raw.dockerfile
@@ -5,14 +5,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.4-cli php8.4-pgsql php8.4-xml php8.4-mbstring > /dev/null
+    apt-get install -yqq git php8.5-cli php8.5-pgsql php8.5-xml php8.5-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.5/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/pgsql/raw/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.4/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.5/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=tracing\n" >> /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity-workerman.dockerfile
@@ -5,14 +5,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq git php8.4-cli php8.4-pgsql php8.4-xml php8.4-mbstring > /dev/null
+    apt-get install -yqq git php8.5-cli php8.5-pgsql php8.5-xml php8.5-mbstring > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get install -y php-pear php8.4-dev libevent-dev > /dev/null
-RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.4/cli/conf.d/event.ini
+RUN apt-get install -y php-pear php8.5-dev libevent-dev > /dev/null
+RUN pecl install event-3.1.4 > /dev/null && echo "extension=event.so" > /etc/php/8.5/cli/conf.d/event.ini
 
-COPY deploy/conf/php-async.ini /etc/php/8.4/cli/php.ini
+COPY deploy/conf/php-async.ini /etc/php/8.5/cli/php.ini
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
@@ -30,8 +30,8 @@ RUN chmod 777 -R /ubiquity/.ubiquity/*
 
 COPY deploy/conf/workerman/pgsql/workerServices.php app/config/workerServices.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.4/cli/php.ini
-RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.4/cli/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php\n" >> /etc/php/8.5/cli/php.ini
+RUN echo "opcache.jit_buffer_size=128M\nopcache.jit=function\n" >> /etc/php/8.5/cli/php.ini
 
 EXPOSE 8080
 

--- a/frameworks/PHP/ubiquity/ubiquity.dockerfile
+++ b/frameworks/PHP/ubiquity/ubiquity.dockerfile
@@ -5,16 +5,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /dev/null
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
-    apt-get install -yqq nginx git unzip php8.4 php8.4-common php8.4-cli php8.4-fpm php8.4-mysql php8.4-dev > /dev/null
+    apt-get install -yqq nginx git unzip php8.5 php8.5-common php8.5-cli php8.5-fpm php8.5-mysql php8.5-dev > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.4/fpm/
+COPY deploy/conf/* /etc/php/8.5/fpm/
 
 ADD ./ /ubiquity
 WORKDIR /ubiquity
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.5/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
@@ -22,9 +22,9 @@ RUN chmod 777 -R /ubiquity/app/cache/*
 
 COPY deploy/conf/ubiquity-config.php app/config/config.php
 
-RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.4/fpm/php.ini
+RUN echo "opcache.preload=/ubiquity/app/config/preloader.script.php" >> /etc/php/8.5/fpm/php.ini
 
 EXPOSE 8080
 
-CMD service php8.4-fpm start && \
+CMD service php8.5-fpm start && \
     nginx -c /ubiquity/deploy/nginx.conf -g "daemon off;"


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Swoole and ngx-php variants, still use PHP 8.4. Till they are available with 8.5.


@jcheron a lot of deprecated warnings 

#10303 