### PR TITLE
[ruby/json] Use JSON.generate instead of Object#to_json

### DIFF
--- a/frameworks/Ruby/hanami/app/actions/db/index.rb
+++ b/frameworks/Ruby/hanami/app/actions/db/index.rb
@@ -11,7 +11,7 @@ module HelloWorld
         def handle(*, response)
           world = world_repo.find(random_id)
           response.format = :json
-          response.body = world.to_h.to_json
+          response.body = JSON.generate(world.to_h)
         end
 
         def random_id

--- a/frameworks/Ruby/hanami/app/actions/queries/index.rb
+++ b/frameworks/Ruby/hanami/app/actions/queries/index.rb
@@ -16,7 +16,7 @@ module HelloWorld
             world_repo.find(id)
           end
           response.format = :json
-          response.body = worlds.map(&:to_h).to_json
+          response.body = JSON.generate(worlds.map(&:to_h))
         end
 
         private

--- a/frameworks/Ruby/hanami/app/actions/updates/index.rb
+++ b/frameworks/Ruby/hanami/app/actions/updates/index.rb
@@ -16,7 +16,7 @@ module HelloWorld
             world_repo.update_random_number(id)
           end
           response.format = :json
-          response.body = worlds.to_json
+          response.body = JSON.generate(worlds)
         end
 
         private

--- a/frameworks/Ruby/hanami/config/routes.rb
+++ b/frameworks/Ruby/hanami/config/routes.rb
@@ -9,7 +9,7 @@ module HelloWorld
          'Content-Type' => 'application/json',
          'Date' => Time.now.httpdate,
        },
-       [{ 'message' => 'Hello, World!' }.to_json]]
+       [JSON.generate({ 'message' => 'Hello, World!' })]]
     end
     get "/db", to: "db.index"
     get "/queries", to: "queries.index"

--- a/frameworks/Ruby/padrino/app/controllers.rb
+++ b/frameworks/Ruby/padrino/app/controllers.rb
@@ -8,14 +8,14 @@ HelloWorld::App.controllers  do
   end
 
   get '/json', :provides => [:json] do
-    {message: "Hello, World!"}.to_json
+    JSON.generate({message: "Hello, World!"})
   end
 
   get '/db', :provides => [:json] do
     world = ActiveRecord::Base.with_connection do
       World.find(rand1).attributes
     end
-    world.to_json
+    JSON.generate(world)
   end
 
   get '/queries', :provides => [:json] do
@@ -24,7 +24,7 @@ HelloWorld::App.controllers  do
         World.find(id).attributes
       end
     end
-    worlds.to_json
+    JSON.generate(worlds)
   end
 
   get '/fortunes' do
@@ -51,7 +51,7 @@ HelloWorld::App.controllers  do
       World.upsert_all(worlds)
     end
 
-    worlds.to_json
+    JSON.generate(worlds)
   end
 
   get '/plaintext' do

--- a/frameworks/Ruby/rack-app/app.rb
+++ b/frameworks/Ruby/rack-app/app.rb
@@ -35,22 +35,23 @@ class App < Rack::App
 
   get '/json' do
     set_headers(JSON_TYPE)
-    { message: 'Hello, World!' }.to_json
+    JSON.generate({ message: 'Hello, World!' })
   end
 
   get '/db' do
     set_headers(JSON_TYPE)
-    World.with_pk(rand1).values.to_json
+    JSON.generate(World.with_pk(rand1).values)
   end
 
   get '/queries' do
     set_headers(JSON_TYPE)
     ids = ALL_IDS.sample(bounded_queries)
-    DB.synchronize do
+    worlds = DB.synchronize do
       ids.map do |id|
         World.with_pk(id).values
       end
-    end.to_json
+    end
+    JSON.generate(worlds)
   end
 
   get '/fortunes' do

--- a/frameworks/Ruby/rack-sequel/hello_world.rb
+++ b/frameworks/Ruby/rack-sequel/hello_world.rb
@@ -105,19 +105,19 @@ class HelloWorld
     case env['PATH_INFO']
     when '/json'
       # Test type 1: JSON serialization
-      respond JSON_TYPE, { message: 'Hello, World!' }.to_json
+      respond JSON_TYPE, JSON.generate({ message: 'Hello, World!' })
     when '/db'
       # Test type 2: Single database query
-      respond JSON_TYPE, db.to_json
+      respond JSON_TYPE, JSON.generate(db)
     when '/queries'
       # Test type 3: Multiple database queries
-      respond JSON_TYPE, queries(env).to_json
+      respond JSON_TYPE, JSON.generate(queries(env))
     when '/fortunes'
       # Test type 4: Fortunes
       respond HTML_TYPE, fortunes
     when '/updates'
       # Test type 5: Database updates
-      respond JSON_TYPE, updates(env).to_json
+      respond JSON_TYPE, JSON.generate(updates(env))
     when '/plaintext'
       # Test type 6: Plaintext
       respond PLAINTEXT_TYPE, 'Hello, World!'

--- a/frameworks/Ruby/rack/hello_world.rb
+++ b/frameworks/Ruby/rack/hello_world.rb
@@ -53,22 +53,22 @@ class HelloWorld
     when '/json'
       # Test type 1: JSON serialization
       respond JSON_TYPE,
