### PR TITLE
[ruby/sequel] Use setter methods instead of Hash

### DIFF
--- a/frameworks/Ruby/rack-app/app.rb
+++ b/frameworks/Ruby/rack-app/app.rb
@@ -23,10 +23,12 @@ class App < Rack::App
   helpers do
     def fortunes
       fortunes = Fortune.all
-      fortunes << Fortune.new(
-        id: 0,
-        message: "Additional fortune added at request time."
-      )
+
+      fortune = Fortune.new
+      fortune.id = 0
+      fortune.message = "Additional fortune added at request time."
+      fortunes << fortune
+
       fortunes.sort_by!(&:message)
     end
   end

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -48,10 +48,12 @@ class HelloWorld
 
   def fortunes
     fortunes = Fortune.all
-    fortunes << Fortune.new(
-      id: 0,
-      message: 'Additional fortune added at request time.'
-    )
+
+    fortune = Fortune.new
+    fortune.id = 0
+    fortune.message = "Additional fortune added at request time."
+    fortunes << fortune
+
     fortunes.sort_by!(&:message)
 
     html = String.new(<<~'HTML')

--- a/frameworks/Ruby/rage-sequel/app/controllers/benchmarks_controller.rb
+++ b/frameworks/Ruby/rage-sequel/app/controllers/benchmarks_controller.rb
@@ -26,7 +26,11 @@ class BenchmarksController < ApplicationController
   def fortunes
     records = Fortune.all
 
-    records << Fortune.new(id: 0, message: "Additional fortune added at request time.")
+    fortune = Fortune.new
+    fortune.id = 0
+    fortune.message = "Additional fortune added at request time."
+    records << fortune
+
     records.sort_by!(&:message)
 
     render plain: FORTUNES_TEMPLATE.result(binding)

--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -67,10 +67,12 @@ class HelloWorld < Roda
     r.is "fortunes" do
       response[CONTENT_TYPE] = HTML_TYPE
       @fortunes = Fortune.all
-      @fortunes << Fortune.new(
-        id: 0,
-        message: "Additional fortune added at request time."
-      )
+
+      fortune = Fortune.new
+      fortune.id = 0
+      fortune.message = "Additional fortune added at request time."
+      @fortunes << fortune
+
       @fortunes.sort_by!(&:message)
       view :fortunes
     end

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -58,10 +58,12 @@ class HelloWorld < Sinatra::Base
   # Test type 4: Fortunes
   get '/fortunes' do
     @fortunes = Fortune.all
-    @fortunes << Fortune.new(
-      id: 0,
-      message: 'Additional fortune added at request time.'
-    )
+
+    fortune = Fortune.new
+    fortune.id = 0
+    fortune.message = "Additional fortune added at request time."
+    @fortunes << fortune
+
     @fortunes.sort_by!(&:message)
 
     render_html :fortunes

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -65,10 +65,10 @@ class HelloWorld < Sinatra::Base
     @fortunes = ActiveRecord::Base.with_connection do
       Fortune.all
     end.to_a
-    @fortunes << Fortune.new(
-      id: 0,
-      message: 'Additional fortune added at request time.'
-    )
+    fortune = Fortune.new
+    fortune.id = 0
+    fortune.message = "Additional fortune added at request time."
+    @fortunes << fortune
     @fortunes.sort_by!(&:message)
 
     render_html :fortunes


### PR DESCRIPTION
Creating a model from a hash calls `Sequel::Model::InstanceMethods#set_restricted` which checks if the keys are defined as setter methods. Calling the setter methods directly perform better.