### PR TITLE
[crystal/amber] Disable database tests, fail for years

### DIFF
--- a/frameworks/Crystal/amber/benchmark_config.json
+++ b/frameworks/Crystal/amber/benchmark_config.json
@@ -3,10 +3,6 @@
   "tests": [{
     "default": {
       "json_url": "/json",
-      "db_url": "/db",
-      "query_url": "/queries?queries=",
-      "fortune_url": "/fortunes",
-      "update_url": "/updates?queries=",
       "plaintext_url": "/plaintext",
       "port": 8080,
       "approach": "Realistic",


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
All the database tests fail:
* [[amber]](https://tfb-status.techempower.com/unzip/results.2025-12-24-21-28-10-233.zip/amber) failed: db query fortune update

https://tfb-status.techempower.com/unzip/results.2025-12-24-21-28-10-233.zip/results/20251217000450/amber/run/amber.log

Ping @crimson-knight @dragosv @vlazar
