### PR TITLE
[ruby/hanami] Remove ostruct dependency

### DIFF
--- a/frameworks/Ruby/hanami/Gemfile
+++ b/frameworks/Ruby/hanami/Gemfile
@@ -16,4 +16,3 @@ gem "rake"
 gem "rom", "~> 5.3"
 gem "rom-sql", "~> 3.6"
 gem "pg"
-gem "ostruct" # required for Ruby 4.0

--- a/frameworks/Ruby/hanami/Gemfile.lock
+++ b/frameworks/Ruby/hanami/Gemfile.lock
@@ -133,7 +133,6 @@ GEM
       hansi (~> 0.2.0)
       mustermann (= 3.0.3)
     nio4r (2.7.4)
-    ostruct (0.6.3)
     pg (1.5.9)
     pp (0.6.3)
       prettyprint
@@ -205,7 +204,6 @@ DEPENDENCIES
   hanami-router (~> 2.3)
   hanami-validations (~> 2.3)
   hanami-view (~> 2.3)
-  ostruct
   pg
   puma
   rake


### PR DESCRIPTION
This is no longer needed.