### PR TITLE
[ruby/puma] Set MIN_THREADS as well for Puma

### DIFF
--- a/frameworks/Ruby/grape/grape.dockerfile
+++ b/frameworks/Ruby/grape/grape.dockerfile
@@ -15,6 +15,7 @@ RUN bundle config set with 'puma'
 RUN bundle install --jobs=8 --gemfile=/grape/Gemfile
 
 ENV WEB_CONCURRENCY=auto
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel-postgres.dockerfile
@@ -17,6 +17,7 @@ RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=postgresql
 
+ENV MIN_THREADS=8
 ENV MAX_THREADS=8
 
 EXPOSE 8080

--- a/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
+++ b/frameworks/Ruby/rack-sequel/rack-sequel.dockerfile
@@ -17,6 +17,7 @@ RUN bundle install --jobs=4 --gemfile=/rack-sequel/Gemfile
 
 ENV DBTYPE=mysql
 
+ENV MIN_THREADS=8
 ENV MAX_THREADS=8
 
 EXPOSE 8080

--- a/frameworks/Ruby/rack/rack-zjit.dockerfile
+++ b/frameworks/Ruby/rack/rack-zjit.dockerfile
@@ -18,6 +18,7 @@ RUN bundle install --jobs=8
 
 COPY . .
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/rack/rack.dockerfile
+++ b/frameworks/Ruby/rack/rack.dockerfile
@@ -18,6 +18,7 @@ RUN bundle install --jobs=8
 
 COPY . .
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel-postgres.dockerfile
@@ -18,6 +18,7 @@ RUN bundle install --jobs=8
 ENV RACK_ENV=production
 ENV DBTYPE=postgresql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
+++ b/frameworks/Ruby/roda-sequel/roda-sequel.dockerfile
@@ -18,6 +18,7 @@ RUN bundle install --jobs=8
 ENV RACK_ENV=production
 ENV DBTYPE=mysql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel-postgres.dockerfile
@@ -16,6 +16,7 @@ RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
+++ b/frameworks/Ruby/sinatra-sequel/sinatra-sequel.dockerfile
@@ -16,6 +16,7 @@ RUN bundle install --jobs=4 --gemfile=/sinatra-sequel/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=mysql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra-postgres.dockerfile
@@ -16,6 +16,7 @@ RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=postgresql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080

--- a/frameworks/Ruby/sinatra/sinatra.dockerfile
+++ b/frameworks/Ruby/sinatra/sinatra.dockerfile
@@ -16,6 +16,7 @@ RUN bundle install --jobs=4 --gemfile=/sinatra/Gemfile
 ENV APP_ENV=production
 ENV DBTYPE=mysql
 
+ENV MIN_THREADS=5
 ENV MAX_THREADS=5
 
 EXPOSE 8080


### PR DESCRIPTION
Setting the MIN_THREADS makes the benchmarks more deterministic when testing single tests that might not activate all threads.