### PR TITLE
[ruby/rack] Revert jruby change to MRI

### DIFF
--- a/frameworks/Ruby/rack/rack-jruby.dockerfile
+++ b/frameworks/Ruby/rack/rack-jruby.dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:4.0-rc
+FROM jruby:10.0
 
 RUN apt-get update -y && apt-get install netbase -y
 


### PR DESCRIPTION
JRuby should not run with MRI.