### PR TITLE
[C++] - introduce aeronet framework for /json and /plaintext endpoints

### DIFF
--- a/frameworks/C++/aeronet/CMakeLists.txt
+++ b/frameworks/C++/aeronet/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.23)
+project(techempower_aeronet CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Fetch aeronet from GitHub
+include(FetchContent)
+
+set(AERONET_GIT_TAG "main" CACHE STRING "Git tag/branch for aeronet")
+
+FetchContent_Declare(
+  aeronet
+  GIT_REPOSITORY https://github.com/sjanel/aeronet.git
+  GIT_TAG ${AERONET_GIT_TAG}
+  GIT_SHALLOW TRUE
+)
+
+# Configure aeronet with minimal features for TechEmpower
+set(AERONET_ENABLE_GLAZE ON CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_ASYNC_HANDLERS OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_HTTP2 OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_BROTLI OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_ZLIB OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_ZSTD OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_OPENSSL OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_OPENTELEMETRY OFF CACHE BOOL "" FORCE)
+set(AERONET_ENABLE_WEBSOCKET OFF CACHE BOOL "" FORCE)
+set(AERONET_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(AERONET_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(AERONET_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(aeronet)
+
+# TechEmpower benchmark executable
+add_executable(benchmark_techempower main.cpp)
+target_link_libraries(benchmark_techempower PRIVATE aeronet)
+

--- a/frameworks/C++/aeronet/README.md
+++ b/frameworks/C++/aeronet/README.md
@@ -1,0 +1,16 @@
+# Aeronet (TechEmpower Framework Benchmarks)
+
+[aeronet](https://github.com/sjanel/aeronet) is a modern C++23 HTTP/1.1 + HTTP/2 server library focused on low overhead and high throughput. This TechEmpower implementation targets the JSON and Plaintext tests using glaze for fast JSON serialization.
+
+## Test Endpoints
+
+- `GET /json` -> `{"message":"Hello, World!"}`
+- `GET /plaintext` -> `Hello, World!`
+
+## Notes
+
+- Built with C++23 and glaze 7.0.2.
+- Linux-only (epoll-based).
+- HTTP/1.1 keep-alive and pipelining supported.
+- TLS, WebSocket, and HTTP/2 supported but not enabled in this benchmark.
+- Other endpoints (e.g. database access) not implemented in this benchmark.

--- a/frameworks/C++/aeronet/aeronet.dockerfile
+++ b/frameworks/C++/aeronet/aeronet.dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:24.04 AS build
+
+ARG AERONET_GIT_TAG=main
+ARG BUILD_MODE=Release
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ninja-build \
+        cmake \
+        git \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY main.cpp CMakeLists.txt ./
+
+RUN mkdir build && cd build && \
+    cmake -GNinja \
+      -DCMAKE_BUILD_TYPE=${BUILD_MODE} \
+      -DAERONET_GIT_TAG=${AERONET_GIT_TAG} \
+      .. && \
+    cmake --build . --target benchmark_techempower && \
+    install -m 0755 benchmark_techempower /app/benchmark_techempower
+
+RUN mkdir -p /deps && \
+    ldd /app/benchmark_techempower \
+    | tr -s '[:blank:]' '\n' \
+    | grep '^/' \
+    | xargs -I % sh -c 'mkdir -p /deps$(dirname %); cp % /deps%;'
+
+FROM scratch
+
+COPY --from=build /etc/ssl/certs /etc/ssl/certs
+COPY --from=build /deps /
+COPY --from=build /app/benchmark_techempower /app/benchmark_techempower
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/benchmark_techempower"]

--- a/frameworks/C++/aeronet/benchmark_config.json
+++ b/frameworks/C++/aeronet/benchmark_config.json
@@ -1,0 +1,26 @@
+{
+  "framework": "aeronet",
+  "maintainers": [ "sjanel" ],
+  "tests": [
+    {
+      "default": {
+        "json_url": "/json",
+        "plaintext_url": "/plaintext",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Micro",
+        "database": "None",
+        "framework": "aeronet",
+        "language": "C++",
+        "orm": "Micro",
+        "platform": "Linux",
+        "webserver": "aeronet",
+        "os": "Linux",
+        "database_os": "Linux",
+        "dockerfile": "aeronet.dockerfile",
+        "notes": "Modern C++23 HTTP server with minimal overhead; JSON via glaze",
+        "versus": ""
+      }
+    }
+  ]
+}

--- a/frameworks/C++/aeronet/config.toml
+++ b/frameworks/C++/aeronet/config.toml
@@ -1,0 +1,15 @@
+[framework]
+name = "aeronet"
+
+[main]
+urls.plaintext = "/plaintext"
+urls.json = "/json"
+approach = "Realistic"
+classification = "Micro"
+database = "None"
+database_os = "Linux"
+os = "Linux"
+orm = "Micro"
+platform = "None"
+webserver = "None"
+versus = "None"

--- a/frameworks/C++/aeronet/main.cpp
+++ b/frameworks/C++/aeronet/main.cpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// TechEmpower Framework Benchmarks - Aeronet Implementation
+// Implements Test 1 (JSON) and Test 6 (Plaintext) endpoints
+
+#include <aeronet/aeronet.hpp>
+#include <aeronet/json-serializer.hpp>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <glaze/glaze.hpp>
+#include <iostream>
+#include <optional>
+#include <system_error>
+
+// Test 1: JSON message structure
+struct MessageResponse {
+  std::string_view message;
+};
+
+// Glaze metadata for JSON serialization
+template <>
+struct glz::meta<MessageResponse> {
+  using T = MessageResponse;
+  static constexpr auto value = glz::object("message", &T::message);
+};
+
+int main(int argc, char* argv[]) {
+  // Enable signal handler for graceful shutdown on Ctrl+C
+  aeronet::SignalHandler::Enable();
+
+  try {
+    using namespace aeronet;
+
+    auto parseEnvUInt = [](const char* envVar) -> std::optional<uint32_t> {
+      const char* value = std::getenv(envVar);
+      if (value == nullptr || value[0] == '\0') {
+        return std::nullopt;
+      }
+      uint32_t parsed = 0;
+      const auto [ptr, errc] = std::from_chars(value, value + std::strlen(value), parsed);
+      if (errc != std::errc{} || ptr != value + std::strlen(value)) {
+        return std::nullopt;
+      }
+      return parsed;
+    };
+
+    uint16_t port = 8080;
+    if (argc > 1) {
+      const auto [ptr, errc] = std::from_chars(argv[1], argv[1] + std::strlen(argv[1]), port);
+      if (errc != std::errc{} || ptr != argv[1] + std::strlen(argv[1])) {
+        std::cerr << "Invalid port number: " << argv[1] << "\n";
+        return EXIT_FAILURE;
+      }
+    }
+
+    HttpServerConfig config;
+    config.port = port;
+    if (const auto threads = parseEnvUInt("AERONET_THREADS"); threads.has_value()) {
+      config.nbThreads = *threads;
+    } else if (const auto threads = parseEnvUInt("THREADS"); threads.has_value()) {
+      config.nbThreads = *threads;
+    }
+
+    Router router;
+
+    // Test 6: Plaintext endpoint
+    // Returns a simple "Hello, World!" text response
+    router.setPath(http::Method::GET, "/plaintext", [](const HttpRequest& req) {
+      return req.makeResponse("Hello, World!", "text/plain; charset=UTF-8");
+    });
+
+    // Test 1: JSON endpoint
+    router.setPath(http::Method::GET, "/json", [](const HttpRequest& req) {
+      MessageResponse msg{"Hello, World!"};
+      return req.makeResponse(aeronet::SerializeToJson(msg), "application/json");
+    });
+
+    // Health check endpoint (optional, useful for Docker)
+    router.setPath(http::Method::GET, "/health",
+                   [](const HttpRequest& req) { return req.makeResponse("OK", "text/plain"); });
+
+    // Start the server
+    std::cout << "Starting TechEmpower benchmark server on port " << port << '\n';
+    std::cout << "  - JSON test (Test 1): GET /json\n";
+    std::cout << "  - Plaintext test (Test 6): GET /plaintext\n";
+    std::cout << "  - Health check: GET /health\n";
+
+    HttpServer server(config, std::move(router));
+    server.run();  // blocking run, until Ctrl+C
+
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << '\n';
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# Aeronet (TechEmpower Framework Benchmarks)

[aeronet](https://github.com/sjanel/aeronet) is a modern C++23 HTTP/1.1 + HTTP/2 server library focused on low overhead and high throughput. This TechEmpower implementation targets the JSON and Plaintext tests using glaze for fast JSON serialization.

## Test Endpoints

- `GET /json` -> `{"message":"Hello, World!"}`
- `GET /plaintext` -> `Hello, World!`

## Notes

- Built with C++23 and glaze 7.0.2.
- Linux-only (epoll-based).
- HTTP/1.1 keep-alive and pipelining supported.
- TLS, WebSocket, and HTTP/2 supported but not enabled in this benchmark.
- Other endpoints (e.g. database access) not implemented in this benchmark.
