### PR TITLE
[rust/ohkami-rt_nio] Marked as broken

### DIFF
--- a/frameworks/Rust/ohkami/benchmark_config.json
+++ b/frameworks/Rust/ohkami/benchmark_config.json
@@ -1,5 +1,6 @@
 {
     "framework": "ohkami",
+    "maintainers": ["kanarus"],
     "tests": [
         {
             "default": {
@@ -72,7 +73,8 @@
                 "database_os":    "Linux",
                 "port":           8000,
                 "json_url":       "/json",
-                "plaintext_url":  "/plaintext"
+                "plaintext_url":  "/plaintext",
+                "tags": ["broken"]
             }
         }
     ]


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
https://tfb-status.techempower.com/unzip/results.2026-02-11-23-41-23-147.zip/results/20260204071442/ohkami-rt_nio/run/ohkami-rt_nio.log

@kanarus Please also check ohkami default:
https://tfb-status.techempower.com/unzip/results.2026-02-11-23-41-23-147.zip/ohkami

https://tfb-status.techempower.com/unzip/results.2026-02-11-23-41-23-147.zip/results/20260204071442/ohkami/fortune/raw.txt
https://tfb-status.techempower.com/unzip/results.2026-02-11-23-41-23-147.zip/results/20260204071442/ohkami/plaintext/raw.txt
...


* [ohkami] failed: json db query fortune update plaintext
* [ohkami-rt_nio] had problems starting or stopping