### PR TITLE
[ruby] Remove RUBY_THREAD_TIMESLICE variable

### DIFF
--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:4.0-rc
 
 ENV RUBY_YJIT_ENABLE=1
-ENV RUBY_THREAD_TIMESLICE=10
 
 # Use Jemalloc
 RUN apt-get update && \

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -4,7 +4,6 @@ ADD ./ /roda-sequel
 WORKDIR /roda-sequel
 
 ENV RUBY_YJIT_ENABLE=1
-ENV RUBY_THREAD_TIMESLICE=10
 
 # Use Jemalloc
 RUN apt-get update && \


### PR DESCRIPTION
This setting seems to improve performance so I'd like to enable it for a lot more frameworks.

By removing it this run and enabling it for all next run, we can have a better comparison.