### PR TITLE
[ruby/rack-sequel] Set puma workers to 1.25 * nproc

### DIFF
--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
@@ -16,9 +16,9 @@ RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production

--- a/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
@@ -16,9 +16,9 @@ RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=mysql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080 -e production


### PR DESCRIPTION
WEB_CONCURRENCY=auto sets the number of workers to the number of processors.
Setting it to 1.25 the number of processors seems to perform better.