### PR TITLE
[java/spring] Set maxPoolSize to 256 for mongo variant

### DIFF
--- a/frameworks/Java/spring/src/main/resources/application.yml
+++ b/frameworks/Java/spring/src/main/resources/application.yml
@@ -32,9 +32,7 @@ spring:
     exclude: org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration
 
 spring.data.mongodb:
-  host: tfb-database
-  port: 27017
-  database: hello_world
+  uri: mongodb://tfb-database:27017/hello_world?maxPoolSize=256
 
 ---
 spring:


### PR DESCRIPTION
Sets maxPoolSize to 256 instead of the default of 100. This is in line with the Postgres implementation which also explicitly sets maximum-pool-size to 256.

Current result:  9,002
https://www.techempower.com/benchmarks/#section=test&shareid=682da8d1-35c1-476a-8189-a843e570e6b8&test=query

With maxPoolSize=256:  16,136
https://www.techempower.com/benchmarks/#section=test&shareid=baa7d620-6977-4b1d-896e-86f583e883de&test=query