### PR TITLE
[ruby/rack] Use 1 thread for rack itsi

### DIFF
--- a/frameworks/Ruby/rack/config/itsi.rb
+++ b/frameworks/Ruby/rack/config/itsi.rb
@@ -9,5 +9,5 @@ preload false
 num_workers, num_threads = auto_tune
 
 workers num_workers
-threads num_threads
+threads ENV.fetch('MAX_THREADS').to_i
 fiber_scheduler false

--- a/frameworks/Ruby/rack/hello_world.rb
+++ b/frameworks/Ruby/rack/hello_world.rb
@@ -43,12 +43,8 @@ class HelloWorld
   </html>'
 
   def initialize
-    if defined?(Puma)
+    if defined?(Puma) || defined?(Itsi)
       max_connections = ENV.fetch('MAX_THREADS')
-    elsif defined?(Itsi)
-      require_relative 'config/auto_tune'
-      _num_workers, num_threads = auto_tune
-      max_connections = num_threads
     else
       max_connections = 512
     end

--- a/frameworks/Ruby/rack/rack-itsi.dockerfile
+++ b/frameworks/Ruby/rack/rack-itsi.dockerfile
@@ -19,6 +19,8 @@ RUN bundle install --jobs=8
 
 COPY . .
 
+ENV MAX_THREADS=1
+
 EXPOSE 8080
 
 CMD bundle exec itsi start -C config/itsi.rb --bind "http://tfb-server:8080"


### PR DESCRIPTION
|     name|         branch_name|  json|   db|query|update|fortune|plaintext|
|---------|--------------------|------|-----|-----|------|-------|---------|
|rack-itsi|              master|128098|37761|35852| 20294|  31924|   257825|
|rack-itsi| rack/itsi-5-threads|128848|46841|44662| 24453|  36894|   241639|
|rack-itsi|  rack/itsi-1-thread|192323|66246|54650| 21881|  46819|   293490|