### PR TITLE
Upgrade to Quarkus 3.32.2

### DIFF
--- a/frameworks/Java/quarkus/README.md
+++ b/frameworks/Java/quarkus/README.md
@@ -13,6 +13,10 @@ There are currently 2 implementations:
 
     ./tfb --mode verify --test quarkus quarkus-hibernate-reactive
 
+After the database container image is created, it can be started independently.
+
+    docker run -d --name tfb-database -e POSTGRES_DB=hello_world -e POSTGRES_PASSWORD=benchmarkdbpass -e POSTGRES_USER=benchmarkdbuser -p 5432:5432 techempower/postgres:latest
+
 ## Versions
 
 * [Java OpenJDK 17](http://openjdk.java.net/)

--- a/frameworks/Java/quarkus/pom.xml
+++ b/frameworks/Java/quarkus/pom.xml
@@ -8,15 +8,15 @@
     <packaging>pom</packaging>
 
     <properties>
-        <compiler-plugin.version>3.14.0</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
+        <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.21.2</quarkus.platform.version>
+        <quarkus.platform.version>3.32.2</quarkus.platform.version>
         <skipITs>true</skipITs>
-        <surefire-plugin.version>3.5.2</surefire-plugin.version>
+        <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <!-- Check https://github.com/netty/netty-incubator-transport-io_uring/tags -->
         <netty.io_uring.version>0.0.26.Final</netty.io_uring.version>
         <rocker.version>1.3.0</rocker.version>
@@ -61,6 +61,16 @@
     </dependencyManagement>
 
     <build>
+        <!--Required during the upgrade to Quarkus 3.32.2-->
+        <!--Otherwise, the container image build fails with:-->
+        <!--Could not find artifact io.netty:netty-transport-native-unix-common:jar:${os.detected.name}-${os.detected.arch}:4.1.130.Final in central-->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>${quarkus.platform.group-id}</groupId>
@@ -81,9 +91,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>

--- a/frameworks/Java/quarkus/quarkus-hibernate-reactive.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-hibernate-reactive.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=resteasy-reactive-hibernate-reactive

--- a/frameworks/Java/quarkus/quarkus-reactive-routes-pgclient.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-reactive-routes-pgclient.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=reactive-routes-pgclient

--- a/frameworks/Java/quarkus/quarkus-vertx.dockerfile
+++ b/frameworks/Java/quarkus/quarkus-vertx.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=vertx

--- a/frameworks/Java/quarkus/quarkus.dockerfile
+++ b/frameworks/Java/quarkus/quarkus.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-21:1.22 as maven
+FROM registry.access.redhat.com/ubi9/openjdk-25:1.24 as maven
 ENV LANGUAGE='en_US:en'
 
 WORKDIR /quarkus
@@ -29,7 +29,7 @@ WORKDIR /quarkus/$MODULE
 RUN mvn package -B -q
 WORKDIR /quarkus
 
-FROM registry.access.redhat.com/ubi9/openjdk-21-runtime:1.22
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
 ENV LANGUAGE='en_US:en'
 WORKDIR /quarkus
 ENV MODULE=resteasy-reactive-hibernate

--- a/frameworks/Java/quarkus/reactive-routes-pgclient/pom.xml
+++ b/frameworks/Java/quarkus/reactive-routes-pgclient/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -75,7 +75,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/pom.xml
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -24,31 +24,26 @@ public class WorldRepository extends BaseRepository {
         return inSession(s -> {
             final LocalRandom random = Randomizer.current();
             int MAX = 10000;
-            Uni<Void>[] unis = new Uni[MAX];
+            Uni<Void> loop = Uni.createFrom().voidItem();
             for (int i = 0; i < MAX; i++) {
                 final World world = new World();
                 world.setId(i + 1);
                 world.setRandomNumber(random.getNextRandom());
-                unis[i] = s.persist(world).map(v -> null);
+                loop = loop.call(() -> s.persist(world));
             }
-            return Uni.combine().all().unis(unis).with(l -> null)
-                    .flatMap(v -> s.flush())
-                    .map(v -> null);
+            return loop.call(s::flush);
         });
     }
 
-    public Uni<List<World>> update(Mutiny.Session session, List<World> worlds) {
-        return session
-                .setBatchSize(worlds.size())
-                .flush()
-                .map(v -> worlds);
+    public Uni<List<World>> update(Mutiny.StatelessSession session, List<World> worlds) {
+        return session.updateMultiple(worlds).replaceWith(worlds);
     }
 
     public Uni<List<World>> findStateless(int count) {
         return inStatelessSession(session -> findStateless(session, count));
     }
 
-    private Uni<List<World>> findStateless(Mutiny.StatelessSession s, int count) {
+    public Uni<List<World>> findStateless(Mutiny.StatelessSession s, int count) {
         //The rules require individual load: we can't use the Hibernate feature which allows load by multiple IDs
         // as one single operation as Hibernate is too smart and will switch to use batched loads automatically.
         // Hence, use this awkward alternative:
@@ -56,23 +51,9 @@ public class WorldRepository extends BaseRepository {
         final List<World> worlds = new ArrayList<>(count);
         Uni<Void> loopRoot = Uni.createFrom().voidItem();
         for (int i = 0; i < count; i++) {
-            loopRoot = loopRoot.chain(() -> s.get(World.class, localRandom.getNextRandom()).invoke(worlds::add).replaceWithVoid());
+            loopRoot = loopRoot.call(() -> s.get(World.class, localRandom.getNextRandom()).invoke(worlds::add));
         }
-        return loopRoot.map(v -> worlds);
-    }
-
-    public Uni<List<World>> findManaged(Mutiny.Session s, int count) {
-        final List<World> worlds = new ArrayList<>(count);
-        //The rules require individual load: we can't use the Hibernate feature which allows load by multiple IDs
-        // as one single operation as Hibernate is too smart and will switch to use batched loads.
-        // But also, we can't use "Uni#join" as we did in the above method as managed entities shouldn't use pipelining -
-        // so we also have to avoid Mutiny optimising things by establishing an explicit chain:
-        final LocalRandom localRandom = Randomizer.current();
-        Uni<Void> loopRoot = Uni.createFrom().voidItem();
-        for (int i = 0; i < count; i++) {
-            loopRoot = loopRoot.chain(() -> s.find(World.class, localRandom.getNextRandom()).invoke(worlds::add).replaceWithVoid());
-        }
-        return loopRoot.map(v -> worlds);
+        return loopRoot.replaceWith(worlds);
     }
 
     public Uni<World> findStateless() {

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/resource/DbResource.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/java/io/quarkus/benchmark/resource/DbResource.java
@@ -44,17 +44,14 @@ public class DbResource {
         return worldRepository.createData();
     }
 
-    private Uni<List<World>> randomWorldsForWrite(Mutiny.Session session, int count) {
-        return worldRepository.findManaged(session, count);
+    private Uni<List<World>> randomWorldsForWrite(Mutiny.StatelessSession session, int count) {
+        return worldRepository.findStateless(session, count);
     }
 
     @GET
     @Path("updates")
     public Uni<List<World>> updates(@QueryParam("queries") String queries) {
-        return worldRepository.inSession(session -> {
-
-            session.setFlushMode(FlushMode.MANUAL);
-
+        return worldRepository.inStatelessSession(session -> {
             Uni<List<World>> worlds = randomWorldsForWrite(session, parseQueryCount(queries));
             return worlds.flatMap(worldsCollection -> {
                 final LocalRandom localRandom = Randomizer.current();
@@ -66,7 +63,6 @@ public class DbResource {
                     //the verification:
                     w.setRandomNumber(localRandom.getNextRandomExcluding(previousRead));
                 } );
-
                 return worldRepository.update(session, worldsCollection);
             });
         });

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate-reactive/src/main/resources/application.properties
@@ -17,6 +17,8 @@ quarkus.hibernate-orm.second-level-caching-enabled=false
 
 #quarkus.vertx.storage=false
 
+quarkus.hibernate-orm.log.sql=false
+
 quarkus.log.console.enable=true
 quarkus.log.console.level=INFO
 quarkus.log.file.enable=false

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/pom.xml
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -79,7 +79,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -1,17 +1,13 @@
 package io.quarkus.benchmark.repository;
 
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
-import jakarta.transaction.Transactional;
-
-import org.hibernate.FlushMode;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.StatelessSession;
-
 import io.quarkus.benchmark.model.World;
 import io.quarkus.benchmark.utils.LocalRandom;
 import io.quarkus.benchmark.utils.Randomizer;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.transaction.Transactional;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
 
 @Singleton
 public class WorldRepository {
@@ -59,9 +55,8 @@ public class WorldRepository {
         //We're again forced to use the "individual load" pattern by the rules:
         final World[] list = loadNWorlds(count);
         final LocalRandom random = Randomizer.current();
-        try (Session s = sf.openSession()) {
+        try (StatelessSession s = sf.openStatelessSession()) {
             s.setJdbcBatchSize(count);
-            s.setHibernateFlushMode(FlushMode.MANUAL);
             for (World w : list) {
                 //Read the one field, as required by the following rule:
                 // # vi. At least the randomNumber field must be read from the database result set.
@@ -71,7 +66,6 @@ public class WorldRepository {
                 w.setRandomNumber(random.getNextRandomExcluding(previousRead));
                 s.update(w);
             }
-            s.flush();
         }
         return list;
     }

--- a/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
+++ b/frameworks/Java/quarkus/resteasy-reactive-hibernate/src/main/java/io/quarkus/benchmark/repository/WorldRepository.java
@@ -1,5 +1,8 @@
 package io.quarkus.benchmark.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.quarkus.benchmark.model.World;
 import io.quarkus.benchmark.utils.LocalRandom;
 import io.quarkus.benchmark.utils.Randomizer;
@@ -53,21 +56,22 @@ public class WorldRepository {
 
     public World[] updateNWorlds(final int count) {
         //We're again forced to use the "individual load" pattern by the rules:
-        final World[] list = loadNWorlds(count);
+        final World[] worlds = loadNWorlds(count);
+        final List<World> worldList = new ArrayList<>(worlds.length);
         final LocalRandom random = Randomizer.current();
         try (StatelessSession s = sf.openStatelessSession()) {
-            s.setJdbcBatchSize(count);
-            for (World w : list) {
+            for (World w : worlds) {
                 //Read the one field, as required by the following rule:
                 // # vi. At least the randomNumber field must be read from the database result set.
                 final int previousRead = w.getRandomNumber();
                 //Update it, but make sure to exclude the current number as Hibernate optimisations would otherwise
                 // skip the write operation:
                 w.setRandomNumber(random.getNextRandomExcluding(previousRead));
-                s.update(w);
+                worldList.add(w);
             }
+            s.updateMultiple(worldList);
         }
-        return list;
+        return worlds;
     }
 
 }

--- a/frameworks/Java/quarkus/vertx/pom.xml
+++ b/frameworks/Java/quarkus/vertx/pom.xml
@@ -26,7 +26,7 @@
         </dependency>
         <dependency>
             <groupId>com.ongres.scram</groupId>
-            <artifactId>client</artifactId>
+            <artifactId>scram-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -75,7 +75,7 @@
                     <dependency>
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
-                        <version>32.0.0-jre</version>
+                        <version>32.0.1-jre</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
It was required to add the `os-maven-plugin`. Otherwise, the container image build fails with:

```
Could not find artifact io.netty:netty-transport-native-unix-common:jar:${os.detected.name}-${os.detected.arch}:4.1.130.Final in central
```

Also, Hibernate no longer has the update method on the regular session.

And, for convenience, added `quarkus.hibernate-orm.log.sql` in application.properties