### PR TITLE
[haskell/wizzardo-inline] Mark as broken

### DIFF
--- a/frameworks/Haskell/wizzardo-inline/benchmark_config.json
+++ b/frameworks/Haskell/wizzardo-inline/benchmark_config.json
@@ -20,7 +20,8 @@
         "database_os": "Linux",
         "display_name": "wizzardo-inline",
         "notes": "",
-        "versus": "warp"
+        "versus": "warp",
+        "tags": ["broken"]
       }
     }
   ]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Fail in the last runs.

@facundominguez Please fix it. Thank you.

Please try that the build use less time, now use 26 minutes (because fail before finish).