### PR TITLE
[java/quarkus] Mark as broken

### DIFF
--- a/frameworks/Java/quarkus/benchmark_config.json
+++ b/frameworks/Java/quarkus/benchmark_config.json
@@ -70,7 +70,8 @@
         "database_os": "Linux",
         "display_name": "Quarkus, Vert.x",
         "notes": "",
-        "versus": "Vert.x"
+        "versus": "Vert.x",
+        "tags": ["broken"]
       },
       "reactive-routes-pgclient": {
         "json_url": "/json",


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
Quarkus Vert-x variant marked as broken as fail in the last runs.

@tsegismont @Sanne @franz1981 @hatahet Please fix it. Thank you.

Another big problem is the use of constant for the length header that is not permitted.

https://github.com/TechEmpower/FrameworkBenchmarks/blob/33531b8fcf4ea52f8c885cb288c3ccfc52c8ba73/frameworks/Java/quarkus/vertx/src/main/java/io/quarkus/benchmark/resource/PlaintextHttpHandler.java#L15

https://github.com/TechEmpower/FrameworkBenchmarks/blob/33531b8fcf4ea52f8c885cb288c3ccfc52c8ba73/frameworks/Java/quarkus/vertx/src/main/java/io/quarkus/benchmark/resource/PlaintextHttpHandler.java#L20