### PR TITLE
[ruby/grape] Use trilogy for the MySQL adapter

### DIFF
--- a/frameworks/Ruby/grape/Gemfile
+++ b/frameworks/Ruby/grape/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'mysql2', '0.5.6'
+gem 'trilogy', '~> 2.9'
 gem 'activerecord', '~> 8.1.0', :require => 'active_record'
 gem 'grape', '2.1.1'
 gem 'json', '~> 2.9'

--- a/frameworks/Ruby/grape/Gemfile.lock
+++ b/frameworks/Ruby/grape/Gemfile.lock
@@ -58,7 +58,6 @@ GEM
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.1.0)
       mustermann (>= 1.0.0)
-    mysql2 (0.5.6)
     nio4r (2.7.4)
     puma (7.1.0)
       nio4r (~> 2.0)
@@ -66,6 +65,7 @@ GEM
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     timeout (0.4.3)
+    trilogy (2.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uri (1.0.3)
@@ -81,8 +81,8 @@ DEPENDENCIES
   grape (= 2.1.1)
   iodine (~> 0.7)
   json (~> 2.9)
-  mysql2 (= 0.5.6)
   puma (~> 7.1)
+  trilogy (~> 2.9)
 
 BUNDLED WITH
    2.7.0

--- a/frameworks/Ruby/grape/config/database.yml
+++ b/frameworks/Ruby/grape/config/database.yml
@@ -1,5 +1,5 @@
 production:
-  adapter: mysql2
+  adapter: trilogy
   encoding: utf8
   host: tfb-database
   database: hello_world
@@ -7,3 +7,6 @@ production:
   password: benchmarkdbpass
   pool: <%= ENV.fetch('MAX_THREADS') %>
   timeout: 5000
+  ssl: true
+  ssl_mode: 4 <%# Trilogy::SSL_PREFERRED_NOVERIFY %>
+  tls_min_version: 3 <%# Trilogy::TLS_VERSION_12 %>


### PR DESCRIPTION
Trilogy is a new client library for MySQL-compatible database servers, designed for performance, flexibility, and ease of embedding. It is used by Github and Shopify in production and will probably replace the mysql2 library.
https://github.com/trilogy-libraries/trilogy

| name|  branch_name|   db|
|-----|-------------|-----|
|grape|       master|19181|
|grape|grape/trilogy|21311|