### PR TITLE
[python/mrhttp] Stripped mrhttp.

### DIFF
--- a/frameworks/Python/mrhttp/benchmark_config.json
+++ b/frameworks/Python/mrhttp/benchmark_config.json
@@ -5,7 +5,7 @@
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "port": 8080,
-      "approach": "Realistic",
+      "approach": "Stripped",
       "classification": "Micro",
       "framework": "mrhttp",
       "language": "Python",


### PR DESCRIPTION
according  to  #9055  issue , mrhttp is response cache in plaintext benchmark and response is wrong implement.

so it should be remove.

#9578 no more fakes.