### PR TITLE
[fortran] Fortran.io marked as broken

### DIFF
--- a/frameworks/Fortran/fortran.io/benchmark_config.json
+++ b/frameworks/Fortran/fortran.io/benchmark_config.json
@@ -18,7 +18,8 @@
         "database_os": "Linux",
         "display_name": "Fortran.io",
         "notes": "",
-        "versus": "None"
+        "versus": "None",
+        "tags": [ "broken" ]
       }
     }
   ]

--- a/frameworks/Fortran/fortran.io/nginx.conf
+++ b/frameworks/Fortran/fortran.io/nginx.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  auto;
 
-error_log  /var/log/nginx/error.log notice;
+error_log  stderr error;
 pid        /var/run/nginx.pid;
 
 
@@ -13,11 +13,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log  /var/log/nginx/access.log  main;
+    access_log  off;
 
     sendfile        on;
     keepalive_timeout  65;


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Fail for a lot of time in the runs.

Also clean `nginx.conf`.

PD: It's using `nginx:latest` :stuck_out_tongue_closed_eyes: tried with versions, but now those images use Trixie.