### PR TITLE
[php/ubiquity] Tag a test as broken

### DIFF
--- a/frameworks/PHP/ubiquity/benchmark_config.json
+++ b/frameworks/PHP/ubiquity/benchmark_config.json
@@ -177,7 +177,8 @@
         "database_os": "Linux",
         "display_name": "ubiquity-workerman-mongo",
         "notes": "",
-        "versus": "php"
+        "versus": "php",
+        "tags": ["broken"]
       },
       "workerman-raw": {
         "json_url": "/Json_",


### PR DESCRIPTION
ubiquity-workerman-mongo had problems starting or stopping.
https://tfb-status.techempower.com/results/125d9074-7092-41c0-8545-5df64cb5302b

Ubiquity also defines 12 tests in benchmark_config.json (max is 10).

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
