### PR TITLE
[c++/cppcms] Postgres variant marked as broken

### DIFF
--- a/frameworks/C++/cppcms/benchmark_config.json
+++ b/frameworks/C++/cppcms/benchmark_config.json
@@ -40,7 +40,8 @@
       "os": "Linux",
       "database_os": "Linux",
       "display_name": "CppCMS-PostgreSQL-nginx",
-      "notes": ""
+      "notes": "",
+      "tags": [ "broken" ]
     }
   }]
 }


### PR DESCRIPTION
Fail from the last Postgres update.

`cppcms, error: Caught exception [cppdb::posgresql: failed to connect: SCRAM authentication requires libpq version 10 or above
cppcms-postgres: ]`

@ecruz-te @ekudritski Please fix it. Thank you.