### PR TITLE
Add operating system info to results.json

### DIFF
--- a/toolset/utils/results.py
+++ b/toolset/utils/results.py
@@ -12,6 +12,7 @@ import re
 import math
 import csv
 import traceback
+import platform
 from datetime import datetime
 
 # Cross-platform colored text
@@ -52,6 +53,10 @@ class Results:
         except Exception:
             #Could not read local git repository, which is fine.
             self.git = None
+        # OS information - only set once during initialization
+        self.operatingSystem = dict()
+        self.operatingSystem['name'] = platform.system()
+        self.operatingSystem['version'] = platform.release()
         self.startTime = int(round(time.time() * 1000))
         self.completionTime = None
         self.concurrencyLevels = self.config.concurrency_levels
@@ -320,6 +325,7 @@ class Results:
         toRet['name'] = self.name
         toRet['environmentDescription'] = self.environmentDescription
         toRet['git'] = self.git
+        toRet['operatingSystem'] = self.operatingSystem
         toRet['startTime'] = self.startTime
         toRet['completionTime'] = self.completionTime
         toRet['concurrencyLevels'] = self.concurrencyLevels


### PR DESCRIPTION
This will, of course, run the entire CICD pipeline and have several failures. Running in my WSL creates a `results.json` that starts:
```
{
  "uuid": "3d8413e9-0740-487a-a14c-a9e37325a616",
  "name": "(unspecified, datetime = 2025-12-08 17:59:52)",
  "environmentDescription": "(unspecified, hostname = 90c615143806)",
  "git": {
    "commitId": "43951add5ca081f90f21d8cf78e4cdf5ce1fe9d3",
    "repositoryUrl": "git@github-msmith:msmith-techempower/FrameworkBenchmarks.git",
    "branchName": "add-os-info"
  },
  "operatingSystem": {
    "name": "Linux",
    "version": "6.6.87.2-microsoft-standard-WSL2"
  },
  "startTime": 1765216793168,
  "completionTime": 1765216975161,
  "concurrencyLevels": [
    16,
    32,
    64,
    128,
    ...
```