-              { message: 'Hello, World!' }.to_json
+        JSON.generate({ message: 'Hello, World!' })
     when '/db'
       # Test type 2: Single database query
       id = random_id
-      respond JSON_TYPE, $db.with{ _1.select_world(id) }.to_json
+      respond JSON_TYPE, JSON.generate($db.with{ _1.select_world(id) })
     when '/queries'
       # Test type 3: Multiple database queries
       queries = bounded_queries(env)
-      respond JSON_TYPE, select_worlds(queries).to_json
+      respond JSON_TYPE, JSON.generate(select_worlds(queries))
     when '/fortunes'
       # Test type 4: Fortunes
       respond HTML_TYPE, fortunes
     when '/updates'
       # Test type 5: Database updates
       queries = bounded_queries(env)
-      respond JSON_TYPE, update_worlds(queries).to_json
+      respond JSON_TYPE, JSON.generate(update_worlds(queries))
     when '/plaintext'
       # Test type 6: Plaintext
       respond PLAINTEXT_TYPE, 'Hello, World!'

--- a/frameworks/Ruby/rails/config/routes.rb
+++ b/frameworks/Ruby/rails/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
          'Content-Type' => 'application/json',
          'Date' => Time.now.httpdate,
        },
-       [{ 'message' => 'Hello, World!' }.to_json]]
+       [JSON.generate({ 'message' => 'Hello, World!' })]]
     end
   else
     ->(env) do
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
          'Server' => 'Rails',
          'Content-Type' => 'application/json'
        },
-       [{ 'message' => 'Hello, World!' }.to_json]]
+       [JSON.generate({ 'message' => 'Hello, World!' })]]
     end
   end
 

--- a/frameworks/Ruby/roda-sequel/hello_world.rb
+++ b/frameworks/Ruby/roda-sequel/hello_world.rb
@@ -41,13 +41,13 @@ class HelloWorld < Roda
     # Test type 1: JSON serialization
     r.is "json" do
       response[CONTENT_TYPE] = JSON_TYPE
-      { message: "Hello, World!" }.to_json
+      JSON.generate({ message: "Hello, World!" })
     end
 
     # Test type 2: Single database query
     r.is "db" do
       response[CONTENT_TYPE] = JSON_TYPE
-      World.with_pk(rand1).values.to_json
+      JSON.generate(World.with_pk(rand1).values)
     end
 
     # Test type 3: Multiple database queries
@@ -60,7 +60,7 @@ class HelloWorld < Roda
             World.with_pk(id).values
           end
         end
-      worlds.to_json
+      JSON.generate(worlds)
     end
 
     # Test type 4: Fortunes
@@ -93,7 +93,7 @@ class HelloWorld < Roda
           end
         World.batch_update(worlds)
       end
-      worlds.map!(&:values).to_json
+      JSON.generate(worlds.map!(&:values))
     end
 
     # Test type 6: Plaintext

--- a/frameworks/Ruby/sinatra-sequel/hello_world.rb
+++ b/frameworks/Ruby/sinatra-sequel/hello_world.rb
@@ -104,7 +104,7 @@ class HelloWorld < Sinatra::Base
   def render_json(data)
     add_headers
     content_type :json
-    data.to_json
+    JSON.generate(data)
   end
 
   def render_html(template)

--- a/frameworks/Ruby/sinatra/hello_world.rb
+++ b/frameworks/Ruby/sinatra/hello_world.rb
@@ -109,7 +109,7 @@ class HelloWorld < Sinatra::Base
   def render_json(data)
     add_headers
     content_type :json
-    data.to_json
+    JSON.generate(data)
   end
 
   def render_html(template)


### PR DESCRIPTION
JSON.generate is faster than calling Object#to_json.

```ruby
require 'benchmark/ips'
require 'json'

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)

  x.report("to_json symbol") do
    { message: 'Hello, World!' }.to_json
  end

  x.report("to_json string") do
    { 'message' => 'Hello, World!' }.to_json
  end

  x.report("JSON.generate symbol") do
    JSON.generate({ message: 'Hello, World!' })
  end

  x.report("JSON.generate string") do
    JSON.generate({ 'message' => 'Hello, World!' })
  end

  x.compare!
end
```

```
ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [arm64-darwin24]
Warming up --------------------------------------
      to_json symbol   330.723k i/100ms
      to_json string   325.411k i/100ms
JSON.generate symbol   490.246k i/100ms
JSON.generate string   495.752k i/100ms
Calculating -------------------------------------
      to_json symbol      3.219M (± 8.2%) i/s  (310.65 ns/i) -     16.205M in   5.097780s
      to_json string      3.250M (± 3.5%) i/s  (307.67 ns/i) -     16.271M in   5.012989s
JSON.generate symbol      4.966M (± 1.5%) i/s  (201.35 ns/i) -     25.003M in   5.035419s
JSON.generate string      4.973M (± 2.1%) i/s  (201.10 ns/i) -     25.283M in   5.086778s

Comparison:
JSON.generate string:  4972636.6 i/s
JSON.generate symbol:  4966478.7 i/s - same-ish: difference falls within error
      to_json string:  3250251.2 i/s - 1.53x  slower
      to_json symbol:  3219106.9 i/s - 1.54x  slower
```

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
