### PR TITLE
[toolset] Update MySQL to v 9.4

### DIFF
--- a/toolset/databases/mysql/mysql.dockerfile
+++ b/toolset/databases/mysql/mysql.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:9.5
+FROM mysql:9.4
 
 ENV MYSQL_ROOT_PASSWORD=root
 ENV MYSQL_USER=benchmarkdbuser


### PR DESCRIPTION
The frameworks don't find the IP for  tfb-database !!
Issues: getaddrinfo for tfb-database failed,  getaddrinfo ENOTFOUND tfb-database, ...

I updated before MySQL, without this problem.

EDIT: update to v9.4, with v9.5 and v9.6 don't find the _tfb-database_ ip, investigating a solution for that.