### PR TITLE
[rust/tachyon-concept] Marked as broken

### DIFF
--- a/frameworks/Rust/tachyon-concept/benchmark_config.json
+++ b/frameworks/Rust/tachyon-concept/benchmark_config.json
@@ -19,7 +19,8 @@
         "database_os": "Linux",
         "display_name": "Tachyon-Concept",
         "notes": "",
-        "versus": "None"
+        "versus": "None",
+        "tags": [ "broken" ]
       },
       "ub": {
         "json_url": "/json",
@@ -38,7 +39,8 @@
         "database_os": "Linux",
         "display_name": "Tachyon-Concept-UB",
         "notes": "",
-        "versus": "None"
+        "versus": "None",
+        "tags": [ "broken" ]
       }
     }
   ]


### PR DESCRIPTION
Fail in the last runs.

@TachyonConcepts @vladcoderlab Please fix it. Thank you.


A good example of use `rust:latest` and later fail.

Please is not permited:
* `rust:latest` please pick an exact version 
* `rustup install nightly`
* `git clone` without a tag

https://github.com/TechEmpower/FrameworkBenchmarks/pull/10650#issuecomment-3855314367

PD: and the new PR will not be accepted, as https://github.com/TechEmpower/FrameworkBenchmarks/issues/8420
