### PR TITLE
[julia/jewelia] Marked as broken

### DIFF
--- a/frameworks/Julia/Jewelia/benchmark_config.json
+++ b/frameworks/Julia/Jewelia/benchmark_config.json
@@ -22,7 +22,8 @@
         "database_os": "Linux",
         "display_name": "Jewelia",
         "notes": "",
-        "versus": "None"
+        "versus": "None",
+        "tags": [ "broken" ]
       }
     }]
 }


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Fail in the last runs.


@abrowao @donavindebartolo @Jayenn @KadeBerry Please fix it.
And don't use _latest_ as image `ubuntu:latest`

Log with the fail:
https://tfb-status.techempower.com/unzip/results.2026-01-26-17-36-11-536.zip/results/20260118211352/jewelia/run/jewelia.log