### PR TITLE
[ruby/sinatra] Use auto-configured workers

### DIFF
--- a/frameworks/Ruby/sinatra/config/puma.rb
+++ b/frameworks/Ruby/sinatra/config/puma.rb
@@ -1,7 +1,6 @@
 require_relative 'auto_tune'
 
 # FWBM only... use the puma_auto_tune gem in production!
-num_workers, num_threads = auto_tune
+_, num_threads = auto_tune
 
-workers num_workers
 threads num_threads, num_threads

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -19,4 +19,4 @@ ENV DBTYPE=postgresql
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080
+CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -19,4 +19,4 @@ ENV DBTYPE=mysql
 ENV WEB_CONCURRENCY=auto
 EXPOSE 8080
 
-CMD bundle exec puma -C config/mri_puma.rb -b tcp://0.0.0.0:8080
+CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080


### PR DESCRIPTION
If WEB_CONCURRENCY=auto we don't need to set the workers in the puma.rb