### PR TITLE
[ruby/rails] Remove references to Agoo

### DIFF
--- a/frameworks/Ruby/rails/app/controllers/concerns/date_header.rb
+++ b/frameworks/Ruby/rails/app/controllers/concerns/date_header.rb
@@ -2,7 +2,7 @@ module DateHeader
   extend ActiveSupport::Concern
 
   included do
-    if defined?(Agoo) || defined?(Falcon) || defined?(Puma)
+    if defined?(Falcon) || defined?(Puma)
       before_action :add_header
     end
   end

--- a/frameworks/Ruby/rails/config/routes.rb
+++ b/frameworks/Ruby/rails/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  JsonApp = if defined?(Falcon) || defined?(Puma) || defined?(Agoo)
+  JsonApp = if defined?(Falcon) || defined?(Puma)
     ->(env) do
       [200,
        {
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
     end
   end
 
-  PlaintextApp = if defined?(Falcon) || defined?(Puma) || defined?(Agoo)
+  PlaintextApp = if defined?(Falcon) || defined?(Puma)
     ->(env) do
       [200,
        {


### PR DESCRIPTION
Rails is no longer tested with Agoo.