### PR TITLE
[js/mesh] Mysql variant marked as broken

### DIFF
--- a/frameworks/JavaScript/mesh/benchmark_config.json
+++ b/frameworks/JavaScript/mesh/benchmark_config.json
@@ -86,7 +86,8 @@
         "database_os": "Linux",
         "display_name": "Mesh",
         "notes": "",
-        "versus": "nodejs"
+        "versus": "nodejs",
+        "tags": ["broken"]
       }
     }
   ]


### PR DESCRIPTION
Fail from the last Mysql update.

`sqlMessage: 'Client does not support authentication protocol requested by server; consider upgrading MySQL client',`

@gabrielcursino Please fix it. Thank you.

EDIT: MongoDb variant also marked as broken.