### PR TITLE
Fix the filter for broken tests in maximum test detection

### DIFF
--- a/toolset/utils/metadata.py
+++ b/toolset/utils/metadata.py
@@ -184,7 +184,7 @@ class Metadata:
         # Loop over them and parse each into a FrameworkTest
         for test in config['tests']:
 
-            tests_to_run = [name for (name, keys) in test.items()]
+            tests_to_run = test.keys()
 
             if "default" not in tests_to_run:
                 log("Framework %s does not define a default test in benchmark_config.json"
@@ -193,8 +193,8 @@ class Metadata:
 
             # Check that each framework does not have more than the maximum number of tests
             maximum_tests = 10
-            non_broken_tests_filter = lambda test: (not hasattr(test, "tags")) or ("broken" not in test.tags)
-            non_broken_tests_to_run = list(filter(non_broken_tests_filter, tests_to_run))
+            non_broken_tests_filter = lambda test: (not ("tags" in test.keys() and ("broken" in test["tags"])))
+            non_broken_tests_to_run = list(filter(non_broken_tests_filter, test.values()))
             if len(non_broken_tests_to_run) > maximum_tests:
                 message = [
                     "Framework %s defines %s tests in benchmark_config.json (max is %s)."


### PR DESCRIPTION
The original implementation didn't correctly filter broken tests.
For example "go" has some tests tagged as broken, but all tests are counted.

Ouput before:

```
Framework cutelyst defines 14 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework ffead-cpp defines 14 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework go defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework falcon defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework officefloor defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework act defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework micronaut defines 12 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework pippo defines 12 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework php defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework ubiquity defines 12 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
```

Output after:
```
Framework cutelyst defines 14 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework falcon defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework micronaut defines 12 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework pippo defines 12 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
Framework php defines 11 tests in benchmark_config.json (max is 10).
Contact maintainers and remove deprecated or discarded ones to make room.
```

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
