### PR TITLE
[ruby] Move database logic to seperate files for clarity

### DIFF
--- a/frameworks/Ruby/rack-app/app.rb
+++ b/frameworks/Ruby/rack-app/app.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
+require 'bundler/setup'
+Bundler.require(:default) # Load core modules
 
 require 'rack/app'
 require 'rack/app/front_end'
+require_relative 'db'
 require 'json'
+require 'time'
 
 class App < Rack::App
   MAX_PK = 10_000

--- a/frameworks/Ruby/rack-app/config.ru
+++ b/frameworks/Ruby/rack-app/config.ru
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_relative 'boot'
 require_relative 'app'
 
 run App

--- a/frameworks/Ruby/rack-app/db.rb
+++ b/frameworks/Ruby/rack-app/db.rb
@@ -1,34 +1,17 @@
 # frozen_string_literal: true
-require 'bundler/setup'
-require 'time'
 
-MAX_PK = 10_000
-ID_RANGE = (1..MAX_PK).freeze
-ALL_IDS = ID_RANGE.to_a
-QUERIES_MIN = 1
-QUERIES_MAX = 500
 SEQUEL_NO_ASSOCIATIONS = true
-SERVER_STRING = "Sinatra"
-
-Bundler.require(:default) # Load core modules
 
 def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
 
   opts = {}
 
-  if dbtype == :mysql
-    adapter = 'trilogy'
-    opts[:ssl] = true
-    opts[:ssl_mode] = 4 # Trilogy::SSL_PREFERRED_NOVERIFY
-    opts[:tls_min_version] = 3 # Trilogy::TLS_VERSION_12
-  else
-    adapter = 'postgresql'
-  end
+  adapter = 'postgresql'
 
   # Determine threading/thread pool size and timeout
-  if defined?(Puma)
-    opts[:max_connections] = ENV.fetch('MAX_THREADS')
+  if defined?(Puma) && (threads = Puma.cli_config.options.fetch(:max_threads)) > 1
+    opts[:max_connections] = threads
     opts[:pool_timeout] = 10
   else
     opts[:max_connections] = 512
@@ -44,7 +27,7 @@ def connect(dbtype)
     }, opts
 end
 
-DB = connect ENV.fetch('DBTYPE').to_sym
+DB = connect 'postgres'
 
 # Define ORM models
 class World < Sequel::Model(:World)

--- a/frameworks/Ruby/rack-sequel/config.ru
+++ b/frameworks/Ruby/rack-sequel/config.ru
@@ -1,4 +1,5 @@
-require_relative 'boot'
+# frozen_string_literal: true
 require_relative 'hello_world'
+
 use Rack::ContentLength
 run HelloWorld.new

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+require 'bundler/setup'
+Bundler.require(:default) # Load core modules
+
+require_relative 'db'
 require 'time'
 
 # Our Rack application to be executed by rackup
@@ -8,8 +12,8 @@ class HelloWorld
   ALL_IDS = ID_RANGE.to_a
   QUERIES_MIN = 1
   QUERIES_MAX = 500
+
   CONTENT_TYPE = 'Content-Type'
-  CONTENT_LENGTH = 'Content-Length'
   JSON_TYPE = 'application/json'
   HTML_TYPE = 'text/html; charset=utf-8'
   PLAINTEXT_TYPE = 'text/plain'

--- a/frameworks/Ruby/rack/hello_world.rb
+++ b/frameworks/Ruby/rack/hello_world.rb
@@ -19,8 +19,8 @@ class HelloWorld
   ALL_IDS = QUERY_RANGE.to_a # enumeration of all the IDs in fortune DB
   MIN_QUERIES = 1 # min number of records that can be retrieved
   MAX_QUERIES = 500 # max number of records that can be retrieved
+
   CONTENT_TYPE = 'Content-Type'
-  CONTENT_LENGTH = 'Content-Length'
   JSON_TYPE = 'application/json'
   HTML_TYPE = 'text/html; charset=utf-8'
   PLAINTEXT_TYPE = 'text/plain'

--- a/frameworks/Ruby/roda-sequel/config.ru
+++ b/frameworks/Ruby/roda-sequel/config.ru
@@ -1,3 +1,4 @@
-require_relative 'boot'
+# frozen_string_literal: true
 require_relative 'hello_world'
+
 run HelloWorld.freeze.app

--- a/frameworks/Ruby/roda-sequel/db.rb
+++ b/frameworks/Ruby/roda-sequel/db.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
-require 'bundler/setup'
 
 SEQUEL_NO_ASSOCIATIONS = true
-
-Bundler.require(:default) # Load core modules
 
 def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
@@ -27,20 +24,21 @@ def connect(dbtype)
     opts[:max_connections] = 512
   end
 
-  Sequel.connect \
-    '%{adapter}://%{host}/%{database}?user=%{user}&password=%{password}' % {
-      adapter: adapter,
-      host: 'tfb-database',
-      database: 'hello_world',
-      user: 'benchmarkdbuser',
-      password: 'benchmarkdbpass'
-    }, opts
+  Sequel.connect "%{adapter}://%{host}/%{database}?user=%{user}&password=%{password}" %
+                   {
+                     adapter: adapter,
+                     host: "tfb-database",
+                     database: "hello_world",
+                     user: "benchmarkdbuser",
+                     password: "benchmarkdbpass"
+                   },
+                 opts
 end
 
