### PR TITLE
[Rust/ntex] Mark platform tests as stripped

### DIFF
--- a/frameworks/Rust/ntex/benchmark_config.json
+++ b/frameworks/Rust/ntex/benchmark_config.json
@@ -119,7 +119,7 @@
         "json_url": "/json",
         "plaintext_url": "/plaintext",
         "port": 8080,
-        "approach": "Realistic",
+        "approach": "Stripped",
         "classification": "Platform",
         "database": "Postgres",
         "framework": "ntex",


### PR DESCRIPTION
Ntex hardcodes HTTP headers for the platform tests, so it should be marked as stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Rust/ntex/src/main_plt.rs#L13-L14

From the [Test Requirements](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview):
> All implementations are expected (but not required) to be based on robust implementations of the HTTP protocol. Implementations that are not based on a realistic HTTP implementation will be marked as Stripped.

Closes: https://github.com/TechEmpower/FrameworkBenchmarks/issues/9578