### PR TITLE
[swift/swift-nio] Mark tests as stripped

### DIFF
--- a/frameworks/Swift/swift-nio/benchmark_config.json
+++ b/frameworks/Swift/swift-nio/benchmark_config.json
@@ -5,7 +5,7 @@
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "port": 8080,
-      "approach": "Realistic",
+      "approach": "Stripped",
       "classification": "Platform",
       "database": "None",
       "framework": "None",


### PR DESCRIPTION
Swift precalculates Content-Length HTTP headers, so these tests should be marked as stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Swift/swift-nio/app/Sources/main.swift#L13-L18

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Swift/swift-nio/app/Sources/main.swift#L68

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Swift/swift-nio/app/Sources/main.swift#L74