-DB = connect ENV.fetch('DBTYPE').to_sym
+DB = connect ENV.fetch("DBTYPE").to_sym
 
 # Define ORM models
-class World < Sequel::Model(:World)
+class World < Sequel.Model(:World)
   def_column_alias(:randomnumber, :randomNumber) if DB.database_type == :mysql
 
   def self.batch_update(worlds)
@@ -50,8 +48,8 @@ class World < Sequel::Model(:World)
       ids = []
       sql = String.new("UPDATE world SET randomnumber = CASE id ")
       worlds.each do |world|
-        sql << "when #{world[:id]} then #{world[:randomnumber]} "
-        ids << world[:id]
+        sql << "when #{world.id} then #{world.randomnumber} "
+        ids << world.id
       end
       sql << "ELSE randomnumber END WHERE id IN ( #{ids.join(',')})"
       DB.run(sql)
@@ -59,7 +57,7 @@ class World < Sequel::Model(:World)
   end
 end
 
-class Fortune < Sequel::Model(:Fortune)
+class Fortune < Sequel.Model(:Fortune)
   # Allow setting id to zero (0) per benchmark requirements
   unrestrict_primary_key
 end

--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -1,7 +1,26 @@
 # frozen_string_literal: true
+require 'bundler/setup'
+Bundler.require(:default) # Load core modules
+
+require_relative 'db'
+require 'time'
 
 # Our Rack application to be executed by rackup
 class HelloWorld < Roda
+  MAX_PK = 10_000
+  QUERY_RANGE = (1..MAX_PK).freeze
+  ALL_IDS = QUERY_RANGE.to_a
+  QUERIES_MIN = 1
+  QUERIES_MAX = 500
+
+  CONTENT_TYPE = 'Content-Type'
+  JSON_TYPE = 'application/json'
+  HTML_TYPE = 'text/html; charset=utf-8'
+  PLAINTEXT_TYPE = 'text/plain'
+  DATE_HEADER = 'Date'
+  SERVER_HEADER = 'Server'
+  SERVER_STRING = 'roda'
+
   plugin :hooks
   plugin :render, escape: true, layout_opts: { cache_key: "default_layout" }
   plugin :default_headers, SERVER_HEADER => SERVER_STRING

--- a/frameworks/Ruby/sinatra-sequel/config.ru
+++ b/frameworks/Ruby/sinatra-sequel/config.ru
@@ -1,3 +1,4 @@
-require_relative 'boot'
+# frozen_string_literal: true
 require_relative 'hello_world'
+
 run HelloWorld.new

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
+require 'bundler/setup'
+Bundler.require(:default) # Load core modules
+
+require_relative 'db'
+require 'time'
 
 # Our Rack application to be executed by rackup
 class HelloWorld < Sinatra::Base
+  MAX_PK = 10_000
+  ID_RANGE = (1..MAX_PK).freeze
+  ALL_IDS = ID_RANGE.to_a
+  QUERIES_MIN = 1
+  QUERIES_MAX = 500
+
+  SERVER_STRING = 'Sinatra'
+
   configure do
     # Static file serving is ostensibly disabled in modular mode but Sinatra
     # still calls an expensive Proc on every request...

--- a/frameworks/Ruby/sinatra/config.ru
+++ b/frameworks/Ruby/sinatra/config.ru
@@ -1,3 +1,4 @@
-require_relative 'boot'
+# frozen_string_literal: true
 require_relative 'hello_world'
+
 run HelloWorld.new

--- a/frameworks/Ruby/sinatra/config/puma.rb
+++ b/frameworks/Ruby/sinatra/config/puma.rb
@@ -1,0 +1,3 @@
+before_fork do
+  ActiveRecord::Base.connection_handler.clear_active_connections!
+end

--- a/frameworks/Ruby/sinatra/db.rb
+++ b/frameworks/Ruby/sinatra/db.rb
@@ -1,15 +1,4 @@
 # frozen_string_literal: true
-require 'bundler/setup'
-require 'time'
-
-MAX_PK = 10_000
-ID_RANGE = (1..MAX_PK).freeze
-ALL_IDS = ID_RANGE.to_a
-QUERIES_MIN = 1
-QUERIES_MAX = 500
-SERVER_STRING = "Sinatra"
-
-Bundler.require(:default) # Load core modules
 
 def connect(dbtype)
   Bundler.require(dbtype) # Load database-specific modules
@@ -64,5 +53,3 @@ end
 class Fortune < ActiveRecord::Base
   self.table_name = name
 end
-
-ActiveRecord::Base.connection_handler.clear_active_connections!

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
+require 'bundler/setup'
+Bundler.require(:default) # Load core modules
+
+require_relative 'db'
+require 'time'
 
 # Our Rack application to be executed by rackup
 class HelloWorld < Sinatra::Base
+  MAX_PK = 10_000
+  ID_RANGE = (1..MAX_PK).freeze
+  ALL_IDS = ID_RANGE.to_a
+  QUERIES_MIN = 1
+  QUERIES_MAX = 500
+
+  SERVER_STRING = 'Sinatra'
+
   configure do
     # Static file serving is ostensibly disabled in modular mode but Sinatra
     # still calls an expensive Proc on every request...


### PR DESCRIPTION
boot.rb contains Bundler initialization, constant definitions, database connections and model definitions.

Extracting the database connection and model definition to a separate db.rb makes it more explicit what belongs where. It also makes it easier to compare the models and database setup across frameworks.