### PR TITLE
[php] Ripple update to PHP 8.5

### DIFF
--- a/frameworks/PHP/ripple/ripple.dockerfile
+++ b/frameworks/PHP/ripple/ripple.dockerfile
@@ -10,6 +10,7 @@ RUN apt-get install -y libevent-dev \
 
 RUN docker-php-ext-install pdo_mysql \
     ffi \
+    posix \
     pcntl \
     sockets >> /dev/null
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Work but show deprecated warnings.

#10303 