### PR TITLE
[ruby/padrino] Use trilogy for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/padrino/Gemfile
+++ b/frameworks/Ruby/padrino/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'mysql2', '> 0.5'
+gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
+
 gem 'json'
 gem 'activerecord', '~> 8.1.0', :require => 'active_record'
 

--- a/frameworks/Ruby/padrino/Gemfile.lock
+++ b/frameworks/Ruby/padrino/Gemfile.lock
@@ -46,7 +46,6 @@ GEM
     moneta (1.6.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.6)
     net-imap (0.5.12)
       date
       net-protocol
@@ -115,6 +114,7 @@ GEM
     thor (1.4.0)
     tilt (2.6.1)
     timeout (0.4.4)
+    trilogy (2.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.3)
@@ -128,11 +128,11 @@ DEPENDENCIES
   activerecord (~> 8.1.0)
   iodine (~> 0.7)
   json
-  mysql2 (> 0.5)
   ostruct
   padrino (= 0.16.0)
   rack
   slim
+  trilogy (~> 2.9)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/padrino/config/database.rb
+++ b/frameworks/Ruby/padrino/config/database.rb
@@ -1,17 +1,19 @@
-Bundler.require('mysql')
+Bundler.require('trilogy')
 opts = {
-  adapter:  'mysql2',
+  adapter:  'trilogy',
   username: 'benchmarkdbuser',
   password: 'benchmarkdbpass',
   host:     'tfb-database',
-  database: 'hello_world'
+  database: 'hello_world',
+  ssl:      true,
+  ssl_mode: 4, # Trilogy::SSL_PREFERRED_NOVERIFY
+  tls_min_version: 3 # Trilogy::TLS_VERSION_12
 }
 
 # Determine threading/thread pool size and timeout
 # TODO: ActiveRecord doesn't have a single-threaded mode?
 opts[:pool] = 512
 opts[:checkout_timeout] = 5
-
 
 # Setup our logger
 ActiveRecord::Base.logger = logger

--- a/frameworks/Ruby/padrino/models/world.rb
+++ b/frameworks/Ruby/padrino/models/world.rb
@@ -4,7 +4,7 @@ class World < ActiveRecord::Base
   alias_attribute(:randomNumber, :randomnumber) \
     if connection.adapter_name.downcase.start_with?('postgres')
 
-  if connection.adapter_name.downcase.start_with?('mysql')
+  if connection.adapter_name.downcase.start_with?('trilogy')
     def self.upsert_all(attributes, on_duplicate: :update, update_only: nil, returning: nil, unique_by: nil, record_timestamps: nil)
       # On MySQL Batch updates verification isn't supported yet by TechEmpower.
       # https://github.com/TechEmpower/FrameworkBenchmarks/issues/5983


### PR DESCRIPTION
Trilogy is a new client library for MySQL-compatible database servers, designed for performance, flexibility, and ease of embedding. It is used by Github and Shopify in production and will probably replace the mysql2 library.
https://github.com/trilogy-libraries/trilogy