### PR TITLE
[d/juptune] Fix build; use new built-in JSON serialiser

### DIFF
--- a/frameworks/D/juptune/benchmark_config.json
+++ b/frameworks/D/juptune/benchmark_config.json
@@ -1,5 +1,6 @@
 {
   "framework": "juptune",
+  "maintainers": ["BradleyChatha"],
   "tests": [
     {
       "default": {
@@ -20,7 +21,7 @@
         "display_name": "Juptune",
         "notes": "",
         "versus": "None",
-        "tags": [ "broken" ]
+        "tags": []
       }
     }
   ]

--- a/frameworks/D/juptune/juptune.dockerfile
+++ b/frameworks/D/juptune/juptune.dockerfile
@@ -1,23 +1,28 @@
-FROM debian:testing
+FROM debian:bookworm
 
 ARG LDC_VERSION=1.41.0
-ARG JUPTUNE_REF=30c9b1d8d0420990075d108445641b5b1de64875
-ARG TFB_TEST_NAME
-
-ENV TEST_NAME=${TFB_TEST_NAME}
+ARG JUPTUNE_REF=1b012d22d4e5e29e88fdf760be4cfa899ce3dfb2
 
 # Install system deps & LDC
 RUN apt update \
     && apt install -y curl xz-utils gnupg libsodium-dev meson unzip pkg-config clang cmake libssl-dev \
     && curl -fsS https://dlang.org/install.sh | bash -s ldc-${LDC_VERSION}
 
-# Install Juptune
+# Install Juptune (Bookworm's meson is kind of old so we have to rename meson.options, 
+#                  and some of the dependencies are older than what Juptune targets, but downgrading is fine for the benchmark's code.)
+#
+# I'm also trying to dummy out some executables from being built so the entire thing builds faster... need to add an option upstream to make that better.
 WORKDIR /juptune
 RUN curl -fsSL https://github.com/Juptune/juptune/archive/${JUPTUNE_REF}.zip -o code.zip \
     && unzip code.zip \
     && cd juptune* \
     && . ~/dlang/ldc-${LDC_VERSION}/activate \
+    && mv meson.options meson_options.txt \
     && sed -i 's/1.0.20/1.0.18/' meson.build \
+    && sed -i 's/3.5.0/1.0.18/' meson.build \
+    && sed -iE "s|.+./examples|#|" meson.build \
+    && sed -iE "s|^subdir|#|" meson.build \
+    && sed -iEz 's|juptune_all_unittest_exe[^)]+)|#|' meson.build \
     && meson setup build --buildtype release -Dlightweight-results=true -Ddefault_library=static \
     && meson install -C build
 


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
* Moves the Dockerfile back towards `debian:bookworm`
* Updates the version of Juptune being used.
* Replaces the adhoc serialiser with the proper one included with Juptune.
* Added myself as a maintainer of this test.

I've also ran this locally with: `./tfb --mode benchmark --test juptune`.