### PR TITLE
Update the set of broken implementations 3

### DIFF
--- a/frameworks/Kotlin/http4k/benchmark_config.json
+++ b/frameworks/Kotlin/http4k/benchmark_config.json
@@ -22,6 +22,7 @@
         "webserver": "None",
         "os": "Linux",
         "notes": "https://http4k.org",
+        "tags": [ "broken" ],
         "versus": "servlet"
       },
       "apache4": {
@@ -88,6 +89,7 @@
         "webserver": "None",
         "os": "Linux",
         "notes": "https://http4k.org",
+        "tags": [ "broken" ],
         "versus": "helidon-jdbc"
       },
       "jetty": {

--- a/frameworks/PHP/flight/benchmark_config.json
+++ b/frameworks/PHP/flight/benchmark_config.json
@@ -45,6 +45,7 @@
       "database_os": "Linux",
       "display_name": "flight [workerman]",
       "notes": "",
+      "tags": [ "broken" ],
       "versus": "php"
     }
   }]

--- a/frameworks/R/plumber/benchmark_config.json
+++ b/frameworks/R/plumber/benchmark_config.json
@@ -4,7 +4,6 @@
     {
       "default": {
         "json_url": "/json",
-        "plaintext_url": "/plaintext",
         "db_url": "/db",
         "query_url": "/query?queries=",
         "fortune_url": "/fortunes",


### PR DESCRIPTION
All affected implementations except `http4k-helidon-pgclient` have been consistently broken since at least [run 809d8655-c602-42a1-9d8c-dc4692738790](https://tfb-status.techempower.com/results/809d8655-c602-42a1-9d8c-dc4692738790). `http4k-helidon-pgclient` started failing after the update to PostgreSQL 18, reflected in [run 40103b8c-8670-4734-8d39-7081cf9441d8](https://tfb-status.techempower.com/results/40103b8c-8670-4734-8d39-7081cf9441d8).

Pinging @daviddenton, @emilmahler, @joanhey, and @fundon.