### PR TITLE
[Rust/sib] Mark as stripped

### DIFF
--- a/frameworks/Rust/sib/benchmark_config.json
+++ b/frameworks/Rust/sib/benchmark_config.json
@@ -6,7 +6,7 @@
         "json_url": "/json",
         "plaintext_url": "/plaintext",
         "port": 8080,
-        "approach": "Realistic",
+        "approach": "Stripped",
         "classification": "Fullstack",
         "framework": "sib",
         "language": "Rust",


### PR DESCRIPTION
Sib hardcodes HTTP headers, so it should be marked as stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Rust/sib/src/main.rs#L34-L39

From the [Test Requirements](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview):
> All implementations are expected (but not required) to be based on robust implementations of the HTTP protocol. Implementations that are not based on a realistic HTTP implementation will be marked as Stripped.