### PR TITLE
[ruby/agoo] Change agoo display name to "agoo"

### DIFF
--- a/frameworks/Ruby/agoo/benchmark_config.json
+++ b/frameworks/Ruby/agoo/benchmark_config.json
@@ -19,7 +19,7 @@
       "webserver": "Agoo",
       "os": "Linux",
       "database_os": "Linux",
-      "display_name": "rack [agoo]",
+      "display_name": "agoo",
       "notes": ""
     }
   }]


### PR DESCRIPTION
"rack [agoo]" implies that it's similar to the other "rack [puma]" or "rack [iodine]" where as agoo has a different implementation.