### PR TITLE
[MongoDB] Add environment variable to enable per-CPU memory pools for tcmalloc

### DIFF
--- a/toolset/databases/mongodb/mongodb.dockerfile
+++ b/toolset/databases/mongodb/mongodb.dockerfile
@@ -1,5 +1,6 @@
 FROM mongo:8.0
 
 ENV MONGO_INITDB_DATABASE=hello_world
+ENV MONGO_TCMALLOC_PER_CPU_CACHE_SIZE_BYTES=16777216
 
 COPY create.js /docker-entrypoint-initdb.d/


### PR DESCRIPTION
per-CPU memory pools are currently not working in docker containers ([MongoDB ticket](https://jira.mongodb.org/browse/SERVER-109273)). To enable this the `MONGO_TCMALLOC_PER_CPU_CACHE_SIZE_BYTES` environment flag can be set. This workaround should improve performance.

A value of 16777216 has been chosen because this is 1/4 of the total memory size for the servers the benchmark runs on ([Citrine has 64gb of memory](https://www.techempower.com/benchmarks/#section=environment)). 