### PR TITLE
[CSharp/beetlex] Mark core tests as stripped

### DIFF
--- a/frameworks/CSharp/beetlex/benchmark_config.json
+++ b/frameworks/CSharp/beetlex/benchmark_config.json
@@ -34,7 +34,7 @@
         "update_url": "/updates?queries=",
         "cached_query_url": "/cached-worlds?queries=",
         "port": 8080,
-        "approach": "Realistic",
+        "approach": "Stripped",
         "classification": "Platform",
         "database": "Postgres",
         "framework": "beetlex",


### PR DESCRIPTION
Beetlex hardcodes HTTP headers for the core tests, so it should be marked as Stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/CSharp/beetlex/PlatformBenchmarks/HttpHandler.plaintext.cs#L14-L18

Closes: https://github.com/TechEmpower/FrameworkBenchmarks/issues/9578