### PR TITLE
[Rust/faf] Mark as stripped

### DIFF
--- a/frameworks/Rust/faf/benchmark_config.json
+++ b/frameworks/Rust/faf/benchmark_config.json
@@ -5,7 +5,7 @@
          "default": {
             "plaintext_url": "/plaintext",
             "port": 8080,
-            "approach": "Realistic",
+            "approach": "Stripped",
             "classification": "Platform",
             "database": "None",
             "framework": "faf",


### PR DESCRIPTION
Faf hardcodes HTTP headers, so it should be marked as stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Rust/faf/src/main.rs#L33

From the [Test Requirements](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview):
> All implementations are expected (but not required) to be based on robust implementations of the HTTP protocol. Implementations that are not based on a realistic HTTP implementation will be marked as Stripped.

Closes: https://github.com/TechEmpower/FrameworkBenchmarks/issues/9578