### PR TITLE
[ruby/rack] Set puma workers to 1.25 * nproc

### DIFF
--- a/frameworks/Ruby/rack/config/puma.rb
+++ b/frameworks/Ruby/rack/config/puma.rb
@@ -1,4 +1,4 @@
-if ENV.fetch('WEB_CONCURRENCY') == 'auto'
+if ENV.fetch('WEB_CONCURRENCY').to_i > 1
   before_fork do
     Sequel::DATABASES.each(&:disconnect)
   end

--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -17,9 +17,9 @@ RUN bundle install --jobs=8
 
 COPY . .
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production


### PR DESCRIPTION
WEB_CONCURRENCY=auto sets the number of workers to the number of processors.
Setting it to 1.25 the number of processors seems to perform better.