### PR TITLE
[CSharp/touchsocket] Mark platform tests as stripped

### DIFF
--- a/frameworks/CSharp/touchsocket/benchmark_config.json
+++ b/frameworks/CSharp/touchsocket/benchmark_config.json
@@ -82,7 +82,7 @@
         "plaintext_url": "/plaintext",
         "json_url": "/json",
         "port": 8080,
-        "approach": "Realistic",
+        "approach": "Stripped",
         "classification": "Platform",
         "database": "Postgres",
         "framework": "touchsocket.httpplatform",


### PR DESCRIPTION
Touchsocket hardcodes HTTP headers for the platform tests, so it should be marked as Stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/CSharp/touchsocket/src/TouchSocketHttpPlatform/MyTcpSessionClientBase.cs#L51-L61

From the [Test Requirements](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview):
> All implementations are expected (but not required) to be based on robust implementations of the HTTP protocol. Implementations that are not based on a realistic HTTP implementation will be marked as Stripped.

Closes: https://github.com/TechEmpower/FrameworkBenchmarks/issues/9578