### PR TITLE
[groovy/grails] Mark tests as broken.

### DIFF
--- a/frameworks/Groovy/grails/benchmark_config.json
+++ b/frameworks/Groovy/grails/benchmark_config.json
@@ -22,7 +22,8 @@
       "database_os": "Linux",
       "display_name": "Grails",
       "notes": "",
-      "versus": "servlet"
+      "versus": "servlet",
+      "tags": ["broken"]
     }
   }]
 }


### PR DESCRIPTION
The current test fails as it is using an EOL version of Java. Grails is actively maintained, so mark it as broken instead.