### PR TITLE
[go/gnet] Mark as stripped

### DIFF
--- a/frameworks/Go/gnet/benchmark_config.json
+++ b/frameworks/Go/gnet/benchmark_config.json
@@ -4,7 +4,7 @@
     "default": {
       "plaintext_url": "/plaintext",
       "port": 8080,
-      "approach": "Realistic",
+      "approach": "Stripped",
       "classification": "Platform",
       "database": "None",
       "framework": "gnet",


### PR DESCRIPTION
Gnet hardcodes HTTP headers, so it should be marked as Stripped: https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Go/gnet/src/main.go#L84-L86

See discussion:
https://github.com/TechEmpower/FrameworkBenchmarks/issues/9916#issuecomment-3411564238