### PR TITLE
[ruby/sequel] Require sequel_pg as recommended

### DIFF
--- a/frameworks/Ruby/rack-app/Gemfile
+++ b/frameworks/Ruby/rack-app/Gemfile
@@ -5,10 +5,10 @@ source 'https://rubygems.org'
 gem 'rack-app'
 gem 'rack-app-front_end'
 gem 'cgi' # for Ruby 4.0
-gem 'iodine', '~> 0.7', platforms: %i[ruby windows]
+gem 'iodine', '~> 0.7'
 gem 'irb' # for Ruby 3.5
 gem 'logger' # for Ruby 3.5
 gem 'json', '~> 2.10'
 gem 'pg', '~> 1.5'
 gem 'sequel', '~> 5.0'
-gem 'sequel_pg', '~> 1.6', require: false
+gem 'sequel_pg', '~> 1.17', require: 'sequel'

--- a/frameworks/Ruby/rack-app/Gemfile.lock
+++ b/frameworks/Ruby/rack-app/Gemfile.lock
@@ -59,7 +59,7 @@ DEPENDENCIES
   rack-app
   rack-app-front_end
   sequel (~> 5.0)
-  sequel_pg (~> 1.6)
+  sequel_pg (~> 1.17)
 
 BUNDLED WITH
-   4.0.3
+  4.0.3

--- a/frameworks/Ruby/rack-sequel/Gemfile
+++ b/frameworks/Ruby/rack-sequel/Gemfile
@@ -6,12 +6,12 @@ gem 'rack', '~> 3.1'
 gem "concurrent-ruby"
 
 group :mysql, optional: true do
-  gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
+  gem 'trilogy', '~> 2.9'
 end
 
 group :postgresql, optional: true do
-  gem 'pg', '~> 1.5', platforms: [:ruby, :windows]
-  gem 'sequel_pg', '~> 1.6', platforms: :ruby, require: false
+  gem 'pg', '~> 1.5'
+  gem 'sequel_pg', '~> 1.17', require: 'sequel'
 end
 
 group :puma, optional: true do

--- a/frameworks/Ruby/rack-sequel/Gemfile.lock
+++ b/frameworks/Ruby/rack-sequel/Gemfile.lock
@@ -30,8 +30,8 @@ DEPENDENCIES
   puma (~> 7.0)
   rack (~> 3.1)
   sequel (~> 5.0)
-  sequel_pg (~> 1.6)
+  sequel_pg (~> 1.17)
   trilogy (~> 2.9)
 
 BUNDLED WITH
-   4.0.3
+  4.0.3

--- a/frameworks/Ruby/rack/Gemfile
+++ b/frameworks/Ruby/rack/Gemfile
@@ -11,7 +11,7 @@ gem 'jdbc-postgres', '~> 42.2', platforms: :jruby, require: 'jdbc/postgres'
 gem 'json', '~> 2.10'
 gem 'pg', '~> 1.5', platforms: %i[ruby windows]
 gem 'sequel'
-gem 'sequel_pg', platforms: %i[ruby windows]
+gem 'sequel_pg', platforms: %i[ruby windows], require: 'sequel'
 gem 'tzinfo-data', '1.2023.3'
 
 group :falcon, optional: true do

--- a/frameworks/Ruby/rage-sequel/Gemfile
+++ b/frameworks/Ruby/rage-sequel/Gemfile
@@ -4,4 +4,4 @@ gem "rage-rb", "~> 1.19"
 
 gem "pg", "~> 1.0"
 gem 'sequel', '~> 5.0'
-gem 'sequel_pg', '~> 1.6', platforms: :ruby, require: false
+gem 'sequel_pg', '~> 1.17', require: 'sequel'

--- a/frameworks/Ruby/rage-sequel/Gemfile.lock
+++ b/frameworks/Ruby/rage-sequel/Gemfile.lock
@@ -31,11 +31,10 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
-  logger
   pg (~> 1.0)
   rage-rb (~> 1.19)
   sequel (~> 5.0)
-  sequel_pg (~> 1.6)
+  sequel_pg (~> 1.17)
 
 BUNDLED WITH
-   4.0.3
+  4.0.3

--- a/frameworks/Ruby/roda-sequel/Gemfile
+++ b/frameworks/Ruby/roda-sequel/Gemfile
@@ -9,12 +9,12 @@ gem "cgi" # Make sure the h plugin uses the faster CGI.escape_html
 gem "concurrent-ruby"
 
 group :mysql, optional: true do
-  gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
+  gem "trilogy", "~> 2.9"
 end
 
 group :postgresql, optional: true do
-  gem "pg", "~> 1.4", platforms: %i[ruby windows]
-  gem "sequel_pg", "~> 1.17", platforms: :ruby, require: false
+  gem "pg", "~> 1.4"
+  gem "sequel_pg", "~> 1.17", require: "sequel"
 end
 
 group :iodine, optional: true do

--- a/frameworks/Ruby/sinatra-sequel/Gemfile
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile
@@ -2,19 +2,19 @@ source 'https://rubygems.org'
 
 gem 'json', '~> 2.8'
 gem 'sequel', '~> 5.0'
-gem 'sinatra', '~> 4.0', :require=>'sinatra/base'
+gem 'sinatra', '~> 4.0', require: 'sinatra/base'
 
 group :mysql, optional: true do
-  gem 'trilogy', '~> 2.9', platforms: [:ruby, :windows]
+  gem 'trilogy', '~> 2.9'
 end
 
 group :postgresql, optional: true do
-  gem 'pg', '~> 1.5', :platforms=>[:ruby, :windows]
-  gem 'sequel_pg', '~> 1.6', :platforms=>:ruby, :require=>false
+  gem 'pg', '~> 1.5'
+  gem 'sequel_pg', '~> 1.17', require: 'sequel'
 end
 
 group :iodine, optional: true do
-  gem 'iodine', '~> 0.7', platforms: [:ruby, :windows], require: false
+  gem 'iodine', '~> 0.7', require: false
 end
 
 group :puma, optional: true do

--- a/frameworks/Ruby/sinatra-sequel/Gemfile.lock
+++ b/frameworks/Ruby/sinatra-sequel/Gemfile.lock
@@ -51,9 +51,9 @@ DEPENDENCIES
   pg (~> 1.5)
   puma (~> 7.1)
   sequel (~> 5.0)
-  sequel_pg (~> 1.6)
+  sequel_pg (~> 1.17)
   sinatra (~> 4.0)
   trilogy (~> 2.9)
 
 BUNDLED WITH
-   4.0.3
+  4.0.3


### PR DESCRIPTION
See: https://github.com/jeremyevans/sequel_pg?tab=readme-ov-file#label-Known+Issues

Also remove platform option as these all run on MRI.