### PR TITLE
[ruby/rack] Hardcode Puma to 5 threads

### DIFF
--- a/frameworks/Ruby/rack/config/puma.rb
+++ b/frameworks/Ruby/rack/config/puma.rb
@@ -1,17 +1,11 @@
-require_relative 'auto_tune'
-
-# FWBM only... use the puma_auto_tune gem in production!
-num_workers, num_threads = auto_tune
-
-if RUBY_PLATFORM == 'java'
-  num_threads = 512
-  num_workers = 0
-end
-
-threads num_threads
-
-if num_workers > 0
+if ENV.fetch('WEB_CONCURRENCY') == 'auto'
   before_fork do
     Sequel::DATABASES.each(&:disconnect)
   end
+else
+  workers ENV.fetch('WEB_CONCURRENCY')
+  require 'concurrent/utility/processor_counter'
+  threads = (::Concurrent.available_processor_count * 1.5).to_i
+  threads threads
+  ENV['MAX_THREADS'] = threads.to_s
 end

--- a/frameworks/Ruby/rack/hello_world.rb
+++ b/frameworks/Ruby/rack/hello_world.rb
@@ -43,8 +43,8 @@ class HelloWorld
   </html>'
 
   def initialize
-    if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
-      max_connections = threads
+    if defined?(Puma)
+      max_connections = ENV.fetch('MAX_THREADS')
     elsif defined?(Itsi)
       require_relative 'config/auto_tune'
       _num_workers, num_threads = auto_tune

--- a/frameworks/Ruby/rack/pg_db.rb
+++ b/frameworks/Ruby/rack/pg_db.rb
@@ -7,8 +7,6 @@ if RUBY_PLATFORM == 'java'
   Jdbc::Postgres.load_driver
 end
 
-
-
 class PgDb
   QUERY_RANGE = (1..10_000).freeze # range of IDs in the Fortune DB
   ALL_IDS = QUERY_RANGE.to_a # enumeration of all the IDs in fortune DB

--- a/frameworks/Ruby/rack/rack-jruby.dockerfile
+++ b/frameworks/Ruby/rack/rack-jruby.dockerfile
@@ -6,13 +6,15 @@ WORKDIR /rack
 
 COPY Gemfile*  ./
 
+#RUN echo $(ruby config/auto_tune.rb | grep -Eo '[0-9]+' | head -n 1)
+
 RUN bundle config set with 'puma'
 RUN bundle install --jobs=8
 
 COPY . .
 
-EXPOSE 8080
+ENV WEB_CONCURRENCY=0
 
-CMD config/java_tune.sh
+EXPOSE 8080
 
 CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production

--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -17,7 +17,9 @@ RUN bundle install --jobs=8
 
 COPY . .
 
-EXPOSE 8080
 ENV WEB_CONCURRENCY=auto
+ENV MAX_THREADS=5
+
+EXPOSE 8080
 
 CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production


### PR DESCRIPTION
This should also improve the performance of JRuby where previously the threads were hardcoded to 512:

|          branch_name| json|   db|query|update|fortune|plaintext|
|---------------------|-----|-----|-----|------|-------|---------|
|               master|15415|14528|12212| 11690|  13936|   144433|
| threads = processors|30345|45011|32726| 22101|  39920|   112966|
|rack/puma-max-threads|29204|50077|45459| 25358|  41560|   117562|

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
