### PR TITLE
[ruby] Set puma workers to 1.25 * nproc

### DIFF
--- a/frameworks/Ruby/hanami/hanami.dockerfile
+++ b/frameworks/Ruby/hanami/hanami.dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:4.0
 
 ENV RUBY_YJIT_ENABLE=1
-ENV WEB_CONCURRENCY=auto
 
 # Use Jemalloc
 RUN apt-get update && \
@@ -21,4 +20,5 @@ ENV HANAMI_ENV=production
 ENV HANAMI_PORT=8080
 ENV DATABASE_URL=postgres://benchmarkdbuser:benchmarkdbpass@tfb-database:5432/hello_world
 
-CMD bundle exec hanami server
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec hanami server

--- a/frameworks/Ruby/rails/rails-mysql.dockerfile
+++ b/frameworks/Ruby/rails/rails-mysql.dockerfile
@@ -20,10 +20,10 @@ RUN bundle install --jobs=8
 
 COPY . /rails/
 
-ENV WEB_CONCURRENCY=auto
 ENV RAILS_MAX_THREADS=5
 ENV RAILS_ENV=production_mysql
 ENV PORT=8080
 ENV REDIS_URL=redis://localhost:6379/0
-CMD service redis-server start && \
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    service redis-server start && \
     bin/rails server

--- a/frameworks/Ruby/rails/rails.dockerfile
+++ b/frameworks/Ruby/rails/rails.dockerfile
@@ -20,10 +20,10 @@ RUN bundle install --jobs=8
 
 COPY . /rails/
 
-ENV WEB_CONCURRENCY=auto
 ENV RAILS_MAX_THREADS=5
 ENV RAILS_ENV=production_postgresql
 ENV PORT=8080
 ENV REDIS_URL=redis://localhost:6379/0
-CMD service redis-server start && \
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    service redis-server start && \
     bin/rails server

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
@@ -19,8 +19,8 @@ ENV RACK_ENV=production
 ENV DBTYPE=postgresql
 
 ENV MAX_THREADS=5
-ENV WEB_CONCURRENCY=auto
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -18,9 +18,9 @@ RUN bundle install --jobs=8
 ENV RACK_ENV=production
 ENV DBTYPE=mysql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
@@ -16,9 +16,9 @@ RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
@@ -16,9 +16,9 @@ RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=mysql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -C config/puma.rb -b tcp://0.0.0.0:8080

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -16,7 +16,6 @@ RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -16,9 +16,9 @@ RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=mysql
 
-ENV WEB_CONCURRENCY=auto
 ENV MAX_THREADS=5
 
 EXPOSE 8080
 
-CMD bundle exec puma -b tcp://0.0.0.0:8080
+CMD export WEB_CONCURRENCY=$(($(nproc)*5/4)) && \
+    bundle exec puma -b tcp://0.0.0.0:8080


### PR DESCRIPTION
WEB_CONCURRENCY=auto sets the number of workers to the number of processors. Setting it to 1.25 the number of processors seems to perform better.