### PR TITLE
[ruby/sinatra] Inline filters

### DIFF
--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -32,42 +32,14 @@ class HelloWorld < Sinatra::Base
     set :add_charset, [mime_type(:html)]
   end
 
-  helpers do
-    def bounded_queries
-      queries = params[:queries].to_i
-      queries.clamp(QUERIES_MIN, QUERIES_MAX)
-    end
-
-    def json(data)
-      content_type :json
-      data.to_json
-    end
-
-    # Return a random number between 1 and MAX_PK
-    def rand1
-      rand(MAX_PK).succ
-    end
-  end
-
-  if defined?(Puma)
-    after do
-      response[SERVER_HEADER] = SERVER_STRING
-      response[DATE_HEADER] = Time.now.httpdate
-    end
-  else
-    after do
-      response[SERVER_HEADER] = SERVER_STRING
-    end
-  end
-
   # Test type 1: JSON serialization
   get '/json' do
-     json :message=>'Hello, World!'
+    render_json message: 'Hello, World!'
   end
 
   # Test type 2: Single database query
   get '/db' do
-    json World.with_pk(rand1).values
+    render_json World.with_pk(rand1).values
   end
 
   # Test type 3: Multiple database queries
@@ -80,19 +52,19 @@ class HelloWorld < Sinatra::Base
         end
       end
 
-    json worlds.map!(&:values)
+    render_json worlds.map!(&:values)
   end
 
   # Test type 4: Fortunes
   get '/fortunes' do
     @fortunes = Fortune.all
     @fortunes << Fortune.new(
-      :id=>0,
-      :message=>'Additional fortune added at request time.'
+      id: 0,
+      message: 'Additional fortune added at request time.'
     )
     @fortunes.sort_by!(&:message)
 
-    erb :fortunes, :layout=>true
+    render_html :fortunes
   end
 
   # Test type 5: Database updates
@@ -111,12 +83,51 @@ class HelloWorld < Sinatra::Base
       World.batch_update(worlds)
     end
 
-    json worlds.map!(&:values)
+    render_json worlds.map!(&:values)
   end
 
   # Test type 6: Plaintext
   get '/plaintext' do
+    render_text 'Hello, World!'
+  end
+
+  private
+
+  def render_json(data)
+    add_headers
+    content_type :json
+    data.to_json
+  end
+
+  def render_html(template)
+    add_headers
+    render :erb, template, layout: true
+  end
+
+  def render_text(content)
+    add_headers
     content_type :text
-    'Hello, World!'
+    content
+  end
+
+  def bounded_queries
+    queries = params[:queries].to_i
+    queries.clamp(QUERIES_MIN, QUERIES_MAX)
+  end
+
+  # Return a random number between 1 and MAX_PK
+  def rand1
+    rand(MAX_PK).succ
+  end
+
+  if defined?(Puma)
+    def add_headers
+      response[SERVER_HEADER] = SERVER_STRING
+      response[DATE_HEADER] = Time.now.httpdate
+    end
+  else
+    def add_headers
+      response[SERVER_HEADER] = SERVER_STRING
+    end
   end
 end


### PR DESCRIPTION
For every filter Sinatra calls Sinatra::Base#process_route, which gets the params from the route and enforces encoding.
This is somewhat overkill for setting some headers.

Instead we just can move this to some private methods.

This also move helpers to regular methods, as these methods aren't called in templates.