### PR TITLE
[java/vertx] Mark tests as stripped

### DIFF
--- a/frameworks/Java/vertx/benchmark_config.json
+++ b/frameworks/Java/vertx/benchmark_config.json
@@ -5,7 +5,7 @@
       "json_url": "/json",
       "plaintext_url": "/plaintext",
       "port": 8080,
-      "approach": "Realistic",
+      "approach": "Stripped",
       "classification": "Platform",
       "database": "None",
       "framework": "Vert.x",


### PR DESCRIPTION
Vertx precalculates HTTP headers, so these tests should be marked as stripped:

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Java/vertx/src/main/java/vertx/App.java#L89

https://github.com/TechEmpower/FrameworkBenchmarks/blob/d36a2ede0db5c69d70da421e2f48aea53973c0c5/frameworks/Java/vertx/src/main/java/vertx/App.java#L129-L146