### PR TITLE
[c++/cpoll_cppsp] Marked postgresql raw variant as broken

### DIFF
--- a/frameworks/C++/cpoll_cppsp/benchmark_config.json
+++ b/frameworks/C++/cpoll_cppsp/benchmark_config.json
@@ -57,7 +57,8 @@
       "database_os": "Linux",
       "display_name": "cpoll-cppsp-raw",
       "notes": "",
-      "versus": "cpoll_cppsp"
+      "versus": "cpoll_cppsp",
+      "tags": [ "broken" ]
     },
     "postgres-raw-threadpool": {
       "db_url": "/db_pg_threadpool",


### PR DESCRIPTION
All other db variants were marked as broken before.
Fail in the runs.

Here exist also to many variants for separate the tests. Only this small variant marked, need 8 minutes to build.