### PR TITLE
[php] DuckPHP update to PHP 8.5

### DIFF
--- a/frameworks/PHP/duckphp/duckphp.dockerfile
+++ b/frameworks/PHP/duckphp/duckphp.dockerfile
@@ -6,18 +6,18 @@ RUN apt-get update -yqq && apt-get install -yqq software-properties-common > /de
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php
 RUN apt-get update -yqq > /dev/null && \
     apt-get install -yqq nginx git unzip \
-    php8.4-cli php8.4-fpm php8.4-mysql php8.4-dev > /dev/null
+    php8.5-cli php8.5-fpm php8.5-mysql php8.5-dev > /dev/null
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-COPY deploy/conf/* /etc/php/8.4/fpm/
+COPY deploy/conf/* /etc/php/8.5/fpm/
 
 WORKDIR /duckphp
 COPY --link . .
 
-RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.4/fpm/php-fpm.conf ; fi;
+RUN if [ $(nproc) = 2 ]; then sed -i "s|pm.max_children = 1024|pm.max_children = 512|g" /etc/php/8.5/fpm/php-fpm.conf ; fi;
 
 RUN composer install --optimize-autoloader --classmap-authoritative --no-dev --quiet
 
-CMD service php8.4-fpm start && \
+CMD service php8.5-fpm start && \
     nginx -c /duckphp/deploy/nginx.conf


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->

#10303 