### PR TITLE
[java/act] Tag some tests as broken

### DIFF
--- a/frameworks/Java/act/benchmark_config.json
+++ b/frameworks/Java/act/benchmark_config.json
@@ -120,7 +120,8 @@
       "database_os": "Linux",
       "display_name": "act-eclipselink-pgsql",
       "notes": "",
-      "versus": "undertow-postgresql"
+      "versus": "undertow-postgresql",
+      "tags": ["broken"]
     },
     "eclipselink-pgsql-rythm": {
       "fortune_url": "/fortunes",


### PR DESCRIPTION
Act exceed the number of allowed tests of 10.
This tags failing tests as broken.